### PR TITLE
Fix/test permissions

### DIFF
--- a/docs/source/conference_builder.rst
+++ b/docs/source/conference_builder.rst
@@ -57,7 +57,7 @@ Open Submissions
 
 This call will setup an invitation to submit papers following the conference type, in this case is double blind, and with the submission deadline for Friday, October 5, 2019
 
-    >>> invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 23, 59))
+    >>> invitation = conference.set_submissions_stage(openreview.SubmissionStage(due_date = datetime.datetime(2019, 10, 5, 23, 59))
 
 
 Close Submissions
@@ -65,7 +65,7 @@ Close Submissions
 
 The submission will be closed when the current date passes the due date specified in open submissions call. In this case it will force the close of the submissions and it will disable the adition and edition of the papers by the authors. They can not edit the submission anymore
 
-    >>> invitation = conference.close_submissions()
+    >>> invitation = conference.setup_post_submission_stage()
 
 
 Recruit Reviewers

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -512,26 +512,6 @@ class Conference(object):
         invitation = self.submission_stage.get_desk_rejected_submission_id(self)
         return list(tools.iterget_notes(self.client, invitation=invitation, details=details))
 
-    ## Deprecated
-    def open_submissions(self):
-        return self.__create_submission_stage()
-
-    def close_submissions(self):
-
-        # Expire invitation
-        invitation = self.__expire_invitation(self.get_submission_id())
-
-        # update submission due date
-        if self.submission_stage.due_date and (
-            tools.datetime_millis(self.submission_stage.due_date) > tools.datetime_millis(datetime.datetime.utcnow())):
-            self.submission_stage.due_date = datetime.datetime.utcnow()
-
-        # Add venue to active venues
-        active_venues_group = self.client.get_group(id = 'active_venues')
-        self.client.add_members_to_group(active_venues_group, [self.get_id()])
-
-        return invitation
-
     def create_withdraw_invitations(self, reveal_authors=False, reveal_submission=False, email_pcs=False, force=False):
 
         if not force and reveal_submission and not self.submission_stage.public:

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -734,6 +734,10 @@ class OfficialCommentInvitation(openreview.Invitation):
                 'forum': note.id,
                 'replyto': None,
                 'readers': reply_readers,
+                'nonreaders': {
+                    'values-dropdown': readers,
+                    'required': False
+                },
                 'writers': {
                     'values-copied': [
                         conference.id,

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -735,8 +735,7 @@ class OfficialCommentInvitation(openreview.Invitation):
                 'replyto': None,
                 'readers': reply_readers,
                 'nonreaders': {
-                    'values-dropdown': readers,
-                    'required': False
+                    'values-dropdown': readers
                 },
                 'writers': {
                     'values-copied': [

--- a/tests/test_builder_console.py
+++ b/tests/test_builder_console.py
@@ -82,7 +82,6 @@ class TestBuilderConsoles():
         assert word_after(pc_group.web, 'ENABLE_REVIEWER_REASSIGNMENT = ') == 'false'
 
         assert "Blind" not in word_after(pc_group.web, 'BLIND_SUBMISSION_ID = ')
-        conference.close_submissions()
-        conference.create_blind_submissions()
+        conference.setup_post_submission_stage(force=True)
         pc_group = client.get_group(conference.get_program_chairs_id())
         assert "Blind"  in word_after(pc_group.web, 'BLIND_SUBMISSION_ID = ')

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -638,7 +638,7 @@ class TestCommentNotification():
         'location': 'Phoenix, Arizona, United States'
         })
         now = datetime.datetime.utcnow()
-        builder.set_submission_stage(name = 'Full_Submission', public = True, due_date = now + datetime.timedelta(minutes = 10))
+        builder.set_submission_stage(name = 'Full_Submission', public = True, due_date = now + datetime.timedelta(minutes = 10), withdrawn_submission_reveal_authors=True, desk_rejected_submission_reveal_authors=True)
         builder.has_area_chairs(True)
         builder.set_comment_stage(unsubmitted_reviewers = True, reader_selection = True, email_pcs = True, authors=True)
         conference = builder.get_result()
@@ -665,9 +665,7 @@ class TestCommentNotification():
         assert logs
         assert logs[0]['status'] == 'ok'
 
-        conference.close_submissions()
-
-        conference.create_paper_groups(authors=True)
+        conference.setup_post_submission_stage(force=True)
         conference.set_program_chairs(emails = ['programchair@colt.io'])
         conference.set_comment_stage(openreview.CommentStage(unsubmitted_reviewers = True, reader_selection = True, email_pcs = True, authors=True))
 
@@ -706,21 +704,24 @@ class TestCommentNotification():
 
         messages = client.get_messages(to = 'author@colt.io')
         assert messages
-        assert len(messages) == 2
+        assert len(messages) == 3
         assert messages[0]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'test@mail.com')
         assert messages
-        assert len(messages) == 12
+        assert len(messages) == 13
         assert messages[10]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[11]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[11]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[12]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'author2@colt.io')
         assert messages
-        assert len(messages) == 2
+        assert len(messages) == 3
         assert messages[0]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'reviewer@colt.io')
         assert messages
