### PR TITLE
Added optional emailing to PCs for paper withdrawals

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -454,7 +454,7 @@ class Conference(object):
 
         return invitation
 
-    def create_withdraw_invitations(self, reveal_authors=False, reveal_submission=False, email_program_chairs=False):
+    def create_withdraw_invitations(self, reveal_authors=False, reveal_submission=False, email_pcs=False):
 
         if reveal_submission and not self.submission_stage.public:
             raise openreview.OpenReviewException('Can not reveal withdrawn submissions that are not originally public')
@@ -462,7 +462,7 @@ class Conference(object):
         if not reveal_authors and not self.submission_stage.double_blind:
             raise openreview.OpenReviewException('Can not hide authors of single blind submissions')
 
-        return self.invitation_builder.set_withdraw_invitation(self, reveal_authors, reveal_submission, email_program_chairs)
+        return self.invitation_builder.set_withdraw_invitation(self, reveal_authors, reveal_submission, email_pcs)
 
     def create_desk_reject_invitations(self, reveal_authors=False, reveal_submission=False):
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -454,7 +454,7 @@ class Conference(object):
 
         return invitation
 
-    def create_withdraw_invitations(self, reveal_authors=False, reveal_submission=False):
+    def create_withdraw_invitations(self, reveal_authors=False, reveal_submission=False, email_program_chairs=False):
 
         if reveal_submission and not self.submission_stage.public:
             raise openreview.OpenReviewException('Can not reveal withdrawn submissions that are not originally public')
@@ -462,7 +462,7 @@ class Conference(object):
         if not reveal_authors and not self.submission_stage.double_blind:
             raise openreview.OpenReviewException('Can not hide authors of single blind submissions')
 
-        return self.invitation_builder.set_withdraw_invitation(self, reveal_authors, reveal_submission)
+        return self.invitation_builder.set_withdraw_invitation(self, reveal_authors, reveal_submission, email_program_chairs)
 
     def create_desk_reject_invitations(self, reveal_authors=False, reveal_submission=False):
 

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -348,7 +348,7 @@ class WithdrawnSubmissionInvitation(openreview.Invitation):
 
 class PaperWithdrawInvitation(openreview.Invitation):
 
-    def __init__(self, conference, note, reveal_authors, reveal_submission):
+    def __init__(self, conference, note, reveal_authors, reveal_submission, email_program_chairs):
 
         content = invitations.withdraw.copy()
 
@@ -396,6 +396,10 @@ class PaperWithdrawInvitation(openreview.Invitation):
             file_content = file_content.replace(
                 'CONFERENCE_YEAR = \'\'',
                 'CONFERENCE_YEAR = \'' + str(conference.get_year()) + '\'')
