### PR TITLE
Fix/author ranking and recruit other committee groups

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1132,7 +1132,8 @@ class Conference(object):
         reviewers_declined_group = self.__create_group(reviewers_declined_id, pcs_id)
         reviewers_invited_group = self.__create_group(reviewers_invited_id, pcs_id)
 
-        committee_roles = self.get_committee_names()
+        official_committee_roles=self.get_committee_names()
+        committee_roles = official_committee_roles if reviewers_name in official_committee_roles else [reviewers_name]
         recruitment_status = {
             'invited': [],
             'reminded': [],

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1703,14 +1703,16 @@ class InvitationBuilder(object):
             'values-copied': [conference.get_id(), '{signatures}']
         }
 
-        signatures_regex = conference.get_anon_area_chair_id(number='.*', anon_id='.*')
+        signatures_regex = '~.*'
 
-        if group_id == conference.get_reviewers_id() and conference.use_area_chairs:
-            readers = {
-                'description': 'The users who will be allowed to read the above content.',
-                'values-regex': conference.get_id() + '|' + conference.get_area_chairs_id(number='.*') + '|~.*'
-            }
-            signatures_regex = conference.get_anon_reviewer_id(number='.*', anon_id='.*')
+        if group_id in [conference.get_area_chairs_id(), conference.get_reviewers_id()]:
+            signatures_regex = conference.get_anon_area_chair_id(number='.*', anon_id='.*')
+
+            if group_id == conference.get_reviewers_id() and conference.use_area_chairs:
+                readers = {
+                    'description': 'The users who will be allowed to read the above content.',
+                    'values-regex': conference.get_id() + '|' + conference.get_area_chairs_id(number='.*') + '|~.*'
+                }
 
         reviewer_paper_ranking_invitation = openreview.Invitation(
             id = conference.get_invitation_id('Paper_Ranking', prefix=group_id),

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -574,7 +574,7 @@ class TestNeurIPSConference():
 
         assert client.get_invitation('NeurIPS.cc/2021/Conference/Paper5/-/Supplementary_Material')
 
-    def test_post_submission_stage(self, conference, helpers, test_client, client):
+    def test_post_submission_stage(self, conference, helpers, test_client, client, request_page, selenium):
 
         #conference.setup_final_deadline_stage(force=True)
         pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
@@ -637,6 +637,14 @@ class TestNeurIPSConference():
 
         assert client.get_group('NeurIPS.cc/2021/Conference/Paper5/Reviewers').nonreaders == ['NeurIPS.cc/2021/Conference/Paper5/Authors']
 
+        ## Open Author paper ranking
+        now = datetime.datetime.utcnow()
+        conference.open_paper_ranking(committee_id=conference.get_authors_id(), due_date=now + datetime.timedelta(days=3))
+
+        authors_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Authors'
+        request_page(selenium, authors_url, test_client.token)
+
+        assert selenium.find_elements_by_class_name('tag-widget')
 
     def test_setup_matching(self, conference, client, helpers):
 


### PR DESCRIPTION
1 - Enable Author Paper Ranking
2 - Allow the recruitment of other committee groups that can overlap with SAC/AC/Reviewers invited groups.