### PR TITLE
Fix/paper ranking readers

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -147,7 +147,14 @@ class Conference(object):
     def __create_review_stage(self):
 
         notes = list(self.get_submissions())
-        return self.invitation_builder.set_review_invitation(self, notes)
+        invitations = self.invitation_builder.set_review_invitation(self, notes)
+        if self.review_stage.rating_field_name:
+            self.webfield_builder.edit_web_string_value(self.client.get_group(self.get_program_chairs_id()), 'REVIEW_RATING_NAME', self.review_stage.rating_field_name)
+            if self.use_area_chairs:
+                self.webfield_builder.edit_web_string_value(self.client.get_group(self.get_area_chairs_id()), 'REVIEW_RATING_NAME', self.review_stage.rating_field_name)
+            self.webfield_builder.edit_web_string_value(self.client.get_group(self.get_reviewers_id()), 'REVIEW_RATING_NAME', self.review_stage.rating_field_name)
+            self.webfield_builder.edit_web_string_value(self.client.get_group(self.get_authors_id()), 'REVIEW_RATING_NAME', self.review_stage.rating_field_name)
+        return invitations
 
     def __create_comment_stage(self):
 
@@ -1000,7 +1007,8 @@ class ReviewStage(object):
         release_to_reviewers = Readers.REVIEWER_SIGNATURE,
         email_pcs = False,
         additional_fields = {},
-        remove_fields = []
+        remove_fields = [],
+        rating_field_name = None
     ):
 
         self.start_date = start_date
@@ -1015,6 +1023,7 @@ class ReviewStage(object):
         self.email_pcs = email_pcs
         self.additional_fields = additional_fields
         self.remove_fields = remove_fields
+        self.rating_field_name = rating_field_name
 
     def _get_reviewer_readers(self, conference, number):
         if self.release_to_reviewers is ReviewStage.Readers.REVIEWERS:

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1263,7 +1263,7 @@ class InvitationBuilder(object):
                     "tag": {
                         "description": "Select value",
                         "order": 1,
-                        "value-dropdown": ['No Ranking'] + [str(e) for e in list(range(1, 31))],
+                        "value-regex": 'No Ranking|[0-9]+\sof\s[0-9]+',
                         "required": True
                     }
                 }

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1231,6 +1231,17 @@ class InvitationBuilder(object):
 
     def set_paper_ranking_invitation(self, conference, group_id, start_date, due_date):
 
