### PR TITLE
AC console fixes

### DIFF
--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -299,7 +299,7 @@ var renderHeader = function() {
   ]);
 };
 
-var renderStatusTable = function(profiles, notes, completedReviews, metaReviews, reviewerIds, container) {
+var renderStatusTable = function(profiles, notes, completedReviews, metaReviews, allInvitations, reviewerIds, container) {
   var rows = _.map(notes, function(note) {
     var revIds = reviewerIds[note.number] || Object.create(null);
     for (var revNumber in revIds) {
@@ -625,6 +625,7 @@ var renderTableAndTasks = function(fetchedData) {
     fetchedData.blindedNotes,
     fetchedData.officialReviews,
     fetchedData.metaReviews,
+    fetchedData.invitations,
     _.cloneDeep(fetchedData.noteToReviewerIds), // Need to clone this dictionary because some values are missing after the first refresh
     '#assigned-papers'
   );


### PR DESCRIPTION
AC console shows confidence stats as "undefined" right now as confidence field does not exist in ICLR reviews.
![Screen Shot 2019-10-24 at 11 31 04 AM](https://user-images.githubusercontent.com/13500158/67501213-e5d16500-f651-11e9-8ac6-58fdb1fc3bd3.png)

This PR removes the columns for Rating and Confidence columns and displays these stats in the Review progress column itself.
This PR also fixes a long standing issue where an AC see a link to submit meta review even when the meta-review invitation has not been created yet, or has expired. 

```
If meta-review is available:
    If meta review invitation is available:
        Show the link to meta-review with the link text "Read/Edit"
    Else
        Show the link to meta-review with the link text "Read"
Else
    If meta review invitation is available:
        Show the link to Submit meta-review
    Else
        Show "No Recommendation"
```

![Screen Shot 2019-10-24 at 11 28 52 AM](https://user-images.githubusercontent.com/13500158/67501004-82473780-f651-11e9-9374-5b2cffa9cd1f.png)






Requires https://github.com/iesl/openreview/pull/1674