### PR TITLE
Fix/Allow export of PC console AC status tab

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -66,6 +66,7 @@ var pcTags = {};
 var selectedNotesById = {};
 var matchingNoteIds = [];
 var paperStatusNeedsRerender = false;
+var tableDataInDisplay = null;
 
 $.getScript('https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.2/FileSaver.min.js');
 
@@ -1779,6 +1780,7 @@ var displayAreaChairsStatusTable = function() {
       order = order === 'asc' ? 'desc' : 'asc';
     }
     var rowDataToRender = _.orderBy(filteredRows === null ? rowData : filteredRows, sortOptions[newOption], order);
+    tableDataInDisplay = rowDataToRender;
     renderTable(container, rowDataToRender);
   }
 
@@ -1804,6 +1806,7 @@ var displayAreaChairsStatusTable = function() {
     } else {
       filteredRows = rowData;
     }
+    tableDataInDisplay = filteredRows;
     renderTable(container, filteredRows);
   };
 
@@ -1926,8 +1929,10 @@ var displayAreaChairsStatusTable = function() {
         '<li><a class="msg-submitted-none-metareviews">Area Chairs with 0 submitted meta reviews</a></li>' +
         '<li><a class="msg-unsubmitted-metareviews">Area Chairs with unsubmitted meta reviews</a></li>' +
       '</ul>' +
-    '</div>'
+    '</div>' +
+    '<div class="btn-group"><button class="btn btn-export-areachairs" type="button">Export</button></div>'
   );
+  tableDataInDisplay = rowData;
   renderTable(container, rowData);
 };
 
@@ -3121,6 +3126,32 @@ var buildReviewersCSV = function(){
   return [rowData.join('')];
 };
 
+var buildAreaChairsCSV = function(){
+  var columnNames = ['id','name','email','assigned papers','reviews completed','meta reviews completed']
+  if(SENIOR_AREA_CHAIRS_ID) columnNames=columnNames.concat(['sac id','sac name','sac email'])
+  var rowData = [];
+  rowData.push(columnNames.join(',') + '\n');
+  _.forEach(tableDataInDisplay, function(ac) {
+    var id = ac.summary?.id;
+    var name = ac.summary?.name;
+    var email = ac.summary?.email;
+    var assignedPapers = ac.reviewProgressData?.numPapers;
+    var reviewsCompleted = ac.reviewProgressData?.numCompletedReviews;
+    var metaReviewsCompleted = ac.reviewProgressData?.numCompletedMetaReviews;
+    var sacId = ac.seniorSummary?.id
+    var sacName = ac.seniorSummary?.name
+    var sacEmail = ac.seniorSummary?.email
+
+    if(SENIOR_AREA_CHAIRS_ID){
+      rowData.push([id,name,email,assignedPapers,reviewsCompleted,metaReviewsCompleted,sacId,sacName,sacEmail].join(',') + '\n');
+    } else {
+      rowData.push([id,name,email,assignedPapers,reviewsCompleted,metaReviewsCompleted].join(',') + '\n');
+    }
+  });
+
+  return [rowData.join('')];
+}
+
 $('#group-container').on('click', 'button.btn.btn-export-data', function(e) {
   var blob = new Blob(buildCSV(), {type: 'text/csv'});
   var fileName = conferenceStatusData.filteredNotes ? SHORT_PHRASE.replace(/\s/g, '_') + '_paper_status(Filtered).csv' : SHORT_PHRASE.replace(/\s/g, '_') + '_paper_status.csv'
@@ -3130,4 +3161,13 @@ $('#group-container').on('click', 'button.btn.btn-export-data', function(e) {
 $('#group-container').on('click', 'button.btn.btn-export-reviewers', function(e) {
   var blob = new Blob(buildReviewersCSV(), {type: 'text/csv'});
   saveAs(blob, SHORT_PHRASE.replace(/\s/g, '_') + '_reviewer_status.csv');
+});
+
+$('#group-container').on('click', 'button.btn.btn-export-areachairs', function(e) {
+  var notFiltered = conferenceStatusData.areaChairs.length === tableDataInDisplay?.length;
+  var blob = new Blob(buildAreaChairsCSV(), {type: 'text/csv'});
+  var fileName = notFiltered
+    ? SHORT_PHRASE.replace(/\s/g, '_') + '_ac_status.csv'
+    : SHORT_PHRASE.replace(/\s/g, '_') + '_ac_status(Filtered).csv'
+  saveAs(blob, fileName);
 });


### PR DESCRIPTION
add export button to AC status tab of PC console

added a variable to store data that is displayed in table to avoid rebuilding the data during export
