### PR TITLE
Create paper groups + Add conference to active_venues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,9 @@ jobs:
     working_directory: ~/openreview-py-repo
     docker:
       - image: circleci/node:12.13.1
-      - image: circleci/redis:3-stretch
-      - image: circleci/mongo:3.6-stretch
-      - image: elastic/elasticsearch:6.2.2
+      - image: circleci/redis:6.0.0
+      - image: circleci/mongo:3.6.4
+      - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
     steps:
       - checkout
       - run: sudo apt-get update

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -642,13 +642,13 @@ class Conference(object):
         return blinded_notes
 
     def setup_venue_papers(self):
-        if self.submission_stage.due_date < datetime.datetime.now():
+        if not self.submission_stage.due_date or self.submission_stage.due_date < datetime.datetime.now():
             # Due date is in the past
             if self.submission_stage.double_blind:
                 # Double Blind venue
                 self.create_blind_submissions()
             else:
-                # Single Blind OR Open venue
+                # Single Blind or Open venue
                 self.create_paper_groups(authors=True, reviewers=True, area_chairs=True)
             
             reveal_authors = False

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -641,7 +641,7 @@ class Conference(object):
 
         return blinded_notes
 
-    def setup_venue_papers(self):
+    def setup_post_submission_stage(self):
         if not self.submission_stage.due_date or self.submission_stage.due_date < datetime.datetime.now():
             # Due date is in the past
             if self.submission_stage.double_blind:
@@ -656,6 +656,11 @@ class Conference(object):
                 reveal_authors = True
             self.create_withdraw_invitations(reveal_authors=reveal_authors, reveal_submission=False)
             self.create_desk_reject_invitations(reveal_authors=reveal_authors, reveal_submission=False)
+
+            self.set_authors()
+            self.set_reviewers()
+            if self.use_area_chairs:
+                self.set_area_chairs()
 
     ## Deprecated
     def open_bids(self):

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -576,6 +576,9 @@ class Conference(object):
         if author_group_ids:
             self.__create_group(self.get_authors_id(), self.id, author_group_ids, public=True)
 
+        # Add this group to active_venues
+        active_venues = self.client.get_group('active_venues')
+        self.client.add_members_to_group(active_venues, self.id)
 
     def create_blind_submissions(self, force=False, hide_fields=[]):
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -827,10 +827,7 @@ class Conference(object):
         return self.__set_reviewer_page()
 
     def set_authors(self):
-        authors_group = self.__create_group(
-            self.get_authors_id(), 
-            self.id, 
-            public=False)
+        authors_group = self.__create_group(self.get_authors_id(), self.id, public=True)
         return self.webfield_builder.set_author_page(self, authors_group)
 
     def setup_matching(self, is_area_chair=False, affinity_score_file=None, tpms_score_file=None, elmo_score_file=None, build_conflicts=False):

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -77,7 +77,7 @@ def get_conference_builder(client, request_form_id, support_user):
     if note.content.get('Area Chairs (Metareviewers)', '') in ['Yes, our venue has Area Chairs', 'Yes, our conference has Area Chairs']:
         builder.has_area_chairs(True)
 
-    double_blind = (note.content.get('Author and Reviewer Anonymity', None) == 'Double-blind')
+    double_blind = (note.content.get('Author and Reviewer Anonymity', '') == 'Double-blind')
 
     public = (note.content.get('Open Reviewing Policy', '') in ['Submissions and reviews should both be public.', 'Submissions should be public, but reviews should be private.'])
 
@@ -88,6 +88,16 @@ def get_conference_builder(client, request_form_id, support_user):
         submission_additional_options = json.loads(submission_additional_options.strip())
 
     submission_remove_options = note.content.get('remove_submission_options', [])
