### PR TITLE
Fix/improve webfields

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1711,10 +1711,7 @@ class ConferenceBuilder(object):
         id = self.conference.get_id()
         groups = self.__build_groups(id)
         for i, g in enumerate(groups[:-1]):
-            # set a landing page only where there is not special webfield
-            writable = g.details.get('writable') if g.details else True
-            if writable and (not g.web or 'VENUE_LINKS' in g.web):
-                self.webfield_builder.set_landing_page(g, groups[i-1] if i > 0 else None)
+            self.webfield_builder.set_landing_page(g, groups[i-1] if i > 0 else None)
 
         host = self.client.get_group(id = 'host')
         root_id = groups[0].id

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1152,9 +1152,19 @@ class Conference(object):
                                 url_forum=submission.forum,
                                 accepted=note_accepted,
                                 anonymous=False)
+            if note_accepted:
+                decision = re.sub(r'[Accept()\W]+', '', decision_note.content['decision'])
+                venueid = self.id
+                venue = self.short_name
+                if decision:
+                    venueid += '/' + decision
+                    venue += ' ' + decision
+                submission.content['venueid'] = venueid
+                submission.content['venue'] = venue
             self.client.post_note(submission)
 
-        self.set_homepage_decisions(decision_heading_map=decision_heading_map)
+        if decision_heading_map:
+            self.set_homepage_decisions(decision_heading_map=decision_heading_map)
         self.client.remove_members_from_group('active_venues', self.id)
 
 class SubmissionStage(object):

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1528,7 +1528,6 @@ class ConferenceBuilder(object):
         self.client = client
         self.conference = Conference(client)
         self.webfield_builder = webfield.WebfieldBuilder(client)
-        self.override_homepage = False
         self.submission_stage = None
         self.expertise_selection_stage = None
         self.registration_stage = None
@@ -1610,9 +1609,6 @@ class ConferenceBuilder(object):
 
     def set_homepage_layout(self, layout):
         self.conference.set_homepage_layout(layout)
-
-    def set_override_homepage(self, override):
-        self.override_homepage = override
 
     def has_area_chairs(self, has_area_chairs):
         self.conference.has_area_chairs(has_area_chairs)
@@ -1739,9 +1735,7 @@ class ConferenceBuilder(object):
             self.conference.set_area_chairs()
 
         home_group = groups[-1]
-        writable = home_group.details.get('writable') if home_group.details else True
-        if writable and (not home_group.web or self.override_homepage):
-            groups[-1] = self.webfield_builder.set_home_page(conference = self.conference, group = home_group, layout = self.conference.layout, options = { 'parent_group_id': groups[-2].id })
+        groups[-1] = self.webfield_builder.set_home_page(conference = self.conference, group = home_group, layout = self.conference.layout, options = { 'parent_group_id': groups[-2].id })
 
         self.conference.set_conference_groups(groups)
         if self.conference.use_area_chairs:

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -81,8 +81,6 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
 
     public = (note.content.get('Open Reviewing Policy', '') in ['Submissions and reviews should both be public.', 'Submissions should be public, but reviews should be private.'])
 
-    builder.set_override_homepage(True)
-
     submission_additional_options = note.content.get('Additional Submission Options', {})
     if isinstance(submission_additional_options, str):
         submission_additional_options = json.loads(submission_additional_options.strip())
@@ -117,7 +115,7 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
         email_pcs_on_withdraw=email_pcs_on_withdraw,
         desk_rejected_submission_public=desk_rejected_submission_public,
         desk_rejected_submission_reveal_authors=desk_rejected_submission_reveal_authors,
