### PR TITLE
Fix/replace member invalid profiles

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -478,6 +478,7 @@ def replace_members_with_ids(client, group):
     """
     ids = []
     emails = []
+    invalid_ids = []
     for member in group.members:
         if '~' not in member:
             try:
@@ -489,9 +490,16 @@ def replace_members_with_ids(client, group):
                 else:
                     raise e
         else:
-            profile = client.get_profile(member)
-            ids.append(profile.id)
+            try:
+                profile = client.get_profile(member)
+                ids.append(profile.id)
+            except openreview.OpenReviewException as e:
+                if 'Profile not found' in e.args[0][0]:
+                    invalid_ids.append(member)
+                else:
+                    raise e
 
+    print('Invalid profile id in group {} : {}'.format(group.id, ', '.join(invalid_ids)))
     group.members = ids + emails
     return client.post_group(group)
 

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -490,14 +490,9 @@ def replace_members_with_ids(client, group):
                 else:
                     raise e
         else:
-            try:
-                profile = client.get_profile(member)
-                ids.append(profile.id)
-            except openreview.OpenReviewException as e:
-                if 'Profile not found' in e.args[0][0]:
-                    invalid_ids.append(member)
-                else:
-                    raise e
+            profile = get_profile(client, member)
+            if not profile:
+                invalid_ids.append(member)
 
     print('Invalid profile id in group {} : {}'.format(group.id, ', '.join(invalid_ids)))
     group.members = ids + emails

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -491,7 +491,9 @@ def replace_members_with_ids(client, group):
                     raise e
         else:
             profile = get_profile(client, member)
-            if not profile:
+            if profile:
+                ids.append(profile.id)
+            else:
                 invalid_ids.append(member)
 
     print('Invalid profile id in group {} : {}'.format(group.id, ', '.join(invalid_ids)))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -237,6 +237,15 @@ class TestTools():
         assert replaced_group
         assert replaced_group.members == ['~Super_User1', '~Test_User1', 'noprofile@mail.com']
 
+        # Test to assert that member is removed while running replace members on a group has a member that is an invalid profile
+        invalid_member_group = client.add_members_to_group(replaced_group, '~Invalid_Profile1')
+        assert len(invalid_member_group.members) == 4
+        assert '~Invalid_Profile1' in invalid_member_group.members
+
+        replaced_group = openreview.tools.replace_members_with_ids(client, invalid_member_group)
+        assert len(replaced_group.members) == 3
+        assert '~Invalid_Profile1' not in invalid_member_group.members
+
     def test_get_conflicts(self, client, helpers):
 
         helpers.create_user('user@gmail.com', 'First', 'Last')


### PR DESCRIPTION
Currently tools.replace_members_with_ids would fail if there is a non-existent profile in the group that is being passed in the arguments. 

[Edit] Instead of calling `client.get_profile` I am now calling `tools.get_profile` which instead of throwing an exception, returns None in case the id does not have a corresponding profile.

NOTE: This will result in elimination of profile id group members when a profile corresponding to the id does not actually exist anymore.