### PR TITLE
Fix/submission revision deadline

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -330,7 +330,7 @@ def get_submission_revision_stage(client, request_forum):
     else:
         submission_revision_start_date = None
 
-    submission_revision_due_date = request_forum.content.get('submission_revision_due_date', '').strip()
+    submission_revision_due_date = request_forum.content.get('submission_revision_deadline', '').strip()
     if submission_revision_due_date:
         try:
             submission_revision_due_date = datetime.datetime.strptime(submission_revision_due_date, '%Y/%m/%d %H:%M')

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -775,7 +775,7 @@ var calcReviewersComplete = function(reviewerGroupMaps, officialReviews) {
     var allSubmitted = _.every(noteNumbers, function(n) {
       var assignedReviewers = reviewerGroupMaps.byNotes[n];
       var anonGroupNumber = _.findKey(assignedReviewers, function(v) { return v === reviewer; });
-      return reviewsBySignature[CONFERENCE_ID + '/Paper' + n + '/AnonReviewer' + anonGroupNumber];
+      return reviewsBySignature[CONFERENCE_ID + '/Paper' + n + '/Reviewer_' + anonGroupNumber];
     });
     return allSubmitted ? numComplete + 1 : numComplete;
   }, 0);

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -1089,4 +1089,5 @@ class TestVenueRequest():
         assert len(revision_invitations[0].reply['content'].keys())==1
         assert 'supplementary_material' in revision_invitations[0].reply['content']
         assert all(x not in revision_invitations[0].reply['content'] for x in ['title','authors', 'authorids','abstract','keywords', 'TL;DR'])
-
+        assert revision_invitations[0].duedate
+        assert revision_invitations[0].expdate


### PR DESCRIPTION
- Submission revision invitations were being created with no due date because of a field name mismatch
- Fix PC console 'Reviewer Progress' count