### PR TITLE
add SAC as readers of withdrawn and desk reject submissions

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -351,6 +351,10 @@ class PaperWithdrawInvitation(openreview.Invitation):
                 file_content = file_content.replace(
                     'PAPER_AREA_CHAIRS_ID = \'\'',
                     'PAPER_AREA_CHAIRS_ID = \'' + conference.get_area_chairs_id(number=note.number) + '\'')
+            if conference.use_senior_area_chairs:
+                file_content = file_content.replace(
+                    'PAPER_SENIOR_AREA_CHAIRS_ID = \'\'',
+                    'PAPER_SENIOR_AREA_CHAIRS_ID = \'' + conference.get_senior_area_chairs_id(number=note.number) + '\'')
             file_content = file_content.replace(
                 'PROGRAM_CHAIRS_ID = \'\'',
                 'PROGRAM_CHAIRS_ID = \'' + conference.get_program_chairs_id() + '\'')
@@ -492,6 +496,10 @@ class PaperDeskRejectInvitation(openreview.Invitation):
                 file_content = file_content.replace(
                     'PAPER_AREA_CHAIRS_ID = \'\'',
                     'PAPER_AREA_CHAIRS_ID = \'' + conference.get_area_chairs_id(number=note.number) + '\'')
+            if conference.use_senior_area_chairs:
+                file_content = file_content.replace(
+                    'PAPER_SENIOR_AREA_CHAIRS_ID = \'\'',
+                    'PAPER_SENIOR_AREA_CHAIRS_ID = \'' + conference.get_senior_area_chairs_id(number=note.number) + '\'')
             file_content = file_content.replace(
                 'PROGRAM_CHAIRS_ID = \'\'',
                 'PROGRAM_CHAIRS_ID = \'' + conference.get_program_chairs_id() + '\'')
@@ -593,14 +601,14 @@ class PaperSubmissionRevisionInvitation(openreview.Invitation):
     def __init__(self, conference, note, submission_content):
 
         submission_revision_stage = conference.submission_revision_stage
-        referent = note.original if conference.submission_stage.double_blind else note.id
-        original_content = note.details['original']['content'] if conference.submission_stage.double_blind else note.content
+        referent = note.original if note.original else note.id
 
         start_date = submission_revision_stage.start_date
         due_date = submission_revision_stage.due_date
         content = None
 
         if submission_revision_stage.allow_author_reorder:
+            original_content = note.details['original']['content'] if conference.submission_stage.double_blind else note.content
 
             content = submission_content.copy()
 

--- a/openreview/conference/templates/desk_reject_process.py
+++ b/openreview/conference/templates/desk_reject_process.py
@@ -7,6 +7,7 @@ def process(client, note, invitation):
     PAPER_AUTHORS_ID = ''
     PAPER_REVIEWERS_ID = ''
     PAPER_AREA_CHAIRS_ID = ''
+    PAPER_SENIOR_AREA_CHAIRS_ID = ''
     PROGRAM_CHAIRS_ID = ''
     DESK_REJECTED_SUBMISSION_ID = ''
     REVEAL_AUTHORS_ON_DESK_REJECT = False
@@ -15,6 +16,8 @@ def process(client, note, invitation):
     committee = [PAPER_AUTHORS_ID, PAPER_REVIEWERS_ID]
     if PAPER_AREA_CHAIRS_ID:
         committee.append(PAPER_AREA_CHAIRS_ID)
+    if PAPER_SENIOR_AREA_CHAIRS_ID:
+        committee.append(PAPER_SENIOR_AREA_CHAIRS_ID)
     committee.append(PROGRAM_CHAIRS_ID)
 
     forum_note = client.get_note(note.forum)

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -7,6 +7,7 @@ def process(client, note, invitation):
     PAPER_AUTHORS_ID = ''
     PAPER_REVIEWERS_ID = ''
     PAPER_AREA_CHAIRS_ID = ''
+    PAPER_SENIOR_AREA_CHAIRS_ID = ''
     PROGRAM_CHAIRS_ID = ''
     WITHDRAWN_SUBMISSION_ID = ''
     REVEAL_AUTHORS_ON_WITHDRAW = False
@@ -16,6 +17,8 @@ def process(client, note, invitation):
     committee = [PAPER_AUTHORS_ID, PAPER_REVIEWERS_ID]
     if PAPER_AREA_CHAIRS_ID:
         committee.append(PAPER_AREA_CHAIRS_ID)
