### PR TITLE
set the reduced load from the request form

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1393,7 +1393,7 @@ class InvitationBuilder(object):
                 ]
             },
             'writers': {
-                'values-copied': [
+                'values': [
                     conference.get_id()
                 ]
             },

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -178,7 +178,7 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
                     'order': 2
                 },
                 'invitee_reduced_load': {
-                    'description': 'Please enter a comma separated values of the reduced load options if the invitee rejected the invitation. (Available for reviewer role only)',
+                    'description': 'Please enter a comma separated list of reduced load options. If an invitee declines the reviewing invitation, they will be able to choose a reduced load from this list. (For reviewer role only)',
                     'values-regex': '[0-9]+',
                     'default': ['1', '2', '3'],
                     'required': False,

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -119,7 +119,7 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
                     'order': 2
                 },
                 'invitee_reduced_load': {
-                    'description': 'Please enter a comma separated value of the reduced load options if the invitee rejected the invitation. (Only for reviewer role)',
+                    'description': 'Please enter a comma separated list of reduced load options. If an invitee declines the reviewing invitation, they will be able to choose a reduced load from this list. (For reviewer role only)',
                     'values-regex': '[0-9]+',
                     'default': ['1', '2', '3'],
                     'required': False,

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -118,23 +118,30 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
                     'required': True,
                     'order': 2
                 },
+                'invitee_reduced_load': {
+                    'description': 'Please enter a comma separated value of the reduced load options if the invitee rejected the invitation. (Only for reviewer role)',
+                    'values-regex': '[0-9]+',
+                    'default': ['1', '2', '3'],
+                    'required': False,
+                    'order': 3
+                },
                 'invitee_details': {
                     'value-regex': '[\\S\\s]{1,50000}',
                     'description': 'Email,Name pairs expected with each line having only one invitee\'s details. E.g. captain_rogers@marvel.com, Captain America',
                     'required': True,
-                    'order': 3
+                    'order': 4
                 },
                 'invitation_email_subject': {
                     'value-regex': '.*',
                     'description': 'Please carefully review the email subject for the recruitment emails. Make sure not to remove the parenthesized tokens.',
-                    'order': 4,
+                    'order': 5,
                     'required': True,
                     'default': recruitment_email_subject
                 },
                 'invitation_email_content': {
                     'value-regex': '[\\S\\s]{1,10000}',
                     'description': 'Please carefully review the template below before you click submit to send out recruitment emails. Make sure not to remove the parenthesized tokens.',
-                    'order': 5,
+                    'order': 6,
                     'required': True,
                     'default': recruitment_email_body
                 }
@@ -170,17 +177,24 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
                     'required': True,
                     'order': 2
                 },
+                'invitee_reduced_load': {
+                    'description': 'Please enter a comma separated values of the reduced load options if the invitee rejected the invitation. (Available for reviewer role only)',
+                    'values-regex': '[0-9]+',
+                    'default': ['1', '2', '3'],
+                    'required': False,
+                    'order': 3
+                },
                 'invitation_email_subject': {
                     'value-regex': '.*',
                     'description': 'Please carefully review the email subject for the reminder emails. Make sure not to remove the parenthesized tokens.',
-                    'order': 3,
+                    'order': 4,
                     'required': True,
                     'default': recruitment_email_subject
                 },
                 'invitation_email_content': {
                     'value-regex': '[\\S\\s]{1,10000}',
                     'description': 'Please carefully review the template below before you click submit to send out reminder emails. Make sure not to remove the parenthesized tokens.',
-                    'order': 4,
+                    'order': 5,
                     'required': True,
                     'default': recruitment_email_body
                 }

--- a/openreview/venue_request/process/recruitmentProcess.py
+++ b/openreview/venue_request/process/recruitmentProcess.py
@@ -2,6 +2,10 @@ def process(client, note, invitation):
     conference = openreview.helpers.get_conference(client, note.forum)
     print('Conference: ', conference.get_id())
 
