### PR TITLE
setup matching for groups vs groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ cov.xml
 tests/drivers/geckodriver
 tests/data/reviewer_affinity_scores.csv
 tests/data/ac_affinity_scores.csv
+tests/data/mentors_affinity_scores.csv
 tests/data/temp.csv

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1114,10 +1114,12 @@ class Conference(object):
 
         return self.webfield_builder.set_impersonate_page(self, impersonate_group)
 
-    def setup_matching(self, committee_id=None, affinity_score_file=None, tpms_score_file=None, elmo_score_file=None, build_conflicts=None):
+    def setup_matching(self, committee_id=None, affinity_score_file=None, tpms_score_file=None, elmo_score_file=None, build_conflicts=None, alternate_matching_group=None):
         if committee_id is None:
             committee_id=self.get_reviewers_id()
-        conference_matching = matching.Matching(self, self.client.get_group(committee_id))
+        if self.use_senior_area_chairs and committee_id is self.get_senior_area_chairs_id() and not alternate_matching_group:
+            alternate_matching_group = self.get_area_chairs_id()
+        conference_matching = matching.Matching(self, self.client.get_group(committee_id), alternate_matching_group)
 
         return conference_matching.setup(affinity_score_file, tpms_score_file, elmo_score_file, build_conflicts)
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1117,7 +1117,7 @@ class Conference(object):
     def setup_matching(self, committee_id=None, affinity_score_file=None, tpms_score_file=None, elmo_score_file=None, build_conflicts=None, alternate_matching_group=None):
         if committee_id is None:
             committee_id=self.get_reviewers_id()
-        if self.use_senior_area_chairs and committee_id is self.get_senior_area_chairs_id() and not alternate_matching_group:
+        if self.use_senior_area_chairs and committee_id == self.get_senior_area_chairs_id() and not alternate_matching_group:
             alternate_matching_group = self.get_area_chairs_id()
         conference_matching = matching.Matching(self, self.client.get_group(committee_id), alternate_matching_group)
 


### PR DESCRIPTION
Setup matching when we want to match people vs people, for example: SAC vs AC or Mentors vs Mentees. 

@carlosmondra you can use this to setup the matching for Mentors and Mentees:

```
conference.setup_matching(committee_id=conference.id + '/Reviewers_Mentors',
affinity_score_file=os.path.join(os.path.dirname(__file__), 'data/mentors_affinity_scores.csv'),
alternate_matching_group=conference.id + '/Reviewers_Mentees')
```