### PR TITLE
keep the same hide_fields when calling different stages

### DIFF
--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -14,7 +14,7 @@ def process(client, note, invitation):
 
     invitation_type = invitation.id.split('/')[-1]
     if invitation_type in ['Bid_Stage', 'Review_Stage', 'Meta_Review_Stage', 'Decision_Stage', 'Submission_Revision_Stage', 'Comment_Stage']:
-        conference.setup_post_submission_stage()
+        conference.setup_post_submission_stage(hide_fields=forum_note.content.get('hide_fields', []))
 
     if invitation_type == 'Bid_Stage':
         ## TODO: run setup_matching inside of BidStage?

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -573,7 +573,8 @@ class TestNeurIPSConference():
                     'title': 'Paper title ' + str(i) ,
                     'abstract': 'This is an abstract ' + str(i),
                     'authorids': ['test@mail.com', 'peter@mail.com', 'andrew@' + domains[i]],
-                    'authors': ['SomeFirstName User', 'Peter SomeLastName', 'Andrew Mc']
+                    'authors': ['SomeFirstName User', 'Peter SomeLastName', 'Andrew Mc'],
+                    'keywords': ['machine learning', 'nlp']
                 }
             )
             if i == 1:
@@ -680,7 +681,7 @@ class TestNeurIPSConference():
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         post_submission_note=pc_client.post_note(openreview.Note(
-            content= { 'force': 'Yes' },
+            content= { 'force': 'Yes', 'hide_fields': ['keywords'] },
             forum= request_form.id,
             invitation= f'openreview.net/Support/-/Request{request_form.number}/Post_Submission',
             readers= ['NeurIPS.cc/2021/Conference/Program_Chairs', 'openreview.net/Support'],
@@ -698,6 +699,9 @@ class TestNeurIPSConference():
 
         submissions = conference.get_submissions()
         assert len(submissions) == 5
+
+        assert submissions[0].content['keywords'] == ''
+
         assert submissions[0].readers == ['NeurIPS.cc/2021/Conference',
             'NeurIPS.cc/2021/Conference/Senior_Area_Chairs',
             'NeurIPS.cc/2021/Conference/Area_Chairs',


### PR DESCRIPTION
- Keep the same hidden fields when calling to different stages(Comment, Review, etc) after the Post Submission Stage. 
