### PR TITLE
Feature/check queue

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -51,6 +51,7 @@ class Client(object):
         self.messages_url = self.baseurl + '/messages'
         self.messages_direct_url = self.baseurl + '/messages/direct'
         self.process_logs_url = self.baseurl + '/logs/process'
+        self.jobs_status = self.baseurl + '/jobs/status'
         self.venues_url = self.baseurl + '/venues'
         self.user_agent = 'OpenReviewPy/v' + str(sys.version_info[0])
 
@@ -1390,6 +1391,18 @@ class Client(object):
         response = requests.get(self.process_logs_url, params = { 'id': id, 'invitation': invitation }, headers = self.headers)
         response = self.__handle_response(response)
         return response.json()['logs']
+
+    def get_jobs_status(self):
+        """
+        **Only for Super User**. Retrieves the jobs status of the queue
+
+        :return: Jobs status
+        :rtype: dict
+        """
+
+        response = requests.get(self.jobs_status, headers=self.headers)
+        response = self.__handle_response(response)
+        return response.json()
 
 class Group(object):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,22 @@ class Helpers:
     def get_user(email):
         return openreview.Client(baseurl = 'http://localhost:3000', username = email, password = '1234')
 
+    @staticmethod
+    def await_queue():
+        super_client = openreview.Client(baseurl='http://localhost:3000', username='openreview.net', password='1234')
+        assert super_client is not None, 'Super Client is none'
+
+        while True:
+            jobs = super_client.get_jobs_status()
+            jobCount = 0
+            for jobName, job in jobs.items():
+                jobCount += job.get('waiting', 0) + job.get('active', 0) + job.get('delayed', 0)
+
+            if jobCount == 0:
+                break
+
+            time.sleep(0.5)
+
 @pytest.fixture(scope="class")
 def helpers():
     return Helpers

--- a/tests/test_agora.py
+++ b/tests/test_agora.py
@@ -6,7 +6,7 @@ from selenium.common.exceptions import NoSuchElementException
 
 class TestAgora():
 
-    def test_setup(self, client, request_page, selenium):
+    def test_setup(self, client, helpers, request_page, selenium):
 
         ##Create support group
 
@@ -54,7 +54,7 @@ class TestAgora():
 
         posted_note = author_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -92,7 +92,7 @@ class TestAgora():
 
         posted_note = editor_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -129,7 +129,7 @@ class TestAgora():
 
         posted_note = editor_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -170,7 +170,7 @@ class TestAgora():
 
         posted_note = article_editor_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -203,7 +203,7 @@ class TestAgora():
 
         posted_note = article_editor_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -240,7 +240,7 @@ class TestAgora():
 
         posted_note = reviewer_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -283,7 +283,7 @@ class TestAgora():
 
         posted_note = reviewer_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -320,7 +320,7 @@ class TestAgora():
 
         posted_note = author_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -360,7 +360,7 @@ class TestAgora():
 
         posted_note = melisa_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -402,7 +402,7 @@ class TestAgora():
 
         posted_note = author_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -442,7 +442,7 @@ class TestAgora():
 
         posted_note = article_editor_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -484,7 +484,7 @@ class TestAgora():
 
         posted_note = author_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1
@@ -509,7 +509,7 @@ class TestAgora():
 
         posted_note = editor_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -51,7 +51,7 @@ class TestCommentNotification():
         note = test_client.post_note(note)
         assert note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = note.id)
         assert logs
@@ -84,7 +84,7 @@ class TestCommentNotification():
             }
         )
         comment_note = reviewer_client.post_note(comment_note)
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = comment_note.id)
         assert logs
@@ -142,7 +142,7 @@ class TestCommentNotification():
 
         reply_comment_note = test_client.post_note(reply_comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         messages = client.get_messages(to = 'author@mail.com')
         assert messages
@@ -197,7 +197,7 @@ class TestCommentNotification():
 
         reply2_comment_note = reviewer_client.post_note(reply2_comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         messages = client.get_messages(to = 'author@mail.com')
         assert messages
@@ -271,7 +271,7 @@ class TestCommentNotification():
 
         reply3_comment_note = pc_client.post_note(reply3_comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         messages = client.get_messages(to = 'author@mail.com')
         assert messages
@@ -374,7 +374,7 @@ class TestCommentNotification():
         note = test_client.post_note(note)
         assert note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = note.id)
         assert logs
@@ -420,7 +420,7 @@ class TestCommentNotification():
         review_note = reviewer_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = review_note.id)
         assert logs
@@ -467,7 +467,7 @@ class TestCommentNotification():
         )
         comment_note = reviewer_client.post_note(comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = comment_note.id)
         assert logs
