### PR TITLE
Feature/reviewer specific conflicts

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1116,6 +1116,10 @@ class Conference(object):
 
         return conference_matching.setup(affinity_score_file, tpms_score_file, elmo_score_file, build_conflicts)
 
+    def set_matching_conflicts(profile_id, build_conflicts=None):
+        # Re-generates conflicts for a single reviewer
+        pass
+
     def setup_assignment_recruitment(self, committee_id, hash_seed, due_date, assignment_title=None, invitation_labels={}, email_template=None):
 
         conference_matching = matching.Matching(self, self.client.get_group(committee_id))

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1116,9 +1116,11 @@ class Conference(object):
 
         return conference_matching.setup(affinity_score_file, tpms_score_file, elmo_score_file, build_conflicts)
 
-    def set_matching_conflicts(profile_id, build_conflicts=None):
+    def set_matching_conflicts(self, profile_id, build_conflicts=True):
         # Re-generates conflicts for a single reviewer
-        pass
+        committee_id=self.get_reviewers_id()
+        conference_matching = matching.Matching(self, self.client.get_group(committee_id))
+        return conference_matching.append_note_conflicts(profile_id, build_conflicts)
 
     def setup_assignment_recruitment(self, committee_id, hash_seed, due_date, assignment_title=None, invitation_labels={}, email_template=None):
 

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -251,6 +251,12 @@ class Matching(object):
             return self._build_profile_conflicts(ac_profiles, user_profiles)
         return self._build_note_conflicts(submissions, user_profiles, get_profile_info)
 
+    def _append_note_conflicts(self, submissions, user_profile, get_profile_info):
+        '''
+        Create conflict edges between the given Notes and a single profile
+        '''
+        pass
+
     def _build_note_conflicts(self, submissions, user_profiles, get_profile_info):
         '''
         Create conflict edges between the given Notes and Profiles

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -676,6 +676,12 @@ Please contact info@openreview.net with any questions or concerns about this int
             tpms_score_file=os.path.join(os.path.dirname(__file__), 'data/temp.csv')
         )
 
+        # Test adding reviewer after conflicts are built
+        r4_client = helpers.create_user('reviewer5@cmu.edu', 'Reviewer', 'ECCV Five')
+        conference.set_reviewers(['~Reviewer_ECCV_One1', '~Reviewer_ECCV_Two1', '~Reviewer_ECCV_Three1', '~Reviewer_ECCV_Four1', '~Reviewer_ECCV_Five1'])
+        assert r4_client.get_edges_count() == 0
+        conference.set_matching_conflicts(r4_client.profile.id)
+        assert r4_client.get_edges_count() > 0
 
         with open(os.path.join(os.path.dirname(__file__), 'data/ac_affinity_scores.csv'), 'w') as file_handle:
             writer = csv.writer(file_handle)

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -677,11 +677,11 @@ Please contact info@openreview.net with any questions or concerns about this int
         )
 
         # Test adding reviewer after conflicts are built
-        r4_client = helpers.create_user('reviewer5@cmu.edu', 'Reviewer', 'ECCV Five')
+        r5_client = helpers.create_user('reviewer5@fb.com', 'Reviewer', 'ECCV Five')
         conference.set_reviewers(['~Reviewer_ECCV_One1', '~Reviewer_ECCV_Two1', '~Reviewer_ECCV_Three1', '~Reviewer_ECCV_Four1', '~Reviewer_ECCV_Five1'])
-        assert r4_client.get_edges_count() == 0
-        conference.set_matching_conflicts(r4_client.profile.id)
-        assert r4_client.get_edges_count() > 0
+        assert r5_client.get_edges_count() == 0
+        conference.set_matching_conflicts(r5_client.profile.id)
+        assert r5_client.get_edges_count() > 0
 
         with open(os.path.join(os.path.dirname(__file__), 'data/ac_affinity_scores.csv'), 'w') as file_handle:
             writer = csv.writer(file_handle)


### PR DESCRIPTION
Closes #595

I've added the function `set_matching_conflicts()` in the `Conference` object - which creates a `Matching` object, and calls the new public helper function `append_note_conflicts()`.
The `append_note_conflicts()` function is very similar to `_build_note_conflicts()`:

1. Sets up required objects that would have been created in a previous call to `setup()` - but the use case is that this is to be called after `setup()` was already performed
2. Adapts the user and invitation objects so that they are compatible with the conflict building loop from `_build_note_conflicts()`
3. Builds the conflicts for a single user
4. Removes existing + adds new conflict edges for the user and performs a sanity check