+    if PAPER_SENIOR_AREA_CHAIRS_ID:
+        committee.append(PAPER_SENIOR_AREA_CHAIRS_ID)
     committee.append(PROGRAM_CHAIRS_ID)
 
     forum_note = client.get_note(note.forum)

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -1856,53 +1856,62 @@ OpenReview Team'''
         notes_panel = selenium.find_element_by_id('notes')
         assert notes_panel
 
-    # def test_withdraw_after_review(self, conference, helpers, test_client, client, selenium, request_page):
+    def test_withdraw_after_review(self, conference, helpers, test_client, client, selenium, request_page):
 
-    #     submissions = test_client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Blind_Submission')
-    #     assert len(submissions) == 5
+        submissions = test_client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Blind_Submission')
+        assert len(submissions) == 5
 
-    #     withdrawn_note = test_client.post_note(openreview.Note(
-    #         forum=submissions[0].id,
-    #         replyto=submissions[0].id,
-    #         invitation=f'NeurIPS.cc/2021/Conference/Paper5/-/Withdraw',
-    #         readers = [
-    #             'NeurIPS.cc/2021/Conference',
-    #             'NeurIPS.cc/2021/Conference/Paper5/Authors',
-    #             'NeurIPS.cc/2021/Conference/Paper5/Reviewers',
-    #             'NeurIPS.cc/2021/Conference/Paper5/Area_Chairs',
-    #             'NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs',
-    #             'NeurIPS.cc/2021/Conference/Program_Chairs'],
-    #         writers = [conference.get_id(), 'NeurIPS.cc/2021/Conference/Paper5/Authors'],
-    #         signatures = ['NeurIPS.cc/2021/Conference/Paper5/Authors'],
-    #         content = {
-    #             'title': 'Submission Withdrawn by the Authors',
-    #             'withdrawal confirmation': 'I have read and agree with the venue\'s withdrawal policy on behalf of myself and my co-authors.'
-    #         }
-    #     ))
-    #     helpers.await_queue()
+        withdrawn_note = test_client.post_note(openreview.Note(
+            forum=submissions[0].id,
+            replyto=submissions[0].id,
+            invitation=f'NeurIPS.cc/2021/Conference/Paper5/-/Withdraw',
+            readers = [
+                'NeurIPS.cc/2021/Conference',
+                'NeurIPS.cc/2021/Conference/Paper5/Authors',
+                'NeurIPS.cc/2021/Conference/Paper5/Reviewers',
+                'NeurIPS.cc/2021/Conference/Paper5/Area_Chairs',
+                'NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs',
+                'NeurIPS.cc/2021/Conference/Program_Chairs'],
+            writers = [conference.get_id(), 'NeurIPS.cc/2021/Conference/Paper5/Authors'],
+            signatures = ['NeurIPS.cc/2021/Conference/Paper5/Authors'],
+            content = {
+                'title': 'Submission Withdrawn by the Authors',
+                'withdrawal confirmation': 'I have read and agree with the venue\'s withdrawal policy on behalf of myself and my co-authors.'
+            }
+        ))
+        helpers.await_queue()
 
-    #     process_logs = client.get_process_logs(id=withdrawn_note.id)
-    #     assert len(process_logs) == 1
-    #     assert process_logs[0]['status'] == 'ok'
+        process_logs = client.get_process_logs(id=withdrawn_note.id)
+        assert len(process_logs) == 1
+        assert process_logs[0]['status'] == 'ok'
 
-    #     pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
+        withdrawn_submission=client.get_note(submissions[0].id)
+        assert withdrawn_submission.invitation == 'NeurIPS.cc/2021/Conference/-/Withdrawn_Submission'
+        assert withdrawn_submission.readers == [
+                'NeurIPS.cc/2021/Conference/Paper5/Authors',
+                'NeurIPS.cc/2021/Conference/Paper5/Reviewers',
+                'NeurIPS.cc/2021/Conference/Paper5/Area_Chairs',
+                'NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs',
+                'NeurIPS.cc/2021/Conference/Program_Chairs']
 
-    #     request_page(selenium, "http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Program_Chairs#paper-status", pc_client.token)
-    #     assert "NeurIPS 2021 Conference Program Chairs | OpenReview" in selenium.title
-    #     notes_panel = selenium.find_element_by_id('notes')
-    #     assert notes_panel
-    #     tabs = notes_panel.find_element_by_class_name('tabs-container')
-    #     assert tabs
-    #     assert tabs.find_element_by_id('venue-configuration')
-    #     assert tabs.find_element_by_id('paper-status')
-    #     assert tabs.find_element_by_id('reviewer-status')
-    #     assert tabs.find_element_by_id('areachair-status')
+        pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
 
-    #     assert '#' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-1').text
-    #     assert 'Paper Summary' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-2').text
-    #     assert 'Review Progress' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-3').text
-    #     assert 'Status' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-4').text
-    #     assert 'Decision' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-5').text
+        request_page(selenium, "http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Program_Chairs#paper-status", pc_client.token)
+        assert "NeurIPS 2021 Conference Program Chairs | OpenReview" in selenium.title
+        notes_panel = selenium.find_element_by_id('notes')
+        assert notes_panel
+        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('venue-configuration')
+        assert tabs.find_element_by_id('paper-status')
+        assert tabs.find_element_by_id('reviewer-status')
+        assert tabs.find_element_by_id('areachair-status')
+
+        assert '#' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-1').text
+        assert 'Paper Summary' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-2').text
+        assert 'Review Progress' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-3').text
+        assert 'Status' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-4').text
+        assert 'Decision' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-5').text
 
 
 


### PR DESCRIPTION
- I need these changes to create the Revision invitations in advance(before first deadline) with a start date = first deadline. Then users don't need to wait until we run setup_first_deadline to see the Revision button. 


- Add the Senior Area Chair to the reader list of withdrawn and desk rejected submissions.