### PR TITLE
Check review completed by signature

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -624,7 +624,7 @@ var calcReviewersComplete = function(reviewerGroupMaps, officialReviews) {
   return _.reduce(reviewerGroupMaps.byReviewers, function(numComplete, noteNumbers, reviewer) {
     var allSubmitted = _.every(noteNumbers, function(n) {
       var assignedReviewers = reviewerGroupMaps.byNotes[n];
-      var anonGroupNumber = _.findKey(assignedReviewers, function(v) { return v == reviewer});
+      var anonGroupNumber = _.findKey(assignedReviewers, function(v) { return v === reviewer; });
       return _.find(officialReviews, function(r) {
         return r.signatures[0] == CONFERENCE_ID + '/Paper' + n + '/AnonReviewer' + anonGroupNumber;
       });

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -626,7 +626,7 @@ var calcReviewersComplete = function(reviewerGroupMaps, officialReviews) {
       var assignedReviewers = reviewerGroupMaps.byNotes[n];
       var anonGroupNumber = _.findKey(assignedReviewers, function(v) { return v === reviewer; });
       return _.find(officialReviews, function(r) {
-        return r.signatures[0] == CONFERENCE_ID + '/Paper' + n + '/AnonReviewer' + anonGroupNumber;
+        return r.signatures[0] === CONFERENCE_ID + '/Paper' + n + '/AnonReviewer' + anonGroupNumber;
       });
     });
     return allSubmitted ? numComplete + 1 : numComplete;

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -562,13 +562,11 @@ var buildReviewerGroupMaps = function(noteNumbers, groups) {
         var reviewer = g.members[0];
         if ((num in noteMap)) {
           noteMap[num][index] = reviewer;
+          if (!(reviewer in reviewerMap)) {
+            reviewerMap[reviewer] = [];
+          }
+          reviewerMap[reviewer].push(num);
         }
-
-        if (!(reviewer in reviewerMap)) {
-          reviewerMap[reviewer] = [];
-        }
-
-        reviewerMap[reviewer].push(num);
       }
     }
   });

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -140,7 +140,7 @@ var main = function() {
       reviewsCount: officialReviews.length,
       assignedReviewsCount: calcAssignedReviewsCount(reviewerGroupMaps.byReviewers),
       reviewersWithAssignmentsCount: Object.keys(reviewerGroupMaps.byReviewers).length,
-      reviewersComplete: calcReviewersComplete(reviewerGroupMaps.byReviewers, officialReviews),
+      reviewersComplete: calcReviewersComplete(reviewerGroupMaps, officialReviews),
       paperReviewsComplete: calcPaperReviewsComplete(reviewerGroupMaps.byNotes, officialReviewMap),
       metaReviewsCount: metaReviews.length,
       metaReviewersComplete: calcMetaReviewersComplete(areaChairGroupMaps.byAreaChairs, metaReviews),
@@ -622,10 +622,14 @@ var calcAssignedReviewsCount = function(reviewerMap) {
   }, 0);
 };
 
-var calcReviewersComplete = function(reviewerMap, officialReviews) {
-  return _.reduce(reviewerMap, function(numComplete, noteNumbers) {
+var calcReviewersComplete = function(reviewerGroupMaps, officialReviews) {
+  return _.reduce(reviewerGroupMaps.byReviewers, function(numComplete, noteNumbers, reviewer) {
     var allSubmitted = _.every(noteNumbers, function(n) {
-      return _.find(officialReviews, ['invitation', getInvitationId(OFFICIAL_REVIEW_NAME, n)]);
+      var assignedReviewers = reviewerGroupMaps.byNotes[n];
+      var anonGroupNumber = _.findKey(assignedReviewers, function(v) { return v == reviewer});
+      return _.find(officialReviews, function(r) {
+        return r.signatures[0] == CONFERENCE_ID + '/Paper' + n + '/AnonReviewer' + anonGroupNumber;
+      });
     });
     return allSubmitted ? numComplete + 1 : numComplete;
   }, 0);


### PR DESCRIPTION
Fix Reviewer Progress calculation, we should check if the user signed the official review with their anonReviewer group number. 

I'm still see a difference between this number and the number of reviewer to send a reminder for ECCV. 

Currently I see the progress: 698 / 2808 and the reminder tries to remind 2066 reviewers, that means the other 742 completed the reviews, the difference is 44 where 14 are reviewers with no assignments what is correct to not send the reminder, what about the other 30 reviewers?