### PR TITLE
Desk reject & Withdraw action should expire some invitations and send mails

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -425,6 +425,9 @@ class PaperDeskRejectInvitation(openreview.Invitation):
             file_content = f.read()
 
             file_content = file_content.replace(
+                'CONFERENCE_ID = \'\'',
+                'CONFERENCE_ID = \'' + conference.get_id() + '\'')
+            file_content = file_content.replace(
                 'DESK_REJECTED_SUBMISSION_ID = \'\'',
                 'DESK_REJECTED_SUBMISSION_ID = \'' + conference.submission_stage.get_desk_rejected_submission_id(conference) + '\'')
             if conference.submission_stage.reveal_authors_on_desk_reject:

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -329,6 +329,25 @@ class PaperWithdrawInvitation(openreview.Invitation):
             file_content = f.read()
 
             file_content = file_content.replace(
+                'CONFERENCE_ID = \'\'',
+                'CONFERENCE_ID = \'' + conference.get_id() + '\'')
+            file_content = file_content.replace(
+                'CONFERENCE_SHORT_NAME = \'\'',
+                'CONFERENCE_SHORT_NAME = \'' + conference.get_short_name() + '\'')
+            file_content = file_content.replace(
+                'PAPER_AUTHORS_ID = \'\'',
+                'PAPER_AUTHORS_ID = \'' + conference.get_authors_id(number=note.number) + '\'')
+            file_content = file_content.replace(
+                'PAPER_REVIEWERS_ID = \'\'',
+                'PAPER_REVIEWERS_ID = \'' + conference.get_reviewers_id(number=note.number) + '\'')
+            if conference.use_area_chairs:
+                file_content = file_content.replace(
+                    'PAPER_AREA_CHAIRS_ID = \'\'',
+                    'PAPER_AREA_CHAIRS_ID = \'' + conference.get_area_chairs_id(number=note.number) + '\'')
+            file_content = file_content.replace(
+                'PROGRAM_CHAIRS_ID = \'\'',
+                'PROGRAM_CHAIRS_ID = \'' + conference.get_program_chairs_id() + '\'')
+            file_content = file_content.replace(
                 'WITHDRAWN_SUBMISSION_ID = \'\'',
                 'WITHDRAWN_SUBMISSION_ID = \'' + conference.submission_stage.get_withdrawn_submission_id(conference) + '\'')
             if conference.submission_stage.reveal_authors_on_withdraw:
@@ -427,6 +446,22 @@ class PaperDeskRejectInvitation(openreview.Invitation):
             file_content = file_content.replace(
                 'CONFERENCE_ID = \'\'',
                 'CONFERENCE_ID = \'' + conference.get_id() + '\'')
+            file_content = file_content.replace(
+                'CONFERENCE_SHORT_NAME = \'\'',
+                'CONFERENCE_SHORT_NAME = \'' + conference.get_short_name() + '\'')
+            file_content = file_content.replace(
+                'PAPER_AUTHORS_ID = \'\'',
+                'PAPER_AUTHORS_ID = \'' + conference.get_authors_id(number=note.number) + '\'')
+            file_content = file_content.replace(
+                'PAPER_REVIEWERS_ID = \'\'',
+                'PAPER_REVIEWERS_ID = \'' + conference.get_reviewers_id(number=note.number) + '\'')
+            if conference.use_area_chairs:
+                file_content = file_content.replace(
+                    'PAPER_AREA_CHAIRS_ID = \'\'',
+                    'PAPER_AREA_CHAIRS_ID = \'' + conference.get_area_chairs_id(number=note.number) + '\'')
+            file_content = file_content.replace(
+                'PROGRAM_CHAIRS_ID = \'\'',
+                'PROGRAM_CHAIRS_ID = \'' + conference.get_program_chairs_id() + '\'')
             file_content = file_content.replace(
                 'DESK_REJECTED_SUBMISSION_ID = \'\'',
                 'DESK_REJECTED_SUBMISSION_ID = \'' + conference.submission_stage.get_desk_rejected_submission_id(conference) + '\'')

--- a/openreview/conference/templates/desk_reject_process.py
+++ b/openreview/conference/templates/desk_reject_process.py
@@ -1,10 +1,32 @@
 def process(client, note, invitation):
+    from datetime import datetime
+    CONFERENCE_ID = ''
+    AUTHORS_ID = ''
+    REVIEWERS_ID = ''
+    AREA_CHAIRS_ID = ''
+    PROGRAM_CHAIRS_ID = ''
     DESK_REJECTED_SUBMISSION_ID = ''
     REVEAL_AUTHORS_ON_DESK_REJECT = False
