### PR TITLE
Allow recruit_reviewers to receive an override url optional param

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -762,7 +762,7 @@ class Conference(object):
                     'Reminder: ' + recruit_message_subj,
                     reviewers_invited_id,
                     verbose = False,
-                    recruitment_link_baseurl = recruitment_link_baseurl)
+                    baseurl = baseurl)
 
         for index, email in enumerate(emails):
             if email not in set(reviewers_invited_group.members):
@@ -776,7 +776,7 @@ class Conference(object):
                     recruit_message_subj,
                     reviewers_invited_id,
                     verbose = False,
-                    recruitment_link_baseurl = recruitment_link_baseurl)
+                    baseurl = baseurl)
 
         return self.client.get_group(id = reviewers_invited_id)
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -682,7 +682,7 @@ class Conference(object):
     def set_recruitment_reduced_load(self, reduced_load_options):
         self.reduced_load_on_decline = reduced_load_options
 
-    def recruit_reviewers(self, emails = [], title = None, message = None, reviewers_name = 'Reviewers', reviewer_accepted_name = None, remind = False, invitee_names = [], recruitment_link_baseurl = ''):
+    def recruit_reviewers(self, emails = [], title = None, message = None, reviewers_name = 'Reviewers', reviewer_accepted_name = None, remind = False, invitee_names = [], baseurl = ''):
 
         pcs_id = self.get_program_chairs_id()
         reviewers_id = self.id + '/' + reviewers_name

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -682,7 +682,7 @@ class Conference(object):
     def set_recruitment_reduced_load(self, reduced_load_options):
         self.reduced_load_on_decline = reduced_load_options
 
-    def recruit_reviewers(self, emails = [], title = None, message = None, reviewers_name = 'Reviewers', reviewer_accepted_name = None, remind = False, invitee_names = []):
+    def recruit_reviewers(self, emails = [], title = None, message = None, reviewers_name = 'Reviewers', reviewer_accepted_name = None, remind = False, invitee_names = [], override_url_root = ''):
 
         pcs_id = self.get_program_chairs_id()
         reviewers_id = self.id + '/' + reviewers_name
@@ -761,7 +761,8 @@ class Conference(object):
                     recruit_message,
                     'Reminder: ' + recruit_message_subj,
                     reviewers_invited_id,
-                    verbose = False)
+                    verbose = False,
+                    recruitment_url_root = override_url_root)
 
         for index, email in enumerate(emails):
             if email not in set(reviewers_invited_group.members):
@@ -774,7 +775,8 @@ class Conference(object):
                     recruit_message,
                     recruit_message_subj,
                     reviewers_invited_id,
-                    verbose = False)
+                    verbose = False,
+                    recruitment_url_root = override_url_root)
 
         return self.client.get_group(id = reviewers_invited_id)
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -682,7 +682,7 @@ class Conference(object):
     def set_recruitment_reduced_load(self, reduced_load_options):
         self.reduced_load_on_decline = reduced_load_options
 
-    def recruit_reviewers(self, emails = [], title = None, message = None, reviewers_name = 'Reviewers', reviewer_accepted_name = None, remind = False, invitee_names = [], override_url_root = ''):
+    def recruit_reviewers(self, emails = [], title = None, message = None, reviewers_name = 'Reviewers', reviewer_accepted_name = None, remind = False, invitee_names = [], recruitment_link_baseurl = ''):
 
         pcs_id = self.get_program_chairs_id()
         reviewers_id = self.id + '/' + reviewers_name
@@ -762,7 +762,7 @@ class Conference(object):
                     'Reminder: ' + recruit_message_subj,
                     reviewers_invited_id,
                     verbose = False,
-                    recruitment_url_root = override_url_root)
+                    recruitment_link_baseurl = recruitment_link_baseurl)
 
         for index, email in enumerate(emails):
             if email not in set(reviewers_invited_group.members):
@@ -776,7 +776,7 @@ class Conference(object):
                     recruit_message_subj,
                     reviewers_invited_id,
                     verbose = False,
