### PR TITLE
Fixes for Iclr2020 - revision, withdraw, and desk reject invitations

### DIFF
--- a/openreview/conference/templates/desk_reject_process.py
+++ b/openreview/conference/templates/desk_reject_process.py
@@ -19,7 +19,7 @@ def process(client, note, invitation):
     client.post_note(forum_note)
 
     # Expire review, meta-review and decision invitations
-    invitation_regex = CONFERENCE_ID + '/Paper' + str(forum_note.number) + '/-/(Official_Review|Meta_Review|Decision|Desk_Reject|Withdraw)$'
+    invitation_regex = CONFERENCE_ID + '/Paper' + str(forum_note.number) + '/-/(Official_Review|Meta_Review|Decision|Revision|Desk_Reject|Withdraw)$'
     all_paper_invitations = openreview.tools.iterget_invitations(client, regex = invitation_regex)
     now = openreview.tools.datetime_millis(datetime.utcnow())
     for invitation in all_paper_invitations:

--- a/openreview/conference/templates/submissionRevisionProcess.js
+++ b/openreview/conference/templates/submissionRevisionProcess.js
@@ -8,11 +8,13 @@ function() {
   forumNote.then(function(result) {
     var forum = result.notes[0];
     var title = note.content.title || forum.content.title;
+    var authorids = note.content.authorids || forum.content.authorids;
+    var abstract = note.content.abstract || forum.content.abstract;
 
     var authorMail = {
-      groups: note.content.authorids,
+      groups: authorids,
       subject: SHORT_PHRASE + ' has received a new revision of your submission titled ' + title,
-      message: 'Your new revision of the submission to ' + SHORT_PHRASE + ' has been posted.\n\nTitle: ' + title + '\n\nAbstract: ' + note.content.abstract + '\n\nTo view your submission, click here: ' + baseUrl + '/forum?id=' + note.forum
+      message: 'Your new revision of the submission to ' + SHORT_PHRASE + ' has been posted.\n\nTitle: ' + title + '\n\nAbstract: ' + abstract + '\n\nTo view your submission, click here: ' + baseUrl + '/forum?id=' + note.forum
     };
 
     return or3client.or3request(or3client.mailUrl, authorMail, 'POST', token);

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -19,7 +19,7 @@ def process(client, note, invitation):
     client.post_note(forum_note)
 
     # Expire review, meta-review and decision invitations
-    invitation_regex = CONFERENCE_ID + '/Paper' + str(forum_note.number) + '/-/(Official_Review|Meta_Review|Decision|Desk_Reject|Withdraw)$'
+    invitation_regex = CONFERENCE_ID + '/Paper' + str(forum_note.number) + '/-/(Official_Review|Meta_Review|Decision|Revision|Withdraw)$'
     all_paper_invitations = openreview.tools.iterget_invitations(client, regex = invitation_regex)
     now = openreview.tools.datetime_millis(datetime.utcnow())
     for invitation in all_paper_invitations:


### PR DESCRIPTION
Revision process -> Use forum.content.authorids to send emails instead of note.content.authorids as the note may not have authorids

Withdraw & Desk-Reject processes -> Expire Revision invitation once a paper has been desk-rejected or withdrawn

Withdraw process -> This should not expire the desk-reject option. Program chairs asked for the option to still desk-reject a withdrawn submission