### PR TITLE
Fix/add pc conf group

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1308,7 +1308,7 @@ class ConferenceBuilder(object):
             options['withdrawn_submission_id'] = self.conference.submission_stage.get_withdrawn_submission_id(self.conference)
             options['desk_rejected_submission_id'] = self.conference.submission_stage.get_desk_rejected_submission_id(self.conference)
             options['public'] = self.conference.submission_stage.public
-            self.webfield_builder.set_home_page(group = home_group, layout = self.conference.layout, options = options)
+            groups[-1] = self.webfield_builder.set_home_page(group = home_group, layout = self.conference.layout, options = options)
 
         self.conference.set_conference_groups(groups)
         if self.conference.use_area_chairs:

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -98,9 +98,10 @@ class WebfieldBuilder(object):
             content = content.replace("var DESK_REJECTED_SUBMISSION_ID = '';", "var DESK_REJECTED_SUBMISSION_ID = '" + options.get('desk_rejected_submission_id', '') + "';")
             content = content.replace("var PUBLIC = false;", "var PUBLIC = true;" if options.get('public', False) else "var PUBLIC = false;")
 
-            group.web = content
-            group.signatures = [group.id]
-            return self.client.post_group(group)
+            current_group = self.client.get_group(group.id)
+            current_group.web = content
+            current_group.signatures = [group.id]
+            return self.client.post_group(current_group)
 
     def set_expertise_selection_page(self, conference, invitation):
 

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -901,7 +901,7 @@ class Client(object):
 
         return response.json()['count']
 
-    def get_grouped_edges(self, invitation=None, head=None, tail=None, groupby='head', select='tail', limit=None, offset=None):
+    def get_grouped_edges(self, invitation=None, head=None, tail=None, label=None, groupby='head', select='tail', limit=None, offset=None):
         '''
         Returns a list of JSON objects where each one represents a group of edges.  For example calling this
         method with default arguments will give back a list of groups where each group is of the form:
@@ -920,6 +920,7 @@ class Client(object):
         params['invitation'] = invitation
         params['head'] = head
         params['tail'] = tail
+        params['label'] = label
         params['groupBy'] = groupby
         params['select'] = select
         params['limit'] = limit

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='openreview-py',
-      version='1.0.10',
+      version='1.0.11',
       description='OpenReview client library',
       url='https://github.com/openreview/openreview-py',
       author='Michael Spector, Melisa Bok, Pam Mander, Mohit Uniyal',

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -47,7 +47,7 @@ class TestDoubleBlindConference():
         assert groups[2].writers == ['AKBC.ws/2019/Conference']
         assert groups[2].signatures == ['AKBC.ws/2019/Conference']
         assert groups[2].signatories == ['AKBC.ws/2019/Conference']
-        assert groups[2].members == []
+        assert groups[2].members == ['AKBC.ws/2019/Conference/Program_Chairs']
         assert '"title": "AKBC.ws/2019/Conference"' in groups[2].web
 
         assert client.get_group(id = 'AKBC.ws')
@@ -98,7 +98,7 @@ class TestDoubleBlindConference():
         assert groups[2].writers == ['AKBC.ws/2019/Conference']
         assert groups[2].signatures == ['AKBC.ws/2019/Conference']
         assert groups[2].signatories == ['AKBC.ws/2019/Conference']
-        assert groups[2].members == []
+        assert groups[2].members == ['AKBC.ws/2019/Conference/Program_Chairs']
         assert '"title": "AKBC.ws/2019/Conference"' in groups[2].web
         assert '"subtitle": "Automated Knowledge Base Construction"' in groups[2].web
 
@@ -171,7 +171,7 @@ class TestDoubleBlindConference():
         assert groups[2].writers == ['AKBC.ws/2019/Conference']
         assert groups[2].signatures == ['AKBC.ws/2019/Conference']
         assert groups[2].signatories == ['AKBC.ws/2019/Conference']
-        assert groups[2].members == []
+        assert groups[2].members == ['AKBC.ws/2019/Conference/Program_Chairs']
         assert '"title": "AKBC 2019"' in groups[2].web
         assert '"subtitle": "Automated Knowledge Base Construction"' in groups[2].web
         assert '"location": "Amherst, Massachusetts, United States"' in groups[2].web

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -49,9 +49,9 @@ class TestSingleBlindConference():
         assert groups[2].readers == ['everyone']
         assert groups[2].nonreaders == []
         assert groups[2].writers == ['NIPS.cc/2018/Workshop']
-        assert groups[2].signatures == ['~Super_User1']
+        assert groups[2].signatures == ['NIPS.cc/2018/Workshop']
         assert groups[2].signatories == ['NIPS.cc/2018/Workshop']
-        assert groups[2].members == []
+        assert groups[2].members == ['NIPS.cc/2018/Workshop/Program_Chairs']
         assert groups[3].id == 'NIPS.cc/2018/Workshop/MLITS'
         assert groups[3].readers == ['everyone']
         assert groups[3].nonreaders == []

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -49,16 +49,16 @@ class TestSingleBlindConference():
         assert groups[2].readers == ['everyone']
         assert groups[2].nonreaders == []
         assert groups[2].writers == ['NIPS.cc/2018/Workshop']
-        assert groups[2].signatures == ['NIPS.cc/2018/Workshop']
+        assert groups[2].signatures == ['~Super_User1']
         assert groups[2].signatories == ['NIPS.cc/2018/Workshop']
-        assert groups[2].members == ['NIPS.cc/2018/Workshop/Program_Chairs']
+        assert groups[2].members == []
         assert groups[3].id == 'NIPS.cc/2018/Workshop/MLITS'
         assert groups[3].readers == ['everyone']
         assert groups[3].nonreaders == []
         assert groups[3].writers == ['NIPS.cc/2018/Workshop/MLITS']
         assert groups[3].signatures == ['NIPS.cc/2018/Workshop/MLITS']
         assert groups[3].signatories == ['NIPS.cc/2018/Workshop/MLITS']
-        assert groups[3].members == []
+        assert groups[3].members == ['NIPS.cc/2018/Workshop/MLITS/Program_Chairs']
         assert '"title": "2018 NIPS MLITS Workshop"' in groups[3].web
         assert '"subtitle": "Machine Learning for Intelligent Transportation Systems"' in groups[3].web
         assert '"location": "Montreal, Canada"' in groups[3].web


### PR DESCRIPTION
This should fix the issue that is not adding the PC group to the conference group.

I think this issue is happening since I changed the signatures of the deploy invitations to be SuperUser, that is the only user that can overwrite the conference group.