-                    recruitment_url_root = override_url_root)
+                    recruitment_link_baseurl = recruitment_link_baseurl)
 
         return self.client.get_group(id = reviewers_invited_id)
 

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -1164,7 +1164,7 @@ class Client(object):
         response = self.__handle_response(response)
         return response.json()
 
-    def get_messages(self, to = None, subject = None):
+    def get_messages(self, to = None, subject = None, offset = None, limit = None):
         """
         **Only for Super User**. Retrieves all the messages sent to a list of usernames or emails and/or a particular e-mail subject
 
@@ -1177,7 +1177,7 @@ class Client(object):
         :rtype: dict
         """
 
-        response = requests.get(self.messages_url, params = { 'to': to, 'subject': subject }, headers = self.headers)
+        response = requests.get(self.messages_url, params = { 'to': to, 'subject': subject, 'offset': offset, 'limit': limit }, headers = self.headers)
         response = self.__handle_response(response)
         return response.json()['messages']
 

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1264,7 +1264,7 @@ def recruit_reviewer(client, user, first,
     recruit_message_subj,
     reviewers_invited_id,
     verbose=True,
-    recruitment_link_baseurl = ''):
+    baseurl = ''):
     """
     Recruit a reviewer. Sends an email to the reviewer with a link to accept or
     reject the recruitment invitation.
@@ -1285,8 +1285,8 @@ def recruit_reviewer(client, user, first,
     :type reviewers_invited_id: str
     :param verbose: Shows response of :meth:`openreview.Client.send_mail` and shows the body of the message sent
     :type verbose: bool, optional
-    :param recruitment_url_root: Use this baseUrl instead of client.baseurl to create recruitment links
-    :type recruitment_url_root: str, optional
+    :param baseurl: Use this baseUrl instead of client.baseurl to create recruitment links
+    :type baseurl: str, optional
     """
 
     # the HMAC.new() function only accepts bytestrings, not unicode.
