### PR TITLE
delete edges for conflicts and scores when they are uploaded

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -166,7 +166,6 @@ class Matching(object):
             })
 
         invitation = self.client.post_invitation(invitation)
-        self.client.delete_edges(invitation.id)
         return invitation
 
     def _build_conflicts(self, submissions, user_profiles):
@@ -223,6 +222,9 @@ class Matching(object):
                         signatures=[self.conference.id]
                     ))
 
+        ## Delete previous conflicts
+        self.client.delete_edges(invitation.id, wait_to_finish=True)
+
         openreview.tools.post_bulk_edges(client=self.client, edges=edges)
 
         # Perform sanity check
@@ -262,6 +264,9 @@ class Matching(object):
                         writers=[self.conference.id],
                         signatures=[self.conference.id]
                     ))
+
+        ## Delete previous conflicts
+        self.client.delete_edges(invitation.id, wait_to_finish=True)
 
         openreview.tools.post_bulk_edges(client=self.client, edges=edges)
 
@@ -308,6 +313,9 @@ class Matching(object):
                         signatures=[self.conference.id]
                     ))
 
+        ## Delete previous scores
+        self.client.delete_edges(invitation.id, wait_to_finish=True)
+
         openreview.tools.post_bulk_edges(client=self.client, edges=edges)
         # Perform sanity check
         edges_posted = self.client.get_edges_count(invitation=invitation.id)
@@ -352,6 +360,9 @@ class Matching(object):
 
         print('deleted papers', deleted_papers)
 
+        ## Delete previous scores
+        self.client.delete_edges(invitation.id, wait_to_finish=True)
+
         openreview.tools.post_bulk_edges(client=self.client, edges=edges)
         # Perform sanity check
         edges_posted = self.client.get_edges_count(invitation=invitation.id)
@@ -376,6 +387,9 @@ class Matching(object):
                     writers=[self.conference.id],
                     signatures=[self.conference.id]
                 ))
+
+        ## Delete previous scores
+        self.client.delete_edges(invitation.id, wait_to_finish=True)
 
         openreview.tools.post_bulk_edges(client=self.client, edges=edges)
         # Perform sanity check
@@ -412,6 +426,9 @@ class Matching(object):
                         writers=[self.conference.id],
                         signatures=[self.conference.id]
                     ))
+
+        ## Delete previous scores
+        self.client.delete_edges(invitation.id, wait_to_finish=True)
 
         openreview.tools.post_bulk_edges(client=self.conference.client, edges=edges)
         # Perform sanity check


### PR DESCRIPTION
This won't delete current custom quotas when the setup_matching is being called several times. 

The same happens when we re-upload the affinity scores and there are already assignments, we shouldn't remove them. 