### PR TITLE
PC console: handle the case when there's no ac

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -2951,13 +2951,13 @@ var buildCSV = function(){
     var areachairProfileOne = {}
     var areachairProfileTwo = {'id':'-', 'name':'-', 'email':'-'}
 
-    if (areachairId) {
+    if (areachairId.length) {
       areachairProfileOne = findProfile(areachairId[0]);
       if (areachairId.length>1) {
         areachairProfileTwo = findProfile(areachairId[1]);
       }
     } else {
-      areachairProfileOne.id = view.prettyId(CONFERENCE_ID + '/Paper' + note.number + '/Area_Chairs');
+      areachairProfileOne.id = view.prettyId(CONFERENCE_ID + '/Paper' + noteNumber + '/Area_Chairs');
       areachairProfileOne.name = '-';
       areachairProfileOne.email = '-';
     }


### PR DESCRIPTION
when some paper don't have ac or the pc can't see the ac, areachairId will be empty array which is evaluated to true and the code will fail at

areachariId[0]

check length instead