+    withdrawn_submission_public = 'Yes' in note.content.get('withdrawn_submissions_visibility', '')
+    email_pcs_on_withdraw = 'Yes' in note.content.get('email_pcs_for_withdrawn_submissions', '')
+    desk_rejected_submission_public = 'Yes' in note.content.get('desk_rejected_submissions_visibility', '')
+    
+    # Authors can not be anonymized only if venue is double-blind
+    withdrawn_submission_author_anonymous = False
+    desk_rejected_submission_author_anonymous = False
+    if double_blind:
+        withdrawn_submission_author_anonymous = 'Yes' in note.content.get('withdrawn_submissions_author_anonymity', '')
+        desk_rejected_submission_author_anonymous = 'Yes' in note.content.get('desk_rejected_submissions_author_anonymity', '')
 
     # Create review invitation during submission process function only when the venue is public, single blind and the review stage is setup.
     create_review_invitation = (not double_blind) and note.content.get('Open Reviewing Policy', '') == 'Submissions and reviews should both be public.' and note.content.get('make_reviews_public', None)
@@ -101,8 +111,12 @@ def get_conference_builder(client, request_form_id, support_user):
         remove_fields = submission_remove_options,
         email_pcs=False, ## Need to add this setting to the form
         create_groups=(not double_blind),
-        create_review_invitation=create_review_invitation
-        )
+        create_review_invitation=create_review_invitation,
+        withdrawn_submission_public=withdrawn_submission_public,
+        withdrawn_submission_author_anonymous=withdrawn_submission_author_anonymous,
+        email_pcs_on_withdraw=email_pcs_on_withdraw,
+        desk_rejected_submission_public=desk_rejected_submission_public,
+        desk_rejected_submission_author_anonymous=desk_rejected_submission_author_anonymous)
 
     paper_matching_options = note.content.get('Paper Matching', [])
     if 'OpenReview Affinity' in paper_matching_options:

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1501,7 +1501,7 @@ class InvitationBuilder(object):
                     "tag": {
                         "description": "Select value",
                         "order": 1,
-                        "value-regex": 'No Ranking|[0-9]+\sof\s[0-9]+',
+                        "value-regex": r'No Ranking|[0-9]+\sof\s[0-9]+',
                         "required": True
                     }
                 }

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -14,8 +14,11 @@ def process(client, note, invitation):
 
     invitation_type = invitation.id.split('/')[-1]
     if invitation_type in ['Bid_Stage', 'Review_Stage', 'Meta_Review_Stage', 'Decision_Stage']:
-        if conference.submission_stage.double_blind and conference.submission_stage.due_date < datetime.datetime.now():
-            conference.create_blind_submissions()
+        if conference.submission_stage.due_date < datetime.datetime.now():
+            if conference.submission_stage.double_blind:
+                conference.create_blind_submissions()
+            else:
+                conference.create_paper_groups(authors=True, reviewers=True, area_chairs=True)
         conference.set_authors()
         conference.set_reviewers()
         if conference.use_area_chairs:

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -14,11 +14,8 @@ def process(client, note, invitation):
 
     invitation_type = invitation.id.split('/')[-1]
     if invitation_type in ['Bid_Stage', 'Review_Stage', 'Meta_Review_Stage', 'Decision_Stage']:
-        conference.setup_venue_papers()
-        conference.set_authors()
-        conference.set_reviewers()
-        if conference.use_area_chairs:
-            conference.set_area_chairs()
+        conference.setup_post_submission_stage()
+        
         if invitation_type == 'Bid_Stage':
             conference.setup_matching(build_conflicts=True)
             if forum_note.content.get('Area Chairs (Metareviewers)', '') == 'Yes, our venue has Area Chairs':

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -14,11 +14,7 @@ def process(client, note, invitation):
 
     invitation_type = invitation.id.split('/')[-1]
     if invitation_type in ['Bid_Stage', 'Review_Stage', 'Meta_Review_Stage', 'Decision_Stage']:
-        if conference.submission_stage.due_date < datetime.datetime.now():
-            if conference.submission_stage.double_blind:
-                conference.create_blind_submissions()
-            else:
-                conference.create_paper_groups(authors=True, reviewers=True, area_chairs=True)
+        conference.setup_venue_papers()
         conference.set_authors()
         conference.set_reviewers()
         if conference.use_area_chairs:

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -15,12 +15,11 @@ def process(client, note, invitation):
     invitation_type = invitation.id.split('/')[-1]
     if invitation_type in ['Bid_Stage', 'Review_Stage', 'Meta_Review_Stage', 'Decision_Stage', 'Submission_Revision_Stage']:
         conference.setup_post_submission_stage()
