### PR TITLE
Fix/recommendation webfield window var

### DIFF
--- a/openreview/conference/templates/recommendationWebfield.js
+++ b/openreview/conference/templates/recommendationWebfield.js
@@ -23,7 +23,7 @@ function load() {
 
 function renderContent() {
   var params = EDGE_BROWSER_PARAMS.replace('{userId}', user.profile.id);
-  var browseUrl = window.location.origin + '/edge/browse?' + params;
+  var browseUrl = location.origin + '/edge/browse?' + params;
 
   $('#content').removeClass('legacy-styles');
   $('#notes').empty().append(


### PR DESCRIPTION
Fix reference to window var in recommendation webfield. The `window` and `document` globals should never be referenced in webfield code.