### PR TITLE
allow actions for public submissions after the decision stage

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1226,7 +1226,7 @@ class InvitationBuilder(object):
         notes = self.client.get_notes(invitation=invitation.id)
 
         ## if the invitation indicates readers is everyone but the submission is not, we ignore the update
-        if 'values' in invitation.reply['readers'] and 'everyone' in invitation.reply['readers']['everyone'] and 'everyone' not in submission.readers:
+        if 'values' in invitation.reply['readers'] and 'everyone' in invitation.reply['readers']['values'] and 'everyone' not in submission.readers:
             return
 
         for note in notes:

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -226,75 +226,6 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
             signatures = ['~Super_User1']
         ))
 
-    review_stage_content = None
-    if forum.content.get('Open Reviewing Policy', None) == 'Submissions and reviews should both be public.':
-        review_stage_content = {
-            'review_start_date': {
-                'description': 'When does reviewing of submissions begin? Please use the following format: YYYY/MM/DD HH:MM (e.g. 2019/01/31 23:59)',
-                'value-regex': r'^[0-9]{4}\/([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[1-2][0-9]|3[0-1])(\s+)?((2[0-3]|[01][0-9]|[0-9]):[0-5][0-9])?(\s+)?$',
-                'order': 10
-            },
-            'review_deadline': {
-                'description': 'When does reviewing of submissions end? Please use the following format: YYYY/MM/DD HH:MM (e.g. 2019/01/31 23:59)',
-                'value-regex': r'^[0-9]{4}\/([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[1-2][0-9]|3[0-1])(\s+)?((2[0-3]|[01][0-9]|[0-9]):[0-5][0-9])?(\s+)?$',
-                'required': True,
-                'order': 11
-            },
-            'make_reviews_public': {
-                'description': 'Should the reviews be made public immediately upon posting? Based on your earlier selections, default is "Yes, reviews should be revealed publicly when they are posted".',
-                'value-radio': [
-                    'Yes, reviews should be revealed publicly when they are posted',
-                    'No, reviews should NOT be revealed publicly when they are posted'
-                ],
-                'required': True,
-                'default': 'Yes, reviews should be revealed publicly when they are posted',
-                'order': 24
-            },
-            'release_reviews_to_authors': {
-                'description': 'Should the reviews be visible to paper\'s authors immediately upon posting? Based on your earlier selections, default is "Yes, reviews should be revealed publicly when they are posted".',
-                'value-radio': [
-                    'Yes, reviews should be revealed when they are posted to the paper\'s authors',
-                    'No, reviews should NOT be revealed when they are posted to the paper\'s authors'
-                ],
-                'required': True,
-                'default': 'Yes, reviews should be revealed publicly when they are posted',
-                'order': 25
-            },
-            'release_reviews_to_reviewers': {
-                'description': 'Should the reviews be visible to all reviewers, all assigned reviewers, assigned reviewers who have already submitted their own review or only the author of the review immediately upon posting? Based on your earlier selections, default is "Reviews should be immediately revealed to all reviewers".',
-                'value-radio': [
-                    'Reviews should be immediately revealed to all reviewers',
-                    'Reviews should be immediately revealed to the paper\'s reviewers',
-                    'Reviews should be immediately revealed to the paper\'s reviewers who have already submitted their review',
-                    'Review should not be revealed to any reviewer, except to the author of the review'
-                ],
-                'required': True,
-                'default': 'Reviews should be immediately revealed to all reviewers',
-                'order': 26
-            },
-            'email_program_chairs_about_reviews': {
-                'description': 'Should Program Chairs be emailed when each review is received? Default is "No, do not email program chairs about received reviews".',
-                'value-radio': [
-                    'Yes, email program chairs for each review received',
-                    'No, do not email program chairs about received reviews'],
-                'required': True,
-                'default': 'No, do not email program chairs about received reviews',
-                'order': 27
-            },
-            'additional_review_form_options': {
-                'order' : 28,
-                'value-dict': {},
-                'required': False,
-                'description': 'Configure additional options in the review form. Valid JSON expected.'
-            },
-            'remove_review_form_options': {
-                'order': 29,
-                'value-regex': r'^[^,]+(,\s*[^,]*)*$',
-                'required': False,
-                'description': 'Comma separated list of fields (review, rating, confidence) that you want removed from the review form.'
-            }
-        }
-
     client.post_invitation(openreview.Invitation(
         id = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Review_Stage',
         super = SUPPORT_GROUP + '/-/Review_Stage',
@@ -305,8 +236,7 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
             'readers': {
                 'description': 'The users who will be allowed to read the above content.',
                 'values' : readers
-            },
-            'content': review_stage_content
+            }
         },
         signatures = ['~Super_User1']
     ))
@@ -343,44 +273,6 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
         signatures=['~Super_User1']
     ))
 