@@ -757,17 +758,19 @@ class TestCommentNotification():
 
         messages = client.get_messages(to = 'author@colt.io')
         assert messages
-        assert len(messages) == 3
+        assert len(messages) == 4
         assert messages[0]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'author2@colt.io')
         assert messages
-        assert len(messages) == 3
+        assert len(messages) == 4
         assert messages[0]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'reviewer@colt.io')
         assert messages
@@ -777,8 +780,8 @@ class TestCommentNotification():
 
         messages = client.get_messages(to = 'test@mail.com')
         assert messages
-        assert len(messages) == 13
-        assert messages[12]['content']['subject'] == '[COLT 2018] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
+        assert len(messages) == 14
+        assert messages[13]['content']['subject'] == '[COLT 2018] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'areachair@colt.io')
         assert messages
@@ -813,27 +816,30 @@ class TestCommentNotification():
 
         messages = client.get_messages(to = 'author@colt.io')
         assert messages
-        assert len(messages) == 4
+        assert len(messages) == 5
         assert messages[0]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[3]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[4]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'test@mail.com')
         assert messages
-        assert len(messages) == 14
+        assert len(messages) == 15
         assert messages[10]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[11]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[12]['content']['subject'] == '[COLT 2018] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[13]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[11]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[12]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[13]['content']['subject'] == '[COLT 2018] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[14]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'author2@colt.io')
         assert messages
-        assert len(messages) == 4
+        assert len(messages) == 5
         assert messages[0]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[3]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[4]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'reviewer@colt.io')
         assert messages
@@ -880,30 +886,33 @@ class TestCommentNotification():
 
         messages = client.get_messages(to = 'author@colt.io')
         assert messages
-        assert len(messages) == 5
+        assert len(messages) == 6
         assert messages[0]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[3]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[4]['content']['subject'] == '[COLT 2018] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[4]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[5]['content']['subject'] == '[COLT 2018] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'test@mail.com')
         assert messages
-        assert len(messages) == 15
+        assert len(messages) == 16
         assert messages[10]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[11]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[12]['content']['subject'] == '[COLT 2018] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[13]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[14]['content']['subject'] == '[COLT 2018] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[11]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[12]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[13]['content']['subject'] == '[COLT 2018] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[14]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[15]['content']['subject'] == '[COLT 2018] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'author2@colt.io')
         assert messages
-        assert len(messages) == 5
+        assert len(messages) == 6
         assert messages[0]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[3]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[4]['content']['subject'] == '[COLT 2018] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2018 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2018] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[4]['content']['subject'] == '[COLT 2018] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[5]['content']['subject'] == '[COLT 2018] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'reviewer@colt.io')
         assert messages
@@ -946,7 +955,7 @@ class TestCommentNotification():
         'location': 'Phoenix, Arizona, United States'
         })
         now = datetime.datetime.utcnow()
-        builder.set_submission_stage(name = 'Full_Submission', public= True, due_date = now + datetime.timedelta(minutes = 10) )
+        builder.set_submission_stage(name = 'Full_Submission', public= True, due_date = now + datetime.timedelta(minutes = 10), withdrawn_submission_reveal_authors=True, desk_rejected_submission_reveal_authors=True)
         builder.has_area_chairs(True)
         builder.set_comment_stage(unsubmitted_reviewers = True, reader_selection=True, authors=True)
         conference = builder.get_result()
@@ -973,8 +982,7 @@ class TestCommentNotification():
         assert logs
         assert logs[0]['status'] == 'ok'
 
-        conference.close_submissions()
-        conference.create_paper_groups(authors=True)
+        conference.setup_post_submission_stage(force=True)
         conference.set_program_chairs(emails = ['programchair@colt17.io'])
         conference.set_comment_stage(openreview.CommentStage(unsubmitted_reviewers = True, reader_selection=True, authors=True))
 
@@ -1012,21 +1020,24 @@ class TestCommentNotification():
 
         messages = client.get_messages(to = 'author@colt17.io')
         assert messages
-        assert len(messages) == 2
+        assert len(messages) == 3
         assert messages[0]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'test@mail.com')
         assert messages
