### PR TITLE
Use post_message instead of send_mail

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -1040,6 +1040,27 @@ class Client(object):
         response = self.__handle_response(response)
         return response.json()
 
+
+    def post_message(self, subject, recipients, message):
+        """
+        Posts a message to the recipients and consequently sends them emails
+
+        :param subject: Subject of the e-mail
+        :type subject: str
+        :param recipients: Recipients of the e-mail. Valid inputs would be tilde username or emails registered in OpenReview
+        :type recipients: list[str]
+        :param message: Message in the e-mail
+        :type message: str
+
+        :return: Contains the message that was sent to each Group
+        :rtype: dict
+        """
+        response = requests.post(self.messages_url, json = {'groups': recipients, 'subject': subject , 'message': message}, headers = self.headers)
+        response = self.__handle_response(response)
+
+        return response.json()
+
+    @deprecated(version='1.0.6', reason="Use post_message instead")
     def send_mail(self, subject, recipients, message):
         """
         Posts a message to the recipients and consequently sends them emails as well

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='openreview-py',
-      version='1.0.5',
+      version='1.0.6',
       description='OpenReview client library',
       url='https://github.com/openreview/openreview-py',
       author='Michael Spector, Melisa Bok, Pam Mander, Mohit Uniyal',

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -573,7 +573,7 @@ class TestCommentNotification():
         subject = 'Remind to reviewers'
         recipients = ['reviewer@auai.org']
         message = 'This is a reminder'
-        response = ac_client.send_mail(subject, recipients, message)
+        response = ac_client.post_message(subject, recipients, message)
         assert response
 
         messages = client.get_messages(subject='Remind to reviewers')
@@ -582,7 +582,7 @@ class TestCommentNotification():
         assert messages[0]['content']['to'] == 'reviewer@auai.org'
 
         recipients = ['auai.org/UAI/2020/Conference/Paper1/AnonReviewer1']
-        response = ac_client.send_mail(subject, recipients, 'This is a second reminder')
+        response = ac_client.post_message(subject, recipients, 'This is a second reminder')
         assert response
 
         messages_2 = client.get_messages(subject='.*Remind to reviewers.*')
@@ -592,9 +592,9 @@ class TestCommentNotification():
         assert messages_2[1]['content']['to'] == 'reviewer@auai.org'
 
         with pytest.raises(openreview.OpenReviewException, match=r'Group Not Found: auai.org/UAI/2020/Conference/Paper2/AnonReviewer1'):
-            ac_client.send_mail(subject, ['auai.org/UAI/2020/Conference/Paper2/AnonReviewer1'], 'This is an invalid reminder')
+            ac_client.post_message(subject, ['auai.org/UAI/2020/Conference/Paper2/AnonReviewer1'], 'This is an invalid reminder')
 
-        ac_client.send_mail(subject, ['auai.org/UAI/2020/Conference/Program_Committee'], 'This is an invalid reminder')
+        ac_client.post_message(subject, ['auai.org/UAI/2020/Conference/Program_Committee'], 'This is an invalid reminder')
 
     def test_notify_all_mandatory_readers(self, client, test_client, helpers):
 


### PR DESCRIPTION
Added py api for post_message which uses a post on messages_url "/messages"
Deprecates send_mail which uses a post on mail_url "/mail"