-        author_names_revealed=author_names_revealed, 
+        author_names_revealed=author_names_revealed,
         papers_released=papers_released)
 
     paper_matching_options = note.content.get('Paper Matching', [])

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -35,7 +35,11 @@ var availableOptions = [];
 
 // Main function is the entry point to the webfield code
 var main = function() {
-  OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
 
   renderHeader();
 

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // Constants
 var CONFERENCE_ID = '';
 var SHORT_PHRASE = '';

--- a/openreview/conference/templates/authorWebfield.js
+++ b/openreview/conference/templates/authorWebfield.js
@@ -27,7 +27,11 @@ function main() {
 
   renderHeader();
 
-  OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
 
   load().then(renderContent).then(Webfield.ui.done);
 }

--- a/openreview/conference/templates/authorWebfield.js
+++ b/openreview/conference/templates/authorWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // ------------------------------------
 // Author Console Webfield
 // ------------------------------------

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // ------------------------------------
 // Add Bid Interface
 // ------------------------------------

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -38,6 +38,12 @@ var paperDisplayOptions = {
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
+
   Webfield.ui.setup('#invitation-container', CONFERENCE_ID);  // required
 
   Webfield.ui.header(HEADER.title, HEADER.instructions);

--- a/openreview/conference/templates/expertiseBidWebfield.js
+++ b/openreview/conference/templates/expertiseBidWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // ------------------------------------
 // Add EXPERTISE SELECTION Interface
 // ------------------------------------

--- a/openreview/conference/templates/expertiseBidWebfield.js
+++ b/openreview/conference/templates/expertiseBidWebfield.js
@@ -14,6 +14,12 @@ var BUFFER = 1000 * 60 * 30;  // 30 minutes
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
+
   Webfield.ui.setup('#invitation-container', CONFERENCE_ID);  // required
 
   Webfield.ui.header(HEADER.title, HEADER.instructions);

--- a/openreview/conference/templates/landingWebfield.js
+++ b/openreview/conference/templates/landingWebfield.js
@@ -1,4 +1,5 @@
 var GROUP_ID = '';
+var PARENT_GROUP_ID = '';
 var HEADER = {
   title: '',
   description: ''
@@ -11,4 +12,11 @@ Webfield.ui.header(HEADER.title, HEADER.description, { underline: true });
 
 Webfield.ui.linksList(VENUE_LINKS);
 
-OpenBanner.welcome();
+if (args && args.referrer) {
+  OpenBanner.referrerLink(args.referrer);
+} else if (PARENT_GROUP_ID.length){
+  OpenBanner.venueHomepageLink(PARENT_GROUP_ID);
+} else {
+  OpenBanner.welcome();
+}
+

--- a/openreview/conference/templates/landingWebfield.js
+++ b/openreview/conference/templates/landingWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 var GROUP_ID = '';
 var PARENT_GROUP_ID = '';
 var HEADER = {

--- a/openreview/conference/templates/landingWebfield.js
+++ b/openreview/conference/templates/landingWebfield.js
@@ -16,7 +16,5 @@ if (args && args.referrer) {
   OpenBanner.referrerLink(args.referrer);
 } else if (PARENT_GROUP_ID.length){
   OpenBanner.venueHomepageLink(PARENT_GROUP_ID);
-} else {
-  OpenBanner.welcome();
 }
 

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // Constants
 var CONFERENCE_ID = '';
 var SHORT_PHRASE = '';

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -44,7 +44,11 @@ var paperStatusNeedsRerender = false;
 $.getScript('https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.2/FileSaver.min.js')
 
 var main = function() {
-  OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
 
   renderHeader();
 

--- a/openreview/conference/templates/recommendationWebfield.js
+++ b/openreview/conference/templates/recommendationWebfield.js
@@ -8,6 +8,12 @@ var EDGE_BROWSER_PARAMS = '';
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
+
   Webfield.ui.setup('#invitation-container', CONFERENCE_ID);  // required
 
   Webfield.ui.header(HEADER.title, HEADER.instructions);

--- a/openreview/conference/templates/recommendationWebfield.js
+++ b/openreview/conference/templates/recommendationWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // ------------------------------------
 // Recommendation Interface
 // ------------------------------------

--- a/openreview/conference/templates/recruitReducedLoadWeb.js
+++ b/openreview/conference/templates/recruitReducedLoadWeb.js
@@ -8,7 +8,11 @@ function main() {
 
   Webfield.ui.venueHeader(HEADER);
 
-  OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
 
   render();
 }

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // Constants
 var CONFERENCE_ID = '';
 var HEADER = {};

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -9,7 +9,11 @@ function main() {
 
   Webfield.ui.venueHeader(HEADER);
 
-  OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
 
   render();
 }

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // Constants
 var CONFERENCE_ID = '';
 var SUBMISSION_ID = '';

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -27,7 +27,11 @@ var main = function() {
 
   Webfield.ui.setup('#group-container', CONFERENCE_ID);  // required
 
-  OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
 
   displayHeader();
 

--- a/openreview/conference/templates/simpleConferenceWebfield.js
+++ b/openreview/conference/templates/simpleConferenceWebfield.js
@@ -7,6 +7,7 @@
 
 // Constants
 var CONFERENCE_ID = '';
+var PARENT_GROUP_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 
@@ -23,6 +24,11 @@ var paperDisplayOptions = {
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else if (PARENT_GROUP_ID.length){
+    OpenBanner.venueHomepageLink(PARENT_GROUP_ID);
+  }
   Webfield.ui.setup('#group-container', CONFERENCE_ID);  // required
 
   renderConferenceHeader();

--- a/openreview/conference/templates/simpleConferenceWebfield.js
+++ b/openreview/conference/templates/simpleConferenceWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // ------------------------------------
 // Basic venue homepage template
 //

--- a/openreview/conference/templates/tabsConferenceDecisionsWebfield.js
+++ b/openreview/conference/templates/tabsConferenceDecisionsWebfield.js
@@ -145,7 +145,9 @@ function groupNotesByDecision(notes, decisionNotes, withdrawnNotes, deskRejected
     }
   });
 
-  papersByDecision['reject'] = papersByDecision['reject'].concat(withdrawnNotes.concat(deskRejectedNotes));
+  if (papersByDecision['reject']) {
+    papersByDecision['reject'] = papersByDecision['reject'].concat(withdrawnNotes.concat(deskRejectedNotes));
+  }
 
   return papersByDecision;
 }

--- a/openreview/conference/templates/tabsConferenceDecisionsWebfield.js
+++ b/openreview/conference/templates/tabsConferenceDecisionsWebfield.js
@@ -7,6 +7,7 @@
 
 // Constants
 var CONFERENCE_ID = '';
+var PARENT_GROUP_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var WITHDRAWN_SUBMISSION_ID = '';
 var DESK_REJECTED_SUBMISSION_ID = '';
@@ -26,6 +27,11 @@ var sections = [];
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else if (PARENT_GROUP_ID.length){
+    OpenBanner.venueHomepageLink(PARENT_GROUP_ID);
+  }
   Webfield.ui.setup('#group-container', CONFERENCE_ID);  // required
 
   renderConferenceHeader();

--- a/openreview/conference/templates/tabsConferenceDecisionsWebfield.js
+++ b/openreview/conference/templates/tabsConferenceDecisionsWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // ------------------------------------
 // Advanced venue homepage template
 //

--- a/openreview/conference/templates/tabsConferenceWebfield.js
+++ b/openreview/conference/templates/tabsConferenceWebfield.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // ------------------------------------
 // Venue homepage template
 //

--- a/openreview/conference/templates/tabsConferenceWebfield.js
+++ b/openreview/conference/templates/tabsConferenceWebfield.js
@@ -7,6 +7,7 @@
 
 // Constants
 var CONFERENCE_ID = '';
+var PARENT_GROUP_ID = '';
 var SUBMISSION_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var WITHDRAWN_SUBMISSION_ID = '';
@@ -39,6 +40,12 @@ var commentDisplayOptions = {
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else if (PARENT_GROUP_ID.length){
+    OpenBanner.venueHomepageLink(PARENT_GROUP_ID);
+  }
+
   Webfield.ui.setup('#group-container', CONFERENCE_ID);  // required
 
   renderConferenceHeader();

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -21,6 +21,25 @@ class WebfieldBuilder(object):
 
         return merged_options
 
+    def __should_update(self, entity):
+        return entity.details.get('writable', False) and (not entity.web or entity.web.startswith('// webfield_template'))
+
+    def __update_invitation(self, invitation, content):
+        current_invitation=self.client.get_invitation(invitation.id)
+        if self.__should_update(current_invitation):
+            current_invitation.web = content
+            return self.client.post_invitation(current_invitation)
+        else:
+            return current_invitation
+
+    def __update_group(self, group, content):
+        current_group=self.client.get_group(group.id)
+        if self.__should_update(current_group):
+            current_group.web = content
+            return self.client.post_group(current_group)
+        else:
+            return current_group
+
     def set_landing_page(self, group, parentGroup, options = {}):
         # sets webfield to show links to child groups
 
@@ -46,8 +65,7 @@ class WebfieldBuilder(object):
                     content = content.replace("var PARENT_GROUP_ID = '';", "var PARENT_GROUP_ID = '" + parentGroup.id + "';")
                 content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
                 content = content.replace("var VENUE_LINKS = [];", "var VENUE_LINKS = " + json.dumps(links) + ";")
-                group.web = content
-                return self.client.post_group(group)
+                return self.__update_group(group, content)
 
         elif links:
             # parse existing webfield and add new links
@@ -55,8 +73,7 @@ class WebfieldBuilder(object):
             link_str = json.dumps(links)
             link_str = link_str[1:-1]
             start_pos = group.web.find('VENUE_LINKS = [') + len('VENUE_LINKS = [')
-            group.web = group.web[:start_pos] +link_str + ','+ group.web[start_pos:]
-            return self.client.post_group(group)
+            return self.__update_group(group, group.web[:start_pos] +link_str + ','+ group.web[start_pos:])
 
 
     def set_home_page(self, conference, group, layout, options = {}):
@@ -100,14 +117,7 @@ class WebfieldBuilder(object):
             content = content.replace("var DESK_REJECTED_SUBMISSION_ID = '';", "var DESK_REJECTED_SUBMISSION_ID = '" + conference.submission_stage.get_desk_rejected_submission_id(conference) + "';")
             content = content.replace("var PUBLIC = false;", "var PUBLIC = true;" if conference.submission_stage.public else "var PUBLIC = false;")
 
-            current_group = self.client.get_group(group.id)
-            writable = current_group.details.get('writable', False)
-            if writable and (not current_group.web or current_group.web.startswith('// webfield_template')):
-                current_group.web = content
-                current_group.signatures = [group.id]
-                return self.client.post_group(current_group)
-            else:
-                return group
+            return self.__update_group(group, content)
 
     def set_expertise_selection_page(self, conference, invitation):
 
@@ -140,8 +150,7 @@ class WebfieldBuilder(object):
             content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + conference.get_submission_id() + "';")
             content = content.replace("var EXPERTISE_BID_ID = '';", "var EXPERTISE_BID_ID = '" + conference.get_expertise_selection_id() + "';")
 
-            invitation.web = content
-            return self.client.post_invitation(invitation)
+            return self.__update_invitation(invitation, content)
 
     def set_bid_page(self, conference, invitation, stage):
 
@@ -212,8 +221,7 @@ class WebfieldBuilder(object):
             if stage.score_ids:
                 content = content.replace("var SCORE_IDS = [];", "var SCORE_IDS = " + json.dumps(stage.score_ids) + ";")
 
-            invitation.web = content
-            return self.client.post_invitation(invitation)
+            return self.__update_invitation(invitation, content)
 
     def set_recommendation_page(self, conference, invitation, assignment_title, score_ids, conflict_id, total_recommendations):
 
@@ -243,8 +251,7 @@ class WebfieldBuilder(object):
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var EDGE_BROWSER_PARAMS = '';", "var EDGE_BROWSER_PARAMS = '" + params + "';")
 
-            invitation.web = content
-            return self.client.post_invitation(invitation)
+            return self.__update_invitation(invitation, content)
 
     def set_paper_ranking_page(self, conference, invitation, group_name):
 
@@ -260,8 +267,7 @@ class WebfieldBuilder(object):
                 content = content.replace("var WILDCARD = '';", "var WILDCARD = '" + conference.get_id() + "/Paper.*/Area_Chairs';")
             else:
                 content = content.replace("var WILDCARD = '';", "var WILDCARD = '" + conference.get_id() + "/Paper.*/AnonReviewer.*';")
-            invitation.web = content
-            return self.client.post_invitation(invitation)
+            return self.__update_invitation(invitation, content)
 
     def set_reduced_load_page(self, conference_id, invitation, options = {}):
 
@@ -281,8 +287,7 @@ class WebfieldBuilder(object):
             content = f.read()
             content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference_id + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
-            invitation.web = content
-            return self.client.post_invitation(invitation)
+            return self.__update_invitation(invitation, content)
 
     def set_recruit_page(self, conference_id, invitation, options = {}):
 
@@ -303,8 +308,7 @@ class WebfieldBuilder(object):
             content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference_id + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var REDUCED_LOAD_INVITATION_NAME = '';", "var REDUCED_LOAD_INVITATION_NAME = 'Reduced_Load';")
-            invitation.web = content
-            return self.client.post_invitation(invitation)
+            return self.__update_invitation(invitation, content)
 
 
     def set_author_page(self, conference, group):
@@ -325,8 +329,7 @@ class WebfieldBuilder(object):
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_stage.name + "';")
             content = content.replace("var OFFICIAL_META_REVIEW_NAME = '';", "var OFFICIAL_META_REVIEW_NAME = '" + conference.meta_review_stage.name + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
-            group.web = content
-            return self.client.post_group(group)
+            return self.__update_group(group, content)
 
     def set_reviewer_page(self, conference, group):
 
@@ -353,8 +356,8 @@ class WebfieldBuilder(object):
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_stage.name + "';")
             content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = true;" if conference.legacy_invitation_id else "var LEGACY_INVITATION_ID = false;")
             content = content.replace("var REVIEW_LOAD = 0;", "var REVIEW_LOAD = " + str(conference.default_reviewer_load) + ";")
-            group.web = content
-            return self.client.post_group(group)
+            return self.__update_group(group, content)
+
 
     def set_area_chair_page(self, conference, group):
 
@@ -389,8 +392,7 @@ class WebfieldBuilder(object):
             if conference.use_secondary_area_chairs:
                 content = content.replace("var SECONDARY_AREA_CHAIR_NAME = '';", "var SECONDARY_AREA_CHAIR_NAME = '" + conference.secondary_area_chairs_name + "';")
                 content = content.replace("var OFFICIAL_SECONDARY_META_REVIEW_NAME = '';", "var OFFICIAL_SECONDARY_META_REVIEW_NAME = 'Secondary_Meta_Review';")
-            group.web = content
-            return self.client.post_group(group)
+            return self.__update_group(group, content)
 
     def set_program_chair_page(self, conference, group):
 
@@ -435,8 +437,8 @@ class WebfieldBuilder(object):
             content = content.replace("var PROGRAM_CHAIRS_ID = '';", "var PROGRAM_CHAIRS_ID = '" + conference.get_program_chairs_id() + "';")
             if conference.request_form_id:
                 content = content.replace("var REQUEST_FORM_ID = '';", "var REQUEST_FORM_ID = '" + conference.request_form_id + "';")
-            group.web = content
-            return self.client.post_group(group)
+            return self.__update_group(group, content)
+
 
     def edit_web_value(self, group, global_name, new_value):
         # replaces a value (ex. true)

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -16,7 +16,8 @@ class WebfieldBuilder(object):
             merged_options[k] = default[k]
 
         for o in options:
-            merged_options[o] = options[o]
+            if options[o] is not None:
+                merged_options[o] = options[o]
 
         return merged_options
 
@@ -100,9 +101,13 @@ class WebfieldBuilder(object):
             content = content.replace("var PUBLIC = false;", "var PUBLIC = true;" if conference.submission_stage.public else "var PUBLIC = false;")
 
             current_group = self.client.get_group(group.id)
-            current_group.web = content
-            current_group.signatures = [group.id]
-            return self.client.post_group(current_group)
+            writable = current_group.details.get('writable', False)
+            if writable and (not current_group.web or current_group.web.startswith('// webfield_template')):
+                current_group.web = content
+                current_group.signatures = [group.id]
+                return self.client.post_group(current_group)
+            else:
+                return group
 
     def set_expertise_selection_page(self, conference, invitation):
 

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -32,8 +32,10 @@ class WebfieldBuilder(object):
         else:
             return current_invitation
 
-    def __update_group(self, group, content):
+    def __update_group(self, group, content, signature=None):
         current_group=self.client.get_group(group.id)
+        if signature:
+            current_group.signatures=[signature]
         if self.__should_update(current_group):
             current_group.web = content
             return self.client.post_group(current_group)
@@ -117,7 +119,7 @@ class WebfieldBuilder(object):
             content = content.replace("var DESK_REJECTED_SUBMISSION_ID = '';", "var DESK_REJECTED_SUBMISSION_ID = '" + conference.submission_stage.get_desk_rejected_submission_id(conference) + "';")
             content = content.replace("var PUBLIC = false;", "var PUBLIC = true;" if conference.submission_stage.public else "var PUBLIC = false;")
 
-            return self.__update_group(group, content)
+            return self.__update_group(group, content, conference.id)
 
     def set_expertise_selection_page(self, conference, invitation):
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -13,7 +13,7 @@ from selenium.common.exceptions import NoSuchElementException
 
 class TestBuilder():
 
-    def test_override_homepage(self, client):
+    def test_override_homepage(self, client, selenium, request_page):
 
         builder = openreview.conference.ConferenceBuilder(client)
         assert builder, 'builder is None'
@@ -27,19 +27,16 @@ class TestBuilder():
         assert len(groups) == 3
         home_group = groups[-1]
         assert home_group.id == 'test.org/2019/Conference'
-        assert 'Venue homepage template' in home_group.web
 
-        home_group.web = 'This is a webfield'
-        client.post_group(home_group)
+        request_page(selenium, 'http://localhost:3030/group?id=test.org/2019/Conference')
+        assert selenium.find_element_by_tag_name('h3').text == 'test.org/2019/Conference'
 
+        builder.set_homepage_header({ 'subtitle': 'TEST 2019' })
         conference = builder.get_result()
-        groups = conference.get_conference_groups()
-        assert 'This is a webfield' in groups[-1].web
 
-        builder.set_override_homepage(True)
-        conference = builder.get_result()
-        groups = conference.get_conference_groups()
-        assert 'Venue homepage template' in groups[-1].web
+        request_page(selenium, 'http://localhost:3030/group?id=test.org/2019/Conference')
+        assert selenium.find_element_by_tag_name('h3').text == 'TEST 2019'
+
 
     def test_web_set_landing_page(self, client):
         builder = openreview.conference.ConferenceBuilder(client)
@@ -56,7 +53,6 @@ class TestBuilder():
         start_pos = group.web.find('VENUE_LINKS')
         insert_pos = group.web.find('];', start_pos)
         group.web = group.web[:insert_pos] + child_str + group.web[insert_pos:]
-        print(group.web)
         client.post_group(group)
 
         builder.set_conference_id("ds.cs.umass.edu/Test_I/2019/Workshop/WS_1")

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -350,7 +350,6 @@ class TestCommentNotification():
             "Algorithms: Distributed and Parallel",
             "Algorithms: Exact Inference",
         ])
-        builder.set_override_homepage(True)
         builder.set_comment_stage(email_pcs = True, unsubmitted_reviewers = False, authors=True)
         builder.set_review_stage(release_to_authors=True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED)
         conference = builder.get_result()

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1719,4 +1719,4 @@ url={'''
 }'''
         assert note.content['_bibtex'] == valid_bibtex
         assert note.content['venue'] == 'AKBC 2019 Oral'
-        assert note.content['venueid'] == 'AKBC.ws/2019/Conference/Accept'
+        assert note.content['venueid'] == 'AKBC.ws/2019/Conference/Oral'

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1683,7 +1683,7 @@ class TestDoubleBlindConference():
         builder.set_decision_stage(public=True)
         conference = builder.get_result()
 
-        conference.post_decision_stage(reveal_authors_accepted=True)
+        conference.post_decision_stage(reveal_authors_accepted=True, decision_heading_map={'Accept (Poster)': 'Accepted poster papers', 'Accept (Oral)': 'Accepted oral papers', 'Reject': 'Reject'})
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference")
         assert "AKBC 2019 Conference | OpenReview" in selenium.title
@@ -1718,3 +1718,5 @@ url={'''
         valid_bibtex = valid_bibtex+'https://openreview.net/forum?id='+note.forum+'''}
 }'''
         assert note.content['_bibtex'] == valid_bibtex
+        assert note.content['venue'] == 'AKBC 2019 Oral'
+        assert note.content['venueid'] == 'AKBC.ws/2019/Conference/Accept'

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -70,7 +70,6 @@ class TestDoubleBlindConference():
 
         builder.set_conference_id('AKBC.ws/2019/Conference')
         builder.set_conference_name('Automated Knowledge Base Construction')
-        builder.set_override_homepage(True)
         builder.has_area_chairs(True)
 
         conference = builder.get_result()
@@ -143,7 +142,6 @@ class TestDoubleBlindConference():
                 </ul></p>',
             'deadline': 'Submission Deadline: Midnight Pacific Time, Friday, November 16, 2018'
         })
-        builder.set_override_homepage(True)
         builder.has_area_chairs(True)
 
         conference = builder.get_result()

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -25,7 +25,6 @@ class TestECCVConference():
 
         builder.set_conference_id('thecvf.com/ECCV/2020/Conference')
         builder.set_conference_short_name('ECCV 2020')
-        builder.set_override_homepage(True)
         builder.has_area_chairs(True)
         builder.set_recruitment_reduced_load(['4','5','6','7'], 7)
         builder.set_homepage_header({

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -25,7 +25,6 @@ class TestICLRConference():
 
         builder.set_conference_id('ICLR.cc/2021/Conference')
         builder.set_conference_short_name('ICLR 2021')
-        builder.set_override_homepage(True)
         builder.has_area_chairs(True)
         builder.set_homepage_header({
             'title': 'International Conference on Learning Representations',

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -47,7 +47,6 @@ class TestMatching():
         builder.set_conference_program_chairs_ids(['pc1@mail.com', 'pc3@mail.com'])
         builder.set_conference_area_chairs_name('Senior_Program_Committee')
         builder.set_conference_reviewers_name('Program_Committee')
-        builder.set_override_homepage(True)
         now = datetime.datetime.utcnow()
         builder.set_submission_stage(due_date = now + datetime.timedelta(minutes = 40), double_blind= True, subject_areas=[
             "Algorithms: Approximate Inference",

--- a/tests/test_open_submissions.py
+++ b/tests/test_open_submissions.py
@@ -25,7 +25,6 @@ class TestOpenSubmissions():
 
         builder.set_conference_id('aclweb.org/ACL/2020/Workshop/NLP-COVID')
         builder.set_conference_short_name('NLP-COVID-2020')
-        builder.set_override_homepage(True)
         builder.has_area_chairs(False)
         builder.set_submission_stage(double_blind=False, public=True, due_date=now + datetime.timedelta(minutes = 40), email_pcs=True, create_groups=True, create_review_invitation=True)
         builder.set_review_stage(public=True, due_date=now + datetime.timedelta(minutes = 40), email_pcs=True)

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -89,7 +89,6 @@ class TestReviewersConference():
         now = datetime.datetime.utcnow()
         builder.set_submission_stage(due_date = now + datetime.timedelta(minutes = 40), public=True)
         builder.set_review_stage(due_date = now + datetime.timedelta(minutes = 10), allow_de_anonymization = True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED)
-        builder.set_override_homepage(True)
         conference = builder.get_result()
 
         note = openreview.Note(invitation = conference.get_submission_id(),

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -149,17 +149,16 @@ class TestSingleBlindConference():
         builder.set_conference_short_name('MLITS 2018')
         now = datetime.datetime.utcnow()
         builder.set_submission_stage(
-            due_date = now + datetime.timedelta(minutes = 40), 
-            public=True, 
-            email_pcs=True, 
-            create_groups=True, 
+            due_date = now + datetime.timedelta(minutes = 40),
+            public=True,
+            email_pcs=True,
+            create_groups=True,
             withdrawn_submission_public=True,
             withdrawn_submission_reveal_authors=True,
             desk_rejected_submission_public=True,
             desk_rejected_submission_reveal_authors=True)
 
         builder.has_area_chairs(True)
-        builder.set_override_homepage(True)
         conference = builder.get_result()
 
         invitation = client.get_invitation(conference.get_submission_id())


### PR DESCRIPTION
- Support referrer parameters in all the webfields.
- Show banner to the parent group for all the webfields, including landing pages.
- Make the decision home page optional when running post decision stage.
- Handle 'Reject' tab as optional.
- Compute 'venue' and 'venueid' for accepted papers. (In the future we can show the decision page using the venueid instead of querying the decision notes).
- Refactor home page webfield, some options were in the header json and we don't need them. 

UPDATE:
- Removed property `set_homepage_override()`
- Added a new line at the beginning of each webfield template to indicate the webfeld can be overwritten. 


Please review, feedback is welcome!