-        if invitation_type == 'Bid_Stage':
-            conference.setup_matching(build_conflicts=True)
-            if forum_note.content.get('Area Chairs (Metareviewers)', '') == 'Yes, our venue has Area Chairs':
-                conference.setup_matching(is_area_chair=True, build_conflicts=True)
 
     if invitation_type == 'Bid_Stage':
+        conference.setup_matching(build_conflicts=True)
+        if forum_note.content.get('Area Chairs (Metareviewers)', '') == 'Yes, our venue has Area Chairs':
+            conference.setup_matching(is_area_chair=True, build_conflicts=True)
         conference.set_bid_stage(openreview.helpers.get_bid_stage(client, forum_note))
 
     elif invitation_type == 'Review_Stage':

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -505,7 +505,9 @@ class VenueRequest():
                     'OpenReview Affinity',
                     'TPMS'
                 ],
-                'order': 17
+                'order': 17,
+                'required': True,
+                'default': ['OpenReview Affinity']
             },
             'Author and Reviewer Anonymity': {
                 'description': 'What policy best describes your anonymity policy? (If none of the options apply then please describe your request below)',
@@ -514,7 +516,8 @@ class VenueRequest():
                     'Single-blind (Reviewers are anonymous)',
                     'No anonymity'
                 ],
-                'order': 18
+                'order': 18,
+                'required': True
             },
             'Open Reviewing Policy': {
                 'description': 'Should submitted papers and/or reviews be visible to the public? (This is independent of anonymity policy)',
@@ -523,7 +526,8 @@ class VenueRequest():
                     'Submissions should be public, but reviews should be private.',
                     'Submissions and reviews should both be public.'
                 ],
-                'order': 19
+                'order': 19,
+                'required': True
             },
             'Public Commentary': {
                 'description': 'Would you like to allow members of the public to comment on papers?',
@@ -534,20 +538,61 @@ class VenueRequest():
                 ],
                 'order': 20
             },
+            'withdrawn_submissions_visibility': {
+                'description': 'Would you like to make withdrawn submissions public?',
+                'value-radio': [
+                    'Yes, withdrawn submissions should be made public.', 
+                    'No, withdrawn submissions should not be made public.'],
+                'default': 'No, withdrawn submissions should not be made public.',
+                'order': 21
+            },
+            'withdrawn_submissions_author_anonymity': {
+                'description': 'Would you like to make authors of withdrawn papers anonymous? Note: Authors can only be anonymized for Double blind submissions.',
+                'value-radio': [
+                    'Yes, authors of withdrawn submissions should be anonymized.', 
+                    'No, authors of withdrawn submissions should not be anonymized.'],
+                'default': 'No, authors of withdrawn submissions should not be anonymized.',
+                'order': 22
+            },
+            'email_pcs_for_withdrawn_submissions': {
+                'description': 'Do you want email notifications to PCs when a submission is withdrawn?',
+                'value-radio': [
+                    'Yes, email PCs.',
+                    'No, do not email PCs.'
+                ],
+                'default': 'No, do not email PCs.',
+                'order': 23
+            },
+            'desk_rejected_submissions_visibility': {
+                'description': 'Would you like to make desk rejected submissions public?',
+                'value-radio': [
+                    'Yes, desk rejected submissions should be made public.', 
+                    'No, desk rejected submissions should not be made public.'],
+                'default': 'No, desk rejected submissions should not be made public.',
+                'order': 24
+            },
+            'desk_rejected_submissions_author_anonymity': {
+                'description': 'Would you like to make authors of desk rejected papers anonymous?  Note: Authors can only be anonymized for Double blind submissions.',
+                'value-radio': [
+                    'Yes, authors of desk rejected submissions should be anonymized.', 
+                    'No, authors of desk rejected submissions should not be anonymized.'],
+                'default': 'No, authors of desk rejected submissions should not be anonymized.',
+                'order': 25
+            },
             'Expected Submissions': {
                 'value-regex': '[0-9]*',
                 'description': 'How many submissions are expected in this venue? Please provide a number.',
-                'order': 21
+                'order': 26
             },
             'Other Important Information': {
                 'value-regex': '[\\S\\s]{1,5000}',
                 'description': 'Please use this space to clarify any questions for which you could not use any of the provided options, and to clarify any other information that you think we may need.',
-                'order': 22
+                'order': 27
             },
             'How did you hear about us?': {
                 'value-regex': '.*',
                 'description': 'Please briefly describe how you heard about OpenReview.',
-                'order': 23
+                'order': 28
             }
         }
 

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1132,8 +1132,6 @@ class TestDoubleBlindConference():
         recipients = [m['content']['to'] for m in messages]
         assert 'reviewer2@mail.com' in recipients
 
