### PR TITLE
Fix/request form

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1225,6 +1225,11 @@ class InvitationBuilder(object):
                 if 'nonreaders' in invitation.reply:
                     note.nonreaders = invitation.reply['nonreaders']['values']
                 self.client.post_note(note)
+            if 'values-copied' in invitation.reply['readers'] and len(note.readers) != len(invitation.reply['readers']['values-copied']):
+                note.readers = [reader.replace('{signatures}', note.signatures[0]) for reader in invitation.reply['readers']['values-copied']]
+                if 'nonreaders' in invitation.reply:
+                    note.nonreaders = invitation.reply['nonreaders']['values']
+                self.client.post_note(note)
 
     def set_submission_invitation(self, conference, under_submission=True, submission_readers=None):
 

--- a/openreview/invitations/content.py
+++ b/openreview/invitations/content.py
@@ -160,7 +160,7 @@ submission = {
         'hidden': True,
     },
     'authorids': {
-        'description': 'Search author profile by first, middle and last name or email address. If the profile is not found, you can add the author completing first, middle, last and name and author email address.',
+        'description': 'Search author profile by first, middle and last name or email address. If the profile is not found, you can add the author by completing first, middle, and last names as well as author email address.',
         'order': 3,
         'values-regex': r'~.*|([a-z0-9_\-\.]{1,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{1,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})',
         'required':True

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -246,13 +246,15 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
                 'order': 25
             },
             'release_reviews_to_reviewers': {
-                'description': 'Should the reviews be visible immediately upon posting to paper\'s reviewers regardless of whether they have reviewed the paper or not? Based on your earlier selections, default is "Yes, reviews should be immediately revealed to the all paper\'s reviewers".',
+                'description': 'Should the reviews be visible to all reviewers, all assigned reviewers, assigned reviewers who have already submitted their own review or only the author of the review immediately upon posting? Based on your earlier selections, default is "Reviews should be immediately revealed to all reviewers".',
                 'value-radio': [
-                    'Yes, reviews should be immediately revealed to the all paper\'s reviewers',
-                    'No, reviews should be immediately revealed only to the reviewers who have already reviewed the paper'
+                    'Reviews should be immediately revealed to all reviewers',
+                    'Reviews should be immediately revealed to the paper\'s reviewers',
+                    'Reviews should be immediately revealed to the paper\'s reviewers who have already submitted their review',
+                    'Review should not be revealed to any reviewer, except to the author of the review'
                 ],
                 'required': True,
-                'default': 'Yes, reviews should be immediately revealed to the all paper\'s reviewers',
+                'default': 'Reviews should be immediately revealed to all reviewers',
                 'order': 26
             },
             'email_program_chairs_about_reviews': {

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -126,7 +126,7 @@ class VenueStages():
                 'order': 25
             },
             'release_reviews_to_reviewers': {
-                'description': 'Should the reviews be visible to the reviewers',
+                'description': 'Should the reviews be visible to all reviewers, all assigned reviewers, assigned reviewers who have already submitted their own review or only the author of the review immediately upon posting?',
                 'value-radio': [
                     'Reviews should be immediately revealed to all reviewers',
                     'Reviews should be immediately revealed to the paper\'s reviewers',


### PR DESCRIPTION
- Fixes venue request form fields when reviews are public
- Updates reader of reviews when invitation.reply['readers'] is `values-copied` (Fixes #802)
- Fixes a small error in the submission's author field description