@@ -514,7 +514,7 @@ class TestCommentNotification():
         review_note = reviewer2_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = review_note.id)
         assert logs
@@ -556,7 +556,7 @@ class TestCommentNotification():
         )
         comment_note = reviewer_client.post_note(comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = comment_note.id)
         assert logs
@@ -648,7 +648,7 @@ class TestCommentNotification():
         note = test_client.post_note(note)
         assert note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = note.id)
         assert logs
@@ -684,7 +684,7 @@ class TestCommentNotification():
         )
         comment_note = reviewer_client.post_note(comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = comment_note.id)
         assert logs
@@ -738,7 +738,7 @@ class TestCommentNotification():
         )
         reply_comment_note = test_client.post_note(reply_comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = reply_comment_note.id)
         assert logs
@@ -794,7 +794,7 @@ class TestCommentNotification():
 
         reply2_comment_note = reviewer_client.post_note(reply2_comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = reply2_comment_note.id)
         assert logs
@@ -861,7 +861,7 @@ class TestCommentNotification():
 
         reply3_comment_note = pc_client.post_note(reply3_comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = reply3_comment_note.id)
         assert logs
@@ -956,7 +956,7 @@ class TestCommentNotification():
         note = test_client.post_note(note)
         assert note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = note.id)
         assert logs
@@ -990,7 +990,7 @@ class TestCommentNotification():
         )
         comment_note = reviewer_client.post_note(comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = comment_note.id)
         assert logs
@@ -1043,7 +1043,7 @@ class TestCommentNotification():
         )
         reply_comment_note = test_client.post_note(reply_comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = reply_comment_note.id)
         assert logs
@@ -1100,7 +1100,7 @@ class TestCommentNotification():
 
         reply3_comment_note = pc_client.post_note(reply3_comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = reply3_comment_note.id)
         assert logs
@@ -1150,7 +1150,7 @@ class TestCommentNotification():
         assert messages[0]['content']['subject'] == 'OpenReview signup confirmation'
         assert messages[1]['content']['subject'] == '[COLT 2017] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
 
-    def test_notify_except_authors_are_program_chairs(self, client, test_client):
+    def test_notify_except_authors_are_program_chairs(self, client, helpers, test_client):
 
         builder = openreview.conference.ConferenceBuilder(client)
 
@@ -1201,7 +1201,7 @@ class TestCommentNotification():
         )
         comment_note = reviewer_client.post_note(comment_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = comment_note.id)
         assert logs

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1039,7 +1039,7 @@ class TestDoubleBlindConference():
         review_note = reviewer_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
@@ -1122,7 +1122,7 @@ class TestDoubleBlindConference():
         review_note = reviewer_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
@@ -1264,7 +1264,7 @@ class TestDoubleBlindConference():
 
         decision_note = pc_client.post_note(note)
         assert decision_note
-        time.sleep(2)
+        helpers.await_queue()
 
         accepted_author_group = client.get_group(conference.get_accepted_authors_id())
         assert accepted_author_group
@@ -1456,7 +1456,7 @@ class TestDoubleBlindConference():
         posted_note = test_client.post_note(withdrawal_note)
         assert posted_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         notes = conference.get_submissions()
         assert notes
@@ -1525,7 +1525,7 @@ class TestDoubleBlindConference():
         posted_note = pc_client.post_note(desk_reject_note)
         assert posted_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         notes = conference.get_submissions()
         assert notes
@@ -1737,7 +1737,7 @@ url={'''
         assert accepted_authors
         assert accepted_authors.members == ['AKBC.ws/2019/Conference/Paper1/Authors']
 
-    def test_enable_camera_ready_revisions(self, client, test_client):
+    def test_enable_camera_ready_revisions(self, client, test_client, helpers):
 
         builder = openreview.conference.ConferenceBuilder(client)
         assert builder, 'builder is None'
@@ -1805,7 +1805,7 @@ url={'''
         posted_note = test_client.post_note(note)
         assert posted_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -490,12 +490,12 @@ Please contact info@openreview.net with any questions or concerns about this int
             )
             test_client.post_note(note)
 
