### PR TITLE
Fix the pdf size for submission invitation

### DIFF
--- a/openreview/invitations/content.py
+++ b/openreview/invitations/content.py
@@ -195,7 +195,7 @@ submission = {
         'order': 9,
         'value-file': {
             'fileTypes': ['pdf'],
-            'size': 50000000
+            'size': 50
         },
         'required':True
     }


### PR DESCRIPTION
This fixes the pdf file size in submission invitation reply template. The default size right now is incorrect.