### PR TITLE
Modify paper assignment invitation to allow edits

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -335,13 +335,15 @@ class Matching(object):
                         'order': 5
                     },
                     'paper_invitation': {
-                        'value': self.conference.get_blind_submission_id(),
+                        'value-regex': self.conference.get_blind_submission_id() + '.*',
+                        'default': self.conference.get_blind_submission_id(),
                         'required': True,
                         'description': 'Invitation to get the configuration note',
                         'order': 6
                     },
                     'match_group': {
-                        'value': self.match_group.id,
+                        'value-regex': '.*',
+                        'default': self.match_group.id,
                         'required': True,
                         'description': 'Invitation to get the configuration note',
                         'order': 7


### PR DESCRIPTION
This allows user to edit paper-invitation to provide content field based filters (required for MIDL 2020) e.g. 'MIDL.io/2020/Conference/-/Blind_Submission&content.paper_type=Full Paper'.

This also allows changing match_group (required by ICML 2020) e.g. instead of ICML.cc/2020/Conference/Reviewers, we may need to provide ICML.cc/2020/Conference/ReviewersType1.