-    def test_submission_edit(self, conference, client, test_client):
+    def test_submission_edit(self, conference, client, helpers, test_client):
 
         existing_notes = client.get_notes(invitation = conference.get_submission_id())
         assert len(existing_notes) == 5
 
-        time.sleep(2)
+        helpers.await_queue()
         note = existing_notes[0]
         process_logs = client.get_process_logs(id = note.id)
         assert len(process_logs) == 1
@@ -509,7 +509,7 @@ Please contact info@openreview.net with any questions or concerns about this int
         note.content['title'] = 'I have been updated'
         client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
         note = client.get_note(note.id)
 
         process_logs = client.get_process_logs(id = note.id)
@@ -920,7 +920,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             weight = 1
         ))
 
-    def test_desk_reject_submission(self, conference, client, test_client, selenium, request_page):
+    def test_desk_reject_submission(self, conference, client, test_client, selenium, request_page, helpers):
 
         conference.close_submissions()
         conference.setup_post_submission_stage(force=True)
@@ -949,7 +949,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         posted_note = pc_client.post_note(desk_reject_note)
         assert posted_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = posted_note.id)
         assert logs
@@ -986,7 +986,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
         assert len(papers.find_elements_by_tag_name('tr')) == 5
 
-    def test_withdraw_submission(self, conference, client, test_client, selenium, request_page):
+    def test_withdraw_submission(self, conference, client, test_client, selenium, request_page, helpers):
 
         conference.setup_post_submission_stage(force=True)
 
@@ -1014,7 +1014,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         posted_note = test_client.post_note(withdrawal_note)
         assert posted_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         logs = client.get_process_logs(id = posted_note.id)
         assert logs
@@ -1047,7 +1047,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
         assert len(papers.find_elements_by_tag_name('tr')) == 4
 
-    def test_review_stage(self, conference, client, test_client, selenium, request_page):
+    def test_review_stage(self, conference, client, test_client, selenium, request_page, helpers):
 
         conference.set_assignment('~AreaChair_ECCV_One1', 1, is_area_chair=True)
         conference.set_assignment('~AreaChair_ECCV_One1', 2, is_area_chair=True)
@@ -1143,7 +1143,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             }
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -1183,7 +1183,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             }
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -1206,7 +1206,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         ## Authors
         assert not client.get_messages(subject = '[ECCV 2020] Review posted to your submission - Paper number: 1, Paper title: "Paper title 1"')
 
-    def test_comment_stage(self, conference, client, test_client, selenium, request_page):
+    def test_comment_stage(self, conference, client, test_client, selenium, request_page, helpers):
 
         conference.set_comment_stage(openreview.CommentStage(official_comment_name='Confidential_Comment', reader_selection=True, unsubmitted_reviewers=True))
 
@@ -1227,7 +1227,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             }
         ))
         assert comment_note
-        time.sleep(2)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id = comment_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -1398,7 +1398,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
                 signatures = ['thecvf.com/ECCV/2020/Conference/Paper1/AnonReviewer2'])
             )
 
-    def test_rebuttal_stage(self, conference, client, test_client, selenium, request_page):
+    def test_rebuttal_stage(self, conference, client, test_client, selenium, request_page, helpers):
 
         blinded_notes = conference.get_submissions()
 
@@ -1433,7 +1433,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             }
         ))
         assert rebuttal_note
-        time.sleep(2)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id = rebuttal_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -1454,7 +1454,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         assert 'reviewer1@fb.com' in recipients
         assert 'ac1@eccv.org' in recipients
 
-    def test_revise_review_stage(self, conference, client, test_client, selenium, request_page):
+    def test_revise_review_stage(self, conference, client, test_client, selenium, request_page, helpers):
 
         blinded_notes = conference.get_submissions()
 
@@ -1512,7 +1512,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             }
         ))
         assert review_revision_note
-        time.sleep(2)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id = review_revision_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'

--- a/tests/test_eswc_conference.py
+++ b/tests/test_eswc_conference.py
@@ -155,7 +155,7 @@ class TestESWCConference():
             }
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
 
         withdrawn_notes = client.get_notes(invitation='eswc-conferences.org/ESWC/2021/Conference/-/Withdrawn_Submission')
         assert len(withdrawn_notes) == 1
