### PR TITLE
Fix/PC console paper progress

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -159,7 +159,6 @@ var main = function() {
   .then(function(profiles) {
     conferenceStatusData.profiles = profiles;
 
-    conferenceStatusData.blindedNotes
     for (var i = 0; i < conferenceStatusData.blindedNotes.length; i++) {
       var note = conferenceStatusData.blindedNotes[i];
       var revIds = conferenceStatusData.reviewerGroups.byNotes[note.number];

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -175,7 +175,7 @@ var main = function() {
       return {
         id: r,
         description: view.prettyId(profile.name) + ' (' + profile.allEmails.join(', ') + ')'
-      }
+      };
     });
 
     $('.tabs-container .nav-tabs > li').removeClass('loading');
@@ -849,7 +849,9 @@ var displayStatsAndConfiguration = function(conferenceStats, conferenceConfig) {
   html += renderStatContainer(
     'Paper Progress:',
     renderProgressStat(conferenceStats.paperReviewsComplete, conferenceStats.blindSubmissionsCount),
-    '% of papers that have received reviews from all assigned reviewers'
+    '% of papers that have received ' + (PAPER_REVIEWS_COMPLETE_THRESHOLD
+      ? 'at least ' + PAPER_REVIEWS_COMPLETE_THRESHOLD + ' reviews'
+      : 'reviews from all assigned reviewers')
   );
   html += '</div>';
   html += '<hr class="spacer" style="margin-bottom: 1rem;">';

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -30,6 +30,7 @@ var PC_PAPER_TAG_INVITATION = PROGRAM_CHAIRS_ID + '/-/Paper_Assignment';
 var REVIEWERS_INVITED_ID = REVIEWERS_ID + '/Invited';
 var AREA_CHAIRS_INVITED_ID = AREA_CHAIRS_ID ? AREA_CHAIRS_ID + '/Invited' : '';
 var ENABLE_REVIEWER_REASSIGNMENT = false;
+var PAPER_REVIEWS_COMPLETE_THRESHOLD = 3;
 var PAGE_SIZE = 25;
 
 // Page State
@@ -635,8 +636,17 @@ var calcReviewersComplete = function(reviewerGroupMaps, officialReviews) {
 
 var calcPaperReviewsComplete = function(noteMap, officialReviewMap) {
   return _.reduce(noteMap, function(numComplete, reviewerMap, n) {
-    var reviewerCount = Object.values(reviewerMap).length;
-    var allSubmitted = officialReviewMap[n] && reviewerCount > 0 && reviewerCount === Object.values(officialReviewMap[n]).length;
+    var allSubmitted;
+    if (officialReviewMap[n]) {
+      var completedReviewsCount = Object.values(officialReviewMap[n]).length;
+      var assignedReviewerCount = Object.values(reviewerMap).length;
+      allSubmitted = PAPER_REVIEWS_COMPLETE_THRESHOLD
+        ? assignedReviewerCount > 0 && completedReviewsCount >= PAPER_REVIEWS_COMPLETE_THRESHOLD
+        : assignedReviewerCount > 0 && completedReviewsCount >= assignedReviewerCount;
+    } else {
+      allSubmitted = false;
+    }
+
     return allSubmitted ? numComplete + 1 : numComplete;
   }, 0);
 };


### PR DESCRIPTION
This PR changes the calculation of paper progress to use a threshold instead of only counting a paper as complete when all of its assigned reviewers had completed a review.

When updating existing PC Console webfields, make sure to add the constant `var PAPER_REVIEWS_COMPLETE_THRESHOLD = 3;` to the list. Setting this constant to `null` or `0` will result in the old method will be used. 

Fixes #665 