-    comment_stage_content = None
-    if forum.content.get('Open Reviewing Policy', None) == 'Submissions and reviews should both be private.':
-        comment_stage_content = {
-            'commentary_start_date': {
-                'description': 'When does official and/or public commentary begin? Please use the following format: YYYY/MM/DD HH:MM (e.g. 2019/01/31 23:59)',
-                'value-regex': r'^[0-9]{4}\/([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[1-2][0-9]|3[0-1])(\s+)?((2[0-3]|[01][0-9]|[0-9]):[0-5][0-9])?(\s+)?$',
-                'order': 27
-            },
-            'commentary_end_date': {
-                'description': 'When does official and/or public commentary end? Please use the following format: YYYY/MM/DD HH:MM (e.g. 2019/01/31 23:59)',
-                'value-regex': r'^[0-9]{4}\/([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[1-2][0-9]|3[0-1])(\s+)?((2[0-3]|[01][0-9]|[0-9]):[0-5][0-9])?(\s+)?$',
-                'order': 28
-            },
-            'participants': {
-                'description': 'Select who should be allowed to post comments on submissions.',
-                'values-checkbox' : [
-                    'Program Chairs',
-                    'Paper Area Chairs',
-                    'Paper Reviewers',
-                    'Paper Submitted Reviewers',
-                    'Authors'
-                ],
-                'required': True,
-                'default': ['Program Chairs'],
-                'order': 29
-            },
-            'email_program_chairs_about_official_comments': {
-                'description': 'Should the PCs receive an email for each official comment made in the venue? Default is "No, do not email PCs for each official comment in the venue"',
-                'value-radio': [
-                    'Yes, email PCs for each official comment made in the venue',
-                    'No, do not email PCs for each official comment made in the venue'
-                ],
-                'required': True,
-                'default': 'No, do not email PCs for each official comment made in the venue',
-                'order': 30
-            }
-        }
-
     # comment_stage_invitation
     client.post_invitation(openreview.Invitation(
         id=SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Comment_Stage',
@@ -391,8 +283,7 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
             'readers' : {
                 'description': 'The users who will be allowed to read the above content.',
                 'values' : readers
-            },
-            'content': comment_stage_content
+            }
         },
         signatures=['~Super_User1']
     ))

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -115,6 +115,16 @@ class VenueStages():
                 'required': True,
                 'order': 11
             },
+            'make_reviews_public': {
+                'description': "Should the reviews be made public immediately upon posting? Note that selecting 'Yes' will automatically release any posted reviews to the public if the submission is also public.",
+                'value-radio': [
+                    'Yes, reviews should be revealed publicly when they are posted',
+                    'No, reviews should NOT be revealed publicly when they are posted'
+                ],
+                'required': True,
+                'default': 'Yes, reviews should be revealed publicly when they are posted',
+                'order': 24
+            },
             'release_reviews_to_authors': {
                 'description': 'Should the reviews be visible to paper\'s authors immediately upon posting? Default is "No, reviews should NOT be revealed when they are posted to the paper\'s authors".',
                 'value-radio': [

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -701,6 +701,7 @@ class TestNeurIPSConference():
         stage_note=client.post_note(openreview.Note(
             content={
                 'review_deadline': due_date.strftime('%Y/%m/%d'),
+                'make_reviews_public': 'No, reviews should NOT be revealed publicly when they are posted',
                 'release_reviews_to_authors': 'No, reviews should NOT be revealed when they are posted to the paper\'s authors',
                 'release_reviews_to_reviewers': 'Review should not be revealed to any reviewer, except to the author of the review',
                 'email_program_chairs_about_reviews': 'No, do not email program chairs about received reviews'

--- a/tests/test_single_blind_private_conference.py
+++ b/tests/test_single_blind_private_conference.py
@@ -179,3 +179,15 @@ class TestSingleBlindPrivateConference():
             notes_panel.find_element_by_class_name('spinner-container')
         assert tabs.find_element_by_id('oral')
         assert tabs.find_element_by_id('poster')
+
+    def test_enable_public_comments(self, conference, helpers, test_client, client):
+        notes = test_client.get_notes(invitation='MICCAI.org/2021/Challenges/-/Submission')
+        assert len(notes) == 5
+
+        conference.submission_stage.papers_released=True
+        conference.set_comment_stage(openreview.CommentStage(unsubmitted_reviewers=True, reader_selection=True, email_pcs=True, authors=True, allow_public_comments=True))
+        public_comment_invitation = openreview.tools.get_invitation(client, conference.get_invitation_id('Public_Comment', number=4))
+        assert public_comment_invitation
+
+        public_comment_invitation = openreview.tools.get_invitation(client, conference.get_invitation_id('Public_Comment', number=5))
+        assert public_comment_invitation is None


### PR DESCRIPTION
- Allow public comments on released submissions after the decision stage.
- Don't restrict the visibility of the comments/reviews in the stages, no matter is the venue is public or private.
- Don't create public comments on submissions that are not public.
- Don't release any reply(decision, meta review or review) is the submission is not public(this will allow the PCs to release the reviews of the accepted papers only)