### PR TITLE
Fix/buddy ac mail

### DIFF
--- a/openreview/conference/templates/commentProcess.js
+++ b/openreview/conference/templates/commentProcess.js
@@ -16,12 +16,13 @@ function(){
       var AUTHORS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/' + AUTHORS_NAME;
       //TODO: use the variable instead, when we have anonymous groups integrated
       var REVIEWERS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Reviewers';
-      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chair1';
+      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chairs';
+      var AREA_CHAIR_1_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chair1';
       var ignoreGroups = note.nonreaders || [];
       ignoreGroups.push(note.tauthor);
 
       var ac_mail = {
-        groups: [AREA_CHAIRS_ID],
+        groups: [AREA_CHAIR_1_ID],
         ignoreGroups: ignoreGroups,
         subject: '[' + SHORT_PHRASE + '] Comment posted to a paper in your area. Paper Number: ' + forumNote.number + ', Paper Title: "' + forumNote.content.title + '"',
         message: 'A comment was posted to a paper for which you are serving as Area Chair.\n\nPaper Number: ' + forumNote.number + '\n\nPaper Title: "' + forumNote.content.title + '"\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id

--- a/openreview/conference/templates/commentProcess.js
+++ b/openreview/conference/templates/commentProcess.js
@@ -16,11 +16,9 @@ function(){
       var AUTHORS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/' + AUTHORS_NAME;
       //TODO: use the variable instead, when we have anonymous groups integrated
       var REVIEWERS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Reviewers';
-      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chairs';
-      var BUDDY_AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Buddy_Area_Chair1';
+      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chair1';
       var ignoreGroups = note.nonreaders || [];
       ignoreGroups.push(note.tauthor);
-      ignoreGroups.push(BUDDY_AREA_CHAIRS_ID);
 
       var ac_mail = {
         groups: [AREA_CHAIRS_ID],

--- a/openreview/conference/templates/commentProcess.js
+++ b/openreview/conference/templates/commentProcess.js
@@ -17,8 +17,10 @@ function(){
       //TODO: use the variable instead, when we have anonymous groups integrated
       var REVIEWERS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Reviewers';
       var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chairs';
+      var BUDDY_AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Buddy_Area_Chair1';
       var ignoreGroups = note.nonreaders || [];
       ignoreGroups.push(note.tauthor);
+      ignoreGroups.push(BUDDY_AREA_CHAIRS_ID);
 
       var ac_mail = {
         groups: [AREA_CHAIRS_ID],

--- a/openreview/conference/templates/reviewProcess.js
+++ b/openreview/conference/templates/reviewProcess.js
@@ -19,10 +19,12 @@ function(){
       //TODO: use the variable instead, when we have anonymous groups integrated
       var REVIEWERS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Reviewers';
       var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Area_Chairs';
+      var BUDDY_AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Buddy_Area_Chair1';
       var ignoreGroups = note.nonreaders || [];
       ignoreGroups.push(note.tauthor);
+      ignoreGroups.push(BUDDY_AREA_CHAIRS_ID);
 
-      if (PROGRAM_CHAIRS_ID){
+      if (PROGRAM_CHAIRS_ID) {
         var program_chair_mail = {
           groups: [PROGRAM_CHAIRS_ID],
           ignoreGroups: ignoreGroups,
@@ -50,7 +52,7 @@ function(){
       }
 
       var reviewers_submitted = REVIEWERS_ID + '/Submitted';
-      if (note.readers.includes('everyone') || note.readers.includes(REVIEWERS_ID)){
+      if (note.readers.includes('everyone') || note.readers.includes(REVIEWERS_ID)) {
         var reviewer_mail = {
           groups: [REVIEWERS_ID],
           ignoreGroups: ignoreGroups,
@@ -79,7 +81,7 @@ function(){
       }
 
       return Promise.all(promises)
-      .then(function(result){
+      .then(function(result) {
         return or3client.addGroupMember(reviewers_submitted, note.signatures[0], token);
       })
     })

--- a/openreview/conference/templates/reviewProcess.js
+++ b/openreview/conference/templates/reviewProcess.js
@@ -18,7 +18,8 @@ function(){
       var AUTHORS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/' + AUTHORS_NAME;
       //TODO: use the variable instead, when we have anonymous groups integrated
       var REVIEWERS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Reviewers';
-      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Area_Chair1';
+      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Area_Chairs';
+      var AREA_CHAIR_1_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Area_Chairs';
       var ignoreGroups = note.nonreaders || [];
       ignoreGroups.push(note.tauthor);
 
@@ -41,7 +42,7 @@ function(){
 
       if (USE_AREA_CHAIRS && (note.readers.includes('everyone') || note.readers.includes(AREA_CHAIRS_ID))) {
         var areachair_mail = {
-          groups: [AREA_CHAIRS_ID],
+          groups: [AREA_CHAIR_1_ID],
           ignoreGroups: ignoreGroups,
           subject : '[' + SHORT_PHRASE + '] Review posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'A submission to ' + SHORT_PHRASE + ', for which you are an official area chair, has received a review. \n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\nReview title: ' + note.content.title + '\n\nReview comment: ' + note.content.review + '\n\nTo view the review, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id

--- a/openreview/conference/templates/reviewProcess.js
+++ b/openreview/conference/templates/reviewProcess.js
@@ -18,11 +18,9 @@ function(){
       var AUTHORS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/' + AUTHORS_NAME;
       //TODO: use the variable instead, when we have anonymous groups integrated
       var REVIEWERS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Reviewers';
-      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Area_Chairs';
-      var BUDDY_AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Buddy_Area_Chair1';
+      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/Area_Chair1';
       var ignoreGroups = note.nonreaders || [];
       ignoreGroups.push(note.tauthor);
-      ignoreGroups.push(BUDDY_AREA_CHAIRS_ID);
 
       if (PROGRAM_CHAIRS_ID) {
         var program_chair_mail = {


### PR DESCRIPTION
Send emails to Area_Chair1 group instead of Area_Chairs. This ensures that Buddy ACs do not receive emails about comments and reviews on their papers.