### PR TITLE
remove parent group parameter when sending reminders

### DIFF
--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -494,7 +494,6 @@ var renderStatusTable = function(profiles, notes, allInvitations, completedRevie
           invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, row[2].number)
         });
         reviewerMessages.push({
-          parentGroup: REVIEWER_GROUP,
           groups: _.map(users, 'id'),
           forumUrl: forumUrl,
           subject: subject,
@@ -1051,7 +1050,6 @@ var registerEventHandlers = function() {
 
     var sendReviewerReminderEmails = function(e) {
       var postData = {
-        parentGroup: REVIEWER_GROUP,
         groups: [userId],
         forumUrl: forumUrl,
         subject: $('#message-reviewers-modal input[name="subject"]').val().trim(),
@@ -1227,7 +1225,6 @@ var registerEventHandlers = function() {
       updateReviewerContainer(paperNumber);
       promptMessage('Email has been sent to ' + view.prettyId(reviewerProfile.id) + ' about their new assignment to paper ' + paperNumber, { overlay: true });
       var postData = {
-        parentGroup: REVIEWER_GROUP,
         groups: [reviewerProfile.id],
         subject: SHORT_PHRASE + ": You have been assigned as a Reviewer for paper number " + paperNumber,
         message: 'This is to inform you that you have been assigned as a Reviewer for paper number ' + paperNumber +
@@ -1346,7 +1343,7 @@ var postReviewerEmails = function(postData) {
     postData.forumUrl
   );
 
-  return Webfield.post('/messages', _.pick(postData, ['groups', 'subject', 'message', 'parentGroup']))
+  return Webfield.post('/messages', _.pick(postData, ['groups', 'subject', 'message']))
     .then(function(response) {
       // Save the timestamp in the local storage
       for (var i = 0; i < postData.groups.length; i++) {


### PR DESCRIPTION
The AC needs to be writer of the `parentGroup` in order to use it to send messages and this is not always the case. I'm going to remove it for now. The AC can still see the messages they sent. 