### PR TITLE
remove double link between pcs and conference.id

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -718,10 +718,8 @@ class Conference(object):
         # if first time, add PC console
         if not pcs.web:
             self.webfield_builder.set_program_chair_page(self, pcs)
-        ## Give program chairs admin permissions and viceversa
+        ## Give program chairs admin permissions
         self.__create_group(self.id, '~Super_User1', [self.get_program_chairs_id()])
-        self.__create_group(pcs.id, '~Super_User1', [self.id])
-
         return pcs
 
     def set_area_chairs(self, emails = []):

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -858,7 +858,7 @@ class PaperReviewRebuttalInvitation(openreview.Invitation):
         super(PaperReviewRebuttalInvitation, self).__init__(id = signature + '/-/' + review_rebuttal_stage.name,
             super = conference.get_invitation_id(review_rebuttal_stage.name),
             writers = [conference.id],
-            signatures = [conference.get_program_chairs_id()],
+            signatures = [conference.id],
             invitees = [paper_group + '/Authors'],
             reply = reply
         )

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -758,7 +758,7 @@ class PaperReviewInvitation(openreview.Invitation):
                 'values': nonreaders
             },
             'writers': {
-                'values-regex': signature_regex,
+                'values-copied': [conference.get_id(), '{signatures}'],
                 'description': 'How your identity will be displayed.'
             },
             'signatures': {
@@ -858,7 +858,7 @@ class PaperReviewRebuttalInvitation(openreview.Invitation):
         super(PaperReviewRebuttalInvitation, self).__init__(id = signature + '/-/' + review_rebuttal_stage.name,
             super = conference.get_invitation_id(review_rebuttal_stage.name),
             writers = [conference.id],
-            signatures = [conference.id],
+            signatures = [conference.get_program_chairs_id()],
             invitees = [paper_group + '/Authors'],
             reply = reply
         )

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -656,7 +656,7 @@ class TestDoubleBlindConference():
         result = conference.set_program_chairs(['pc@mail.com', 'pc2@mail.com'])
         assert result
         assert result.members
-        assert ['AKBC.ws/2019/Conference', 'akbc_pc_1@akbc.ws', 'pc@mail.com', 'pc2@mail.com'] == result.members
+        assert ['akbc_pc_1@akbc.ws', 'pc@mail.com', 'pc2@mail.com'] == result.members
 
         #Sign up as Program Chair
         pc_client = openreview.Client(baseurl = 'http://localhost:3000')

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -1096,7 +1096,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             invitation='thecvf.com/ECCV/2020/Conference/Paper1/-/Official_Review',
             readers=['thecvf.com/ECCV/2020/Conference/Program_Chairs', 'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chairs', 'thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer1'],
             nonreaders=['thecvf.com/ECCV/2020/Conference/Paper1/Authors'],
-            writers=['thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer1'],
+            writers=['thecvf.com/ECCV/2020/Conference', 'thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer1'],
             signatures=['thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer1'],
             content={
                 'summary_of_contributions': 'summary_of_contributions',
@@ -1136,7 +1136,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             invitation='thecvf.com/ECCV/2020/Conference/Paper1/-/Official_Review',
             readers=['thecvf.com/ECCV/2020/Conference/Program_Chairs', 'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chairs', 'thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer2'],
             nonreaders=['thecvf.com/ECCV/2020/Conference/Paper1/Authors'],
-            writers=['thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer2'],
+            writers=['thecvf.com/ECCV/2020/Conference', 'thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer2'],
             signatures=['thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer2'],
             content={
                 'summary_of_contributions': 'summary_of_contributions',
@@ -1469,7 +1469,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chairs',
             'thecvf.com/ECCV/2020/Conference/Paper1/Reviewers/Submitted',
             'thecvf.com/ECCV/2020/Conference/Paper1/Authors'],
-            writers=['thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer2'],
+            writers=['thecvf.com/ECCV/2020/Conference', 'thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer2'],
             signatures=['thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer2'],
             content={
                 'final_rating': '5: Weak accept',


### PR DESCRIPTION
Revert change that I made a few weeks ago. Conference.id shouldn't be member of the PC group. This will stop sending notifications to all the members of the Support group.