### PR TITLE
Update note readers based on the invitation reply value

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -938,6 +938,17 @@ class InvitationBuilder(object):
 
         return merged_options
 
+    def __update_readers(self, invitation):
+        ## Update readers of current notes
+        notes = self.client.get_notes(invitation=invitation.id)
+
+        for note in notes:
+            if 'values' in invitation.reply['readers'] and note.readers != invitation.reply['readers']['values']:
+                note.readers = invitation.reply['readers']['values']
+                if 'nonreaders' in invitation.reply:
+                    note.nonreaders = invitation.reply['nonreaders']['values']
+                self.client.post_note(note)
+
     def set_submission_invitation(self, conference):
 
         return self.client.post_invitation(SubmissionInvitation(conference))
@@ -1004,8 +1015,11 @@ class InvitationBuilder(object):
 
         invitations = []
         self.client.post_invitation(ReviewInvitation(conference))
+
         for note in notes:
-            invitations.append(self.client.post_invitation(PaperReviewInvitation(conference, note)))
+            invitation = self.client.post_invitation(PaperReviewInvitation(conference, note))
+            self.__update_readers(invitation)
+            invitations.append(invitation)
 
         return invitations
 
@@ -1014,7 +1028,9 @@ class InvitationBuilder(object):
         invitations = []
         self.client.post_invitation(MetaReviewInvitation(conference))
         for note in notes:
-            invitations.append(self.client.post_invitation(PaperMetaReviewInvitation(conference, note)))
+            invitation = self.client.post_invitation(PaperMetaReviewInvitation(conference, note))
+            self.__update_readers(invitation)
+            invitations.append(invitation)
 
         return invitations
 
@@ -1023,7 +1039,9 @@ class InvitationBuilder(object):
         invitations = []
         self.client.post_invitation(DecisionInvitation(conference))
         for note in notes:
-            invitations.append(self.client.post_invitation(PaperDecisionInvitation(conference, note)))
+            invitation = self.client.post_invitation(PaperDecisionInvitation(conference, note))
+            self.__update_readers(invitation)
+            invitations.append(invitation)
 
         return invitations
 

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1506,3 +1506,70 @@ class TestDoubleBlindConference():
         assert 'akbc_pc_1@akbc.ws' in recipients
         assert 'akbc_pc@mail.com' in recipients
         assert 'pc2@mail.com' in recipients
+
+    def test_release_reviews(self, client, helpers):
+
+        builder = openreview.conference.ConferenceBuilder(client)
+        assert builder, 'builder is None'
+
+        builder.set_conference_id('AKBC.ws/2019/Conference')
+        builder.set_submission_stage(double_blind = True, public = True)
+        builder.set_conference_short_name('AKBC 2019')
+        builder.set_conference_year(2019)
+        builder.has_area_chairs(True)
+        builder.set_conference_year(2019)
+        builder.set_review_stage(public=True)
+        builder.get_result()
+
+        reviews = client.get_notes(invitation='AKBC.ws/2019/Conference/Paper.*/-/Official_Review')
+        assert(reviews)
+        assert len(reviews) == 1
+        assert reviews[0].readers == ['everyone']
+
+    def test_release_meta_reviews(self, client, helpers):
+
+        builder = openreview.conference.ConferenceBuilder(client)
+        assert builder, 'builder is None'
+
+        builder.set_conference_id('AKBC.ws/2019/Conference')
+        builder.set_submission_stage(double_blind = True, public = True)
+        builder.set_conference_short_name('AKBC 2019')
+        builder.set_conference_year(2019)
+        builder.has_area_chairs(True)
+        builder.set_conference_year(2019)
+        builder.set_meta_review_stage(public=True, additional_fields = {
+            'best paper' : {
+                'description' : 'Nominate as best paper?',
+                'value-radio' : ['Yes', 'No'],
+                'required' : False
+            }
+        })
+        builder.get_result()
+
+        reviews = client.get_notes(invitation='AKBC.ws/2019/Conference/Paper.*/-/Meta_Review')
+        assert(reviews)
+        print(reviews)
+        assert len(reviews) == 2
+        assert reviews[0].readers == ['everyone']
+        assert reviews[1].readers == ['everyone']
+
+    def test_release_decisions(self, client, helpers):
+
+        builder = openreview.conference.ConferenceBuilder(client)
+        assert builder, 'builder is None'
+
+        builder.set_conference_id('AKBC.ws/2019/Conference')
+        builder.set_submission_stage(double_blind = True, public = True)
+        builder.set_conference_short_name('AKBC 2019')
+        builder.set_conference_year(2019)
+        builder.has_area_chairs(True)
+        builder.set_conference_year(2019)
+        builder.set_decision_stage(public=True)
+        builder.get_result()
+
+        decisions = client.get_notes(invitation='AKBC.ws/2019/Conference/Paper.*/-/Decision')
+        assert(decisions)
+        assert len(decisions) == 3
+        assert decisions[0].readers == ['everyone']
+        assert decisions[1].readers == ['everyone']
+        assert decisions[2].readers == ['everyone']


### PR DESCRIPTION
When posting the review/metareview/decision stage, if there are existent notes with different readers/nonreaders then update all the notes with the values of the invitation.

This is going to help us to release the reviews, meta reviews and decisions to the authors or everyone. 