-
-
     def test_open_meta_reviews(self, client, test_client, selenium, request_page, helpers):
 
         now = datetime.datetime.utcnow()
@@ -1338,7 +1336,6 @@ class TestDoubleBlindConference():
         dropdown_Options=selenium.find_element_by_xpath('//*[@id="1-add-reviewer"]/div/div')
         assert len(dropdown_Options.find_elements_by_xpath('//*[@id="1-add-reviewer"]/div/div/div'))==2
 
-
     def test_open_revise_submissions(self, client, test_client, helpers):
 
         builder = openreview.conference.ConferenceBuilder(client)
@@ -1461,7 +1458,6 @@ class TestDoubleBlindConference():
         assert len(author_group.members) == 2
         assert 'AKBC.ws/2019/Conference/Paper3/Authors' not in author_group.members
 
-
     def test_desk_reject_submission(self, client, helpers):
 
         builder = openreview.conference.ConferenceBuilder(client)
@@ -1546,7 +1542,6 @@ class TestDoubleBlindConference():
         reviewer_client = openreview.Client(baseurl = 'http://localhost:3000', username='reviewer2@mail.com', password='1234')
 
         request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/Reviewer/-/Paper_Ranking", reviewer_client.token)
-
 
     def test_edit_revision_as_pc(self, client, test_client, helpers):
 

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1486,7 +1486,6 @@ class TestDoubleBlindConference():
         builder.has_area_chairs(True)
         builder.set_conference_year(2019)
         conference = builder.get_result()
-        # conference.create_withdraw_invitations(reveal_authors=True, reveal_submission=True, email_pcs=True)
         conference.setup_post_submission_stage()
 
         notes = conference.get_submissions()
@@ -1555,7 +1554,6 @@ class TestDoubleBlindConference():
         builder.set_conference_year(2019)
         conference = builder.get_result()
         conference.setup_post_submission_stage()
-        # conference.create_desk_reject_invitations(reveal_authors=True, reveal_submission=True)
 
         notes = conference.get_submissions()
         assert notes

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -838,7 +838,7 @@ class TestDoubleBlindConference():
         assert blind_submissions[0].id == blind_submissions_3[0].id
         assert blind_submissions_3[2].readers == ['everyone']
 
-    def test_setup_venue_papers(self, client, helpers, test_client, selenium, request_page):
+    def test_setup_post_submission_stage(self, client, helpers, test_client, selenium, request_page):
 
         builder = openreview.conference.ConferenceBuilder(client)
         assert builder, 'builder is None'
@@ -866,7 +866,7 @@ class TestDoubleBlindConference():
         builder.set_submission_stage(double_blind=True, public=True, additional_fields=additional_fields)
         conference = builder.get_result()
 
-        conference.setup_venue_papers()
+        conference.setup_post_submission_stage()
         blind_submissions = conference.get_submissions()
         assert not blind_submissions
 
@@ -894,7 +894,7 @@ class TestDoubleBlindConference():
         note.content['pdf'] = url
         client.post_note(note)
 
-        conference.setup_venue_papers()
+        conference.setup_post_submission_stage()
         blind_submissions_2 = conference.get_submissions()
         assert blind_submissions_2
         assert len(blind_submissions_2) == 1
@@ -921,7 +921,7 @@ class TestDoubleBlindConference():
 
         builder.set_submission_stage(public=True, double_blind=True)
         conference = builder.get_result()
-        conference.setup_venue_papers()
+        conference.setup_post_submission_stage()
         blind_submissions_3 = conference.get_submissions()
         assert blind_submissions_3
         assert len(blind_submissions_3) == 2

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -897,20 +897,18 @@ class TestDoubleBlindConference():
         assert len(blind_submissions_3) == 2
         assert blind_submissions_3[-1].readers == ['everyone']
 