-        assert len(messages) == 17
-        assert messages[15]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[16]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert len(messages) == 19
+        assert messages[16]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[17]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[18]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'author2@colt17.io')
         assert messages
-        assert len(messages) == 2
+        assert len(messages) == 3
         assert messages[0]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'reviewer@colt17.io')
         assert messages
@@ -1062,24 +1073,27 @@ class TestCommentNotification():
 
         messages = client.get_messages(to = 'author@colt17.io')
         assert messages
-        assert len(messages) == 3
+        assert len(messages) == 4
         assert messages[0]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2017] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2017] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'author2@colt17.io')
         assert messages
-        assert len(messages) == 3
+        assert len(messages) == 4
         assert messages[0]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2017] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2017] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'test@mail.com')
         assert messages
-        assert len(messages) == 18
-        assert messages[15]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[16]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[17]['content']['subject'] == '[COLT 2017] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
+        assert len(messages) == 20
+        assert messages[16]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[17]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[18]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[19]['content']['subject'] == '[COLT 2017] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'reviewer@colt17.io')
         assert messages
@@ -1119,27 +1133,30 @@ class TestCommentNotification():
 
         messages = client.get_messages(to = 'author@colt17.io')
         assert messages
-        assert len(messages) == 4
+        assert len(messages) == 5
         assert messages[0]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2017] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[3]['content']['subject'] == '[COLT 2017] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2017] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[4]['content']['subject'] == '[COLT 2017] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'test@mail.com')
         assert messages
-        assert len(messages) == 19
-        assert messages[15]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[16]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[17]['content']['subject'] == '[COLT 2017] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[18]['content']['subject'] == '[COLT 2017] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert len(messages) == 21
+        assert messages[16]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[17]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[18]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[19]['content']['subject'] == '[COLT 2017] Your comment was received on Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[20]['content']['subject'] == '[COLT 2017] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'author2@colt17.io')
         assert messages
-        assert len(messages) == 4
+        assert len(messages) == 5
         assert messages[0]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
-        assert messages[1]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[2]['content']['subject'] == '[COLT 2017] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
-        assert messages[3]['content']['subject'] == '[COLT 2017] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[1]['content']['subject'] == 'COLT 2017 has received your submission titled Paper title'
+        assert messages[2]['content']['subject'] == '[COLT 2017] AnonReviewer1 commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[3]['content']['subject'] == '[COLT 2017] An author commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
+        assert messages[4]['content']['subject'] == '[COLT 2017] Program Chairs commented on your submission. Paper Number: 1, Paper Title: "Paper title"'
 
         messages = client.get_messages(to = 'reviewer@colt17.io')
         assert messages

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -709,16 +709,6 @@ class TestDoubleBlindConference():
         assert len(selenium.find_elements_by_class_name('edit_button')) == 1
         assert len(selenium.find_elements_by_class_name('trash_button')) == 1
 
-        conference.close_submissions()
-        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Submission')
-        submission = notes[0]
-        assert [conference.id, 'test@mail.com', 'peter@mail.com', 'andrew@mail.com', '~Test_User1'] == submission.writers
-
-        request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token)
-
-        assert len(selenium.find_elements_by_class_name('edit_button')) == 0
-        assert len(selenium.find_elements_by_class_name('trash_button')) == 0
-
     def test_create_blind_submissions(self, client):
 
         builder = openreview.conference.ConferenceBuilder(client)
@@ -1580,13 +1570,12 @@ class TestDoubleBlindConference():
         assert builder, 'builder is None'
 
         builder.set_conference_id('AKBC.ws/2019/Conference')
-        builder.set_submission_stage(double_blind = True, public = True)
+        builder.set_submission_stage(double_blind = True, public = True, due_date= now - datetime.timedelta(minutes = 60))
         builder.set_conference_short_name('AKBC 2019')
         builder.set_conference_year(2019)
         builder.has_area_chairs(True)
         builder.set_conference_year(2019)
         conference = builder.get_result()
-        conference.close_submissions()
 
         notes = conference.get_submissions()
         assert notes

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1569,6 +1569,7 @@ class TestDoubleBlindConference():
         builder = openreview.conference.ConferenceBuilder(client)
         assert builder, 'builder is None'
 
+        now = datetime.datetime.utcnow()
         builder.set_conference_id('AKBC.ws/2019/Conference')
         builder.set_submission_stage(double_blind = True, public = True, due_date= now - datetime.timedelta(minutes = 60))
         builder.set_conference_short_name('AKBC 2019')

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -922,7 +922,6 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
     def test_desk_reject_submission(self, conference, client, test_client, selenium, request_page, helpers):
 