@@ -199,7 +199,7 @@ url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
 
         test_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         author_group = client.get_group('eswc-conferences.org/ESWC/2021/Conference/Paper2/Authors')
         assert len(author_group.members) == 3
@@ -222,7 +222,7 @@ url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
         revision_note.content['title'] = 'EDITED Rev 2 Paper title 5'
         test_client.post_note(revision_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         messages = client.get_messages(subject='ESWC 2021 has received a new revision of your submission titled EDITED Rev 2 Paper title 5')
         assert len(messages) == 3
@@ -251,7 +251,7 @@ url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
             }
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
 
         desk_rejected_notes = client.get_notes(invitation='eswc-conferences.org/ESWC/2021/Conference/-/Desk_Rejected_Submission')
         assert len(desk_rejected_notes) == 1
@@ -287,7 +287,7 @@ url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
             }
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
 
         withdrawn_notes = client.get_notes(invitation='eswc-conferences.org/ESWC/2021/Conference/-/Withdrawn_Submission')
         assert len(withdrawn_notes) == 2

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -550,7 +550,7 @@ Naila, Katja, Alice, and Ivan
 
         test_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         author_group = client.get_group('ICLR.cc/2021/Conference/Paper5/Authors')
         assert len(author_group.members) == 3
@@ -573,7 +573,7 @@ Naila, Katja, Alice, and Ivan
         revision_note.content['title'] = 'EDITED Rev 2 Paper title 5'
         test_client.post_note(revision_note)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         messages = client.get_messages(subject='ICLR 2021 has received a new revision of your submission titled EDITED Rev 2 Paper title 5')
         assert len(messages) == 3
@@ -602,7 +602,7 @@ Naila, Katja, Alice, and Ivan
             }
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
 
         withdrawn_notes = client.get_notes(invitation='ICLR.cc/2021/Conference/-/Withdrawn_Submission')
         assert len(withdrawn_notes) == 1
@@ -639,7 +639,7 @@ Naila, Katja, Alice, and Ivan
             }
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
 
         withdrawn_notes = client.get_notes(invitation='ICLR.cc/2021/Conference/-/Withdrawn_Submission')
         assert len(withdrawn_notes) == 2

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1038,7 +1038,7 @@ class TestMatching():
             signatures=['auai.org/UAI/2019/Conference/Paper1/AnonReviewer1']
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'

--- a/tests/test_open_submissions.py
+++ b/tests/test_open_submissions.py
@@ -36,7 +36,7 @@ class TestOpenSubmissions():
         return conference
 
 
-    def test_post_submission(self, client, conference, test_client):
+    def test_post_submission(self, client, conference, test_client, helpers):
 
         note = openreview.Note(invitation = conference.get_submission_id(),
             readers = [conference.id, '~Test_User1', 'peter@mail.com', 'andrew@mail.com'],
@@ -53,7 +53,7 @@ class TestOpenSubmissions():
         note.content['pdf'] = url
         note = test_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
         note = client.get_note(note.id)
 
         process_logs = client.get_process_logs(id = note.id)
@@ -78,7 +78,7 @@ class TestOpenSubmissions():
         assert client.get_group('aclweb.org/ACL/2020/Workshop/NLP-COVID/Paper1/Reviewers/Submitted')
         assert client.get_invitation('aclweb.org/ACL/2020/Workshop/NLP-COVID/Paper1/-/Official_Review')
 
-    def test_post_comments(self, client, conference, test_client):
+    def test_post_comments(self, client, conference, test_client, helpers):
 
         submissions = conference.get_submissions()
         assert submissions
@@ -101,7 +101,7 @@ class TestOpenSubmissions():
         )
         note = test_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
         note = client.get_note(note.id)
 
         process_logs = client.get_process_logs(id = note.id)
@@ -134,7 +134,7 @@ class TestOpenSubmissions():
         )
         note = pc_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
         note = client.get_note(note.id)
 
         process_logs = client.get_process_logs(id = note.id)

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -140,7 +140,7 @@ class TestSingleBlindConference():
         assert tabs.find_element_by_id('recent-activity')
         assert len(tabs.find_element_by_id('recent-activity').find_elements_by_tag_name('ul')) == 0
 
-    def test_post_submissions(self, client, test_client, peter_client, selenium, request_page):
+    def test_post_submissions(self, client, test_client, peter_client, selenium, request_page, helpers):
 
         builder = openreview.conference.ConferenceBuilder(client)
         assert builder, 'builder is None'
