### PR TITLE
Fix/improve build conflicts

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -167,33 +167,49 @@ class Matching(object):
         Create conflict edges between the given Notes and Profiles
         '''
         invitation = self._create_edge_invitation(self.conference.get_conflict_score_id(self.match_group.id))
-        authorids_profiles = {}
+        user_profiles_info = [openreview.tools.get_profile_info(p) for p in user_profiles]
 
-        edge_count = 0
+        edges = []
+
         for submission in tqdm(submissions, total=len(submissions), desc='_build_conflicts'):
-            edges = []
-            for profile in user_profiles:
-                authorids = submission.content['authorids']
-                if submission.details and submission.details.get('original'):
-                    authorids = submission.details['original']['content']['authorids']
-                if submission.number not in authorids_profiles:
-                    profiles = _get_profiles(self.client, authorids)
-                    authorids_profiles[submission.number] = profiles
-                author_profiles = authorids_profiles[submission.number]
-                conflicts = openreview.tools.get_conflicts(author_profiles, profile)
+            # Get author profiles
+            authorids = submission.content['authorids']
+            if submission.details and submission.details.get('original'):
+                authorids = submission.details['original']['content']['authorids']
+
+            # Extract domains from each profile
+            author_profiles = _get_profiles(self.client, authorids)
+            author_domains = set()
+            author_emails = set()
+            author_relations = set()
+
+            for author_profile in author_profiles:
+                author_info = openreview.tools.get_profile_info(author_profile)
+                author_domains.update(author_info['domains'])
+                author_emails.update(author_info['emails'])
+                author_relations.update(author_info['relations'])
+
+            # Compute conflict with user and all the authors
+            for user_info in user_profiles_info:
+                conflicts = set()
+                conflicts.update(author_domains.intersection(user_info['domains']))
+                conflicts.update(author_relations.intersection(user_info['emails']))
+                conflicts.update(author_emails.intersection(user_info['relations']))
+                conflicts.update(author_emails.intersection(user_info['emails']))
+                conflicts = list(conflicts)
                 if conflicts:
                     edges.append(openreview.Edge(
                         invitation=invitation.id,
                         head=submission.id,
-                        tail=profile.id,
+                        tail=user_info['id'],
                         weight=-1,
                         label=_conflict_label(conflicts),
-                        readers=self._get_edge_readers(tail=profile.id),
+                        readers=self._get_edge_readers(tail=user_info['id']),
                         writers=[self.conference.id],
                         signatures=[self.conference.id]
                     ))
-            openreview.tools.post_bulk_edges(client=self.client, edges=edges)
-            edge_count += len(edges)
+
+        openreview.tools.post_bulk_edges(client=self.client, edges=edges)
 
         # Perform sanity check
         edges_posted = self.client.get_edges_count(invitation=invitation.id)

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -167,6 +167,7 @@ class Matching(object):
         Create conflict edges between the given Notes and Profiles
         '''
         invitation = self._create_edge_invitation(self.conference.get_conflict_score_id(self.match_group.id))
+        # Get profile info from the match group
         user_profiles_info = [openreview.tools.get_profile_info(p) for p in user_profiles]
 
         edges = []
@@ -189,14 +190,13 @@ class Matching(object):
                 author_emails.update(author_info['emails'])
                 author_relations.update(author_info['relations'])
 
-            # Compute conflict with user and all the authors
+            # Compute conflicts for each user and all the paper authors
             for user_info in user_profiles_info:
                 conflicts = set()
                 conflicts.update(author_domains.intersection(user_info['domains']))
                 conflicts.update(author_relations.intersection(user_info['emails']))
                 conflicts.update(author_emails.intersection(user_info['relations']))
                 conflicts.update(author_emails.intersection(user_info['emails']))
-                conflicts = list(conflicts)
                 if conflicts:
                     edges.append(openreview.Edge(
                         invitation=invitation.id,

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1543,6 +1543,7 @@ def get_profile_info(profile):
         domains.remove('gmail.com')
 
     return {
+        'id': profile.id,
         'domains': domains,
         'emails': emails,
         'relations': relations

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -264,3 +264,16 @@ class TestTools():
 
         assert replaced_group.members == ['~Super_User1', '~Test_User1', 'noprofile@mail.com']
 
+    def test_get_conflicts(self, client, helpers):
+
+        user = helpers.create_user('user@gmail.com', 'First', 'Last')
+
+        user_profile = client.get_profile(email_or_id='user@gmail.com')
+
+        conflicts = openreview.tools.get_conflicts([user_profile], user_profile)
+        assert conflicts
+
+
+
+
+


### PR DESCRIPTION
Compute each profile info only once to speed up the conflict computation. 

Now it takes ~3min to build all the conflicts for ECCV instead of 2hours 🥇 

![Screen Shot 2020-03-15 at 2 20 50 PM](https://user-images.githubusercontent.com/545506/76708000-f9956a80-66c9-11ea-9064-41d11eb83f0d.png)
