### PR TITLE
check invitees that are already members

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1247,6 +1247,7 @@ class Conference(object):
             'invited': [],
             'reminded': [],
             'already_invited': {},
+            'already_member': {},
             'errors': []
         }
 
@@ -1358,14 +1359,21 @@ Program Chairs
         for index, email in enumerate(tqdm(invitees, desc='send_invitations')):
             memberships = [g.id for g in self.client.get_groups(member=email, regex=self.id)] if tools.get_group(self.client, email) else []
             invited_roles = [f'{self.id}/{role}/Invited' for role in committee_roles]
+            member_roles = [f'{self.id}/{role}' for role in committee_roles]
 
             invited_group_ids=list(set(invited_roles) & set(memberships))
+            member_group_ids=list(set(member_roles) & set(memberships))
 
             if invited_group_ids:
                 invited_group_id=invited_group_ids[0]
                 if invited_group_id not in recruitment_status['already_invited']:
                     recruitment_status['already_invited'][invited_group_id] = []
                 recruitment_status['already_invited'][invited_group_id].append(email)
+            elif member_group_ids:
+                member_group_id = member_group_ids[0]
+                if member_group_id not in recruitment_status['already_member']:
+                    recruitment_status['already_member'][member_group_id] = []
+                recruitment_status['already_member'][member_group_id].append(email)
             else:
                 name = invitee_names[index] if (invitee_names and index < len(invitee_names)) else None
                 if not name:

--- a/openreview/venue_request/process/recruitmentProcess.py
+++ b/openreview/venue_request/process/recruitmentProcess.py
@@ -55,6 +55,10 @@ def process(client, note, invitation):
 
 {recruitment_status.get('already_invited', {})}''' if recruitment_status.get('already_invited') else ''
 
+    already_member_status=f'''No recruitment invitation was sent to the following users because they are already members of the group:
+
+{recruitment_status.get('already_member', '')}''' if recruitment_status.get('already_member') else ''
+
     comment_note = openreview.Note(
         invitation = note.invitation.replace('Recruitment', 'Comment'),
         forum = note.forum,
@@ -68,6 +72,8 @@ def process(client, note, invitation):
 Invited: {len(recruitment_status.get('invited', []))} users.
 
 {non_invited_status}
+
+{already_member_status}
 
 Please check the invitee group to see more details: https://openreview.net/group?id={conference.id}/{role_name}/Invited
             '''

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -225,6 +225,68 @@ class TestNeurIPSConference():
         assert len(accepted_group.members) == 1
         assert '~Area_CMUChair1' in accepted_group.members
 
+        ## Manual add an AC to the group and then invite them
+        client.add_members_to_group('aclweb.org/ACL/ARR/2021/September/Area_Chairs', 'previous_ac@mail.com')
+
+        accepted_group = client.get_group(id='aclweb.org/ACL/ARR/2021/September/Area_Chairs')
+        assert len(accepted_group.members) == 2
+        assert '~Area_CMUChair1' in accepted_group.members
+        assert 'previous_ac@mail.com' in accepted_group.members
+
+        reviewer_details = '''previous_ac@mail.com, Previous AC'''
+        recruitment_note = pc_client.post_note(openreview.Note(
+            content={
+                'title': 'Recruitment',
+                'invitee_role': 'area chair',
+                'allow_role_overlap': 'Yes',
+                'invitee_details': reviewer_details,
+                'invitation_email_subject': '[ARR 2021 - September] Invitation to serve as {invitee_role}',
+                'invitation_email_content': 'Dear {name},\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as {invitee_role}.\n\nACCEPT LINK:\n\n{accept_url}\n\nDECLINE LINK:\n\n{decline_url}\n\nCheers!\n\nProgram Chairs'
+            },
+            forum=request_form.forum,
+            replyto=request_form.forum,
+            invitation='openreview.net/Support/-/Request{}/Recruitment'.format(request_form.number),
+            readers=['aclweb.org/ACL/ARR/2021/September/Program_Chairs', 'openreview.net/Support'],
+            signatures=['~Program_ARRChair1'],
+            writers=[]
+        ))
+        assert recruitment_note
+
+        helpers.await_queue()
+
+        recruitment_status_notes=client.get_notes(forum=recruitment_note.forum, replyto=recruitment_note.id)
+        assert len(recruitment_status_notes) == 1
+        assert 'Invited: 0 users.' in recruitment_status_notes[0].content['comment']
+        assert 'No recruitment invitation was sent to the following users because they are already members of the group:\n\n{\'aclweb.org/ACL/ARR/2021/September/Area_Chairs\': [\'previous_ac@mail.com\']}' in recruitment_status_notes[0].content['comment']
+        assert "Please check the invitee group to see more details: https://openreview.net/group?id=aclweb.org/ACL/ARR/2021/September/Area_Chairs/Invited" in recruitment_status_notes[0].content['comment']
+
+        reviewer_details = '''previous_ac@mail.com, Previous AC'''
+        recruitment_note = pc_client.post_note(openreview.Note(
+            content={
+                'title': 'Recruitment',
+                'invitee_role': 'reviewer',
+                'allow_role_overlap': 'Yes',
+                'invitee_details': reviewer_details,
+                'invitation_email_subject': '[ARR 2021 - September] Invitation to serve as {invitee_role}',
+                'invitation_email_content': 'Dear {name},\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as {invitee_role}.\n\nACCEPT LINK:\n\n{accept_url}\n\nDECLINE LINK:\n\n{decline_url}\n\nCheers!\n\nProgram Chairs'
+            },
+            forum=request_form.forum,
+            replyto=request_form.forum,
+            invitation='openreview.net/Support/-/Request{}/Recruitment'.format(request_form.number),
+            readers=['aclweb.org/ACL/ARR/2021/September/Program_Chairs', 'openreview.net/Support'],
+            signatures=['~Program_ARRChair1'],
+            writers=[]
+        ))
+        assert recruitment_note
+
+        helpers.await_queue()
+
+        recruitment_status_notes=client.get_notes(forum=recruitment_note.forum, replyto=recruitment_note.id)
+        assert len(recruitment_status_notes) == 1
+        assert 'Invited: 1 users.' in recruitment_status_notes[0].content['comment']
+        assert "Please check the invitee group to see more details: https://openreview.net/group?id=aclweb.org/ACL/ARR/2021/September/Reviewers/Invited" in recruitment_status_notes[0].content['comment']
+
+
 
     def test_submit_papers(self, test_client, client, helpers):
 


### PR DESCRIPTION
ARR is copying the reviewers members from one cycle to the other without copying the invited ones. The recruitment process assumes that all the reviewers come from an invitation (they are members of the /Invited group). In this case the validation wouldn't detect the reviewers that are already in the Reviewers group and it would send an invitation anyway. 

To solve this I'm adding an extra validation that check if the invitee is in the Reviewers group and don't send the invitation email. Also report this in the status message.