### PR TITLE
Fix/PC console refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             sudo apt-get install firefox-esr
             mkdir ~/openreview-py-repo/tests/drivers
             cd ~/openreview-py-repo/tests/drivers
-            wget https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz
+            wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
             tar -xvzf geckodriver*
             chmod +x geckodriver
       - run:

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -1,4 +1,3 @@
-
 // Constants
 var CONFERENCE_ID = '';
 var SHORT_PHRASE = '';

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -166,7 +166,7 @@ var getReviewerGroups = function() {
 
 var getAreaChairGroups = function() {
   if (!AREA_CHAIRS_ID) {
-    return $.Deferred.resolve([]);
+    return $.Deferred().resolve([]);
   }
 
   return Webfield.getAll('/groups', {
@@ -216,7 +216,7 @@ var getUserProfiles = function(userIds) {
 
 var getMetaReviews = function() {
   if (!AREA_CHAIRS_ID) {
-    return $.Deferred.resolve([]);
+    return $.Deferred().resolve([]);
   }
 
   return Webfield.getAll('/notes', {

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -103,6 +103,7 @@ var main = function() {
   .then(function(profiles) {
     conferenceStatusData.profiles = profiles;
 
+    $('.tabs-container .nav-tabs > li').removeClass('loading');
     Webfield.ui.done();
   })
   .fail(function() {
@@ -459,6 +460,7 @@ var renderHeader = function() {
   });
 
   Webfield.ui.tabPanel(tabs);
+  $('.tabs-container .nav-tabs > li').not(':first-child').addClass('loading');
 };
 
 var displayConfiguration = function(requestForm, invitations, registrationForms) {
@@ -1797,6 +1799,11 @@ $('#group-container').on('click', 'a.unassign-reviewer-link', function(e) {
     paperStatusNeedsRerender = true;
   });
   return false;
+});
+
+$('#group-container').on('show.bs.tab', 'ul.nav-tabs li a', function(e) {
+  // Don't allow the user to switch tabs until all data is finished loading
+  return !$(e.target).parent().hasClass('loading');
 });
 
 $('#group-container').on('shown.bs.tab', 'ul.nav-tabs li a', function(e) {

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -224,8 +224,8 @@ class TestBuilder():
         paper_status_tab = selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert paper_status_tab
 
-        WebDriverWait(selenium, 5).until(
-            EC.presence_of_element_located((By.ID, 'div-msg-reviewers'))
+        WebDriverWait(selenium, 10).until(
+            EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
         )
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -225,13 +225,9 @@ class TestBuilder():
         assert selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert selenium.find_element_by_xpath('//div[@id="venue-configuration"]//h3')
 
-        try:
-            WebDriverWait(selenium, 30).until(
-                EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
-            )
-        except TimeoutException:
-            paper_status_tab = selenium.find_element_by_id('paper-status')
-            print(paper_status_tab.get_attribute('innerHTML'))
+        WebDriverWait(selenium, 10).until(
+            EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
+        )
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -217,11 +217,12 @@ class TestBuilder():
         pc_client = helpers.create_user('pc_testconsole1@mail.com', 'Test', 'PCConsole')
         request_page(selenium, 'http://localhost:3000/group?id=' + conference.get_program_chairs_id() + '#paper-status', pc_client.token)
 
-        assert selenium.find_element_by_xpath('//a[@href="#paper-status"]')
+        paper_status_tab = selenium.find_element_by_xpath('//a[@href="#paper-status"]')
+        assert paper_status_tab
+        paper_status_tab.click()
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']
-
         for option in expected_options:
             assert selenium.find_element_by_id('-'.join(option.split(' ')) + '-paper-status')
 
@@ -233,6 +234,7 @@ class TestBuilder():
         conference = builder.get_result()
 
         request_page(selenium, 'http://localhost:3000/group?id=' + conference.get_program_chairs_id() + '#paper-status', pc_client.token)
+
         expected_options.append('Meta Review Missing')
         for option in expected_options:
             assert selenium.find_element_by_id('-'.join(option.split(' ')) + '-paper-status')

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -224,6 +224,7 @@ class TestBuilder():
         paper_status_tab = selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert paper_status_tab
 
+        assert selenium.find_element_by_xpath('//div[@id="venue-configuration"]//h3')
         WebDriverWait(selenium, 10).until(
             EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
         )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -220,9 +220,9 @@ class TestBuilder():
 
         paper_status_tab = selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert paper_status_tab
-        paper_status_tab.click()
 
         time.sleep(2)
+        paper_status_tab.click()
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import datetime
 import json
+import time
 import openreview
 import pytest
 from selenium.common.exceptions import NoSuchElementException
@@ -220,6 +221,8 @@ class TestBuilder():
         paper_status_tab = selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert paper_status_tab
         paper_status_tab.click()
+
+        time.sleep(2)
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -8,7 +8,6 @@ import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
 class TestBuilder():
@@ -225,13 +224,9 @@ class TestBuilder():
         assert selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert selenium.find_element_by_xpath('//div[@id="venue-configuration"]//h3')
 
-        try:
-            WebDriverWait(selenium, 10).until(
-                EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
-            )
-        except TimeoutException:
-            paper_status_tab = selenium.find_element_by_id('paper-status')
-            print(paper_status_tab.get_attribute('innerHTML'))
+        time.sleep(15)
+        paper_status_tab = selenium.find_element_by_id('paper-status')
+        print(paper_status_tab.get_attribute('innerHTML'))
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -8,6 +8,7 @@ import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
 class TestBuilder():
@@ -224,9 +225,13 @@ class TestBuilder():
         assert selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert selenium.find_element_by_xpath('//div[@id="venue-configuration"]//h3')
 
-        time.sleep(15)
-        paper_status_tab = selenium.find_element_by_id('paper-status')
-        print(paper_status_tab.get_attribute('innerHTML'))
+        try:
+            WebDriverWait(selenium, 30).until(
+                EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
+            )
+        except TimeoutException:
+            paper_status_tab = selenium.find_element_by_id('paper-status')
+            print(paper_status_tab.get_attribute('innerHTML'))
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -221,10 +221,9 @@ class TestBuilder():
         pc_client = helpers.create_user('pc_testconsole1@mail.com', 'Test', 'PCConsole')
         request_page(selenium, 'http://localhost:3000/group?id=' + conference.get_program_chairs_id() + '#paper-status', pc_client.token)
 
-        paper_status_tab = selenium.find_element_by_xpath('//a[@href="#paper-status"]')
-        assert paper_status_tab
-
+        assert selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert selenium.find_element_by_xpath('//div[@id="venue-configuration"]//h3')
+
         WebDriverWait(selenium, 10).until(
             EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
         )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -8,6 +8,7 @@ import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
 class TestBuilder():
@@ -224,9 +225,13 @@ class TestBuilder():
         assert selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert selenium.find_element_by_xpath('//div[@id="venue-configuration"]//h3')
 
-        WebDriverWait(selenium, 10).until(
-            EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
-        )
+        try:
+            WebDriverWait(selenium, 10).until(
+                EC.presence_of_element_located((By.ID, 'message-reviewers-btn'))
+            )
+        except TimeoutException:
+            paper_status_tab = selenium.find_element_by_id('paper-status')
+            print(paper_status_tab.get_attribute('innerHTML'))
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -5,6 +5,9 @@ import json
 import time
 import openreview
 import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import NoSuchElementException
 
 class TestBuilder():
@@ -221,8 +224,9 @@ class TestBuilder():
         paper_status_tab = selenium.find_element_by_xpath('//a[@href="#paper-status"]')
         assert paper_status_tab
 
-        time.sleep(2)
-        paper_status_tab.click()
+        WebDriverWait(selenium, 5).until(
+            EC.presence_of_element_located((By.ID, 'div-msg-reviewers'))
+        )
 
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']


### PR DESCRIPTION
This improves PC console performance by attempting to load all data in parallel (profiles still must be loaded after other data loads). In addition the configuration table is now loaded independently so that it shows almost immediately. Other tabs are not rendered until actually clicked on.

This PR also fixes a bug where selecting all papers in a filtered list actually selected all submitted papers.

Related to https://github.com/openreview/openreview/issues/1888