### PR TITLE
Allow customization in recruitment web page and post a reason of the decline response.

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1069,7 +1069,7 @@ class Conference(object):
             invitation = self.webfield_builder.set_reduced_load_page(self.id, invitation, self.get_homepage_options())
 
         invitation = self.invitation_builder.set_reviewer_recruiter_invitation(self, options)
-        invitation = self.webfield_builder.set_recruit_page(self.id, invitation, self.get_homepage_options())
+        invitation = self.webfield_builder.set_recruit_page(self.id, invitation, self.get_homepage_options(), options['reviewers_name'])
 
         role = 'reviewer' if reviewers_name == 'Reviewers' else 'area chair'
         recruit_message = '''Dear {name},

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1462,7 +1462,8 @@ class InvitationBuilder(object):
             },
             'writers': {
                 'values': [
-                    conference.get_id()
+                    conference.get_id(),
+                    '(anonymous)'
                 ]
             },
             'content': invitations.recruitment

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -107,7 +107,7 @@ class BlindSubmissionsInvitation(openreview.Invitation):
         )
 
 class BidInvitation(openreview.Invitation):
-    def __init__(self, conference, bid_stage):
+    def __init__(self, conference, bid_stage, current_invitation):
 
         match_group_id = bid_stage.committee_id
 
@@ -169,11 +169,12 @@ class BidInvitation(openreview.Invitation):
                         'required': True
                     }
                 }
-            }
+            },
+            web_string = current_invitation.web if current_invitation else None
         )
 
 class ExpertiseSelectionInvitation(openreview.Invitation):
-    def __init__(self, conference):
+    def __init__(self, conference, current_invitation):
 
         expertise_selection_stage = conference.expertise_selection_stage
 
@@ -187,6 +188,10 @@ class ExpertiseSelectionInvitation(openreview.Invitation):
         if conference.use_area_chairs:
             readers.append(conference.get_area_chairs_id())
             invitees.append(conference.get_area_chairs_id())
+
+        if conference.use_senior_area_chairs:
+            readers.append(conference.get_senior_area_chairs_id())
+            invitees.append(conference.get_senior_area_chairs_id())
 
         super(ExpertiseSelectionInvitation, self).__init__(id = conference.get_expertise_selection_id(),
             cdate = tools.datetime_millis(expertise_selection_stage.start_date),
@@ -216,7 +221,8 @@ class ExpertiseSelectionInvitation(openreview.Invitation):
                         'required': True
                     }
                 }
-            }
+            },
+            web_string = current_invitation.web if current_invitation else None
         )
 
 class CommentInvitation(openreview.Invitation):
@@ -1237,13 +1243,18 @@ class InvitationBuilder(object):
 
     def set_expertise_selection_invitation(self, conference):
 
-        invitation = ExpertiseSelectionInvitation(conference)
+        invitation_id=conference.get_expertise_selection_id()
+        current_invitation=openreview.tools.get_invitation(self.client, id = invitation_id)
+
+        invitation = ExpertiseSelectionInvitation(conference, current_invitation)
 
         return self.client.post_invitation(invitation)
 
     def set_bid_invitation(self, conference, stage):
 
-        return self.client.post_invitation(BidInvitation(conference, stage))
+        invitation_id=conference.get_bid_id(stage.committee_id)
+        current_invitation=openreview.tools.get_invitation(self.client, id = invitation_id)
+        return self.client.post_invitation(BidInvitation(conference, stage, current_invitation))
 
     def set_comment_invitation(self, conference, notes):
 
@@ -1380,7 +1391,7 @@ class InvitationBuilder(object):
                 ]
             },
             'signatures': {
-                'values-regex': '\\(anonymous\\)|~.*'
+                'values-regex': '\\(anonymous\\)'
             },
             'content': {
                 'user': {
@@ -1410,6 +1421,9 @@ class InvitationBuilder(object):
             }
         }
 
+        invitation_id=conference.get_invitation_id('Reduced_Load')
+        current_invitation=openreview.tools.get_invitation(self.client, id = invitation_id)
+
         with open(os.path.join(os.path.dirname(__file__), 'templates/recruitReducedLoadProcess.js')) as f:
             content = f.read()
             content = content.replace("var SHORT_PHRASE = '';", "var SHORT_PHRASE = '" + conference.get_short_name() + "';")
@@ -1419,7 +1433,7 @@ class InvitationBuilder(object):
             content = content.replace("var HASH_SEED = '';", "var HASH_SEED = '" + options.get('hash_seed') + "';")
 
             reduced_load_invitation = openreview.Invitation(
-                    id = conference.get_invitation_id('Reduced_Load'),
+                    id = invitation_id,
                     duedate = tools.datetime_millis(options.get('due_date', datetime.datetime.utcnow())),
                     readers = ['everyone'],
                     nonreaders = [],
@@ -1428,7 +1442,8 @@ class InvitationBuilder(object):
                     writers = [conference.get_id()],
                     signatures = [conference.get_id()],
                     reply = reduced_load_invitation_reply,
-                    process_string = content)
+                    process_string = content,
+                    web_string = current_invitation.web if current_invitation else None)
             return self.client.post_invitation(reduced_load_invitation)
 
     def set_reviewer_recruiter_invitation(self, conference, options = {}):
@@ -1437,17 +1452,25 @@ class InvitationBuilder(object):
             'forum': None,
             'replyto': None,
             'readers': {
-                'values': [conference.get_id()]
+                'values-copied': [
+                    conference.get_id(),
+                    '{content.user}'
+                ]
             },
             'signatures': {
                 'values-regex': '\\(anonymous\\)'
             },
             'writers': {
-                'values': []
+                'values': [
+                    conference.get_id()
+                ]
             },
             'content': invitations.recruitment
         }
         reply = self.__build_options(default_reply, options.get('reply', {}))
+
+        invitation_id=conference.get_invitation_id('Recruit_' + options.get('reviewers_name', 'Reviewers'))
+        current_invitation=openreview.tools.get_invitation(self.client, id = invitation_id)
 
         with open(os.path.join(os.path.dirname(__file__), 'templates/recruitReviewersProcess.py')) as f:
             content = f.read()
@@ -1466,7 +1489,7 @@ class InvitationBuilder(object):
             content = content.replace("HASH_SEED = ''", "HASH_SEED = '" + options.get('hash_seed') + "'")
             if conference.reduced_load_on_decline and options.get('reviewers_name', '') == 'Reviewers':
                 content = content.replace("REDUCED_LOAD_INVITATION_NAME = ''", "REDUCED_LOAD_INVITATION_NAME = 'Reduced_Load'")
-            invitation = openreview.Invitation(id = conference.get_invitation_id('Recruit_' + options.get('reviewers_name', 'Reviewers')),
+            invitation = openreview.Invitation(id = invitation_id,
                 duedate = tools.datetime_millis(options.get('due_date', datetime.datetime.utcnow())),
                 readers = ['everyone'],
                 nonreaders = [],
@@ -1475,14 +1498,18 @@ class InvitationBuilder(object):
                 writers = [conference.get_id()],
                 signatures = [conference.get_id()],
                 reply = reply,
-                process_string = content)
+                process_string = content,
+                web_string = current_invitation.web if current_invitation else None)
 
             return self.client.post_invitation(invitation)
 
     def set_recommendation_invitation(self, conference, start_date, due_date, total_recommendations):
 
+        invitation_id=conference.get_recommendation_id()
+        current_invitation=openreview.tools.get_invitation(self.client, id = invitation_id)
+
         recommendation_invitation = openreview.Invitation(
-            id = conference.get_recommendation_id(),
+            id = invitation_id,
             cdate = tools.datetime_millis(start_date),
             duedate = tools.datetime_millis(due_date),
             expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)) if due_date else None,
@@ -1522,7 +1549,8 @@ class InvitationBuilder(object):
                         'required': True
                     }
                 }
-            }
+            },
+            web_string = current_invitation.web if current_invitation else None
         )
 
         return self.client.post_invitation(recommendation_invitation)

--- a/openreview/conference/templates/legacyProgramchairWebfield.js
+++ b/openreview/conference/templates/legacyProgramchairWebfield.js
@@ -2006,11 +2006,7 @@ var buildPaperTableRow = function(note, reviewerIds, completedReviews, metaRevie
         name: reviewer.name,
         email: reviewer.email,
         forum: note.forum,
-        forumUrl: '/forum?' + $.param({
-          id: note.forum,
-          noteId: note.id,
-          invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, note.number)
-        }),
+        forumUrl: forumUrl,
         paperNumber: note.number,
         reviewerNumber: reviewerNum,
         lastReminderSent: lastReminderSent ?

--- a/openreview/conference/templates/recruitReducedLoadWeb.js
+++ b/openreview/conference/templates/recruitReducedLoadWeb.js
@@ -1,3 +1,6 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
 // Constants
 var CONFERENCE_ID = '';
 var HEADER = {};

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -57,14 +57,24 @@ function render() {
         } else {
           var message = 'You have declined the invitation from ' + HEADER.title + '.';
           $response.append('<div><h3 style="line-height:normal;">' + message + '</h3></div>');
-          $response.append('<form><textarea id="comment" class="form-control"></textarea><button type="submit" class="btn btn-sm btn-submit">Submit</button></form>');
+          $response.append([
+            '<form>',
+              '<div class="form-group">',
+                '<h5 style="line-height:normal;">Please tell us the reason why you are declining the invitation:</h5>',
+                '<textarea id="comment" class="form-control" style="width: 50%"></textarea>',
+              '</div>',
+              '<button type="submit" class="btn btn-sm btn-submit">Submit</button>',
+            '</form>'
+          ].join('\n'));
           $('#notes').on('click', 'button.btn.btn-submit', function(e) {
-            console.log('save');
-            note.content.comment = $('#comment').val();
-            Webfield.post('/notes', note)
-            .then(function(result) {
-              console.log('TODO: Clear the form!');
-            });
+            var comment = $('#comment').val();
+            if (comment && comment.length) {
+              note.content.comment = comment;
+              Webfield.post('/notes', note)
+              .then(function(result) {
+                $('#notes').empty().append('<div><h5 style="line-height:normal;">Thanks!</h5></div>');
+             });
+            }
             return false;
           });
         }

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -60,7 +60,7 @@ function render() {
           $response.append([
             '<form>',
               '<div class="form-group">',
-                '<h5 style="line-height:normal;">Please tell us the reason why you are declining the invitation:</h5>',
+                '<h5 style="line-height:normal;">Please tell us why you are declining the invitation:</h5>',
                 '<textarea id="comment" class="form-control" style="width: 50%"></textarea>',
               '</div>',
               '<button type="submit" class="btn btn-sm btn-submit">Submit</button>',
@@ -72,7 +72,7 @@ function render() {
               note.content.comment = comment;
               Webfield.post('/notes', note)
               .then(function(result) {
-                $('#notes').empty().append('<div><h5 style="line-height:normal;">Thanks!</h5></div>');
+                $('#notes').empty().append('<div><h5 style="line-height:normal;">Thank you for your response.</h5></div>');
              });
             }
             return false;

--- a/openreview/conference/templates/recruitResponseWebfield.js
+++ b/openreview/conference/templates/recruitResponseWebfield.js
@@ -4,7 +4,7 @@
 // Constants
 var CONFERENCE_ID = '';
 var HEADER = {};
-var REDUCED_LOAD_INVITATION_NAME = '';
+var REDUCED_LOAD_INVITATION_ID = '';
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
@@ -47,17 +47,26 @@ function render() {
       ].join('\n'));
     } else if (declined) {
       // Get invitation to request max load
-      var reduced_load_invitation_id = CONFERENCE_ID + '/-/' + REDUCED_LOAD_INVITATION_NAME;
-      Webfield.get('/invitations', { regex: reduced_load_invitation_id })
+      Webfield.get('/invitations', { regex: REDUCED_LOAD_INVITATION_ID })
       .then(function(result) {
         if (result.hasOwnProperty('invitations') && result.invitations.length) {
           invitation = result.invitations[0];
           var message = 'You have declined the invitation from ' + HEADER.title + '.';
           $response.append('<div><h3 style="line-height:normal;">' + message + '</h3></div>');
-          $response.append('<div><h3 style="line-height:normal;">In case you only declined because you think you cannot handle the maximum load of papers, you can reduce your load slightly. Be aware that this will decrease your overall score for an outstanding reviewer award, since all good reviews will accumulate a positive score. You can request a reduced reviewer load by clicking here: <a style="font-weight:bold;" href="/invitation?id=' + reduced_load_invitation_id + '&user=' + args.user + '&key=' + args.key + '">Request reduced load</a></h3></div>');
+          $response.append('<div><h3 style="line-height:normal;">In case you only declined because you think you cannot handle the maximum load of papers, you can reduce your load slightly. Be aware that this will decrease your overall score for an outstanding reviewer award, since all good reviews will accumulate a positive score. You can request a reduced reviewer load by clicking here: <a style="font-weight:bold;" href="/invitation?id=' + REDUCED_LOAD_INVITATION_ID + '&user=' + args.user + '&key=' + args.key + '">Request reduced load</a></h3></div>');
         } else {
           var message = 'You have declined the invitation from ' + HEADER.title + '.';
           $response.append('<div><h3 style="line-height:normal;">' + message + '</h3></div>');
+          $response.append('<form><textarea id="comment" class="form-control"></textarea><button type="submit" class="btn btn-sm btn-submit">Submit</button></form>');
+          $('#notes').on('click', 'button.btn.btn-submit', function(e) {
+            console.log('save');
+            note.content.comment = $('#comment').val();
+            Webfield.post('/notes', note)
+            .then(function(result) {
+              console.log('TODO: Clear the form!');
+            });
+            return false;
+          });
         }
       })
       .fail(function(error) {

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -280,7 +280,7 @@ class WebfieldBuilder(object):
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             return self.__update_invitation(invitation, content)
 
-    def set_recruit_page(self, conference_id, invitation, options = {}):
+    def set_recruit_page(self, conference_id, invitation, options = {}, reviewers_name='Reviewers'):
 
         default_header = {
             'title': conference_id,
@@ -298,7 +298,11 @@ class WebfieldBuilder(object):
             content = f.read()
             content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference_id + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
-            content = content.replace("var REDUCED_LOAD_INVITATION_NAME = '';", "var REDUCED_LOAD_INVITATION_NAME = 'Reduced_Load';")
+            if reviewers_name == 'Reviewers':
+                content = content.replace("var REDUCED_LOAD_INVITATION_ID = '';", "var REDUCED_LOAD_INVITATION_ID = '" + conference_id + '/-/Reduced_Load' + "';")
+            else:
+                ## Reduce load is disabled, so we should set an invalid invitation
+                content = content.replace("var REDUCED_LOAD_INVITATION_ID = '';", "var REDUCED_LOAD_INVITATION_ID = '" + conference_id + '/-/no_name' + "';")
             return self.__update_invitation(invitation, content)
 
 

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -260,22 +260,6 @@ class WebfieldBuilder(object):
 
             return self.__update_invitation(invitation, content)
 
-    def set_paper_ranking_page(self, conference, invitation, group_name):
-
-        header = {}
-        with open(os.path.join(os.path.dirname(__file__), 'templates/paperRankingWebfield.js')) as f:
-            content = f.read()
-            content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference.get_id() + "';")
-            content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
-            content = content.replace("var PAPER_RANKING_ID = '';", "var PAPER_RANKING_ID = '" + invitation.id + "';")
-            content = content.replace("var GROUP_NAME = '';", "var GROUP_NAME = '" + group_name + "';")
-
-            if group_name == 'Area Chairs':
-                content = content.replace("var WILDCARD = '';", "var WILDCARD = '" + conference.get_id() + "/Paper.*/Area_Chairs';")
-            else:
-                content = content.replace("var WILDCARD = '';", "var WILDCARD = '" + conference.get_anon_reviewer_id(number='.*', anon_id='.*') + "';")
-            return self.__update_invitation(invitation, content)
-
     def set_reduced_load_page(self, conference_id, invitation, options = {}):
 
         default_header = {

--- a/openreview/invitations/content.py
+++ b/openreview/invitations/content.py
@@ -217,5 +217,12 @@ recruitment = {
         'order': 4,
         'value-radio': ['Yes', 'No'],
         'required':True
+    },
+    'comment': {
+        'order': 5,
+        'value-regex': '[\\S\\s]{1,5000}',
+        'description': 'Add your comment',
+        'required': False,
+        'markdown': True
     }
 }

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -78,7 +78,7 @@ class TestNeurIPSConference():
                 'Location': 'Virtual',
                 'Paper Matching': [
                     'Reviewer Bid Scores',
-                    'Reviewer Recommendation Scores'],
+                    'OpenReview Affinity'],
                 'Author and Reviewer Anonymity': 'Double-blind',
                 'reviewer_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair', 'Assigned Reviewers'],
                 'Open Reviewing Policy': 'Submissions and reviews should both be private.',


### PR DESCRIPTION
- PCs can use the Invitation editor to change the text shown in the invitation landing page. Webfield templates are not overwritten when the template mark is removed.
- Make the response notes editable so users can append a comment when they decline the invitation:



<img width="1170" alt="Screen Shot 2021-03-05 at 8 54 08 AM" src="https://user-images.githubusercontent.com/545506/110124955-c2afdd00-7d90-11eb-86cc-f21f64bf076f.png">


<img width="1069" alt="Screen Shot 2021-03-05 at 8 54 16 AM" src="https://user-images.githubusercontent.com/545506/110124968-c6436400-7d90-11eb-86f0-6e24babf134d.png">