-    blind_note = client.get_note(note.forum)
-    blind_note.invitation = DESK_REJECTED_SUBMISSION_ID
+
+    forum_note = client.get_note(note.forum)
+    forum_note.invitation = DESK_REJECTED_SUBMISSION_ID
     if REVEAL_AUTHORS_ON_DESK_REJECT:
+        # REVEAL_AUTHORS_ON_DESK_REJECT will only be True if this is a double blind conference
         original_note = client.get_note(id = blind_note.original)
         blind_note.content['authors'] = original_note.content['authors']
         blind_note.content['authorids'] = original_note.content['authorids']
     client.post_note(blind_note)
+
+    # Expire review, meta-review and decision invitations
+    paper_number = blind_note.number
+    invitation_regex = CONFERENCE_ID + '/Paper' + str(paper_number) + '/-/(Official_Review|Meta_Review|Decision)$'
+    all_paper_invitations = openreview.tools.get_invitations(client, regex = invitation_regex)
+    for invitation in all_paper_invitations:
+        invitation.expdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        client.post_invitation(invitation)
+
+    # Mail Authors, Reviewers, ACs (if present) and PCs
+    email_subject = '''{CONFERENCE_ID}: Paper {paper_title} has been marked desk rejected'''.format(CONFERENCE_ID = CONFERENCE_ID, )
+    email_body = ''''''
+
+

--- a/openreview/conference/templates/desk_reject_process.py
+++ b/openreview/conference/templates/desk_reject_process.py
@@ -27,11 +27,11 @@ def process(client, note, invitation):
         client.post_invitation(invitation)
 
     # Mail Authors, Reviewers, ACs (if present) and PCs
