### PR TITLE
Make sure later stages do not overwrite readers and author reveal

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -97,8 +97,8 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
     # Create review invitation during submission process function only when the venue is public, single blind and the review stage is setup.
     create_review_invitation = (not double_blind) and (note.content.get('Open Reviewing Policy', '') == 'Submissions and reviews should both be public.') and note.content.get('make_reviews_public', None)
 
-    author_names_revealed = 'reveal author identities' in note.content.get('reveal_authors', '')
-    papers_released = 'papers to the public' in note.content.get('release_submissions', '')
+    author_names_revealed = 'Reveal author identities of all submissions to the public' in note.content.get('reveal_authors', '') or 'Reveal author identities of only accepted submissions to the public' in note.content.get('reveal_authors', '')
+    papers_released = 'Release all submissions to the public'in note.content.get('release_submissions', '') or 'Release only accepted submission to the public' in note.content.get('release_submissions', '')
 
     builder.set_submission_stage(
         double_blind=double_blind,

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -91,7 +91,7 @@ def process(client, note, invitation):
             reveal_authors_accepted=forum_note.content.get('reveal_authors', '') == 'Reveal author identities of only accepted submissions to the public'
         if 'release_submissions' in forum_note.content:
             release_all_notes=forum_note.content.get('release_submissions', '') == 'Release all submissions to the public'
-            release_notes_accepted=forum_note.content.get('release_submissions', '') == 'Release only accepted papers to the public'
+            release_notes_accepted=forum_note.content.get('release_submissions', '') == 'Release only accepted submission to the public'
         conference.post_decision_stage(reveal_all_authors,reveal_authors_accepted,release_all_notes,release_notes_accepted, decision_heading_map=forum_note.content.get('home_page_tab_names'))
 
     print('Conference: ', conference.get_id())

--- a/tests/test_eswc_conference.py
+++ b/tests/test_eswc_conference.py
@@ -103,7 +103,7 @@ class TestESWCConference():
         assert pc_group.web
 
     def test_submit_papers(self, conference, helpers, test_client, client):
-
+        year = datetime.datetime.now().year
         domains = ['umass.edu', 'umass.edu', 'fb.com', 'umass.edu', 'google.com', 'mit.edu']
         for i in range(1,6):
             note = openreview.Note(invitation = 'eswc-conferences.org/ESWC/2021/Conference/-/Submission',
@@ -166,10 +166,10 @@ class TestESWCConference():
             'eswc-conferences.org/ESWC/2021/Conference/Program_Chairs'
         ]
         assert withdrawn_notes[0].content['_bibtex'] == '''@misc{
-user2020paper,
+user'''+str(year)+'''paper,
 title={Paper title 1},
 author={Test User and Peter Test and Andrew Mc},
-year={2020},
+year={'''+str(year)+'''},
 url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
 }'''
         assert len(conference.get_submissions()) == 4
@@ -264,7 +264,7 @@ url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
         assert len(conference.get_submissions()) == 3
 
     def test_post_submission_stage(self, conference, helpers, test_client, client):
-
+        year = datetime.datetime.now().year
         conference.setup_final_deadline_stage(force=True)
 
         submissions = conference.get_submissions()
@@ -301,9 +301,9 @@ url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
             'eswc-conferences.org/ESWC/2021/Conference/Program_Chairs'
         ]
         assert withdrawn_notes[0].content['_bibtex'] == '''@misc{
-user2020paper,
+user'''+str(year)+'''paper,
 title={Paper title 5},
 author={Test User and Peter Test and Andrew Mc},
-year={2020},
+year={'''+str(year)+'''},
 url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
 }'''


### PR DESCRIPTION
Fixes #801 

Any stage that calls setup_post_submission_stage() was overwriting changes made by post_decision_stage because we were not setting `submission_stage.author_names_revealed` and `submission_stage.papers_released` correctly. 