### PR TITLE
ICLR 2021 proposed change to recruitment landing page

### DIFF
--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -33,7 +33,7 @@ function render() {
           '<div class="row">',
             '<h4>Please complete the following steps now:</h4>',
               '<ol>',
-                '<li><p>Log in to your OpenReview account (if you do not already have an OpenReview account, you can sign up <a style="font-weight:bold;" href="/signup">here</a>).</p></li>',
+                '<li><p>Log in to your OpenReview account. If you do not already have an account, you can sign up <a style="font-weight:bold;" href="/signup">here</a>).</p></li>',
                 '<li><p>Ensure that the email address ' + email + ' that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p></li>',
                 '<li><p>Complete your pending <a style="font-weight:bold;" href="/tasks">tasks</a> (if any) for ' + HEADER.subtitle + '.</p></li>',
               '</ol>',

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -26,6 +26,7 @@ function render() {
       // Display response text
       var message = 'Thank you for accepting this invitation from ' + HEADER.title;
       $response.append('<div class="panel"><div class="row"><h3 style="line-height:normal;">' + message + '</h3></div></div>');
+      var email = args.user.indexOf('@') > -1 ? '(<strong>' + args.user + '</strong>) ' : '';
 
       $response.append([
         '<div class="panel">',
@@ -33,8 +34,8 @@ function render() {
             '<h4>Please complete the following steps now:</h4>',
               '<ol>',
                 '<li><p>Log in to your OpenReview account (if you do not already have an OpenReview account, you can sign up <a style="font-weight:bold;" href="/signup">here</a>).</p></li>',
-                '<li><p>Ensure that the email address that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p></li>',
-                '<li><p>Complete your pending <a style="font-weight:bold;" href="/tasks">tasks</a> for ' + HEADER.subtitle + '.</p></li>',
+                '<li><p>Ensure that the email address ' + email + 'that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p></li>',
+                '<li><p>Complete your pending <a style="font-weight:bold;" href="/tasks">tasks</a> (if any) for ' + HEADER.subtitle + '.</p></li>',
               '</ol>',
           '</div>',
         '</div>'

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -26,7 +26,7 @@ function render() {
       // Display response text
       var message = 'Thank you for accepting this invitation from ' + HEADER.title;
       $response.append('<div class="panel"><div class="row"><h3 style="line-height:normal;">' + message + '</h3></div></div>');
-      var email = args.user.indexOf('@') > -1 ? '(<strong>' + args.user + '</strong>) ' : '';
+      var email = args.user.indexOf('@') > -1 ? '(<strong>' + args.user + '</strong>)' : '';
 
       $response.append([
         '<div class="panel">',
@@ -34,7 +34,7 @@ function render() {
             '<h4>Please complete the following steps now:</h4>',
               '<ol>',
                 '<li><p>Log in to your OpenReview account (if you do not already have an OpenReview account, you can sign up <a style="font-weight:bold;" href="/signup">here</a>).</p></li>',
-                '<li><p>Ensure that the email address ' + email + 'that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p></li>',
+                '<li><p>Ensure that the email address ' + email + ' that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p></li>',
                 '<li><p>Complete your pending <a style="font-weight:bold;" href="/tasks">tasks</a> (if any) for ' + HEADER.subtitle + '.</p></li>',
               '</ol>',
           '</div>',

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -33,7 +33,7 @@ function render() {
           '<div class="row">',
             '<h4>Please complete the following steps now:</h4>',
               '<ol>',
-                '<li><p>Log in to your OpenReview account. If you do not already have an account, you can sign up <a style="font-weight:bold;" href="/signup">here</a>).</p></li>',
+                '<li><p>Log in to your OpenReview account. If you do not already have an account, you can sign up <a style="font-weight:bold;" href="/signup">here</a>.</p></li>',
                 '<li><p>Ensure that the email address ' + email + ' that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p></li>',
                 '<li><p>Complete your pending <a style="font-weight:bold;" href="/tasks">tasks</a> (if any) for ' + HEADER.subtitle + '.</p></li>',
               '</ol>',

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -30,8 +30,12 @@ function render() {
       $response.append([
         '<div class="panel">',
           '<div class="row">',
-            '<p>If you do not already have an OpenReview account, please sign up <a style="font-weight:bold;" href="/signup">here</a>.</p>',
-            '<p>If you have an existing OpenReview account, please ensure that the email address that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p>',
+            '<h4>Please complete the following steps now:</h4>',
+              '<ol>',
+                '<li><p>Log in to your OpenReview account (if you do not already have an OpenReview account, you can sign up <a style="font-weight:bold;" href="/signup">here</a>).</p></li>',
+                '<li><p>Ensure that the email address that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p></li>',
+                '<li><p>Complete your pending <a style="font-weight:bold;" href="/tasks">tasks</a> for ' + HEADER.subtitle + '.</p></li>',
+              '</ol>',
           '</div>',
         '</div>'
       ].join('\n'));


### PR DESCRIPTION
Updated based on Melisa's comments:
1. Showing user's email if available.
2. Showing `if any` for the instruction asking user to complete their tasks.

<img width="1440" alt="Screen Shot 2020-06-19 at 6 06 31 PM" src="https://user-images.githubusercontent.com/13500158/85133106-b104c480-b257-11ea-8594-bd1c6d16280d.png">