@@ -188,7 +188,7 @@ class TestSingleBlindConference():
         note.content['pdf'] = url
         note = test_client.post_note(note)
 
-        time.sleep(2)
+        helpers.await_queue()
         note = client.get_note(note.id)
 
         process_logs = client.get_process_logs(id = note.id)
@@ -446,7 +446,7 @@ class TestSingleBlindConference():
         review_note = reviewer_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
@@ -493,7 +493,7 @@ class TestSingleBlindConference():
         review_note = reviewer2_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         notes = reviewer2_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/Paper1/-/Official_Review')
         assert len(notes) == 2
@@ -709,7 +709,7 @@ url={https://openreview.net/forum?id='''
 
         assert submissions[0].content['_bibtex'] == valid_bibtex
 
-    def test_enable_camera_ready_revisions(self, client, test_client):
+    def test_enable_camera_ready_revisions(self, client, test_client, helpers):
 
         builder = openreview.conference.ConferenceBuilder(client)
         assert builder, 'builder is None'
@@ -745,7 +745,7 @@ url={https://openreview.net/forum?id='''
         posted_note = test_client.post_note(note)
         assert posted_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = posted_note.id)
         assert len(process_logs) == 1

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -8,12 +8,12 @@ from openreview import VenueRequest
 class TestVenueRequest():
 
     @pytest.fixture(scope='class')
-    def venue(self, client, support_client, test_client):
+    def venue(self, client, support_client, test_client, helpers):
         super_id = 'openreview.net'
         support_group_id = super_id + '/Support'
         VenueRequest(client, support_group_id, super_id)
 
-        time.sleep(2)
+        helpers.await_queue()
 
         # Add support group user to the support group object
         support_group = client.get_group(support_group_id)
@@ -54,7 +54,7 @@ class TestVenueRequest():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100'
             }))
-        time.sleep(5)
+        helpers.await_queue()
 
         # Post a deploy note
         client.post_note(openreview.Note(
@@ -76,7 +76,7 @@ class TestVenueRequest():
         }
         return venue_details
 
-    def test_venue_setup(self, client):
+    def test_venue_setup(self, client, helpers):
 
         super_id = 'openreview.net'
         support_group_id = super_id + '/Support'
@@ -101,7 +101,7 @@ class TestVenueRequest():
         support_group_id = super_id + '/Support'
         VenueRequest(client, support_group_id, super_id)
 
-        time.sleep(2)
+        helpers.await_queue()
         request_page(selenium, 'http://localhost:3030/group?id={}&mode=default'.format(support_group_id), client.token)
 
         helpers.create_user('new_test_user@mail.com', 'Newtest', 'User')
@@ -182,13 +182,13 @@ class TestVenueRequest():
         ))
         assert deploy_note
 
-        time.sleep(5)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id=deploy_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
         assert process_logs[0]['invitation'] == '{}/-/Request{}/Deploy'.format(support_group_id, request_form_note.number)
 
-    def test_venue_revision(self, client, test_client, selenium, request_page, venue):
+    def test_venue_revision(self, client, test_client, selenium, request_page, venue, helpers):
 
         # Test Revision
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token)
@@ -235,7 +235,7 @@ class TestVenueRequest():
         ))
         assert venue_revision_note
 
-        time.sleep(5)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id=venue_revision_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -248,7 +248,7 @@ class TestVenueRequest():
         assert title_tag
         assert title_tag.text == '{} Updated'.format(venue['request_form_note'].content['title'])
 
-    def test_venue_recruitment(self, client, test_client, selenium, request_page, venue):
+    def test_venue_recruitment(self, client, test_client, selenium, request_page, venue, helpers):
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token)
@@ -277,7 +277,7 @@ class TestVenueRequest():
         ))
         assert recruitment_note
 
-        time.sleep(5)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id=recruitment_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -293,7 +293,7 @@ class TestVenueRequest():
         assert messages[0]['content']['subject'] == '[TestVenue@OR2030] Invitation to serve as reviewer'
         assert messages[0]['content']['text'].startswith('Dear Reviewer Two,\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as reviewer.')
 
