### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -16,7 +16,7 @@ from Crypto.Hash import HMAC, SHA256
 from multiprocessing import Pool
 from tqdm import tqdm
 from ortools.graph import pywrapgraph
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import tld
 import urllib.parse as urlparse
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='openreview-py',
           "Deprecated",
           'pylatexenc',
           'ortools',
-          'fuzzywuzzy',
+          'rapidfuzz',
           'tld==0.10'
       ],
       extras_require={


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.