-        request_page(selenium, "http://localhost:3000/forum?id=" + blind_submissions_3[-1].id, test_client.token)
+        withdraw_invitation = test_client.get_invitations(replyForum=blind_submissions_3[-1].id)
+        assert withdraw_invitation and len(withdraw_invitation) == 1
+        assert withdraw_invitation[0].id == 'AKBC.ws/2025/Conference/Paper1/-/Withdraw'
+        assert withdraw_invitation[0].invitees == ['AKBC.ws/2025/Conference/Paper1/Authors', 'OpenReview.net/Support']
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Withdraw' == reply_row.find_elements_by_class_name('btn')[0].text
-
-        conference.set_program_chairs(emails = ['akbc_pc99@mail.com'])
+        conference.set_program_chairs(emails=['akbc_pc99@mail.com'])
         pc_client = helpers.create_user('akbc_pc99@mail.com', 'AKBC', 'Pctwo')
-
-        request_page(selenium, "http://localhost:3000/forum?id=" + blind_submissions_3[-1].id, pc_client.token)
-
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Desk Reject' == reply_row.find_elements_by_class_name('btn')[0].text
+        
+        desk_reject_invitation = pc_client.get_invitations(replyForum=blind_submissions_3[-1].id)
+        assert desk_reject_invitation and len(desk_reject_invitation) == 1
+        assert desk_reject_invitation[0].id == 'AKBC.ws/2025/Conference/Paper1/-/Desk_Reject'
+        assert desk_reject_invitation[0].invitees == ['AKBC.ws/2025/Conference/Program_Chairs', 'OpenReview.net/Support']
 
     def test_author_groups_inorder(self, client):
 
@@ -1349,7 +1347,7 @@ class TestDoubleBlindConference():
         builder.set_submission_stage(double_blind = True, public = True)
         builder.set_conference_short_name('AKBC 2019')
         builder.has_area_chairs(True)
-        conference = builder.get_result()
+        builder.get_result()
 
         #Program chair user
         pc_client = openreview.Client(baseurl = 'http://localhost:3000', username='pc@mail.com', password='1234')
@@ -1388,7 +1386,7 @@ class TestDoubleBlindConference():
         builder.set_conference_short_name('AKBC 2019')
         builder.has_area_chairs(True)
         builder.enable_reviewer_reassignment(True)#enable review reassignment so that the assign_Reviewer_Textbox is rendered on page
-        conference = builder.get_result()
+        builder.get_result()
 
         #area chair to reassign reviewer
         ac_client=openreview.Client(baseurl = 'http://localhost:3000', username='ac@mail.com', password='1234')
@@ -1677,7 +1675,7 @@ class TestDoubleBlindConference():
         builder.set_conference_year(2019)
         builder.has_area_chairs(True)
         builder.set_conference_year(2019)
-        conference = builder.get_result()
+        builder.get_result()
 
         builder.set_review_stage(public=True)
         builder.get_result()
@@ -1771,7 +1769,7 @@ class TestDoubleBlindConference():
         assert len(notes) == 1
         note = notes[0]
 
