### PR TITLE
Fix invitee issue

### DIFF
--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -504,24 +504,24 @@ class TestWorkshop():
         recipients = [m['content']['to'] for m in messages]
         assert 'program_chairs@hsdip.org' in recipients
 
+        random_user = helpers.create_user(email='random_user1@mail.co', first='Random', last='User')
         note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Public_Comment',
             forum = submission.id,
             replyto = review.id,
             readers = ['everyone'],
-            writers = ['~Reviewer_Four1'],
-            signatures = ['~Reviewer_Four1'],
+            writers = ['~Random_User1'],
+            signatures = ['~Random_User1'],
             content = {
                 'title': 'Comment title',
                 'comment': 'Paper is very good!'
             }
         )
-        reviewer_client = openreview.Client(username='reviewer4@mail.com', password='1234')
-        review_note = reviewer_client.post_note(note)
-        assert review_note
+        public_comment_note = random_user.post_note(note)
+        assert public_comment_note
 
         time.sleep(2)
 
-        process_logs = client.get_process_logs(id = review_note.id)
+        process_logs = client.get_process_logs(id = public_comment_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
 


### PR DESCRIPTION
Created a new user to test successfully posting a public comment. 

The test was failing earlier because it used a reviewer user to post a public comment while the public comment invitation has added the reviewer in non-invitee list.