### PR TITLE
Fix/agora setup

### DIFF
--- a/openreview/agora/agora.py
+++ b/openreview/agora/agora.py
@@ -308,7 +308,7 @@ class Agora(object):
             client.post_invitation(revision_invitation)
 
         assign_editor_invitation = openreview.Invitation(
-            id = '{}/-/Assign_Editor'.format(covid_group_id),
+            id = '{}/-/Editors_Assignment'.format(covid_group_id),
             readers = ['everyone'],
             writers = [support_group_id],
             signatures = [support_group_id],
@@ -333,7 +333,7 @@ class Agora(object):
             client.post_invitation(assign_editor_invitation)
 
         assign_reviewer_invitation = openreview.Invitation(
-            id = '{}/-/Assign_Reviewer'.format(covid_group_id),
+            id = '{}/-/Reviewers_Assignment'.format(covid_group_id),
             readers = ['everyone'],
             writers = [support_group_id],
             signatures = [support_group_id],
@@ -388,7 +388,7 @@ class Agora(object):
             client.post_invitation(review_invitation)
 
         suggest_reviewer_invitation = openreview.Invitation(
-            id = '{}/-/Suggest_Reviewers'.format(covid_group_id),
+            id = '{}/-/Reviewers_Suggestion'.format(covid_group_id),
             readers = ['everyone'],
             writers = [support_group_id],
             signatures = [support_group_id],
@@ -397,15 +397,15 @@ class Agora(object):
                 'content': {
                     'suggested_reviewers': {
                         'description': 'Comma separated list of reviewer email addresses or OpenReview profile ids',
-                        'order': 1,
+                        'order': 2,
                         'values-regex': "~.*|([a-z0-9_\-\.]{1,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{1,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})",
                         'required':True
                     },
                     'comment': {
                         'description': 'Why are you suggesting this reviewer?',
-                        'order': 2,
-                        'value-regex': "[\\S\\s]{1,5000}",
-                        'required':True
+                        'order': 3,
+                        'value-regex': "[\\S\\s]{1,200}",
+                        'required':False
                     }
                 }
             }

--- a/openreview/agora/agora.py
+++ b/openreview/agora/agora.py
@@ -387,6 +387,44 @@ class Agora(object):
             review_invitation.process = file_content
             client.post_invitation(review_invitation)
 
+        meta_review_invitation = openreview.Invitation(
+            id = '{}/-/Meta_Review'.format(covid_group_id),
+            readers = ['everyone'],
+            writers = [support_group_id],
+            signatures = [support_group_id],
+            multiReply = False,
+            reply = {
+                'content': {
+                    'title': {
+                        'description': 'Brief summary of your meta review.',
+                        'order': 1,
+                        'value-regex': ".{0,500}",
+                        'required':True
+                    },
+                    'metareview': {
+                        'description': 'You can include Markdown formatting and LaTeX forumulas, for more information see https://openreview.net/faq , max length: 5000',
+                        'order': 2,
+                        'value-regex': "[\\S\\s]{1,5000}",
+                        'required':True,
+                        'markdown':True
+                    },
+                    'recommendation': {
+                        'order': 3,
+                        'value-dropdown': [
+                            'Accept',
+                            'Needs more work'
+                        ],
+                        'required': True
+                    }
+                }
+            }
+        )
+        with open(os.path.join(os.path.dirname(__file__), 'process/meta_review_process.py')) as f:
+            file_content = f.read()
+            file_content = file_content.replace("support = 'OpenReview.net/Support'", "support = '" + support_group_id + "'")
+            meta_review_invitation.process = file_content
+            client.post_invitation(meta_review_invitation)
+
         suggest_reviewer_invitation = openreview.Invitation(
             id = '{}/-/Reviewers_Suggestion'.format(covid_group_id),
             readers = ['everyone'],

--- a/openreview/agora/agora.py
+++ b/openreview/agora/agora.py
@@ -198,7 +198,7 @@ class Agora(object):
             client.post_invitation(submission_invitation)
 
         moderate_invitation = openreview.Invitation(
-            id = '{}/-/Moderate'.format(covid_group_id),
+            id = '{}/-/Moderation'.format(covid_group_id),
             invitees = [covid_editors],
             readers = ['everyone'],
             writers = [support_group_id],

--- a/openreview/agora/agora.py
+++ b/openreview/agora/agora.py
@@ -32,39 +32,44 @@ class Agora(object):
 
         header = {
             "title": "Agora (ἀγορά) COVID-19",
-            "subtitle": "OpenReview public space for COVID-19 related articles",
+            "subtitle": "A venue for open discussion of research articles related to COVID-19",
             "location": "Everywhere",
             "date": "Ongoing",
             "website": "https://openreview.net",
             "instructions": '''
             <p>
-                <strong>Editor-in-chief:</strong><br>
-                <p>This venue is managed by a group of Editors-in-Chief who check each submission and decide whether to release it to the public or not. The Editors-in-Chief determine the editors for each submitted article.
-                To see the list of members, click <a href="https://openreview.net/group?id={covid_editors}">here</a>.</p>
+                <strong>Editor-in-chief:</strong> {editor_id}
             </p>
             <p>
-                <strong>Submission:</strong><br>
-                <p>Anyone with an OpenReview profile can submit an article. The article submission form also allows the authors to suggest one or more "editors" by specifying their OpenReview usernames (e.g. "~Jane_Doe1").
-                Before the submitted article is made visible to the public, it goes to the Editor-in-Chief who examines it briefly, checking for spam but not for scientific validity. If it is not spam, the article is made visible, and editors are assigned to the paper.
-                Authors can upload a revision to any part of their submission at any time.  The full history of past uploads will always be available through the "Show Revisions" option.</p>
+                <strong>Submission, Reviewing, Commenting, and Approval Workflow:</strong><br>
+                <p>Any OpenReview logged-in user may submit an article. The article submission form allows the Authors to suggest for their article one or
+                multiple Editors (from among people who have created OpenReview profiles). The article is not immediately visible to the public, but is sent
+                to the Editors-in-Chief, any of whom may perform a basic evaluation of the submission (e.g. checking for spam). If not immediately rejected
+                at this step, an Editor-in-Chief assigns one or more Editors to the article (perhaps from the authors’ suggestions, perhaps from their own choices),
+                and the article is made visible to the public. Authors may upload revisions to any part of their submission at any time. (The full history of past
+                revisions is  available through the "Show Revisions" link.)</p>
             </p>
             <p>
-                <strong>Editor:</strong><br>
-                <p>The Editor-in-Chief decides on assigned editors, following the suggestions of the authors or making their own choices.  The editor assignments are non-anonymous.
-                The article authors can edit their list of requested editors by revising their submission. The Editor-in-Chief can add or remove editors from the article at any time.</p>
+                Assigned Editors are non-anonymous. The article Authors may revise their list of requested editors by revising their submission. The Editors-in-Chief
+                may add or remove Editors for the article at any time.
             </p>
             <p>
-                <strong>Reviewers:</strong><br>
-                <p>Only assigned reviewers can review or comment on the article. Reviews are public and reviewers are non-anonymous.
-                Editors of the article can add (or remove) people from the reviewers group by adding/removing their OpenReview usernames to the "Assigned Reviewers" field of the article.
-                Any logged-in user can suggest reviewers for an article and an assigned editor will decide to add them to the reviewers group them or not.</p>
+                Reviewers are assigned to the article by any of the Editors of the article.  Any of the Editors can add (or remove) Reviewers at any time. Any logged-in
+                user can suggest additional Reviewers for this article; these suggestions are public and non-anonymous.  (Thus the public may apply social pressure on
+                the Editors for diversity of views in reviewing and commenting.) To avoid spam, only assigned Reviewers, Editors and the Editors-in-Chief can contribute
+                comments (or reviews) on the article.  Such comments are public and associated with their non-anonymous reviewers.  There are no system-enforced deadlines
+                for any of the above steps, (although social pressure may be applied out-of-band).
             </p>
             <p>
-                <strong>Questions or Concerns:</strong><br>
-                Please contact the OpenReview support team at
-                <a href="mailto:info@openreview.net">info@openreview.net</a> with any questions or concerns.
+                At some point, any of the Editors may contribute a meta-review, making an Approval recommendation to the Editors-in-Chief.  Any of the Editors-in-Chief may
+                 at any time add or remove the venue’s Approval from the article (indicating a kind of “acceptance” of the article).
             </p>
-            '''.format(covid_editors=covid_editors),
+            <p>
+                For questions about editorial content and process, email the Editors-in-Chief.<br>
+                For questions about software infrastructure or profiles, email the OpenReview support team at
+                <a href="mailto:info@openreview.net">info@openreview.net</a>.
+            </p>
+            '''.format(editor_id=editor_id),
             "deadline": "",
             "contact": "info@openreview.net"
         }

--- a/openreview/agora/process/article_process.py
+++ b/openreview/agora/process/article_process.py
@@ -137,6 +137,29 @@ def process_update(client, note, invitation, existing_note):
     )
     client.post_invitation(review_invitation)
 
+    meta_review_invitation = openreview.Invitation(
+        id = '{}/-/Meta_Review'.format(article_group.id),
+        super = '{}/-/Meta_Review'.format(covid_group_id),
+        invitees = [editors_group_id, support],
+        writers = [support],
+        signatures = [support],
+        reply = {
+            'forum': note.forum,
+            'replyto': note.forum,
+            'readers': {
+                'values': ['everyone'],
+                'default': ['everyone']
+            },
+            'writers': {
+                'values-copied': ['{signatures}', support]
+            },
+            'signatures': {
+                'values-regex': '~.*|{}'.format(support)
+            }
+        }
+    )
+    client.post_invitation(meta_review_invitation)
+
     suggest_reviewer_invitation = openreview.Invitation(
         id = '{}/-/Reviewers_Suggestion'.format(article_group.id),
         super = '{}/-/Reviewers_Suggestion'.format(covid_group_id),

--- a/openreview/agora/process/article_process.py
+++ b/openreview/agora/process/article_process.py
@@ -70,8 +70,8 @@ def process_update(client, note, invitation, existing_note):
     client.post_invitation(revision_invitation)
 
     assign_editor_invitation = openreview.Invitation(
-        id = '{}/-/Assign_Editor'.format(article_group.id),
-        super = '{}/-/Assign_Editor'.format(covid_group_id),
+        id = '{}/-/Editors_Assignment'.format(article_group.id),
+        super = '{}/-/Editors_Assignment'.format(covid_group_id),
         invitees = [editor, support],
         writers = [support],
         signatures = [support],
@@ -89,8 +89,8 @@ def process_update(client, note, invitation, existing_note):
     client.post_invitation(assign_editor_invitation)
 
     assign_reviewer_invitation = openreview.Invitation(
-        id = '{}/-/Assign_Reviewer'.format(article_group.id),
-        super = '{}/-/Assign_Reviewer'.format(covid_group_id),
+        id = '{}/-/Reviewers_Assignment'.format(article_group.id),
+        super = '{}/-/Reviewers_Assignment'.format(covid_group_id),
         invitees = [editor, editors_group_id, support],
         writers = [support],
         signatures = [support],
@@ -138,8 +138,8 @@ def process_update(client, note, invitation, existing_note):
     client.post_invitation(review_invitation)
 
     suggest_reviewer_invitation = openreview.Invitation(
-        id = '{}/-/Suggest_Reviewers'.format(article_group.id),
-        super = '{}/-/Suggest_Reviewers'.format(covid_group_id),
+        id = '{}/-/Reviewers_Suggestion'.format(article_group.id),
+        super = '{}/-/Reviewers_Suggestion'.format(covid_group_id),
         invitees = ['everyone'],
         noninvitees = [blocked],
         writers = [support],

--- a/openreview/agora/process/meta_review_process.py
+++ b/openreview/agora/process/meta_review_process.py
@@ -1,0 +1,39 @@
+def process_update(client, note, invitation, existing_note):
+
+    covid_group_id = '-Agora/COVID-19'
+    support = 'OpenReview.net/Support'
+    article_group_id = invitation.id.split('/-/')[0]
+    reviewers_group_id = '{}/Reviewers'.format(article_group_id)
+    submission = client.get_note(note.forum)
+
+    action = 'posted'
+    if existing_note:
+        action = 'deleted' if note.ddate else 'updated'
+
+
+    client.post_message(subject='[Agora/COVID-19] Meta Review {action} to your article titled "{title}"'.format(action=action, title=submission.content['title']),
+        recipients=submission.content['authorids'],
+        message='''A meta review has been {action} to your article titled "{title}".
+
+The meta review can be viewed on OpenReview here: https://openreview.net/forum?id={forum}&noteId={id}'''.format(action=action, title=submission.content['title'], forum=note.forum, id=note.id),
+        ignoreRecipients=None,
+        sender=None
+    )
+
+    client.post_message(subject='[Agora/COVID-19] Your meta review has been {action} on your assigned article titled "{title}"'.format(action=action, title=submission.content['title']),
+        recipients=note.signatures,
+        message='''Your meta review has been {action} to your assigned article titled "{title}".
+
+The meta review can be viewed on OpenReview here: https://openreview.net/forum?id={forum}&noteId={id}'''.format(action=action, title=submission.content['title'], forum=note.forum, id=note.id),
+        ignoreRecipients=None,
+        sender=None
+    )
+
+    client.post_message(subject='[Agora/COVID-19] A meta review has been {action} on the article titled "{title}"'.format(action=action, title=submission.content['title']),
+        recipients=[reviewers_group_id],
+        message='''A meta review has been {action} to the article titled "{title}" where you are an assigned reviewer.
+
+The meta review can be viewed on OpenReview here: https://openreview.net/forum?id={forum}&noteId={id}'''.format(action=action, title=submission.content['title'], forum=note.forum, id=note.id),
+        ignoreRecipients=None,
+        sender=None
+    )

--- a/openreview/agora/process/submission_process.py
+++ b/openreview/agora/process/submission_process.py
@@ -63,8 +63,8 @@ To your submission can be viewed on OpenReview here: https://openreview.net/foru
     client.post_group(authors_group)
 
     moderate_invitation = openreview.Invitation(
-        id = '{}/-/Moderate'.format(submission_group.id),
-        super = '{}/-/Moderate'.format(covid_group_id),
+        id = '{}/-/Moderation'.format(submission_group.id),
+        super = '{}/-/Moderation'.format(covid_group_id),
         writers = [support],
         signatures = [superuser],
         reply = {

--- a/tests/test_agora.py
+++ b/tests/test_agora.py
@@ -421,6 +421,50 @@ class TestAgora():
         assert 'reviewer@agora.net' in recipients
         assert 'reviewer2@agora.net' in recipients
 
+    def test_post_metareview(self, client, helpers):
+
+        article_editor_client = openreview.Client(username='article_editor@agora.net', password='1234')
+
+        articles = article_editor_client.get_notes(invitation='-Agora/COVID-19/-/Article')
+        assert articles
+
+        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Meta_Review',
+            readers = ['everyone'],
+            writers = ['openreview.net/Support', '~ArticleEditor_One1'],
+            signatures = ['~ArticleEditor_One1'],
+            forum = articles[0].id,
+            replyto = articles[0].id,
+            content = {
+                'title': 'review title',
+                'metareview': 'excelent paper',
+                'recommendation': 'Accept'
+            }
+        )
+
+        posted_note = article_editor_client.post_note(note)
+
+        time.sleep(2)
+
+        process_logs = client.get_process_logs(id = posted_note.id)
+        assert len(process_logs) == 1
+        assert process_logs[0]['status'] == 'ok'
+
+        messages = client.get_messages(subject = '[Agora/COVID-19] Meta Review posted to your article titled "Paper title"')
+        assert len(messages) == 1
+        recipients = [m['content']['to'] for m in messages]
+        assert 'author@agora.net' in recipients
+
+        messages = client.get_messages(subject = '[Agora/COVID-19] Your meta review has been posted on your assigned article titled "Paper title"')
+        assert len(messages) == 1
+        recipients = [m['content']['to'] for m in messages]
+        assert 'article_editor@agora.net' in recipients
+
+        messages = client.get_messages(subject = '[Agora/COVID-19] A meta review has been posted on the article titled "Paper title"')
+        assert len(messages) == 2
+        recipients = [m['content']['to'] for m in messages]
+        assert 'reviewer@agora.net' in recipients
+        assert 'reviewer2@agora.net' in recipients
+
     def test_desk_reject(self, client, helpers):
 
         author_client = openreview.Client(username = 'author@agora.net', password = '1234')

--- a/tests/test_agora.py
+++ b/tests/test_agora.py
@@ -117,7 +117,7 @@ class TestAgora():
         articles = editor_client.get_notes(invitation='-Agora/COVID-19/-/Article')
         assert articles
 
-        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Assign_Editor',
+        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Editors_Assignment',
             readers = ['everyone'],
             writers = ['openreview.net/Support', '-Agora/COVID-19/Editors'],
             signatures = ['~Editor_One1'],
@@ -158,7 +158,7 @@ class TestAgora():
         articles = article_editor_client.get_notes(invitation='-Agora/COVID-19/-/Article')
         assert articles
 
-        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Assign_Reviewer',
+        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Reviewers_Assignment',
             readers = ['everyone'],
             writers = ['openreview.net/Support', '-Agora/COVID-19/Article1/Editors'],
             signatures = ['~ArticleEditor_One1'],
@@ -191,7 +191,7 @@ class TestAgora():
         recipients = [m['content']['to'] for m in messages]
         assert 'reviewer@agora.net' in recipients
 
-        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Assign_Reviewer',
+        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Reviewers_Assignment',
             readers = ['everyone'],
             writers = ['openreview.net/Support', '-Agora/COVID-19/Article1/Editors'],
             signatures = ['~ArticleEditor_One1'],
@@ -347,7 +347,7 @@ class TestAgora():
         articles = melisa_client.get_notes(invitation='-Agora/COVID-19/-/Article')
         assert articles
 
-        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Suggest_Reviewers',
+        note = openreview.Note(invitation = '-Agora/COVID-19/Article1/-/Reviewers_Suggestion',
             readers = ['everyone'],
             writers = ['openreview.net/Support', '~Melissa_Agora1'],
             signatures = ['~Melissa_Agora1'],

--- a/tests/test_agora.py
+++ b/tests/test_agora.py
@@ -79,7 +79,7 @@ class TestAgora():
         submissions = editor_client.get_notes(invitation='-Agora/COVID-19/-/Submission')
         assert submissions
 
-        note = openreview.Note(invitation = '-Agora/COVID-19/Submission1/-/Moderate',
+        note = openreview.Note(invitation = '-Agora/COVID-19/Submission1/-/Moderation',
             readers = ['openreview.net/Support', '-Agora/COVID-19/Editors', '-Agora/COVID-19/Submission1/Authors'],
             writers = ['openreview.net/Support'],
             signatures = ['~Editor_One1'],
@@ -496,7 +496,7 @@ class TestAgora():
         submissions = editor_client.get_notes(invitation='-Agora/COVID-19/-/Submission')
         assert submissions
 
-        note = openreview.Note(invitation = '-Agora/COVID-19/Submission2/-/Moderate',
+        note = openreview.Note(invitation = '-Agora/COVID-19/Submission2/-/Moderation',
             readers = ['openreview.net/Support', '-Agora/COVID-19/Editors', '-Agora/COVID-19/Submission2/Authors'],
             writers = ['openreview.net/Support'],
             signatures = ['~Editor_One1'],


### PR DESCRIPTION
- Change home page instructions based on Andrew's feedback.
- Use nouns instead of verbs for invitation ids.
- Add meta review invitation.
- Restrict the comment length to suggest reviewers.