### PR TITLE
Feature/meta review sans title

### DIFF
--- a/openreview/invitations/content.py
+++ b/openreview/invitations/content.py
@@ -122,20 +122,14 @@ review = {
 }
 
 meta_review = {
-    'title': {
-        'order': 1,
-        'value-regex': '.{1,500}',
-        'description': 'Brief summary of your review.',
-        'required': True
-    },
     'metareview': {
-        'order': 2,
+        'order': 1,
         'value-regex': '[\\S\\s]{1,5000}',
         'description': 'Please provide an evaluation of the quality, clarity, originality and significance of this work, including a list of its pros and cons. Add TeX formulas using the following formats: $In-line Formula$ or $$Block Formula$$',
         'required': True
     },
     'recommendation': {
-        'order': 3,
+        'order': 2,
         'value-dropdown': [
             'Accept (Oral)',
             'Accept (Poster)',
@@ -144,7 +138,7 @@ meta_review = {
         'required': True
     },
     'confidence': {
-        'order': 4,
+        'order': 3,
         'value-radio': [
             '5: The area chair is absolutely certain',
             '4: The area chair is confident but not absolutely certain',

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1062,7 +1062,6 @@ note={under review}
             writers = ['AKBC.ws/2019/Conference/Program_Chairs', 'AKBC.ws/2019/Conference/Paper1/Area_Chairs'],
             signatures = ['AKBC.ws/2019/Conference/Paper1/Area_Chair1'],
             content = {
-                'title': 'Meta review title',
                 'metareview': 'Paper is very good!',
                 'recommendation': 'Accept (Oral)',
                 'confidence': '4: The area chair is confident but not absolutely certain'
@@ -1105,7 +1104,6 @@ note={under review}
             writers = ['AKBC.ws/2019/Conference/Program_Chairs', 'AKBC.ws/2019/Conference/Paper1/Area_Chairs'],
             signatures = ['AKBC.ws/2019/Conference/Paper1/Area_Chair2'],
             content = {
-                'title': 'Meta review title',
                 'metareview': 'Excellent Paper!',
                 'recommendation': 'Accept (Oral)',
                 'confidence': '4: The area chair is confident but not absolutely certain'

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -625,7 +625,6 @@ class TestWorkshop():
             writers = ['icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs'],
             signatures = ['icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs'],
             content = {
-                'title': 'Meta review title',
                 'metareview': 'Paper is very good!',
                 'recommendation': 'Accept (Oral)',
                 'confidence': '4: The area chair is confident but not absolutely certain'


### PR DESCRIPTION
Updated meta review template to remove content.title field.

This change is based on a recent PR https://github.com/openreview/openreview/pull/1742