### PR TITLE
Use request form contact info for the invitation emails

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1212,14 +1212,6 @@ class Conference(object):
         invitation = self.invitation_builder.set_reviewer_recruiter_invitation(self, options)
         invitation = self.webfield_builder.set_recruit_page(self.id, invitation, self.get_homepage_options(), options['reviewers_name'])
 
-        contact_email = 'info@openreview.net'
-        try:
-            request_form = self.client.get_note(self.request_form_id)
-            if 'contact_email' in request_form.content.keys():
-                contact_email = request_form.content['contact_email']
-        except:
-            raise openreview.OpenReviewException('Error in retrieving request form note')
-
         role = 'reviewer' if reviewers_name == 'Reviewers' else 'area chair'
         recruit_message = '''Dear {name},
 
@@ -1241,7 +1233,7 @@ class Conference(object):
 
         If you accept, please make sure that your OpenReview account is updated and lists all the emails you are using.  Visit http://openreview.net/profile after logging in.
 
-        If you have any questions, please contact ''' + contact_email + '''.
+        If you have any questions, please contact {contact_info}.
 
         Cheers!
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1174,7 +1174,7 @@ class Conference(object):
     def set_recruitment_reduced_load(self, reduced_load_options):
         self.reduced_load_on_decline = reduced_load_options
 
-    def recruit_reviewers(self, invitees = [], title = None, message = None, reviewers_name = 'Reviewers', remind = False, invitee_names = [], retry_declined=False):
+    def recruit_reviewers(self, invitees = [], title = None, message = None, reviewers_name = 'Reviewers', remind = False, invitee_names = [], retry_declined=False, contact_info = None):
 
         pcs_id = self.get_program_chairs_id()
         reviewers_id = self.id + '/' + reviewers_name

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1292,6 +1292,7 @@ class Conference(object):
                             recruit_message,
                             recruit_message_subj,
                             reviewers_invited_id,
+                            contact_info,
                             verbose = False)
                     except openreview.OpenReviewException as e:
                         self.client.remove_members_from_group(reviewers_invited_group, reviewer_id)
@@ -1320,6 +1321,7 @@ class Conference(object):
                         recruit_message,
                         recruit_message_subj,
                         reviewers_invited_id,
+                        contact_info,
                         verbose = False)
                     recruitment_status['invited'].append(email)
                 except openreview.OpenReviewException as e:

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1174,7 +1174,7 @@ class Conference(object):
     def set_recruitment_reduced_load(self, reduced_load_options):
         self.reduced_load_on_decline = reduced_load_options
 
-    def recruit_reviewers(self, invitees = [], title = None, message = None, reviewers_name = 'Reviewers', remind = False, invitee_names = [], retry_declined=False, contact_info = None):
+    def recruit_reviewers(self, invitees = [], title = None, message = None, reviewers_name = 'Reviewers', remind = False, invitee_names = [], retry_declined=False, contact_info = 'info@openreview.net'):
 
         pcs_id = self.get_program_chairs_id()
         reviewers_id = self.id + '/' + reviewers_name
@@ -1267,7 +1267,7 @@ class Conference(object):
                             recruit_message,
                             'Reminder: ' + recruit_message_subj,
                             reviewers_invited_id,
-                            contact_info,
+                            contact_info = contact_info,
                             verbose = False)
                         recruitment_status['reminded'].append(reviewer_id)
                     except openreview.OpenReviewException as e:
@@ -1292,7 +1292,7 @@ class Conference(object):
                             recruit_message,
                             recruit_message_subj,
                             reviewers_invited_id,
-                            contact_info,
+                            contact_info = contact_info,
                             verbose = False)
                     except openreview.OpenReviewException as e:
                         self.client.remove_members_from_group(reviewers_invited_group, reviewer_id)
@@ -1321,7 +1321,7 @@ class Conference(object):
                         recruit_message,
                         recruit_message_subj,
                         reviewers_invited_id,
-                        contact_info,
+                        contact_info = contact_info,
                         verbose = False)
                     recruitment_status['invited'].append(email)
                 except openreview.OpenReviewException as e:

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1267,6 +1267,7 @@ class Conference(object):
                             recruit_message,
                             'Reminder: ' + recruit_message_subj,
                             reviewers_invited_id,
+                            contact_info,
                             verbose = False)
                         recruitment_status['reminded'].append(reviewer_id)
                     except openreview.OpenReviewException as e:

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1212,6 +1212,14 @@ class Conference(object):
         invitation = self.invitation_builder.set_reviewer_recruiter_invitation(self, options)
         invitation = self.webfield_builder.set_recruit_page(self.id, invitation, self.get_homepage_options(), options['reviewers_name'])
 
+        contact_email = 'info@openreview.net'
+        try:
+            request_form = self.client.get_note(self.request_form_id)
+            if 'contact_email' in request_form.content.keys():
+                contact_email = request_form.content['contact_email']
+        except:
+            raise openreview.OpenReviewException('Error in retrieving request form note')
+
         role = 'reviewer' if reviewers_name == 'Reviewers' else 'area chair'
         recruit_message = '''Dear {name},
 
