### PR TITLE
Fix/Error messaging reviewers with unsubmitted reviews

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -2125,7 +2125,7 @@ var displayReviewerStatusTable = function() {
         return row.summary.completedBids === 0;
       },
       'msg-unsubmitted-reviews': function(row) {
-        return row.reviewProgressData.numCompletedReviews < row.reviewProgressData.numPapers;
+        return row.reviewerProgressData.numCompletedReviews < row.reviewerProgressData.numPapers;
       }
     }
     var usersToMessage = rowData.filter(filterFuncs[filter]).map(function(row) {


### PR DESCRIPTION
pc of a workshop reported that messaging reviewers with unsubmitted reviews function stopped working
looks like it's reading a wrong field

there are two different but similar objects used: 

- reviewProgressData
- reviewerProgressData

i think the one to use in reviewer tab should be reviewerProgressData
did a search in pc console webfield and i think this is the only place where it got wrong
maybe we should rename these fields