### PR TITLE
Keep blind papers blind when adding revision after decisions

### DIFF
--- a/openreview/conference/templates/submission_revision_process.py
+++ b/openreview/conference/templates/submission_revision_process.py
@@ -38,17 +38,22 @@ To view your submission, click here: https://openreview.net/forum?id={}'''.forma
         notes=client.get_notes(original=forum.id)
         if notes:
             bibtex_note=notes[0]
+            released_note = bibtex_note.content.get('authors') != ['Anonymous']
             bibtex_note.content = {
                 'venue': bibtex_note.content.get('venue'),
                 'venueid': bibtex_note.content.get('venueid')
             }
+            if not released_note:
+                bibtex_note.content['authors'] = ['Anonymous']
+                bibtex_note.content['authorids'] = CONFERENCE_ID + '/Paper' + str(bibtex_note.number) + '/' + AUTHORS_NAME
+
         bibtex_note.content['_bibtex'] = openreview.tools.get_bibtex(
             note,
             venue_fullname=CONFERENCE_NAME,
             year=CONFERENCE_YEAR,
             url_forum=bibtex_note.id,
             accepted=True,
-            anonymous=forum.content.get('authorids', []) == ['Anonymous']
+            anonymous=bibtex_note.content.get('authors', []) == ['Anonymous']
         )
         client.post_note(bibtex_note)
 

--- a/openreview/conference/templates/submission_revision_process.py
+++ b/openreview/conference/templates/submission_revision_process.py
@@ -38,14 +38,14 @@ To view your submission, click here: https://openreview.net/forum?id={}'''.forma
         notes=client.get_notes(original=forum.id)
         if notes:
             bibtex_note=notes[0]
-            released_note = bibtex_note.content.get('authors') != ['Anonymous']
+            anonymous_note = bibtex_note.content.get('authors') == ['Anonymous']
             bibtex_note.content = {
                 'venue': bibtex_note.content.get('venue'),
                 'venueid': bibtex_note.content.get('venueid')
             }
-            if not released_note:
+            if anonymous_note:
                 bibtex_note.content['authors'] = ['Anonymous']
-                bibtex_note.content['authorids'] = CONFERENCE_ID + '/Paper' + str(bibtex_note.number) + '/' + AUTHORS_NAME
+                bibtex_note.content['authorids'] = [CONFERENCE_ID + '/Paper' + str(bibtex_note.number) + '/' + AUTHORS_NAME]
 
         bibtex_note.content['_bibtex'] = openreview.tools.get_bibtex(
             note,
@@ -56,4 +56,3 @@ To view your submission, click here: https://openreview.net/forum?id={}'''.forma
             anonymous=bibtex_note.content.get('authors', []) == ['Anonymous']
         )
         client.post_note(bibtex_note)
-


### PR DESCRIPTION
When the submission revision is enabled for accepted papers only after decisions are posted (but before author names are revealed) and we add 'venue' and `venueid` to the content of the blind submission, we stop hiding author names. 

Now, I check if submission is still blind and then add `Anonymous` and the author group as `authors` and `authorids` to the blind copy's content. 