@@ -1233,7 +1241,7 @@ class Conference(object):
 
         If you accept, please make sure that your OpenReview account is updated and lists all the emails you are using.  Visit http://openreview.net/profile after logging in.
 
-        If you have any questions, please contact info@openreview.net.
+        If you have any questions, please contact ''' + contact_email + '''.
 
         Cheers!
 

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1328,7 +1328,8 @@ def recruit_reviewer(client, user, first,
     personalized_message = recruit_message.format(
         name = first,
         accept_url = url + "Yes",
-        decline_url = url + "No"
+        decline_url = url + "No",
+        contact_info = contact_info
     )
 
     client.add_members_to_group(reviewers_invited_id, [user])

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1281,6 +1281,7 @@ def recruit_reviewer(client, user, first,
     recruit_message,
     recruit_message_subj,
     reviewers_invited_id,
+    contact_info,
     verbose=True):
     """
     Recruit a reviewer. Sends an email to the reviewer with a link to accept or
@@ -1300,6 +1301,8 @@ def recruit_reviewer(client, user, first,
     :type recruit_message_subj: str
     :param reviewers_invited_id: group ID for the "Reviewers Invited" group, often used to keep track of which reviewers have already been emailed. str
     :type reviewers_invited_id: str
+    :param contact_info: The information used to contact support for questions
+    :type contact_info: str
     :param verbose: Shows response of :meth:`openreview.Client.post_message` and shows the body of the message sent
     :type verbose: bool, optional
     :param baseurl: Use this baseUrl instead of client.baseurl to create recruitment links

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1281,7 +1281,7 @@ def recruit_reviewer(client, user, first,
     recruit_message,
     recruit_message_subj,
     reviewers_invited_id,
-    contact_info,
+    contact_info='info@openreview.net',
     verbose=True):
     """
     Recruit a reviewer. Sends an email to the reviewer with a link to accept or

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -64,6 +64,14 @@ The OpenReview Team
         signatures = ['~Super_User1']
     ))
 
+    contact_email = 'info@openreview.net'
+    try:
+        request_form = client.get_note(conference.request_form_id)
+        if 'contact_email' in request_form.content.keys():
+            contact_email = request_form.content['contact_email']
+    except:
+        raise OpenReviewException('Error in retrieving request form note')
+
     recruitment_email_subject = '[{Abbreviated_Venue_Name}] Invitation to serve as {invitee_role}'.replace('{Abbreviated_Venue_Name}', conference.get_short_name())
     recruitment_email_body = '''Dear {name},
 
@@ -85,7 +93,7 @@ Please answer within 10 days.
 
 If you accept, please make sure that your OpenReview account is updated and lists all the emails you are using.  Visit http://openreview.net/profile after logging in.
 
-If you have any questions, please contact info@openreview.net.
+If you have any questions, please contact ''' + contact_email + '''.
 
 Cheers!
 

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -64,13 +64,6 @@ The OpenReview Team
         signatures = ['~Super_User1']
     ))
 
-    contact_email = 'info@openreview.net'
-    try:
-        request_form = client.get_note(conference.request_form_id)
-        if 'contact_email' in request_form.content.keys():
-            contact_email = request_form.content['contact_email']
-    except:
-        raise OpenReviewException('Error in retrieving request form note')
 
     recruitment_email_subject = '[{Abbreviated_Venue_Name}] Invitation to serve as {invitee_role}'.replace('{Abbreviated_Venue_Name}', conference.get_short_name())
     recruitment_email_body = '''Dear {name},
@@ -93,7 +86,7 @@ Please answer within 10 days.
 
 If you accept, please make sure that your OpenReview account is updated and lists all the emails you are using.  Visit http://openreview.net/profile after logging in.
 
-If you have any questions, please contact ''' + contact_email + '''.
+If you have any questions, please contact {contact_info}.
 
 Cheers!
 

--- a/openreview/venue_request/process/recruitmentProcess.py
+++ b/openreview/venue_request/process/recruitmentProcess.py
@@ -36,9 +36,11 @@ def process(client, note, invitation):
     }
 
     # Fetch contact info
