### PR TITLE
Change review rating readers to include signature

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1837,7 +1837,7 @@ class ReviewRatingStage(object):
         readers = [ conference.get_program_chairs_id()]
 
         if conference.use_area_chairs:
-            readers.append(conference.get_area_chairs_id(number = number))
+            readers.append('{signatures}')
 
         if self.release_to_reviewers is not ReviewRatingStage.Readers.NO_REVIEWERS:
             readers.append(self._get_reviewer_readers(conference, number, review_signature))

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1064,7 +1064,7 @@ class PaperReviewRatingInvitation(openreview.Invitation):
             'replyto': review.id,
             'readers': {
                 'description': 'Select all user groups that should be able to read this comment.',
-                'values': readers
+                'values-copied': readers
             },
             'writers': {
                 'values-copied': [conference.get_id(), '{signatures}'],

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -1609,7 +1609,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
             replyto=reviews[1].id,
             invitation=reviews[1].signatures[0] + '/-/Review_Rating',
             readers=['thecvf.com/ECCV/2020/Conference/Program_Chairs',
-            'thecvf.com/ECCV/2020/Conference/Paper1/Area_Chairs'],
+            signatory],
             writers=[signatory],
             signatures=[signatory],
             content={

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -2314,7 +2314,7 @@ OpenReview Team'''
             replyto=reviews[0].id,
             invitation=reviews[0].signatures[0] + '/-/Review_Rating',
             readers=['NeurIPS.cc/2021/Conference/Program_Chairs',
-            'NeurIPS.cc/2021/Conference/Paper5/Area_Chairs'],
+            ac_anon_id],
             writers=[ac_anon_id],
             signatures=[ac_anon_id],
             content={


### PR DESCRIPTION
Sometimes papers may have multiple assigned ACs, and we don't want an AC of a paper to see the reviewer feedback posted by another AC.