@@ -1297,7 +1297,7 @@ def recruit_reviewer(client, user, first,
 
     # build the URL to send in the message
     url = '{baseurl}/invitation?id={recruitment_inv}&user={user}&key={hashkey}&response='.format(
-        baseurl = recruitment_link_baseurl if recruitment_link_baseurl else client.baseurl,
+        baseurl = baseurl if baseurl else client.baseurl,
         recruitment_inv = recruit_reviewers_id,
         user = user,
         hashkey = hashkey

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1263,7 +1263,8 @@ def recruit_reviewer(client, user, first,
     recruit_message,
     recruit_message_subj,
     reviewers_invited_id,
-    verbose=True):
+    verbose=True,
+    recruitment_url_root = ''):
     """
     Recruit a reviewer. Sends an email to the reviewer with a link to accept or
     reject the recruitment invitation.
@@ -1284,6 +1285,8 @@ def recruit_reviewer(client, user, first,
     :type reviewers_invited_id: str
     :param verbose: Shows response of :meth:`openreview.Client.send_mail` and shows the body of the message sent
     :type verbose: bool, optional
+    :param recruitment_url_root: Use this baseUrl instead of client.baseurl to create recruitment links
+    :type recruitment_url_root: str, optional
     """
 
     # the HMAC.new() function only accepts bytestrings, not unicode.
@@ -1294,7 +1297,7 @@ def recruit_reviewer(client, user, first,
 
     # build the URL to send in the message
     url = '{baseurl}/invitation?id={recruitment_inv}&user={user}&key={hashkey}&response='.format(
-        baseurl = client.baseurl,
+        baseurl = recruitment_url_root if recruitment_url_root else client.baseurl,
         recruitment_inv = recruit_reviewers_id,
         user = user,
         hashkey = hashkey

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1264,7 +1264,7 @@ def recruit_reviewer(client, user, first,
     recruit_message_subj,
     reviewers_invited_id,
     verbose=True,
-    recruitment_url_root = ''):
+    recruitment_link_baseurl = ''):
     """
     Recruit a reviewer. Sends an email to the reviewer with a link to accept or
     reject the recruitment invitation.
@@ -1297,7 +1297,7 @@ def recruit_reviewer(client, user, first,
 
     # build the URL to send in the message
     url = '{baseurl}/invitation?id={recruitment_inv}&user={user}&key={hashkey}&response='.format(
-        baseurl = recruitment_url_root if recruitment_url_root else client.baseurl,
+        baseurl = recruitment_link_baseurl if recruitment_link_baseurl else client.baseurl,
         recruitment_inv = recruit_reviewers_id,
         user = user,
         hashkey = hashkey

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -562,6 +562,54 @@ class TestDoubleBlindConference():
         assert 'mohit@mail.com' in tos
         assert 'other@mail.com' in tos
 
+    def test_recruit_reviewers_use_different_baseurl(self, client, selenium, request_page):
+
+        builder = openreview.conference.ConferenceBuilder(client)
+        assert builder, 'builder is None'
+
+        builder.set_conference_id('ABCD.ws/2020/Conference')
+        builder.set_conference_short_name('ABCD 2020')
+        builder.set_submission_stage(double_blind = True, public = True)
+        builder.has_area_chairs(True)
+        conference = builder.get_result()
+
+        result = conference.recruit_reviewers(['test_subject1@mail.com', 'test_subject2@mail.com'], override_url_root = 'https://testme_1234.com')
+        assert result
+        assert result.id == 'ABCD.ws/2020/Conference/Reviewers/Invited'
+        assert 'test_subject1@mail.com' in result.members
+        assert 'test_subject2@mail.com' in result.members
+
+        group = client.get_group('ABCD.ws/2020/Conference/Reviewers')
+        assert group
+        assert group.id == 'ABCD.ws/2020/Conference/Reviewers'
+        assert 'ABCD.ws/2020/Conference/Area_Chairs' in group.readers
+        assert len(group.members) == 0
+
+        group = client.get_group('ABCD.ws/2020/Conference/Reviewers/Invited')
+        assert group
+        assert len(group.members) == 2
+
+        group = client.get_group('ABCD.ws/2020/Conference/Reviewers/Declined')
+        assert group
+        assert len(group.members) == 0
+
+        messages = client.get_messages(to = 'test_subject1@mail.com', subject = 'ABCD.ws/2020/Conference: Invitation to Review')
+        text = messages[0]['content']['text']
+        assert 'Dear invitee,' in text
+        assert 'You have been nominated by the program chair committee of ABCD 2020' in text
+        assert 'https://testme_1234.com' in text
+        assert 'http://localhost:3000' not in text
+
+        # Test if the reminder mail has "Dear invitee" for unregistered users in case the name is not provided to recruit_reviewers
+        # In the same test, check if recruitment link baseurl has been overridden
+        result = conference.recruit_reviewers(remind = True, emails = ['test_subject1@mail.com'], override_url_root = 'https://testme_1234.com')
+        messages = client.get_messages(to = 'test_subject1@mail.com', subject = 'Reminder: ABCD.ws/2020/Conference: Invitation to Review')
+        text = messages[0]['content']['text']
+        assert 'Dear invitee,' in text
+        assert 'You have been nominated by the program chair committee of ABCD 2020' in text
+        assert 'https://testme_1234.com' in text
+        assert 'http://localhost:3000' not in text
+
     def test_set_program_chairs(self, client, selenium, request_page):
 
         builder = openreview.conference.ConferenceBuilder(client)

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -572,7 +572,7 @@ class TestDoubleBlindConference():
         builder.set_submission_stage(double_blind = True, public = True)
         builder.has_area_chairs(True)
         conference = builder.get_result()
-        result = conference.recruit_reviewers(['test_subject1@mail.com', 'test_subject2@mail.com'], recruitment_link_baseurl = 'https://testme_1234.com')
+        result = conference.recruit_reviewers(['test_subject1@mail.com', 'test_subject2@mail.com'], baseurl = 'https://testme_1234.com')
         assert result
         assert result.id == 'ABCD.ws/2020/Conference/Reviewers/Invited'
         assert 'test_subject1@mail.com' in result.members
@@ -601,7 +601,7 @@ class TestDoubleBlindConference():
 
         # Test if the reminder mail has "Dear invitee" for unregistered users in case the name is not provided to recruit_reviewers
         # In the same test, check if recruitment link baseurl has been overridden
-        result = conference.recruit_reviewers(remind = True, emails = ['test_subject1@mail.com'], recruitment_link_baseurl = 'https://testme_1234.com')
+        result = conference.recruit_reviewers(remind = True, emails = ['test_subject1@mail.com'], baseurl = 'https://testme_1234.com')
         messages = client.get_messages(to = 'test_subject1@mail.com', subject = 'Reminder: ABCD.ws/2020/Conference: Invitation to Review')
         text = messages[0]['content']['text']
         assert 'Dear invitee,' in text

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -572,8 +572,7 @@ class TestDoubleBlindConference():
         builder.set_submission_stage(double_blind = True, public = True)
         builder.has_area_chairs(True)
         conference = builder.get_result()
-
-        result = conference.recruit_reviewers(['test_subject1@mail.com', 'test_subject2@mail.com'], override_url_root = 'https://testme_1234.com')
+        result = conference.recruit_reviewers(['test_subject1@mail.com', 'test_subject2@mail.com'], recruitment_link_baseurl = 'https://testme_1234.com')
         assert result
         assert result.id == 'ABCD.ws/2020/Conference/Reviewers/Invited'
         assert 'test_subject1@mail.com' in result.members
@@ -602,7 +601,7 @@ class TestDoubleBlindConference():
 
         # Test if the reminder mail has "Dear invitee" for unregistered users in case the name is not provided to recruit_reviewers
         # In the same test, check if recruitment link baseurl has been overridden
-        result = conference.recruit_reviewers(remind = True, emails = ['test_subject1@mail.com'], override_url_root = 'https://testme_1234.com')
+        result = conference.recruit_reviewers(remind = True, emails = ['test_subject1@mail.com'], recruitment_link_baseurl = 'https://testme_1234.com')
         messages = client.get_messages(to = 'test_subject1@mail.com', subject = 'Reminder: ABCD.ws/2020/Conference: Invitation to Review')
         text = messages[0]['content']['text']
         assert 'Dear invitee,' in text

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,11 +10,11 @@ class TestTools():
 
     def test_get_submission_invitations(self, client):
         invitations = openreview.tools.get_submission_invitations(client)
-        assert len(invitations) == 13, "Invitations could not be retrieved"
+        assert len(invitations) == 14, "Invitations could not be retrieved"
 
     def test_get_all_venues(self, client):
         venues = openreview.tools.get_all_venues(client)
-        assert len(venues) == 10, "Venues could not be retrieved"
+        assert len(venues) == 11, "Venues could not be retrieved"
 
     def test_iterget_notes(self, client):
         notes_iterator = openreview.tools.iterget_notes(client)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,11 +10,11 @@ class TestTools():
 
     def test_get_submission_invitations(self, client):
         invitations = openreview.tools.get_submission_invitations(client)
-        assert len(invitations) == 15, "Invitations could not be retrieved"
+        assert len(invitations) == 16, "Invitations could not be retrieved"
 
     def test_get_all_venues(self, client):
         venues = openreview.tools.get_all_venues(client)
-        assert len(venues) == 11, "Venues could not be retrieved"
+        assert len(venues) == 12, "Venues could not be retrieved"
 
     def test_iterget_notes(self, client):
         notes_iterator = openreview.tools.iterget_notes(client)


### PR DESCRIPTION
With this change we can run recruit_reviewer from the cloud machine while still using localhost baseurl for creating a client.