+    reduced_load=note.content.get('invitee_reduced_load')
+    if reduced_load:
+        conference.reduced_load_on_decline=reduced_load
+
     note.content['invitation_email_subject'] = note.content['invitation_email_subject'].replace('{invitee_role}', note.content.get('invitee_role', 'reviewer'))
     note.content['invitation_email_content'] = note.content['invitation_email_content'].replace('{invitee_role}', note.content.get('invitee_role', 'reviewer'))
 

--- a/openreview/venue_request/process/remindRecruitmentProcess.py
+++ b/openreview/venue_request/process/remindRecruitmentProcess.py
@@ -2,11 +2,21 @@ def process(client, note, invitation):
     conference = openreview.helpers.get_conference(client, note.forum)
     print('Conference: ', conference.get_id())
 
+    reduced_load=note.content.get('invitee_reduced_load')
+    if reduced_load:
+        conference.reduced_load_on_decline=reduced_load
+
     note.content['invitation_email_subject'] = note.content['invitation_email_subject'].replace('{invitee_role}', note.content.get('invitee_role', 'reviewer'))
     note.content['invitation_email_content'] = note.content['invitation_email_content'].replace('{invitee_role}', note.content.get('invitee_role', 'reviewer'))
-    
+
+    roles={
+        'reviewer': 'Reviewers',
+        'area chair': 'Area_Chairs',
+        'senior area chair': 'Senior_Area_Chairs'
+    }
+
     conference.recruit_reviewers(
-        reviewers_name = 'Area_Chairs' if note.content['invitee_role'].strip() == 'area chair' else 'Reviewers',
+        reviewers_name = roles[note.content['invitee_role'].strip()],
         title = note.content['invitation_email_subject'].strip(),
         message = note.content['invitation_email_content'].strip(),
         remind=True

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -882,7 +882,7 @@ class VenueRequest():
                 'order': 2
             },
             'invitee_reduced_load': {
-                'description': 'Please enter a comma separated values of the reduced load options if the invitee rejected the invitation. (Available for reviewer role only)',
+                'description': 'Please enter a comma separated list of reduced load options. If an invitee declines the reviewing invitation, they will be able to choose a reduced load from this list. (For reviewer role only)',
                 'values-regex': '[0-9]+',
                 'default': ['1', '2', '3'],
                 'required': False,

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -881,6 +881,13 @@ class VenueRequest():
                 'required': True,
                 'order': 2
             },