-    def test_venue_remind_recruitment(self, client, test_client, selenium, request_page, venue):
+    def test_venue_remind_recruitment(self, client, test_client, selenium, request_page, venue, helpers):
 
         # Test Reviewer Remind Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token)
@@ -320,7 +320,7 @@ class TestVenueRequest():
         ))
         assert remind_recruitment_note
 
-        time.sleep(5)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id=remind_recruitment_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -368,7 +368,7 @@ class TestVenueRequest():
         ))
         assert bid_stage_note
 
-        time.sleep(5)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id=bid_stage_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['invitation'] == '{}/-/Request{}/Bid_Stage'.format(venue['support_group_id'], venue['request_form_note'].number)
@@ -430,7 +430,7 @@ class TestVenueRequest():
             writers=['~Test_User1']
         ))
         assert review_stage_note
-        time.sleep(5)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = review_stage_note.id)
         assert len(process_logs) == 1
@@ -525,7 +525,7 @@ class TestVenueRequest():
             writers=['~Test_User1']
         ))
         assert meta_review_stage_note
-        time.sleep(5)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = meta_review_stage_note.id)
         assert len(process_logs) == 1
@@ -578,7 +578,7 @@ class TestVenueRequest():
             writers=['~Test_User1']
         ))
         assert comment_stage_note
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id=comment_stage_note.id)
         assert len(process_logs) == 1
@@ -610,13 +610,13 @@ class TestVenueRequest():
             }
         ))
         assert official_comment_note
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id=official_comment_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
 
-    def test_venue_decision_stage(self, client, test_client, selenium, request_page, venue):
+    def test_venue_decision_stage(self, client, test_client, selenium, request_page, venue, helpers):
 
         submissions = test_client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']))
         assert submissions and len(submissions) == 2
@@ -648,7 +648,7 @@ class TestVenueRequest():
             writers=['~Test_User1']
         ))
         assert decision_stage_note
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = decision_stage_note.id)
         assert len(process_logs) == 1
@@ -677,7 +677,7 @@ class TestVenueRequest():
         ))
 
         assert decision_note
-        time.sleep(5)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = decision_stage_note.id)
         assert len(process_logs) == 1
@@ -735,7 +735,7 @@ class TestVenueRequest():
         ))
         assert revision_stage_note
 
-        time.sleep(5)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id=revision_stage_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -771,7 +771,7 @@ class TestVenueRequest():
         ))
         assert revision_note
 
-        time.sleep(5)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id=revision_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
@@ -831,7 +831,7 @@ class TestVenueRequest():
             writers=['~Test_User1']
         ))
         assert post_decision_stage_note
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = post_decision_stage_note.id)
         assert len(process_logs) == 1
@@ -874,7 +874,7 @@ class TestVenueRequest():
         ))
         assert revision_stage_note
 
-        time.sleep(5)
+        helpers.await_queue()
         process_logs = client.get_process_logs(id=revision_stage_note.id)
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -296,7 +296,7 @@ class TestWorkshop():
         review_note = reviewer_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
@@ -345,7 +345,7 @@ class TestWorkshop():
         review_note = reviewer_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
@@ -384,7 +384,7 @@ class TestWorkshop():
         public_comment_note = random_user.post_note(note)
         assert public_comment_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = public_comment_note.id)
         assert len(process_logs) == 1
@@ -422,7 +422,7 @@ class TestWorkshop():
         review_note = reviewer_client.post_note(note)
         assert review_note
 
-        time.sleep(2)
+        helpers.await_queue()
 
         process_logs = client.get_process_logs(id = review_note.id)
         assert len(process_logs) == 1
@@ -580,7 +580,7 @@ class TestWorkshop():
         with pytest.raises(NoSuchElementException):
             assert tabs.find_element_by_id('paper-status').find_element_by_class_name('row-5')
 
-    def test_accepted_papers(self, client, conference, test_client):
+    def test_accepted_papers(self, client, conference, test_client, helpers):
 
         accepted_authors = client.get_group('icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Authors/Accepted')
         assert accepted_authors
@@ -605,7 +605,7 @@ class TestWorkshop():
             }
         ))
 
-        time.sleep(2)
+        helpers.await_queue()
 
         notes = conference.get_submissions(accepted=True)
         assert len(notes) == 1


### PR DESCRIPTION
We have been using time.sleep(2) for process functions and messages that is not very reliable, so this PR checks the queue instead and waits until the elements in the queue are empty before moving on.