### PR TITLE
Make openreview-py compatible with Refresh and Access Tokens

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def request_page():
     def request(selenium, url, token = None, alert=False):
         if token:
             selenium.get('http://localhost:3000')
-            selenium.add_cookie({'name': 'openreview_sid', 'value': token.replace('Bearer ', '')})
+            selenium.add_cookie({'name': 'openreview.accessToken', 'value': token.replace('Bearer ', '')})
         else:
             selenium.delete_all_cookies()
         selenium.get(url)


### PR DESCRIPTION
Merge after openreview/openreview/pull/1835 is merged.

It looks like A LOT of changes, but it's simply adding an error handler when the token expires. This handler needs to be included in the `__handle_response` method. A new parameter was included to the method to allow a retry when a request is made and the token has expired.