### PR TITLE
show primary meta review in the secondary ac tab

### DIFF
--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -624,7 +624,7 @@ var renderStatusTable = function(profiles, notes, allInvitations, completedRevie
   }
 };
 
-var renderSecondaryStatusTable = function(profiles, notes, allInvitations, completedReviews, metaReviews, reviewerIds, container) {
+var renderSecondaryStatusTable = function(profiles, notes, allInvitations, completedReviews, metaReviews, reviewerIds, acRankingByPaper, reviewerRankingByPaper, container) {
   var rows = _.map(notes, function(note) {
     var revIds = reviewerIds[note.number] || Object.create(null);
     for (var revNumber in revIds) {
@@ -635,7 +635,7 @@ var renderSecondaryStatusTable = function(profiles, notes, allInvitations, compl
     var metaReview = _.find(metaReviews, ['invitation', getInvitationId(OFFICIAL_META_REVIEW_NAME, note.number)]);
     var noteCompletedReviews = completedReviews[note.number] || Object.create(null);
 
-    return buildTableRow(note, revIds, noteCompletedReviews, metaReview, undefined, {}, {}, 'secondary');
+    return buildTableRow(note, revIds, noteCompletedReviews, metaReview, undefined, acRankingByPaper[note.forum], reviewerRankingByPaper[note.forum] || {}, 'secondary');
   });
 
   var order = 'desc';
@@ -875,7 +875,7 @@ var renderTableAndTasks = function(fetchedData) {
   renderStatusTable(
     fetchedData.profiles,
     primaryAssignments,
-    _.filter(fetchedData.invitations, filterFunc),
+    fetchedData.invitations,
     fetchedData.officialReviews,
     fetchedData.metaReviews,
     _.cloneDeep(fetchedData.noteToReviewerIds), // Need to clone this dictionary because some values are missing after the first refresh
@@ -892,6 +892,8 @@ var renderTableAndTasks = function(fetchedData) {
       fetchedData.officialReviews,
       fetchedData.metaReviews,
       _.cloneDeep(fetchedData.noteToReviewerIds), // Need to clone this dictionary because some values are missing after the first refresh
+      fetchedData.acRankingByPaper,
+      fetchedData.reviewerRankingByPaper,
       '#secondary-papers'
     );
   }

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -843,10 +843,6 @@ var postRenderTable = function(rows) {
   });
 };
 
-var filterFunc = function(inv) {
-  return _.some(inv.invitees, function(invitee) { return invitee.indexOf(AREA_CHAIR_NAME) !== -1; });
-};
-
 var renderTasks = function(invitations, edgeInvitations, tagInvitations) {
   //  My Tasks tab
   var tasksOptions = {
@@ -856,12 +852,7 @@ var renderTasks = function(invitations, edgeInvitations, tagInvitations) {
   }
   $(tasksOptions.container).empty();
 
-  // filter out non-areachair tasks
-  var areachairInvitations = _.filter(invitations, filterFunc);
-  var areachairTagInvitations = _.filter(tagInvitations, filterFunc);
-  var areachairEdgeInvitations = _.filter(edgeInvitations, filterFunc);
-
-  Webfield.ui.newTaskList(areachairInvitations, areachairTagInvitations.concat(areachairEdgeInvitations), tasksOptions);
+  Webfield.ui.newTaskList(invitations, tagInvitations.concat(edgeInvitations), tasksOptions);
   $('.tabs-container a[href="#areachair-tasks"]').parent().show();
 }
 

--- a/openreview/conference/templates/commentProcess.js
+++ b/openreview/conference/templates/commentProcess.js
@@ -6,6 +6,7 @@ function(){
     var AUTHORS_NAME = '';
     var REVIEWERS_NAME = '';
     var AREA_CHAIRS_NAME = '';
+    var SECONDARY_AREA_CHAIR_NAME = '';
     var PROGRAM_CHAIRS_ID = '';
     var USE_AREA_CHAIRS = false;
 
@@ -18,6 +19,7 @@ function(){
       var REVIEWERS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Reviewers';
       var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chairs';
       var AREA_CHAIR_1_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chair1';
+      var AREA_CHAIR_2_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/' + SECONDARY_AREA_CHAIR_NAME;
       var ignoreGroups = note.nonreaders || [];
       ignoreGroups.push(note.tauthor);
 
@@ -26,6 +28,13 @@ function(){
         ignoreGroups: ignoreGroups,
         subject: '[' + SHORT_PHRASE + '] Comment posted to a paper in your area. Paper Number: ' + forumNote.number + ', Paper Title: "' + forumNote.content.title + '"',
         message: 'A comment was posted to a paper for which you are serving as Area Chair.\n\nPaper Number: ' + forumNote.number + '\n\nPaper Title: "' + forumNote.content.title + '"\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+      };
+
+      var ac2_mail = {
+        groups: [AREA_CHAIR_2_ID],
+        ignoreGroups: ignoreGroups,
+        subject: '[' + SHORT_PHRASE + '] Comment posted to a paper in your area. Paper Number: ' + forumNote.number + ', Paper Title: "' + forumNote.content.title + '"',
+        message: 'A comment was posted to a paper for which you are serving as secondary Area Chair.\n\nPaper Number: ' + forumNote.number + '\n\nPaper Title: "' + forumNote.content.title + '"\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
       var comment_author_mail = {
@@ -81,6 +90,10 @@ function(){
 
       if(USE_AREA_CHAIRS && (note.readers.includes(AREA_CHAIRS_ID) || note.readers.includes('everyone'))){
         promises.push(or3client.or3request(or3client.mailUrl, ac_mail, 'POST', token));
+
+        if (SECONDARY_AREA_CHAIR_NAME) {
+          promises.push(or3client.or3request(or3client.mailUrl, ac2_mail, 'POST', token));
+        }
       }
 
       if(PROGRAM_CHAIRS_ID && (note.readers.includes(PROGRAM_CHAIRS_ID) || note.readers.includes('everyone'))){

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -659,16 +659,16 @@ Please contact info@openreview.net with any questions or concerns about this int
 
         conference.setup_matching(is_area_chair=True, affinity_score_file=os.path.join(os.path.dirname(__file__), 'data/ac_affinity_scores.csv'),
             tpms_score_file=os.path.join(os.path.dirname(__file__), 'data/temp.csv'))
-        
+
         request_page(selenium, url='http://localhost:3000/assignments?group=thecvf.com/ECCV/2020/Conference/Reviewers', token=conference.client.token)
         new_assignment_btn = selenium.find_element_by_id('new-configuration-button')
         assert new_assignment_btn
         new_assignment_btn.click()
-        
+
         pop_up_div = selenium.find_element_by_id('note-editor-modal')
         assert pop_up_div
         assert pop_up_div.get_attribute('class') == 'modal fade in'
-        
+
         custom_user_demand_invitation = selenium.find_element_by_name('custom_user_demand_invitation')
         assert custom_user_demand_invitation
         assert custom_user_demand_invitation.get_attribute('value') == 'thecvf.com/ECCV/2020/Conference/Reviewers/-/Custom_User_Demands'
@@ -1550,6 +1550,10 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         assert review_rating_note
 
     def test_secondary_assignments(self, conference, client, test_client, selenium, request_page):
+
+        now = datetime.datetime.utcnow()
+
+        conference.set_meta_review_stage(openreview.MetaReviewStage(due_date =  now + datetime.timedelta(minutes = 1440)))
 
         ac_client = openreview.Client(username='ac1@eccv.org', password='1234')
         ac_url = 'http://localhost:3000/group?id=thecvf.com/ECCV/2020/Conference/Area_Chairs'


### PR DESCRIPTION
- Show primary meta review in the secondary tab.
- Show sorting options in the secondary tab.
- Show secondary meta reviews in the tasks tab, remove filter function.
- Send email notification to secondary AC when a comment is posted.