### PR TITLE
search profiles by confirmed Emails

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1171,7 +1171,7 @@ class Conference(object):
     def remind_registration_stage(self, subject, message, committee_id):
 
         reviewers = self.client.get_group(committee_id).members
-        profiles_by_email = self.client.search_profiles(emails=[m for m in reviewers if '@' in m])
+        profiles_by_email = self.client.search_profiles(confirmedEmails=[m for m in reviewers if '@' in m])
         confirmations = {c.tauthor: c for c in list(tools.iterget_notes(self.client, invitation=self.get_registration_id(committee_id)))}
         print('reviewers:', len(reviewers))
         print('profiles:', len(profiles_by_email))

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -43,7 +43,7 @@ def _get_profiles(client, ids_or_emails):
 
     for j in range(0, len(emails), batch_size):
         batch_emails = emails[j:j+batch_size]
-        batch_profile_by_email = client.search_profiles(emails=batch_emails)
+        batch_profile_by_email = client.search_profiles(confirmedEmails=batch_emails)
         profile_by_email.update(batch_profile_by_email)
 
     for email in emails:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,37 +100,47 @@ class TestClient():
         assert openreview.tools.get_profile(client, '~Super_User1')
         assert not openreview.tools.get_profile(client, 'mbok@sss.edu')
 
-    def test_get_profiles(self, client):
+    def test_search_profiles(self, client, helpers):
         guest = openreview.Client()
         guest.register_user(email = 'mbok@mail.com', first = 'Melisa', last = 'Bok', password = '1234')
         guest.register_user(email = 'andrew@mail.com', first = 'Andrew', last = 'McCallum', password = '1234')
 
-        profiles = client.get_profiles(['mbok@mail.com'])
+        profiles = client.search_profiles(confirmedEmails=['mbok@mail.com'])
         assert profiles, "Could not get the profile by email"
         assert isinstance(profiles, dict)
         assert isinstance(profiles['mbok@mail.com'], openreview.Profile)
         assert profiles['mbok@mail.com'].id == '~Melisa_Bok1'
 
-        profiles = client.get_profiles(['~Melisa_Bok1', '~Andrew_McCallum1'])
+        profiles = client.search_profiles(ids=['~Melisa_Bok1', '~Andrew_McCallum1'])
         assert profiles, "Could not get the profile by id"
         assert isinstance(profiles, list)
         assert len(profiles) == 2
         assert '~Melisa_Bok1' in profiles[1].id
         assert '~Andrew_McCallum1' in profiles[0].id
 
-        profiles = client.get_profiles([])
+        profiles = client.search_profiles(emails=[])
         assert len(profiles) == 0
 
-        profiles = client.get_profiles()
-        assert len(profiles) == 1
-        assert profiles[0].id == '~Super_User1'
+        assert client.profile
+        assert client.profile.id == '~Super_User1'
 
-        assert '~Melisa_Bok1' == client.get_profiles(id = '~Melisa_Bok1')[0].id
-        assert '~Melisa_Bok1' == client.get_profiles(email = 'mbok@mail.com')[0].id
-        assert '~Melisa_Bok1' == client.get_profiles(first = 'Melisa')[0].id
-        assert len(client.get_profiles(id = '~Melisa_Bok2')) == 0
-        assert len(client.get_profiles(email = 'mail@mail.com')) == 0
-        assert len(client.get_profiles(first = 'Anna')) == 0
+        assert '~Melisa_Bok1' == client.search_profiles(ids = ['~Melisa_Bok1'])[0].id
+        assert '~Melisa_Bok1' == client.search_profiles(confirmedEmails = ['mbok@mail.com'])['mbok@mail.com'].id
+        assert '~Melisa_Bok1' == client.search_profiles(first = 'Melisa')[0].id
+        assert len(client.search_profiles(ids = ['~Melisa_Bok2'])) == 0
+        assert len(client.search_profiles(emails = ['mail@mail.com'])) == 0
+        assert len(client.search_profiles(first = 'Anna')) == 0
+
+        user_a = helpers.create_user('user_a@mail.com', 'User', 'A', alternates=['users@alternate.com'])
+        user_b = helpers.create_user('user_b@mail.com', 'User', 'B', alternates=['users@alternate.com'])
+        profiles = client.search_profiles(emails = ['users@alternate.com'])
+        assert profiles
+        assert 'users@alternate.com' in profiles
+        assert len(profiles['users@alternate.com']) == 2
+
+        profiles = client.search_profiles(confirmedEmails = ['users@alternate.com'])
+        assert not profiles
+
 
     def test_confirm_registration(self):
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -220,7 +220,8 @@ class TestTools():
                     'last': 'Name',
                     'username': '~Another_Name1'
                     }
-                ]
+                ],
+                'emails': ['alternate@mail.com']
             }
         ))
 
@@ -247,6 +248,18 @@ class TestTools():
         replaced_group = openreview.tools.replace_members_with_ids(client, invalid_member_group)
         assert len(replaced_group.members) == 3
         assert '~Invalid_Profile1' not in invalid_member_group.members
+
+        ## Replace emails with only profile with confirmed emails
+        posted_group = client.post_group(openreview.Group(id='test.org',
+            readers=['everyone'],
+            writers=['~Super_User1'],
+            signatures=['~Super_User1'],
+            signatories=['~Super_User1'],
+            members=['~Super_User1', 'alternate@mail.com', 'noprofile@mail.com']
+        ))
+        replaced_group = openreview.tools.replace_members_with_ids(client, posted_group)
+        assert replaced_group
+        assert replaced_group.members == ['~Super_User1', 'alternate@mail.com', 'noprofile@mail.com']
 
     def test_get_conflicts(self, client, helpers):
 


### PR DESCRIPTION
- Make sure the builder and tools functions search profiles by confirmed emails. There is still an option to search profiles by any email and the result will be a dictionary with a profile array for each email key.

- Remove deprecated function to get_profiles.