-    email_subject = '''{CONFERENCE_SHORT_NAME}: Paper #{paper_number} marked desk rejected by Program Chairs'''.format(
+    email_subject = '''{CONFERENCE_SHORT_NAME}: Paper #{paper_number} marked desk rejected by program chairs'''.format(
         CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
         paper_number = forum_note.number
     )
-    email_body = '''The {CONFERENCE_SHORT_NAME} paper title "{paper_title}" has been marked desk rejected by the Program Chairs.'''.format(
+    email_body = '''The {CONFERENCE_SHORT_NAME} paper title "{paper_title}" has been marked desk rejected by the program chairs.'''.format(
         CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
         paper_title = forum_note.content['title']
     )

--- a/openreview/conference/templates/desk_reject_process.py
+++ b/openreview/conference/templates/desk_reject_process.py
@@ -1,9 +1,10 @@
 def process(client, note, invitation):
     from datetime import datetime
     CONFERENCE_ID = ''
-    AUTHORS_ID = ''
-    REVIEWERS_ID = ''
-    AREA_CHAIRS_ID = ''
+    CONFERENCE_SHORT_NAME = ''
+    PAPER_AUTHORS_ID = ''
+    PAPER_REVIEWERS_ID = ''
+    PAPER_AREA_CHAIRS_ID = ''
     PROGRAM_CHAIRS_ID = ''
     DESK_REJECTED_SUBMISSION_ID = ''
     REVEAL_AUTHORS_ON_DESK_REJECT = False
@@ -12,21 +13,29 @@ def process(client, note, invitation):
     forum_note.invitation = DESK_REJECTED_SUBMISSION_ID
     if REVEAL_AUTHORS_ON_DESK_REJECT:
         # REVEAL_AUTHORS_ON_DESK_REJECT will only be True if this is a double blind conference
-        original_note = client.get_note(id = blind_note.original)
-        blind_note.content['authors'] = original_note.content['authors']
-        blind_note.content['authorids'] = original_note.content['authorids']
-    client.post_note(blind_note)
+        original_note = client.get_note(id = forum_note.original)
+        forum_note.content['authors'] = original_note.content['authors']
+        forum_note.content['authorids'] = original_note.content['authorids']
+    client.post_note(forum_note)
 
     # Expire review, meta-review and decision invitations
-    paper_number = blind_note.number
-    invitation_regex = CONFERENCE_ID + '/Paper' + str(paper_number) + '/-/(Official_Review|Meta_Review|Decision)$'
-    all_paper_invitations = openreview.tools.get_invitations(client, regex = invitation_regex)
+    invitation_regex = CONFERENCE_ID + '/Paper' + str(forum_note.number) + '/-/(Official_Review|Meta_Review|Decision|Desk_Reject|Withdraw)$'
+    all_paper_invitations = openreview.tools.iterget_invitations(client, regex = invitation_regex)
+    now = openreview.tools.datetime_millis(datetime.utcnow())
     for invitation in all_paper_invitations:
-        invitation.expdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.expdate = now
         client.post_invitation(invitation)
 
     # Mail Authors, Reviewers, ACs (if present) and PCs
-    email_subject = '''{CONFERENCE_ID}: Paper {paper_title} has been marked desk rejected'''.format(CONFERENCE_ID = CONFERENCE_ID, )
-    email_body = ''''''
-
-
+    email_subject = '''{CONFERENCE_SHORT_NAME}: Paper #{paper_number} marked desk rejected by Program Chairs'''.format(
+        CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
+        paper_number = forum_note.number
+    )
+    email_body = '''The {CONFERENCE_SHORT_NAME} paper title "{paper_title}" has been marked desk rejected by the Program Chairs.'''.format(
+        CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
+        paper_title = forum_note.content['title']
+    )
+    recipients = [PAPER_AUTHORS_ID, PAPER_REVIEWERS_ID, PROGRAM_CHAIRS_ID]
+    if PAPER_AREA_CHAIRS_ID:
+        recipients.append(PAPER_AREA_CHAIRS_ID)
+    client.send_mail(email_subject, recipients, email_body)

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -27,11 +27,11 @@ def process(client, note, invitation):
         client.post_invitation(invitation)
 
     # Mail Authors, Reviewers, ACs (if present) and PCs
-    email_subject = '''{CONFERENCE_SHORT_NAME}: Paper #{paper_number} withdrawn by Paper Authors'''.format(
+    email_subject = '''{CONFERENCE_SHORT_NAME}: Paper #{paper_number} withdrawn by paper authors'''.format(
         CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
         paper_number = forum_note.number
     )
-    email_body = '''The {CONFERENCE_SHORT_NAME} paper title "{paper_title}" has been withdrawn by the Paper Authors.'''.format(
+    email_body = '''The {CONFERENCE_SHORT_NAME} paper title "{paper_title}" has been withdrawn by the paper authors.'''.format(
         CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
         paper_title = forum_note.content['title']
     )

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -1,10 +1,41 @@
 def process(client, note, invitation):
+    from datetime import datetime
+    CONFERENCE_ID = ''
+    CONFERENCE_SHORT_NAME = ''
+    PAPER_AUTHORS_ID = ''
+    PAPER_REVIEWERS_ID = ''
+    PAPER_AREA_CHAIRS_ID = ''
+    PROGRAM_CHAIRS_ID = ''
     WITHDRAWN_SUBMISSION_ID = ''
     REVEAL_AUTHORS_ON_WITHDRAW = False
-    blind_note = client.get_note(note.forum)
-    blind_note.invitation = WITHDRAWN_SUBMISSION_ID
+
+    forum_note = client.get_note(note.forum)
+    forum_note.invitation = WITHDRAWN_SUBMISSION_ID
     if REVEAL_AUTHORS_ON_WITHDRAW:
-        original_note = client.get_note(id = blind_note.original)
-        blind_note.content['authors'] = original_note.content['authors']
-        blind_note.content['authorids'] = original_note.content['authorids']
-    client.post_note(blind_note)
+        # REVEAL_AUTHORS_ON_WITHDRAW will only be True if this is a double blind conference
+        original_note = client.get_note(id = forum_note.original)
+        forum_note.content['authors'] = original_note.content['authors']
+        forum_note.content['authorids'] = original_note.content['authorids']
+    client.post_note(forum_note)
+
+    # Expire review, meta-review and decision invitations
+    invitation_regex = CONFERENCE_ID + '/Paper' + str(forum_note.number) + '/-/(Official_Review|Meta_Review|Decision|Desk_Reject|Withdraw)$'
+    all_paper_invitations = openreview.tools.iterget_invitations(client, regex = invitation_regex)
+    now = openreview.tools.datetime_millis(datetime.utcnow())
+    for invitation in all_paper_invitations:
+        invitation.expdate = now
+        client.post_invitation(invitation)
+
+    # Mail Authors, Reviewers, ACs (if present) and PCs
+    email_subject = '''{CONFERENCE_SHORT_NAME}: Paper #{paper_number} withdrawn by Paper Authors'''.format(
+        CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
+        paper_number = forum_note.number
+    )
+    email_body = '''The {CONFERENCE_SHORT_NAME} paper title "{paper_title}" has been withdrawn by the Paper Authors.'''.format(
+        CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
+        paper_title = forum_note.content['title']
+    )
+    recipients = [PAPER_AUTHORS_ID, PAPER_REVIEWERS_ID, PROGRAM_CHAIRS_ID]
+    if PAPER_AREA_CHAIRS_ID:
+        recipients.append(PAPER_AREA_CHAIRS_ID)
+    client.send_mail(email_subject, recipients, email_body)


### PR DESCRIPTION
This expires any of the available paper's invitations out of the list: [Official_Review|Meta_Review|Decision|Desk_Reject|Withdraw]

Emails are sent to Paper Authors, Reviewers, ACs and PCs about desk reject/withdraw.