+            'invitee_reduced_load': {
+                'description': 'Please enter a comma separated values of the reduced load options if the invitee rejected the invitation. (Available for reviewer role only)',
+                'values-regex': '[0-9]+',
+                'default': ['1', '2', '3'],
+                'required': False,
+                'order': 2
+            },
             'invitee_details': {
                 'value-regex': '[\\S\\s]{1,50000}',
                 'description': 'Email,Name pairs expected with each line having only one invitee\'s details. E.g. captain_rogers@marvel.com, Captain America',

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -29,7 +29,8 @@ class TestNeurIPSConference():
         helpers.create_user('ac1@mit.edu', 'Area', 'IBMChair', institution='ibm.com')
         helpers.create_user('ac2@gmail.com', 'Area', 'GoogleChair', institution='google.com')
         helpers.create_user('ac3@umass.edu', 'Area', 'UMassChair', institution='umass.edu')
-
+        helpers.create_user('reviewer1@umass.edu', 'Reviewer', 'UMass', institution='umass.edu')
+        helpers.create_user('reviewer2@mit.edu', 'Reviewer', 'MIT', institution='mit.edu')
 
         request_form_note = pc_client.post_note(openreview.Note(
             invitation='openreview.net/Support/-/Request_Form',
@@ -161,6 +162,134 @@ class TestNeurIPSConference():
         assert invitation
         assert invitation.reply['content']['paper_invitation']['value-regex'] == 'NeurIPS.cc/2021/Conference/Area_Chairs'
         assert invitation.reply['content']['paper_invitation']['default'] == 'NeurIPS.cc/2021/Conference/Area_Chairs'
+
+
+    def test_recruit_reviewers(self, client, selenium, request_page, helpers):
+
+        pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
+        request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+
+        # Test Reviewer Recruitment
+        request_page(selenium, 'http://localhost:3030/forum?id={}'.format(request_form.id), pc_client.token)
+        recruitment_div = selenium.find_element_by_id('note_{}'.format(request_form.id))
+        assert recruitment_div
+        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        assert reply_row
+        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        assert [btn for btn in buttons if btn.text == 'Recruitment']
+
+
+        reviewer_details = '''reviewer1@umass.edu, Reviewer UMass\nreviewer2@mit.edu, Reviewer MIT'''
+        recruitment_note = pc_client.post_note(openreview.Note(
+            content={
+                'title': 'Recruitment',
+                'invitee_role': 'reviewer',
+                'invitee_reduced_load': ['2', '3', '4'],
+                'invitee_details': reviewer_details,
+                'invitation_email_subject': '[' + request_form.content['Abbreviated Venue Name'] + '] Invitation to serve as {invitee_role}',
+                'invitation_email_content': 'Dear {name},\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as {invitee_role}.\n\nACCEPT LINK:\n\n{accept_url}\n\nDECLINE LINK:\n\n{decline_url}\n\nCheers!\n\nProgram Chairs'
+            },
+            forum=request_form.forum,
+            replyto=request_form.forum,
+            invitation='openreview.net/Support/-/Request{}/Recruitment'.format(request_form.number),
+            readers=['NeurIPS.cc/2021/Conference/Program_Chairs', 'openreview.net/Support'],
+            signatures=['~Program_NeurIPSChair1'],
+            writers=[]
+        ))
+        assert recruitment_note
+
+        helpers.await_queue()
+        process_logs = client.get_process_logs(id=recruitment_note.id)
+        assert len(process_logs) == 1
+        assert process_logs[0]['status'] == 'ok'
+        assert process_logs[0]['invitation'] == 'openreview.net/Support/-/Request{}/Recruitment'.format(request_form.number)
+
+        messages = client.get_messages(to='reviewer1@umass.edu', subject='[NeurIPS 2021] Invitation to serve as reviewer')
+        assert messages and len(messages) == 1
+        assert messages[0]['content']['subject'] == '[NeurIPS 2021] Invitation to serve as reviewer'
+        assert messages[0]['content']['text'].startswith('Dear Reviewer UMass,\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as reviewer.')
+        reject_url = re.search('https://.*response=No', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030')
+        request_page(selenium, reject_url, alert=True)
+        notes = selenium.find_element_by_id("notes")
+        assert notes
+        messages = notes.find_elements_by_tag_name("h3")
+        assert messages
+        assert 'You have declined the invitation from Conference on Neural Information Processing Systems.' == messages[0].text
+        assert 'In case you only declined because you think you cannot handle the maximum load of papers, you can reduce your load slightly. Be aware that this will decrease your overall score for an outstanding reviewer award, since all good reviews will accumulate a positive score. You can request a reduced reviewer load by clicking here: Request reduced load' == messages[1].text
+
+        assert len(client.get_group('NeurIPS.cc/2021/Conference/Reviewers').members) == 0
+
+        group = client.get_group('NeurIPS.cc/2021/Conference/Reviewers/Declined')
+        assert group
+        assert len(group.members) == 1
+        assert 'reviewer1@umass.edu' in group.members
+
+        messages = client.get_messages(to='reviewer1@umass.edu', subject='[NeurIPS 2021] Reviewer Invitation declined')
+        assert messages
+        assert len(messages)
+        assert messages[0]['content']['text'].startswith('You have declined the invitation to become a Reviewer for NeurIPS 2021.\n\nIf you would like to change your decision, please click the Accept link in the previous invitation email.\n\nIn case you only declined because you think you cannot handle the maximum load of papers, you can reduce your load slightly. Be aware that this will decrease your overall score for an outstanding reviewer award, since all good reviews will accumulate a positive score. You can request a reduced reviewer load by clicking here:')
+
+        notes = client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Recruit_Reviewers', content={'user': 'reviewer1@umass.edu'})
+        assert notes
+        assert len(notes) == 1
+
+        client.post_note(openreview.Note(
+            invitation='NeurIPS.cc/2021/Conference/-/Reduced_Load',
+            readers=['NeurIPS.cc/2021/Conference', 'reviewer1@umass.edu'],
+            writers=['NeurIPS.cc/2021/Conference'],
+            signatures=['(anonymous)'],
+            content={
+                'user': 'reviewer1@umass.edu',
+                'key': notes[0].content['key'],
+                'response': 'Yes',
+                'reviewer_load': '4'
+            }
+        ))
+
+        helpers.await_queue()
+
+        reviewers_group=client.get_group('NeurIPS.cc/2021/Conference/Reviewers')
+        assert len(reviewers_group.members) == 1
+        assert 'reviewer1@umass.edu' in reviewers_group.members
+
+        ## Remind reviewers
+        recruitment_note = pc_client.post_note(openreview.Note(
+            content={
+                'title': 'Remind Recruitment',
+                'invitee_role': 'reviewer',
+                'invitee_reduced_load': ['2', '3', '4'],
+                'invitation_email_subject': '[' + request_form.content['Abbreviated Venue Name'] + '] Invitation to serve as {invitee_role}',
+                'invitation_email_content': 'Dear {name},\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as {invitee_role}.\n\nACCEPT LINK:\n\n{accept_url}\n\nDECLINE LINK:\n\n{decline_url}\n\nCheers!\n\nProgram Chairs'
+            },
+            forum=request_form.forum,
+            replyto=request_form.forum,
+            invitation='openreview.net/Support/-/Request{}/Remind_Recruitment'.format(request_form.number),
+            readers=['NeurIPS.cc/2021/Conference/Program_Chairs', 'openreview.net/Support'],
+            signatures=['~Program_NeurIPSChair1'],
+            writers=[]
+        ))
+
+        helpers.await_queue()
+
+        messages = client.get_messages(to='reviewer2@mit.edu', subject='Reminder: [NeurIPS 2021] Invitation to serve as reviewer')
+        assert messages and len(messages) == 1
+        assert messages[0]['content']['subject'] == 'Reminder: [NeurIPS 2021] Invitation to serve as reviewer'
+        assert messages[0]['content']['text'].startswith('Dear invitee,\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as reviewer.')
+        reject_url = re.search('https://.*response=No', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030')
+        request_page(selenium, reject_url, alert=True)
+
+        helpers.await_queue()
+
+        group = client.get_group('NeurIPS.cc/2021/Conference/Reviewers/Declined')
+        assert group
+        assert len(group.members) == 1
+        assert 'reviewer2@mit.edu' in group.members
+
+        messages = client.get_messages(to='reviewer2@mit.edu', subject='[NeurIPS 2021] Reviewer Invitation declined')
+        assert messages
+        assert len(messages)
+        assert messages[0]['content']['text'].startswith('You have declined the invitation to become a Reviewer for NeurIPS 2021.\n\nIf you would like to change your decision, please click the Accept link in the previous invitation email.\n\nIn case you only declined because you think you cannot handle the maximum load of papers, you can reduce your load slightly. Be aware that this will decrease your overall score for an outstanding reviewer award, since all good reviews will accumulate a positive score. You can request a reduced reviewer load by clicking here:')
+
 
 
 #     def test_recruit_reviewer(self, conference, client, helpers, selenium, request_page):


### PR DESCRIPTION
PCs can select a reduce load option if the user declines the invitation, please check the wording 🙏 

`'Please enter a comma separated values of the reduced load options if the invitee rejected the invitation. (Available for reviewer role only)'`