### PR TITLE
Add markdown and modify recruitment emails

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -951,15 +951,15 @@ class Conference(object):
 
         invitation = self.invitation_builder.set_reviewer_recruiter_invitation(self, options)
         invitation = self.webfield_builder.set_recruit_page(self.id, invitation, self.get_homepage_options())
+
+        role = 'reviewer' if reviewers_name == 'Reviewers' else 'area chair'
         recruit_message = '''Dear {name},
 
-        You have been nominated by the program chair committee of ''' + self.short_name + ''' to serve as a reviewer.  As a respected researcher in the area, we hope you will accept and help us make the conference a success.
+        You have been nominated by the program chair committee of '''+ self.get_short_name() + ''' to serve as '''+ role +'''. As a respected researcher in the area, we hope you will accept and help us make ''' + self.short_name + ''' a success.
 
-        Reviewers are also welcome to submit papers, so please also consider submitting to the conference!
+        You are also welcome to submit papers, so please also consider submitting to '''+ self.get_short_name() + '''.
 
-        We will be using OpenReview.net and a reviewing process that we hope will be engaging and inclusive of the whole community.
-
-        The success of the conference depends on the quality of the reviewing process and ultimately on the quality and dedication of the reviewers. We hope you will accept our invitation.
+        We will be using OpenReview.net with the intention of have an engaging reviewing process inclusive of the whole community.
 
         To ACCEPT the invitation, please click on the following link:
 
@@ -973,14 +973,15 @@ class Conference(object):
 
         If you accept, please make sure that your OpenReview account is updated and lists all the emails you are using.  Visit http://openreview.net/profile after logging in.
 
-        If you have any questions, please contact us at info@openreview.net.
+        If you have any questions, please contact info@openreview.net.
 
         Cheers!
 
         Program Chairs
 
         '''
