### PR TITLE
Enable reviewer reassignment when there is manual assignments requested

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1088,6 +1088,9 @@ class ConferenceBuilder(object):
     def has_area_chairs(self, has_area_chairs):
         self.conference.has_area_chairs(has_area_chairs)
 
+    def enable_reviewer_reassignment(self, enable):
+        self.conference.enable_reviewer_reassignment = enable
+
     def set_submission_stage(
             self,
             name='Submission',

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -86,6 +86,9 @@ def get_conference(client, request_form_id):
     if 'OpenReview Affinity' in paper_matching_options:
         builder.set_expertise_selection_stage(due_date = submission_due_date)
 
+    if 'Organizers will assign papers manually' in paper_matching_options:
+        builder.enable_reviewer_reassignment(enable = True)
+
     conference = builder.get_result()
     conference.set_program_chairs(emails = note.content['Contact Emails'])
     return conference


### PR DESCRIPTION
Set default to true when there is no matching to run. 