+            if email_program_chairs:
+                file_content = file_content.replace(
+                    'EMAIL_PROGRAM_CHAIRS = False',
+                    'EMAIL_PROGRAM_CHAIRS = True')
             if reveal_authors:
                 file_content = file_content.replace(
                     'REVEAL_AUTHORS_ON_WITHDRAW = False',
@@ -407,6 +411,7 @@ class PaperWithdrawInvitation(openreview.Invitation):
 
             super(PaperWithdrawInvitation, self).__init__(
                 id=conference.get_invitation_id('Withdraw', note.number),
+                super=conference.submission_stage.get_withdrawn_submission_id(conference),
                 cdate=tools.datetime_millis(conference.submission_stage.due_date) if conference.submission_stage.due_date else None,
                 duedate = None,
                 expdate = tools.datetime_millis(conference.submission_stage.due_date + datetime.timedelta(days = 90)) if conference.submission_stage.due_date else None,
@@ -553,6 +558,7 @@ class PaperDeskRejectInvitation(openreview.Invitation):
 
             super(PaperDeskRejectInvitation, self).__init__(
                 id=conference.get_invitation_id('Desk_Reject', note.number),
+                super=conference.submission_stage.get_desk_rejected_submission_id(conference),
                 cdate=tools.datetime_millis(conference.submission_stage.due_date) if conference.submission_stage.due_date else None,
                 duedate = None,
                 expdate = tools.datetime_millis(conference.submission_stage.due_date + datetime.timedelta(days = 90)) if conference.submission_stage.due_date else None,
@@ -987,7 +993,7 @@ class InvitationBuilder(object):
 
         return invitations
 
-    def set_withdraw_invitation(self, conference, reveal_authors, reveal_submission):
+    def set_withdraw_invitation(self, conference, reveal_authors, reveal_submission, email_program_chairs):
 
         invitations = []
 
@@ -995,7 +1001,7 @@ class InvitationBuilder(object):
 
         notes = list(conference.get_submissions())
         for note in notes:
-            invitations.append(self.client.post_invitation(PaperWithdrawInvitation(conference, note, reveal_authors, reveal_submission)))
+            invitations.append(self.client.post_invitation(PaperWithdrawInvitation(conference, note, reveal_authors, reveal_submission, email_program_chairs)))
 
         return invitations
 

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -348,7 +348,7 @@ class WithdrawnSubmissionInvitation(openreview.Invitation):
 
 class PaperWithdrawInvitation(openreview.Invitation):
 
-    def __init__(self, conference, note, reveal_authors, reveal_submission, email_program_chairs):
+    def __init__(self, conference, note, reveal_authors, reveal_submission, email_pcs):
 
         content = invitations.withdraw.copy()
 
@@ -396,7 +396,7 @@ class PaperWithdrawInvitation(openreview.Invitation):
             file_content = file_content.replace(
                 'CONFERENCE_YEAR = \'\'',
                 'CONFERENCE_YEAR = \'' + str(conference.get_year()) + '\'')
-            if email_program_chairs:
+            if email_pcs:
                 file_content = file_content.replace(
                     'EMAIL_PROGRAM_CHAIRS = False',
                     'EMAIL_PROGRAM_CHAIRS = True')
@@ -991,7 +991,7 @@ class InvitationBuilder(object):
 
         return invitations
 
-    def set_withdraw_invitation(self, conference, reveal_authors, reveal_submission, email_program_chairs):
+    def set_withdraw_invitation(self, conference, reveal_authors, reveal_submission, email_pcs):
 
         invitations = []
 
@@ -999,7 +999,7 @@ class InvitationBuilder(object):
 
         notes = list(conference.get_submissions())
         for note in notes:
-            invitations.append(self.client.post_invitation(PaperWithdrawInvitation(conference, note, reveal_authors, reveal_submission, email_program_chairs)))
+            invitations.append(self.client.post_invitation(PaperWithdrawInvitation(conference, note, reveal_authors, reveal_submission, email_pcs)))
 
         return invitations
 

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -411,7 +411,6 @@ class PaperWithdrawInvitation(openreview.Invitation):
 
             super(PaperWithdrawInvitation, self).__init__(
                 id=conference.get_invitation_id('Withdraw', note.number),
-                super=conference.submission_stage.get_withdrawn_submission_id(conference),
                 cdate=tools.datetime_millis(conference.submission_stage.due_date) if conference.submission_stage.due_date else None,
                 duedate = None,
                 expdate = tools.datetime_millis(conference.submission_stage.due_date + datetime.timedelta(days = 90)) if conference.submission_stage.due_date else None,
@@ -558,7 +557,6 @@ class PaperDeskRejectInvitation(openreview.Invitation):
 
             super(PaperDeskRejectInvitation, self).__init__(
                 id=conference.get_invitation_id('Desk_Reject', note.number),
-                super=conference.submission_stage.get_desk_rejected_submission_id(conference),
                 cdate=tools.datetime_millis(conference.submission_stage.due_date) if conference.submission_stage.due_date else None,
                 duedate = None,
                 expdate = tools.datetime_millis(conference.submission_stage.due_date + datetime.timedelta(days = 90)) if conference.submission_stage.due_date else None,

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -11,6 +11,7 @@ def process(client, note, invitation):
     WITHDRAWN_SUBMISSION_ID = ''
     REVEAL_AUTHORS_ON_WITHDRAW = False
     REVEAL_SUBMISSIONS_ON_WITHDRAW = False
+    EMAIL_PROGRAM_CHAIRS = False
 
     committee = [PAPER_AUTHORS_ID, PAPER_REVIEWERS_ID]
     if PAPER_AREA_CHAIRS_ID:
@@ -63,4 +64,7 @@ def process(client, note, invitation):
         CONFERENCE_SHORT_NAME = CONFERENCE_SHORT_NAME,
         paper_title_or_num = forum_note.content.get('title', '#'+str(forum_note.number))
     )
+
+    if not EMAIL_PROGRAM_CHAIRS:
+        committee.remove(PROGRAM_CHAIRS_ID)
     client.post_message(email_subject, committee, email_body)

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1428,7 +1428,7 @@ class TestDoubleBlindConference():
         builder.has_area_chairs(True)
         builder.set_conference_year(2019)
         conference = builder.get_result()
-        conference.create_withdraw_invitations(reveal_authors=True, reveal_submission=True, email_program_chairs=True)
+        conference.create_withdraw_invitations(reveal_authors=True, reveal_submission=True, email_pcs=True)
 
         notes = conference.get_submissions()
         assert notes

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1428,7 +1428,7 @@ class TestDoubleBlindConference():
         builder.has_area_chairs(True)
         builder.set_conference_year(2019)
         conference = builder.get_result()
-        conference.create_withdraw_invitations(reveal_authors=True, reveal_submission=True)
+        conference.create_withdraw_invitations(reveal_authors=True, reveal_submission=True, email_program_chairs=True)
 
         notes = conference.get_submissions()
         assert notes


### PR DESCRIPTION
This would be needed for large conferences such as ECCV where PCs might not want to receive emails for each paper withdrawal. 
I did not add the same option for desk-rejects as PCs would mostly want to be notified of those.