+        readers = {
+            'description': 'The users who will be allowed to read the above content.',
+            'values-copied': [conference.get_id(), '{signatures}']
+        }
+
+        if group_id == conference.get_reviewers_id() and conference.use_area_chairs:
+            readers = {
+                'description': 'The users who will be allowed to read the above content.',
+                'values-regex': conference.get_id() + '|' + conference.get_area_chairs_id(number='.*') + '|~.*'
+            }
+
         reviewer_paper_ranking_invitation = openreview.Invitation(
             id = conference.get_invitation_id('Paper_Ranking', prefix=group_id),
             cdate = tools.datetime_millis(start_date),
@@ -1243,10 +1254,7 @@ class InvitationBuilder(object):
             multiReply = True,
             reply = {
                 "invitation": conference.get_submission_id(),
-                'readers': {
-                    'description': 'The users who will be allowed to read the above content.',
-                    'values-copied': [conference.get_id(), '{signatures}']
-                },
+                'readers': readers,
                 'signatures': {
                     'description': 'How your identity will be displayed with the above content.',
                     'values-regex': '~.*'

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1236,11 +1236,14 @@ class InvitationBuilder(object):
             'values-copied': [conference.get_id(), '{signatures}']
         }
 
+        signatures_regex = conference.get_id() + '/Paper.*/Area_Chair[0-9]+'
+
         if group_id == conference.get_reviewers_id() and conference.use_area_chairs:
             readers = {
                 'description': 'The users who will be allowed to read the above content.',
                 'values-regex': conference.get_id() + '|' + conference.get_area_chairs_id(number='.*') + '|~.*'
             }
+            signatures_regex = conference.get_id() + '/Paper.*/AnonReviewer[0-9]+'
 
         reviewer_paper_ranking_invitation = openreview.Invitation(
             id = conference.get_invitation_id('Paper_Ranking', prefix=group_id),
@@ -1257,7 +1260,7 @@ class InvitationBuilder(object):
                 'readers': readers,
                 'signatures': {
                     'description': 'How your identity will be displayed with the above content.',
-                    'values-regex': '~.*'
+                    'values-regex': signatures_regex
                 },
                 'content': {
                     "tag": {

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -684,8 +684,8 @@ var postRenderTable = function(rows) {
           var body = {
             id: id,
             tag: value,
-            signatures: [user.profile.id],
-            readers: [CONFERENCE_ID],
+            signatures: [CONFERENCE_ID + '/Paper' + noteNumber + '/Area_Chair1'],
+            readers: [CONFERENCE_ID, CONFERENCE_ID + '/Paper' + noteNumber + '/Area_Chair1'],
             forum: noteId,
             invitation: invitationId,
             ddate: deleted ? Date.now() : null

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -720,7 +720,10 @@ var renderTableAndTasks = function(fetchedData) {
 
   paperRankingInvitation = _.find(fetchedData.tagInvitations, ['id', PAPER_RANKING_ID]);
   if (paperRankingInvitation) {
-    availableOptions = paperRankingInvitation.reply.content.tag['value-dropdown'].slice(0, fetchedData.blindedNotes.length + 1);
+    availableOptions = ['No Ranking'];
+    fetchedData.blindedNotes.forEach(function(note, index) {
+      availableOptions.push((index + 1) + ' of ' + fetchedData.blindedNotes.length );
+    })
   }
   if (paperRankingInvitation || Object.keys(fetchedData.rankingByPaper).length) {
     showRankings = true;

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -7,6 +7,8 @@ var HEADER = {};
 var AREA_CHAIR_NAME = '';
 var REVIEWER_NAME = '';
 var OFFICIAL_REVIEW_NAME = '';
+var REVIEW_RATING_NAME = 'rating';
+var REVIEW_CONFIDENCE_NAME = 'confidence';
 var OFFICIAL_META_REVIEW_NAME = '';
 var LEGACY_INVITATION_ID = false;
 var ENABLE_REVIEWER_REASSIGNMENT = false;
@@ -214,9 +216,9 @@ var getOfficialReviews = function(noteNumbers) {
       if (num) {
         if (num in noteMap) {
           // Need to parse rating and confidence strings into ints
-          ratingMatch = n.content.rating && n.content.rating.match(ratingExp);
+          ratingMatch = n.content[REVIEW_RATING_NAME] && n.content[REVIEW_RATING_NAME].match(ratingExp);
           n.rating = ratingMatch ? parseInt(ratingMatch[1], 10) : null;
-          confidenceMatch = n.content.confidence && n.content.confidence.match(ratingExp);
+          confidenceMatch = n.content[REVIEW_CONFIDENCE_NAME] && n.content[REVIEW_CONFIDENCE_NAME].match(ratingExp);
           n.confidence = confidenceMatch ? parseInt(confidenceMatch[1], 10) : null;
 
           noteMap[num][index] = n;

--- a/openreview/conference/templates/authorWebfield.js
+++ b/openreview/conference/templates/authorWebfield.js
@@ -8,6 +8,8 @@ var SUBMISSION_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var OFFICIAL_REVIEW_NAME = '';
 var OFFICIAL_META_REVIEW_NAME = '';
+var REVIEW_RATING_NAME = 'rating';
+var REVIEW_CONFIDENCE_NAME = 'confidence';
 var HEADER = {};
 var AUTHOR_NAME = 'Authors';
 
@@ -234,13 +236,13 @@ function buildTableRow(note, completedReviews, metaReview) {
 
     // Need to parse rating and confidence strings into ints
     var ratingExp = /^(\d+): .*$/;
-    var ratingMatch = review.content.rating && review.content.rating.match(ratingExp);
+    var ratingMatch = review.content[REVIEW_RATING_NAME] && review.content[REVIEW_RATING_NAME].match(ratingExp);
     var rating = ratingMatch ? parseInt(ratingMatch[1], 10) : null;
     if (rating) {
       ratings.push(rating);
       reviewFormatted.rating = rating;
     }
-    var confidenceMatch = review.content.confidence && review.content.confidence.match(ratingExp);
+    var confidenceMatch = review.content[REVIEW_CONFIDENCE_NAME] && review.content[REVIEW_CONFIDENCE_NAME].match(ratingExp);
     var confidence = confidenceMatch ? parseInt(confidenceMatch[1], 10) : null;
     if (confidence) {
       confidences.push(confidence);

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -8,6 +8,8 @@ var DESK_REJECTED_SUBMISSION_ID = '';
 var HEADER = {};
 var LEGACY_INVITATION_ID = false;
 var OFFICIAL_REVIEW_NAME = '';
+var REVIEW_RATING_NAME = 'rating';
+var REVIEW_CONFIDENCE_NAME = 'confidence';
 var OFFICIAL_META_REVIEW_NAME = '';
 var DECISION_NAME = '';
 var BID_NAME = '';
@@ -536,9 +538,9 @@ var buildOfficialReviewMap = function(noteNumbers, notes) {
     }
 
     if (num && num in noteMap) {
-      ratingMatch = n.content.rating && n.content.rating.match(ratingExp);
+      ratingMatch = n.content[REVIEW_RATING_NAME] && n.content[REVIEW_RATING_NAME].match(ratingExp);
       n.rating = ratingMatch ? parseInt(ratingMatch[1], 10) : null;
-      confidenceMatch = n.content.confidence && n.content.confidence.match(ratingExp);
+      confidenceMatch = n.content[REVIEW_CONFIDENCE_NAME] && n.content[REVIEW_CONFIDENCE_NAME].match(ratingExp);
       n.confidence = confidenceMatch ? parseInt(confidenceMatch[1], 10) : null;
       noteMap[num][index] = n;
     }

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -92,9 +92,6 @@ var getReviewerNoteNumbers = function() {
     if (!result.groups) {
       return [];
     }
-    // return _.without(result.groups.map(function(group) {
-    //   return getNumberFromGroup(group.id, 'Paper');
-    // }), null);
     return result.groups.reduce(function(groupByNumber, group) {
       var number = getNumberFromGroup(group.id, 'Paper');
       if (number) {

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -4,6 +4,7 @@ var SUBMISSION_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var REVIEWER_NAME = '';
+var AREACHAIR_NAME = '';
 var OFFICIAL_REVIEW_NAME = '';
 var LEGACY_INVITATION_ID = false;
 var REVIEW_LOAD = 0;
@@ -304,12 +305,11 @@ var displayPaperRanking = function(notes, paperRankingInvitation, paperRankingTa
             id: id,
             tag: value,
             signatures: [user.profile.id],
-            readers: [CONFERENCE_ID],
+            readers: [CONFERENCE_ID, CONFERENCE_ID + '/Paper' + note.number + '/' + AREACHAIR_NAME, user.profile.id],
             forum: note.id,
             invitation: invitationId,
             ddate: deleted ? Date.now() : null
           };
-          body = view.getCopiedValues(body, invitation.reply);
           Webfield.post('/tags', body)
             .then(function(result) {
               if (index !== -1) {

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -273,7 +273,10 @@ var buildTableRow = function(note, officialReview) {
 var displayPaperRanking = function(notes, paperRankingInvitation, paperRankingTags) {
   var invitation = paperRankingInvitation ? _.cloneDeep(paperRankingInvitation) : null;
   if (invitation) {
-    var availableOptions = invitation.reply.content.tag['value-dropdown'].slice(0, notes.length + 1);
+    var availableOptions = ['No Ranking'];
+    notes.forEach(function(note, index) {
+      availableOptions.push((index + 1) + ' of ' + notes.length );
+    })
     var currentRankings = paperRankingTags.map(function(tag) {
       if (!tag.tag || tag.tag === 'No Ranking') {
         return null;

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -6,6 +6,7 @@ var HEADER = {};
 var REVIEWER_NAME = '';
 var AREACHAIR_NAME = '';
 var OFFICIAL_REVIEW_NAME = '';
+var REVIEW_RATING_NAME = 'rating';
 var LEGACY_INVITATION_ID = false;
 var REVIEW_LOAD = 0;
 
@@ -267,7 +268,7 @@ var buildTableRow = function(note, officialReview) {
     invitationName: 'Official Review'
   };
   if (officialReview) {
-    reviewStatus.paperRating = officialReview.content.rating;
+    reviewStatus.paperRating = officialReview.content[REVIEW_RATING_NAME];
     reviewStatus.review = officialReview.content.review;
     reviewStatus.editUrl = '/forum?id=' + note.forum + '&noteId=' + officialReview.id + '&referrer=' + referrerUrl;
   }

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -340,6 +340,7 @@ class WebfieldBuilder(object):
             content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var REVIEWER_NAME = '';", "var REVIEWER_NAME = '" + conference.reviewers_name + "';")
+            content = content.replace("var AREACHAIR_NAME = '';", "var AREACHAIR_NAME = '" + conference.area_chairs_name + "';")
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_stage.name + "';")
             content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = true;" if conference.legacy_invitation_id else "var LEGACY_INVITATION_ID = false;")
             content = content.replace("var REVIEW_LOAD = 0;", "var REVIEW_LOAD = " + str(conference.default_reviewer_load) + ";")

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -1307,8 +1307,8 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         ac_client.post_tag(openreview.Tag(invitation = 'thecvf.com/ECCV/2020/Conference/Area_Chairs/-/Paper_Ranking',
             forum = blinded_notes[-1].id,
             tag = '1 of 2',
-            readers = ['thecvf.com/ECCV/2020/Conference', '~AreaChair_ECCV_One1'],
-            signatures = ['~AreaChair_ECCV_One1'])
+            readers = ['thecvf.com/ECCV/2020/Conference', 'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chair1'],
+            signatures = ['thecvf.com/ECCV/2020/Conference/Paper1/Area_Chair1'])
         )
 
         reviewer_url = 'http://localhost:3000/group?id=thecvf.com/ECCV/2020/Conference/Reviewers'
@@ -1328,6 +1328,6 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         reviewer_client.post_tag(openreview.Tag(invitation = 'thecvf.com/ECCV/2020/Conference/Reviewers/-/Paper_Ranking',
             forum = blinded_notes[-1].id,
             tag = '2 of 2',
-            readers = ['thecvf.com/ECCV/2020/Conference', 'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chairs', '~Reviewer_ECCV_One1'],
-            signatures = ['~Reviewer_ECCV_One1'])
+            readers = ['thecvf.com/ECCV/2020/Conference', 'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chairs', 'thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer1'],
+            signatures = ['thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer1'])
         )

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -1306,7 +1306,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
         ac_client.post_tag(openreview.Tag(invitation = 'thecvf.com/ECCV/2020/Conference/Area_Chairs/-/Paper_Ranking',
             forum = blinded_notes[-1].id,
-            tag = '1',
+            tag = '1 of 2',
             readers = ['thecvf.com/ECCV/2020/Conference', '~AreaChair_ECCV_One1'],
             signatures = ['~AreaChair_ECCV_One1'])
         )
@@ -1327,7 +1327,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
         reviewer_client.post_tag(openreview.Tag(invitation = 'thecvf.com/ECCV/2020/Conference/Reviewers/-/Paper_Ranking',
             forum = blinded_notes[-1].id,
-            tag = '1',
+            tag = '2 of 2',
             readers = ['thecvf.com/ECCV/2020/Conference', 'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chairs', '~Reviewer_ECCV_One1'],
             signatures = ['~Reviewer_ECCV_One1'])
         )

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -1069,7 +1069,8 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
                     'required': True
                 }
             },
-            remove_fields = ['title', 'rating', 'review']))
+            remove_fields = ['title', 'rating', 'review'],
+            rating_field_name = 'preliminary_rating'))
 
         r1_client = openreview.Client(username='reviewer1@fb.com', password='1234')
         r2_client = openreview.Client(username='reviewer2@google.com', password='1234')

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -1302,6 +1302,15 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         assert options
         assert len(options) == 3
 
+        blinded_notes = conference.get_submissions()
+
+        ac_client.post_tag(openreview.Tag(invitation = 'thecvf.com/ECCV/2020/Conference/Area_Chairs/-/Paper_Ranking',
+            forum = blinded_notes[-1].id,
+            tag = '1',
+            readers = ['thecvf.com/ECCV/2020/Conference', '~AreaChair_ECCV_One1'],
+            signatures = ['~AreaChair_ECCV_One1'])
+        )
+
         reviewer_url = 'http://localhost:3000/group?id=thecvf.com/ECCV/2020/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token)
 
@@ -1315,3 +1324,10 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         options = tags[0].find_elements_by_tag_name("a")
         assert options
         assert len(options) == 3
+
+        reviewer_client.post_tag(openreview.Tag(invitation = 'thecvf.com/ECCV/2020/Conference/Reviewers/-/Paper_Ranking',
+            forum = blinded_notes[-1].id,
+            tag = '1',
+            readers = ['thecvf.com/ECCV/2020/Conference', 'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chairs', '~Reviewer_ECCV_One1'],
+            signatures = ['~Reviewer_ECCV_One1'])
+        )


### PR DESCRIPTION
- Post ranking tags as a string with the format: '2 of 2' or '1 of 3', depending of the number of assigned papers for each AC/Reviewer.
- Sign the tags anonymously, using the Area_Chair1 or AnonReviewer group. 
- Allow ACs to read reviewer paper rankings.
- Show reviewer rankings in the AC Console. (Should we do the same in the PC Console?)
- Parametrize the review rating field name.

Depends on https://github.com/openreview/openreview/pull/2057