### PR TITLE
export paper status tab to a csv file

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -2503,8 +2503,6 @@ var buildCSV = function(){
     ].join(',') + '\n');
   });
 
-  console.log(rowData);
-
   return [rowData.join('')];
 };
 

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -2494,6 +2494,7 @@ var buildCSV = function(){
   'average confidence',
   'ac recommendation',
   'ac profile id',
+  'ac email',
   'ac ranking'].join(',') + '\n');
 
   _.forEach(notes, function(note) {
@@ -2523,6 +2524,7 @@ var buildCSV = function(){
     paperTableRow.reviewProgressData.averageConfidence,
     paperTableRow.areachairProgressData.metaReview && paperTableRow.areachairProgressData.metaReview.content.recommendation,
     areachairProfile.id,
+    areachairProfile.email,
     acRankingByPaper[note.forum] && acRankingByPaper[note.forum].tag
     ].join(',') + '\n');
   });

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -2472,7 +2472,7 @@ var buildCSV = function(){
   var decisions = conferenceStatusData.decisions;
 
   var rowData = [];
-  rowData.push(['id', 'number', 'title', 'num reviewers', 'min rating', 'max rating', 'average rating', 'min confidence', 'max confidence', 'ac recommendation'].join(',') + '\n');
+  rowData.push(['id', 'number', 'title', 'num reviewers', 'min rating', 'max rating', 'average rating', 'min confidence', 'max confidence', 'average confidence', 'ac recommendation'].join(',') + '\n');
 
   _.forEach(notes, function(note) {
     var revIds = reviewerIds[note.number];
@@ -2498,6 +2498,7 @@ var buildCSV = function(){
     paperTableRow.reviewProgressData.averageRating,
     paperTableRow.reviewProgressData.minConfidence,
     paperTableRow.reviewProgressData.maxConfidence,
+    paperTableRow.reviewProgressData.averageConfidence,
     paperTableRow.areachairProgressData.metaReview && paperTableRow.areachairProgressData.metaReview.content.recommendation
     ].join(',') + '\n');
   });

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -1358,8 +1358,8 @@ var displayPaperStatusTable = function() {
         '<li><a class="msg-submitted-reviewers">Reviewers of selected papers with submitted reviews</a></li>' +
         '<li><a class="msg-unsubmitted-reviewers">Reviewers of selected papers with unsubmitted reviews</a></li>' +
       '</ul>' +
-      '</div>' +
-      '<div class="btn-group"><button class="btn btn-export-data">Export</button></div>');
+    '</div>' +
+    '<div class="btn-group"><button class="btn btn-export-data">Export</button></div>');
     renderTable(container, rowData);
   } else {
     $(container).empty().append('<p class="empty-message">No papers have been submitted. ' +

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -90,8 +90,15 @@ var main = function() {
     invitationMap
   ) {
     var noteNumbers = blindedNotes.map(function(note) { return note.number; });
+    var acRankingByPaper = {};
     blindedNotes.forEach(function(n) {
       selectedNotesById[n.id] = false;
+      var tags = n.details['tags'];
+      tags.forEach(function(t) {
+        if (t.invitation === AREA_CHAIRS_ID + '/-/Paper_Ranking') {
+          acRankingByPaper[n.forum] = t;
+        }
+      })
     });
 
     reviewerSummaryMap = buildNoteMap(noteNumbers);
@@ -105,16 +112,6 @@ var main = function() {
         pcTags[tag.forum] = [];
       }
       pcTags[tag.forum].push(tag);
-    });
-
-    var acRankingByPaper = {};
-    blindedNotes.forEach(function(n) {
-      var tags = n.details['tags'];
-      tags.forEach(function(t) {
-        if (t.invitation === AREA_CHAIRS_ID + '/-/Paper_Ranking') {
-          acRankingByPaper[n.forum] = t;
-        }
-      })
     });
 
     conferenceStatusData = {
@@ -984,7 +981,6 @@ var displaySortPanel = function(container, sortOptions, sortResults, searchResul
   $(container).html(
     '<form class="form-inline search-form clearfix" role="search">' +
       '<div class="pull-left"></div>' +
-      '<div class="pull-middle"></div>' +
       '<div class="pull-right">' +
         searchBarHtml +
         sortDropdownHtml +
@@ -1362,8 +1358,8 @@ var displayPaperStatusTable = function() {
         '<li><a class="msg-submitted-reviewers">Reviewers of selected papers with submitted reviews</a></li>' +
         '<li><a class="msg-unsubmitted-reviewers">Reviewers of selected papers with unsubmitted reviews</a></li>' +
       '</ul>' +
-    '</div>');
-    $(container).find('form.search-form .pull-middle').html('<div><button class="btn btn-export-data">Export</button></div>');
+      '</div>' +
+      '<div class="btn-group"><button class="btn btn-export-data">Export</button></div>');
     renderTable(container, rowData);
   } else {
     $(container).empty().append('<p class="empty-message">No papers have been submitted. ' +
@@ -2535,6 +2531,6 @@ var buildCSV = function(){
 };
 
 $('#group-container').on('click', 'button.btn.btn-export-data', function(e) {
-  var blob = new Blob(buildCSV(), {type: 'text/plain;charset=utf-8'});
-  saveAs(blob, SHORT_PHRASE.replace(' ', '_') + '_paper_status.csv',);
+  var blob = new Blob(buildCSV(), {type: 'text/csv'});
+  saveAs(blob, SHORT_PHRASE.replace(/\s/g, '_') + '_paper_status.csv',);
 });


### PR DESCRIPTION
New button to export the current paper status. This is a work in progress and I would like to use it for ECCV

<img width="1251" alt="Screen Shot 2020-06-15 at 5 36 10 PM" src="https://user-images.githubusercontent.com/545506/84708543-b6e46800-af2e-11ea-9b69-957a89d52ba7.png">

I need to ask @zbialecki if we should add filesaver.min.js to vendors or link it externally. 