-        valid_bibtex = '''@inproceedings{
+        valid_bibtex = r'''@inproceedings{
 user2019paper,
 title={Paper title {\{}REVISED{\}}},
 author={Test User and Peter User and Andrew Mc},

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1475,13 +1475,19 @@ class TestDoubleBlindConference():
         assert builder, 'builder is None'
 
         builder.set_conference_id('AKBC.ws/2019/Conference')
-        builder.set_submission_stage(double_blind = True, public = True)
+        builder.set_submission_stage(
+            double_blind=True,
+            public=True,
+            withdrawn_submission_public=True,
+            withdrawn_submission_author_anonymous=False,
+            email_pcs_on_withdraw=True)
         builder.set_conference_short_name('AKBC 2019')
         builder.set_conference_year(2019)
         builder.has_area_chairs(True)
         builder.set_conference_year(2019)
         conference = builder.get_result()
-        conference.create_withdraw_invitations(reveal_authors=True, reveal_submission=True, email_pcs=True)
+        # conference.create_withdraw_invitations(reveal_authors=True, reveal_submission=True, email_pcs=True)
+        conference.setup_post_submission_stage()
 
         notes = conference.get_submissions()
         assert notes
@@ -1509,7 +1515,7 @@ class TestDoubleBlindConference():
         assert notes
         assert len(notes) == 2
 
-        withdrawn_notes = client.get_notes(invitation = conference.submission_stage.get_withdrawn_submission_id(conference))
+        withdrawn_notes = client.get_notes(invitation=conference.submission_stage.get_withdrawn_submission_id(conference))
 
         assert len(withdrawn_notes) == 1
         assert withdrawn_notes[0].content.get('_bibtex')
@@ -1538,13 +1544,18 @@ class TestDoubleBlindConference():
         assert builder, 'builder is None'
 
         builder.set_conference_id('AKBC.ws/2019/Conference')
-        builder.set_submission_stage(double_blind = True, public = True)
+        builder.set_submission_stage(
+            double_blind=True,
+            public=True,
+            desk_rejected_submission_public=True,
+            desk_rejected_submission_author_anonymous=False)
         builder.set_conference_short_name('AKBC 2019')
         builder.set_conference_year(2019)
         builder.has_area_chairs(True)
         builder.set_conference_year(2019)
         conference = builder.get_result()
-        conference.create_desk_reject_invitations(reveal_authors=True, reveal_submission=True)
+        conference.setup_post_submission_stage()
+        # conference.create_desk_reject_invitations(reveal_authors=True, reveal_submission=True)
 
         notes = conference.get_submissions()
         assert notes

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -237,7 +237,12 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
                     "required": True
                 }
             },
-            remove_fields=['keywords'])
+            remove_fields=['keywords'],
+            withdrawn_submission_public=False,
+            withdrawn_submission_author_anonymous=True,
+            email_pcs_on_withdraw=True,
+            desk_rejected_submission_public=False,
+            desk_rejected_submission_author_anonymous=True)
 
 
         instructions = '''<p class="dark"><strong>Instructions:</strong></p>

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -898,7 +898,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
     def test_desk_reject_submission(self, conference, client, test_client, selenium, request_page):
 
         conference.close_submissions()
-        conference.create_desk_reject_invitations(reveal_submission=False)
+        conference.setup_post_submission_stage()
 
         blinded_notes = conference.get_submissions()
         assert len(blinded_notes) == 5
@@ -963,7 +963,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
     def test_withdraw_submission(self, conference, client, test_client, selenium, request_page):
 
-        conference.create_withdraw_invitations(reveal_submission=False)
+        conference.setup_post_submission_stage()
 
         blinded_notes = conference.get_submissions()
         assert len(blinded_notes) == 4

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -518,6 +518,10 @@ Please contact info@openreview.net with any questions or concerns about this int
         note = submissions[0]
         now = datetime.datetime.utcnow()
 
+        # check if conference is added in active_venues
+        active_venues = client.get_group('active_venues')
+        assert conference.id in active_venues.members
+
         for submission in submissions:
             id = conference.get_invitation_id('Supplementary_Material', submission.number)
             invitation = openreview.Invitation(

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -145,6 +145,11 @@ class TestVenueRequest():
                 'Author and Reviewer Anonymity': 'Single-blind (Reviewers are anonymous)',
                 'Open Reviewing Policy': 'Submissions and reviews should both be private.',
                 'Public Commentary': 'Yes, allow members of the public to comment non-anonymously.',
+                'withdrawn_submissions_visibility': 'No, withdrawn submissions should not be made public.',
+                'withdrawn_submissions_author_anonymity': 'No, authors of withdrawn submissions should not be anonymized.',
+                'email_pcs_for_withdrawn_submissions': 'Yes, email PCs.',
+                'desk_rejected_submissions_visibility': 'No, desk rejected submissions should not be made public.',
+                'desk_rejected_submissions_author_anonymity': 'No, authors of desk rejected submissions should not be anonymized.',
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100'
             }))


### PR DESCRIPTION
[Updated]
Note that now if you call `set_submission_stage` you need to make sure to pass the correct values for the params for withdraw and desk-reject to ensure that they are not set to their corresponding defaults.
This is because the desk-reject and withdraw params have been made a part of submission stage now.

Fixes https://github.com/openreview/openreview-py/issues/695, https://github.com/openreview/openreview-py/issues/659, https://github.com/openreview/openreview-py/issues/650