-        recruit_message_subj = self.id + ': Invitation to Review'
+
+        recruit_message_subj = '[' + self.get_short_name() + ']: Invitation to serve as ' + role.capitalize()
 
         if title:
             recruit_message_subj = title

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -27,16 +27,15 @@ We have set up the venue based on the information that you provided here: {baseu
 
 You can use the following links to access the venue:
 
-Venue home page: {baseurl}/group?id={conference_id}
-Venue Program Chairs console: {baseurl}/group?id={program_chairs_id}
+- Venue home page: {baseurl}/group?id={conference_id}
+- Venue Program Chairs console: {baseurl}/group?id={program_chairs_id}
 
-If you need to make a change to the information provided in your request form, please feel free to revise it directly using the "Revision" button. You can also control several stages of your venue by using the Stage buttons. Note that any change you make will be immediately applied to your venue.
+If you need to make a change to the information provided in your request form, please feel free to revise it directly using the "Revision" button. You can also control several stages of your venue by using the Stage buttons. Note that any change you make will be immediately applied to your venue.  
 If you have any questions, please refer to our FAQ: https://openreview.net/faq
 
 If you need special features that are not included in your request form, you can post a comment here or contact us at info@openreview.net and we will assist you.
 
-Best,
-
+Best,  
 The OpenReview Team
             '''.format(baseurl = FRONTEND_URL, noteId = forum.id, conference_id = conference.get_id(), program_chairs_id = conference.get_program_chairs_id())
         }

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -24,8 +24,8 @@ class VenueStages():
         }
         revision_content['remove_submission_options'] = {
             'order': 19,
-            'values-dropdown':  ['keywords', 'pdf', 'TL;DR'],
-            'description': 'Fields to remove from the default form: keywords, pdf, TL;DR'
+            'values-dropdown':  ['abstract','keywords', 'pdf', 'TL;DR'],
+            'description': 'Fields to remove from the default form: abstract, keywords, pdf, TL;DR'
         }
         revision_content['homepage_override'] = {
             'order': 20,
@@ -769,7 +769,8 @@ class VenueRequest():
                             'order': 2,
                             'value-regex': '[\\S\\s]{1,5000}',
                             'description': 'Your comment or reply (max 5000 characters).',
-                            'required': True
+                            'required': True,
+                            'markdown': True
                         }
                     }
                 }

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -460,25 +460,25 @@ class TestDoubleBlindConference():
         assert invitation.process
         assert invitation.web
 
-        messages = client.get_messages(to = 'michael@mail.com', subject = 'AKBC.ws/2019/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'michael@mail.com', subject = '[AKBC 2019]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
         assert 'Dear Michael Spector,' in text
         assert 'You have been nominated by the program chair committee of AKBC 2019' in text
 
-        messages = client.get_messages(to = 'mbok@mail.com', subject = 'AKBC.ws/2019/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'mbok@mail.com', subject = '[AKBC 2019]: Invitation to serve as Reviewer')
         assert messages
         assert len(messages) == 1
 
         # Test if the reminder mail has "Dear invitee" for unregistered users in case the name is not provided to recruit_reviewers
         result = conference.recruit_reviewers(remind = True, invitees = ['mbok@mail.com'])
-        messages = client.get_messages(to = 'mbok@mail.com', subject = 'Reminder: AKBC.ws/2019/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'mbok@mail.com', subject = 'Reminder: [AKBC 2019]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
         assert 'Dear invitee,' in text
         assert 'You have been nominated by the program chair committee of AKBC 2019' in text
 
         # Test if the mail has "Dear <name>" for unregistered users in case the name is provided to recruit_reviewers
         result = conference.recruit_reviewers(remind = True, invitees = ['mbok@mail.com'], invitee_names = ['Melisa Bok'])
-        messages = client.get_messages(to = 'mbok@mail.com', subject = 'Reminder: AKBC.ws/2019/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'mbok@mail.com', subject = 'Reminder: [AKBC 2019]: Invitation to serve as Reviewer')
         text = messages[1]['content']['text']
         assert 'Dear Melisa Bok,' in text
         assert 'You have been nominated by the program chair committee of AKBC 2019' in text
@@ -540,7 +540,7 @@ class TestDoubleBlindConference():
         assert messages[0]['content']['text'] == 'You have declined the invitation to become a Reviewer for AKBC 2019.\n\nIf you would like to change your decision, please click the Accept link in the previous invitation email.\n\n'
 
         # Accept invitation using encoded user email
-        messages = client.get_messages(to = 'mbok@mail.com', subject = 'AKBC.ws/2019/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'mbok@mail.com', subject = '[AKBC 2019]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
 
         accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
@@ -578,7 +578,7 @@ class TestDoubleBlindConference():
         assert 'other@mail.com' in result.members
 
         # Don't send the invitation twice
-        messages = client.get_messages(to = 'michael@mail.com', subject = 'AKBC.ws/2019/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'michael@mail.com', subject = '[AKBC 2019]: Invitation to serve as Reviewer')
         assert messages
         assert len(messages) == 1
 
@@ -587,7 +587,7 @@ class TestDoubleBlindConference():
         assert invited
         assert len(invited.members) == 5
 
-        messages = client.get_messages(to = 'another@mail.com', subject = 'AKBC.ws/2019/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'another@mail.com', subject = '[AKBC 2019]: Invitation to serve as Reviewer')
         assert messages
         assert len(messages) == 1
         text = messages[0]['content']['text']
@@ -601,7 +601,7 @@ class TestDoubleBlindConference():
         assert group
         assert len(group.members) == 0
 
-        messages = client.get_messages(subject = 'Reminder: AKBC.ws/2019/Conference: Invitation to Review')
+        messages = client.get_messages(subject = 'Reminder: [AKBC 2019]: Invitation to serve as Reviewer')
         assert messages
         assert len(messages) == 9
         tos = set([m['content']['to'] for m in messages])

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -304,10 +304,10 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         assert 'test_reviewer_eccv@mail.com' in result.members
         assert 'mohit+1@mail.com' in result.members
 
-        messages = client.get_messages(to = 'mohit+1@mail.com', subject = 'thecvf.com/ECCV/2020/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'mohit+1@mail.com', subject = '[ECCV 2020]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
         assert 'Dear invitee,' in text
-        assert 'You have been nominated by the program chair committee of ECCV 2020 to serve as a reviewer' in text
+        assert 'You have been nominated by the program chair committee of ECCV 2020 to serve as reviewer' in text
 
         # Test to check that a user is not able to accept/decline if they are not a part of the invited group
         reject_url = re.search('https://.*response=No', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
@@ -369,7 +369,7 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
             }
         ))
 
-        messages = client.get_messages(to = 'test_reviewer_eccv@mail.com', subject = 'thecvf.com/ECCV/2020/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'test_reviewer_eccv@mail.com', subject = '[ECCV 2020]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
 
         accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -221,10 +221,10 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         assert 'iclr2021_seven@mail.com' in result.members
         assert 'iclr2021_one_alternate@mail.com' not in result.members
 
-        messages = client.get_messages(to = 'iclr2021_one@mail.com', subject = 'ICLR.cc/2021/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'iclr2021_one@mail.com', subject = '[ICLR 2021]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
         assert 'Dear invitee,' in text
-        assert 'You have been nominated by the program chair committee of ICLR 2021 to serve as a reviewer' in text
+        assert 'You have been nominated by the program chair committee of ICLR 2021 to serve as reviewer' in text
 
         reject_url = re.search('https://.*response=No', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
         accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
@@ -243,10 +243,10 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         accepted_group = client.get_group(id='ICLR.cc/2021/Conference/Reviewers')
         assert len(accepted_group.members) == 1
 
-        messages = client.get_messages(to = 'iclr2021_two@mail.com', subject = 'ICLR.cc/2021/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'iclr2021_two@mail.com', subject = '[ICLR 2021]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
         assert 'Dear invitee,' in text
-        assert 'You have been nominated by the program chair committee of ICLR 2021 to serve as a reviewer' in text
+        assert 'You have been nominated by the program chair committee of ICLR 2021 to serve as reviewer' in text
 
         reject_url = re.search('https://.*response=No', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
         accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
@@ -257,10 +257,10 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         accepted_group = client.get_group(id='ICLR.cc/2021/Conference/Reviewers')
         assert len(accepted_group.members) == 1
 
-        messages = client.get_messages(to = 'iclr2021_four@mail.com', subject = 'ICLR.cc/2021/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'iclr2021_four@mail.com', subject = '[ICLR 2021]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
         assert 'Dear invitee,' in text
-        assert 'You have been nominated by the program chair committee of ICLR 2021 to serve as a reviewer' in text
+        assert 'You have been nominated by the program chair committee of ICLR 2021 to serve as reviewer' in text
 
         reject_url = re.search('https://.*response=No', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
         accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
@@ -271,7 +271,7 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         accepted_group = client.get_group(id='ICLR.cc/2021/Conference/Reviewers')
         assert len(accepted_group.members) == 2
 
-        messages = client.get_messages(to = 'iclr2021_five@mail.com', subject = 'ICLR.cc/2021/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'iclr2021_five@mail.com', subject = '[ICLR 2021]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
         accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
         request_page(selenium, accept_url, alert=True)
@@ -280,7 +280,7 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         accepted_group = client.get_group(id='ICLR.cc/2021/Conference/Reviewers')
         assert len(accepted_group.members) == 3
 
-        messages = client.get_messages(to = 'iclr2021_six_alternate@mail.com', subject = 'ICLR.cc/2021/Conference: Invitation to Review')
+        messages = client.get_messages(to = 'iclr2021_six_alternate@mail.com', subject = '[ICLR 2021]: Invitation to serve as Reviewer')
         text = messages[0]['content']['text']
         accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
         request_page(selenium, accept_url, alert=True)
@@ -476,7 +476,7 @@ Naila, Katja, Alice, and Ivan
         'iclr2021_nine@mail.com',
         'iclr2021_six_alternate@mail.com'], invitee_names=['', '', '', '', '', '', '', '', 'Melisa Bok', ''])
 
-        messages = client.get_messages(subject = 'ICLR.cc/2021/Conference: Invitation to Review')
+        messages = client.get_messages(subject = '[ICLR 2021]: Invitation to serve as Reviewer')
         assert len(messages) == 9
 
         assert 'Melisa Bok' in messages[8]['content']['text']


### PR DESCRIPTION
Closes:
- #811 
- #810 

I changed recruit_reviewers email to be the same as the one used in the request form, which includes venue role in subject and message (previous message always said 'to serve as reviewer' even if ACs were being recruited which would cause confusion).

Added some formatting to deployment comment.

Added abstract to remove submission options. 