-    contact_info = note.content.get('contact_info', None)
-    if not contact_info:
-        raise openreview.OpenReviewException('Request note content missing field: contact_info')
+    if conference.request_form_id:
+        contact_info = client.get_note(conference.request_form_id).content.get('contact_email', None)
+
+    if not conference.request_form_id or not contact_info:
+        raise openreview.OpenReviewException(f'Unable to retrieve field contact_email from the request form')
 
     role_name=roles[note.content['invitee_role'].strip()]
     recruitment_status=conference.recruit_reviewers(

--- a/openreview/venue_request/process/recruitmentProcess.py
+++ b/openreview/venue_request/process/recruitmentProcess.py
@@ -36,10 +36,9 @@ def process(client, note, invitation):
     }
 
     # Fetch contact info
-    if conference.request_form_id:
-        contact_info = client.get_note(conference.request_form_id).content.get('contact_email', None)
+    contact_info = request_form.content.get('contact_email', None)
 
-    if not conference.request_form_id or not contact_info:
+    if not contact_info:
         raise openreview.OpenReviewException(f'Unable to retrieve field contact_email from the request form')
 
     role_name=roles[note.content['invitee_role'].strip()]

--- a/openreview/venue_request/process/recruitmentProcess.py
+++ b/openreview/venue_request/process/recruitmentProcess.py
@@ -40,7 +40,8 @@ def process(client, note, invitation):
         invitee_names = invitee_names,
         reviewers_name = role_name,
         title = note.content['invitation_email_subject'].strip(),
-        message = note.content['invitation_email_content'].strip()
+        message = note.content['invitation_email_content'].strip(),
+        contact_infor = contact_info
     )
 
     non_invited_status=f'''No recruitment invitation was sent to the following users because they have already been invited:

--- a/openreview/venue_request/process/recruitmentProcess.py
+++ b/openreview/venue_request/process/recruitmentProcess.py
@@ -34,6 +34,12 @@ def process(client, note, invitation):
         'area chair': 'Area_Chairs',
         'senior area chair': 'Senior_Area_Chairs'
     }
+
+    # Fetch contact info
+    contact_info = note.content.get('contact_info', None)
+    if not contact_info:
+        raise openreview.OpenReviewException('Request note content missing field: contact_info')
+
     role_name=roles[note.content['invitee_role'].strip()]
     recruitment_status=conference.recruit_reviewers(
         invitees = invitee_emails,
@@ -41,7 +47,7 @@ def process(client, note, invitation):
         reviewers_name = role_name,
         title = note.content['invitation_email_subject'].strip(),
         message = note.content['invitation_email_content'].strip(),
-        contact_infor = contact_info
+        contact_info = contact_info
     )
 
     non_invited_status=f'''No recruitment invitation was sent to the following users because they have already been invited:

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -382,7 +382,7 @@ class TestNeurIPSConference():
                 'invitee_reduced_load': ['2', '3', '4'],
                 'invitee_details': reviewer_details,
                 'invitation_email_subject': '[' + request_form.content['Abbreviated Venue Name'] + '] Invitation to serve as {invitee_role}',
-                'invitation_email_content': 'Dear {name},\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as {invitee_role}.\n\nACCEPT LINK:\n\n{accept_url}\n\nDECLINE LINK:\n\n{decline_url}\n\nCheers!\n\nProgram Chairs'
+                'invitation_email_content': 'Dear {name},\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as {invitee_role}.\n\nACCEPT LINK:\n\n{accept_url}\n\nDECLINE LINK:\n\n{decline_url}\n\nIf you have any questions, please contact {contact_info}.\n\nCheers!\n\nProgram Chairs'
             },
             forum=request_form.forum,
             replyto=request_form.forum,
@@ -408,6 +408,7 @@ class TestNeurIPSConference():
         assert messages and len(messages) == 1
         assert messages[0]['content']['subject'] == '[NeurIPS 2021] Invitation to serve as reviewer'
         assert messages[0]['content']['text'].startswith('Dear Reviewer UMass,\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as reviewer.')
+        assert 'pc@neurips.cc' in messages[0]['content']['text']
         reject_url = re.search('https://.*response=No', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030')
         request_page(selenium, reject_url, alert=True)
         notes = selenium.find_element_by_id("notes")


### PR DESCRIPTION
Resolves #938

In `builder.py` and `deployProcess.py`, the request form note is retrieved and searched for the key `contact_email` in the content field. If no contact email is present, defaults to info@openreview.net