-        conference.close_submissions()
         conference.setup_post_submission_stage(force=True)
 
         blinded_notes = conference.get_submissions()

--- a/tests/test_legacy_invitations.py
+++ b/tests/test_legacy_invitations.py
@@ -28,7 +28,7 @@ class TestLegacyInvitations():
         builder.use_legacy_invitation_id(True)
         now = datetime.datetime.utcnow()
         builder.set_submission_stage(
-            public = True, 
+            public = True,
             due_date = now + datetime.timedelta(minutes = 40),
             withdrawn_submission_public=True,
             withdrawn_submission_reveal_authors=True,
@@ -53,7 +53,6 @@ class TestLegacyInvitations():
         note.content['pdf'] = url
         test_client.post_note(note)
 
-        # conference.create_paper_groups(authors=True, reviewers=True, area_chairs=True)
         conference.setup_final_deadline_stage()
 
         submissions = conference.get_submissions()

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -87,7 +87,7 @@ class TestReviewersConference():
         'instructions': ' '
         })
         now = datetime.datetime.utcnow()
-        builder.set_submission_stage(due_date = now + datetime.timedelta(minutes = 40), public=True)
+        builder.set_submission_stage(due_date = now + datetime.timedelta(minutes = 40), public=True, withdrawn_submission_reveal_authors=True, desk_rejected_submission_reveal_authors=True)
         builder.set_review_stage(due_date = now + datetime.timedelta(minutes = 10), allow_de_anonymization = True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED)
         conference = builder.get_result()
 
@@ -107,7 +107,7 @@ class TestReviewersConference():
         note = test_client.post_note(note)
         assert note
 
-        conference.create_paper_groups(authors=True, reviewers=True)
+        conference.setup_post_submission_stage(force=True)
         conference.set_reviewers(['reviewer_kgb@mail.com', 'reviewer_kgb2@mail.com'])
         conference.set_program_chairs([])
         conference.set_assignment(number = 1, user = 'reviewer_kgb@mail.com')

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -312,16 +312,6 @@ class TestSingleBlindConference():
         assert len(selenium.find_elements_by_class_name('edit_button')) == 1
         assert len(selenium.find_elements_by_class_name('trash_button')) == 1
 
-        conference.close_submissions()
-        notes = test_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Submission')
-        submission = notes[0]
-        assert [conference.id, 'test@mail.com', 'peter@mail.com', 'andrew@mail.com', '~Test_User1'] == submission.writers
-
-        request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token)
-
-        assert len(selenium.find_elements_by_class_name('edit_button')) == 0
-        assert len(selenium.find_elements_by_class_name('trash_button')) == 0
-
     def test_open_comments(self, client, test_client, selenium, request_page):
 
         builder = openreview.conference.ConferenceBuilder(client)

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -33,7 +33,7 @@ class TestWorkshop():
         'location': 'Berkeley, CA, USA'
         })
         builder.has_area_chairs(False)
-        builder.set_submission_stage(double_blind = True, public = False, due_date = now + datetime.timedelta(minutes = 10))
+        builder.set_submission_stage(double_blind = True, public = True, due_date = now + datetime.timedelta(minutes = 10))
 
         conference = builder.get_result()
         conference.set_program_chairs(emails = ['program_chairs@hsdip.org'])
@@ -195,9 +195,7 @@ class TestWorkshop():
         assert len(blind_submissions_2) == 2
         assert blind_submissions[0].id == blind_submissions_2[1].id
         assert blind_submissions_2[1].readers == [
-            'icaps-conference.org/ICAPS/2019/Workshop/HSDIP',
-            'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Reviewers',
-            'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/Authors'
+            'everyone'
         ]
 
         note = openreview.Note(invitation = conference.get_submission_id(),
@@ -330,7 +328,6 @@ class TestWorkshop():
             forum = submission.id,
             replyto = review.id,
             readers = [
-                'everyone',
                 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/Authors',
                 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/Reviewers',
                 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs'],
@@ -372,7 +369,7 @@ class TestWorkshop():
         random_user = helpers.create_user(email='random_user1@mail.co', first='Random', last='User')
         note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Public_Comment',
             forum = submission.id,
-            replyto = review.id,
+            replyto = submission.id,
             readers = ['everyone'],
             writers = ['~Random_User1'],
             signatures = ['~Random_User1'],


### PR DESCRIPTION
- Remove deprecated code `open_submissions` and `close_submissions`, use the SubmissionStage class or `setup_post_submissions_stage`.

- Fix some tests where the replies can not read the forum.
