### PR TITLE
Default header update for expertise invitation

### DIFF
--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -113,7 +113,7 @@ class WebfieldBuilder(object):
                         <b>By default, we consider all of these papers to formulate your expertise. Please click on \"Exclude\" for papers that you do  NOT want to be used to represent your expertise.</b>
                         <br>
                         <br>
-                        Your previously authored papers from selected conferences were imported automatically from <a href=https://dblp.org>DBLP.org</a>. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If there are missing DBLP papers, you can add them by editing your <a href=/profile?mode=edit>OpenReview profile</a> and then clicking on 'Add DBLP Papers to Profile'.
+                        Your previously authored papers from selected conferences were imported automatically from <a href=https://dblp.org>DBLP.org</a>. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If there are DBLP papers missing, you can add them by editing your <a href=/profile?mode=edit>OpenReview profile</a> and then clicking on 'Add DBLP Papers to Profile'.
                 </p>
                 <br>
                     Papers not automatically included as part of this import process can be uploaded by using the <b>Upload</b> button. Make sure that your email is part of the "authorids" field of the upload form. Otherwise the paper will not appear in the list, though it will be included in the recommendations process. Only upload papers co-authored by you.

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -113,7 +113,7 @@ class WebfieldBuilder(object):
                         <b>By default, we consider all of these papers to formulate your expertise. Please click on \"Exclude\" for papers that you do  NOT want to be used to represent your expertise.</b>
                         <br>
                         <br>
-                        Your previously authored papers from selected conferences were imported automatically from <a href=https://dblp.org>DBLP.org</a>. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process.
+                        Your previously authored papers from selected conferences were imported automatically from <a href=https://dblp.org>DBLP.org</a>. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If you need to upload more <a href=https://dblp.org>DBLP.org</a> papers, you can do so by going to your OpenReview profile edit page and then clicking on 'Add DBLP Papers to Profile'.
                 </p>
                 <br>
                     Papers not automatically included as part of this import process can be uploaded by using the <b>Upload</b> button. Make sure that your email is part of the "authorids" field of the upload form. Otherwise the paper will not appear in the list, though it will be included in the recommendations process. Only upload papers co-authored by you.

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -113,7 +113,7 @@ class WebfieldBuilder(object):
                         <b>By default, we consider all of these papers to formulate your expertise. Please click on \"Exclude\" for papers that you do  NOT want to be used to represent your expertise.</b>
                         <br>
                         <br>
-                        Your previously authored papers from selected conferences were imported automatically from <a href=https://dblp.org>DBLP.org</a>. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If you need to upload more <a href=https://dblp.org>DBLP.org</a> papers, you can do so by going to your OpenReview profile edit page and then clicking on 'Add DBLP Papers to Profile'.
+                        Your previously authored papers from selected conferences were imported automatically from <a href=https://dblp.org>DBLP.org</a>. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If there are missing DBLP papers, you can add them by editing your <a href=/profile?mode=edit>OpenReview profile</a> and then clicking on 'Add DBLP Papers to Profile'.
                 </p>
                 <br>
                     Papers not automatically included as part of this import process can be uploaded by using the <b>Upload</b> button. Make sure that your email is part of the "authorids" field of the upload form. Otherwise the paper will not appear in the list, though it will be included in the recommendations process. Only upload papers co-authored by you.

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -399,7 +399,7 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
 
 By default, we consider all of these papers to formulate your expertise. Please click on "Exclude" for papers that you do NOT want to be used to represent your expertise.
 
-Your previously authored papers from selected conferences were imported automatically from DBLP.org. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process.
+Your previously authored papers from selected conferences were imported automatically from DBLP.org. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If you need to upload more DBLP.org papers, you can do so by going to your OpenReview profile edit page and then clicking on 'Add DBLP Papers to Profile'.
 
 Papers not automatically included as part of this import process can be uploaded by using the Upload button. Make sure that your email is part of the "authorids" field of the upload form. Otherwise the paper will not appear in the list, though it will be included in the recommendations process. Only upload papers co-authored by you.
 

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -399,7 +399,7 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
 
 By default, we consider all of these papers to formulate your expertise. Please click on "Exclude" for papers that you do NOT want to be used to represent your expertise.
 
-Your previously authored papers from selected conferences were imported automatically from DBLP.org. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If there are missing DBLP papers, you can add them by editing your OpenReview profile and then clicking on 'Add DBLP Papers to Profile'.
+Your previously authored papers from selected conferences were imported automatically from DBLP.org. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If there are DBLP papers missing, you can add them by editing your OpenReview profile and then clicking on 'Add DBLP Papers to Profile'.
 
 Papers not automatically included as part of this import process can be uploaded by using the Upload button. Make sure that your email is part of the "authorids" field of the upload form. Otherwise the paper will not appear in the list, though it will be included in the recommendations process. Only upload papers co-authored by you.
 

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -399,7 +399,7 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
 
 By default, we consider all of these papers to formulate your expertise. Please click on "Exclude" for papers that you do NOT want to be used to represent your expertise.
 
-Your previously authored papers from selected conferences were imported automatically from DBLP.org. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If you need to upload more DBLP.org papers, you can do so by going to your OpenReview profile edit page and then clicking on 'Add DBLP Papers to Profile'.
+Your previously authored papers from selected conferences were imported automatically from DBLP.org. The keywords in these papers will be used to rank submissions for you during the bidding process, and to assign submissions to you during the review process. If there are missing DBLP papers, you can add them by editing your OpenReview profile and then clicking on 'Add DBLP Papers to Profile'.
 
 Papers not automatically included as part of this import process can be uploaded by using the Upload button. Make sure that your email is part of the "authorids" field of the upload form. Otherwise the paper will not appear in the list, though it will be included in the recommendations process. Only upload papers co-authored by you.
 


### PR DESCRIPTION
I wanted to add a link directly to the edit profile page but the end point for that is different in openreview and openreview-web.
Currently, I can use `/profile?mode=edit` but on openreview-web it is `/profile/edit`. Not wanting to add inconsistent links I skipped on adding this link to the instructions on expertise page.