### PR TITLE
Fix/sync ac vs sac

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1940,6 +1940,16 @@ class InvitationBuilder(object):
         is_senior_area_chair = committee_id == conference.get_senior_area_chairs_id()
         is_reviewer = committee_id == conference.get_reviewers_id()
 
+        if is_senior_area_chair:
+            with open(os.path.join(os.path.dirname(__file__), 'templates/sac_assignment_post_process.py')) as post:
+                post_content = post.read()
+                post_content = post_content.replace("CONFERENCE_ID = ''", "CONFERENCE_ID = '" + conference.id + "'")
+                post_content = post_content.replace("PAPER_GROUP_ID = ''", "PAPER_GROUP_ID = '" + conference.get_senior_area_chairs_id(number='{number}') + "'")
+                post_content = post_content.replace("AC_ASSIGNMENT_INVITATION_ID = ''", "AC_ASSIGNMENT_INVITATION_ID = '" + conference.get_paper_assignment_id(conference.get_area_chairs_id(), deployed=True) + "'")
+                invitation.process=post_content
+                invitation.signatures=[conference.get_program_chairs_id()] ## Program Chairs can see the reviews
+                return self.client.post_invitation(invitation)
+
         with open(os.path.join(os.path.dirname(__file__), 'templates/assignment_pre_process.py')) as pre:
             pre_content = pre.read()
             pre_content = pre_content.replace("REVIEW_INVITATION_ID = ''", "REVIEW_INVITATION_ID = '" + conference.get_invitation_id(conference.meta_review_stage.name if is_area_chair else conference.review_stage.name, '{number}') + "'")
@@ -1953,6 +1963,7 @@ class InvitationBuilder(object):
                 post_content = post_content.replace("GROUP_ID = ''", "GROUP_ID = '" + (conference.get_area_chairs_id() if is_area_chair else conference.get_reviewers_id()) + "'")
                 if conference.use_senior_area_chairs and is_area_chair:
                     post_content = post_content.replace("SYNC_SAC_ID = ''", "SYNC_SAC_ID = '" + conference.get_senior_area_chairs_id(number='{number}') + "'")
+                    post_content = post_content.replace("SAC_ASSIGNMENT_INVITATION_ID = ''", "SAC_ASSIGNMENT_INVITATION_ID = '" + conference.get_paper_assignment_id(conference.get_senior_area_chairs_id(), deployed=True) + "'")
                 invitation.process=post_content
                 invitation.preprocess=pre_content
                 invitation.signatures=[conference.get_program_chairs_id()] ## Program Chairs can see the reviews

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1935,8 +1935,11 @@ class InvitationBuilder(object):
 
     def set_assignment_invitation(self, conference, committee_id):
 
-        invitation=self.client.get_invitation(conference.get_paper_assignment_id(committee_id, deployed=True))
-        is_area_chair=committee_id == conference.get_area_chairs_id()
+        invitation = self.client.get_invitation(conference.get_paper_assignment_id(committee_id, deployed=True))
+        is_area_chair = committee_id == conference.get_area_chairs_id()
+        is_senior_area_chair = committee_id == conference.get_senior_area_chairs_id()
+        is_reviewer = committee_id == conference.get_reviewers_id()
+
         with open(os.path.join(os.path.dirname(__file__), 'templates/assignment_pre_process.py')) as pre:
             pre_content = pre.read()
             pre_content = pre_content.replace("REVIEW_INVITATION_ID = ''", "REVIEW_INVITATION_ID = '" + conference.get_invitation_id(conference.meta_review_stage.name if is_area_chair else conference.review_stage.name, '{number}') + "'")
@@ -1948,6 +1951,8 @@ class InvitationBuilder(object):
                 post_content = post_content.replace("PAPER_GROUP_ID = ''", "PAPER_GROUP_ID = '" + (conference.get_area_chairs_id(number='{number}') if is_area_chair else conference.get_reviewers_id(number='{number}')) + "'")
                 post_content = post_content.replace("GROUP_NAME = ''", "GROUP_NAME = '" + (conference.get_area_chairs_name(pretty=True) if is_area_chair else conference.get_reviewers_name(pretty=True)) + "'")
                 post_content = post_content.replace("GROUP_ID = ''", "GROUP_ID = '" + (conference.get_area_chairs_id() if is_area_chair else conference.get_reviewers_id()) + "'")
+                if conference.use_senior_area_chairs and is_area_chair:
+                    post_content = post_content.replace("SYNC_SAC_ID = ''", "SYNC_SAC_ID = '" + conference.get_senior_area_chairs_id(number='{number}') + "'")
                 invitation.process=post_content
                 invitation.preprocess=pre_content
                 invitation.signatures=[conference.get_program_chairs_id()] ## Program Chairs can see the reviews

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -1236,16 +1236,18 @@ class Matching(object):
                         sac_group.members.append(sac)
                         self.client.post_group(sac_group)
 
-                        assignment_edges.append(openreview.Edge(
-                            invitation=assignment_invitation_id,
-                            head=ac,
-                            tail=sac_assignment['tail'],
-                            readers=sac_assignment['readers'],
-                            nonreaders=sac_assignment['nonreaders'],
-                            writers=sac_assignment['writers'],
-                            signatures=sac_assignment['signatures'],
-                            weight=sac_assignment.get('weight')
-                        ))
+        for head, sac_assignments in proposed_assignment_edges.items():
+            for sac_assignment in sac_assignments:
+                assignment_edges.append(openreview.Edge(
+                    invitation=assignment_invitation_id,
+                    head=head,
+                    tail=sac_assignment['tail'],
+                    readers=sac_assignment['readers'],
+                    nonreaders=sac_assignment['nonreaders'],
+                    writers=sac_assignment['writers'],
+                    signatures=sac_assignment['signatures'],
+                    weight=sac_assignment.get('weight')
+                ))
 
         print('POsting assignments edges', len(assignment_edges))
         openreview.tools.post_bulk_edges(client=self.client, edges=assignment_edges)

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -1330,7 +1330,7 @@ class Matching(object):
                     weight=sac_assignment.get('weight')
                 ))
 
-        print('POsting assignments edges', len(assignment_edges))
+        print('Posting assignments edges', len(assignment_edges))
         openreview.tools.post_bulk_edges(client=self.client, edges=assignment_edges)
 
 

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -1204,8 +1204,10 @@ class Matching(object):
 
         papers = list(openreview.tools.iterget_notes(self.client, invitation=self.conference.get_blind_submission_id()))
 
-        assignment_edges =  { g['id']['head']: g['values'] for g in self.client.get_grouped_edges(invitation=self.conference.get_paper_assignment_id(self.match_group.id),
-            label=assignment_title, groupby='head', select='tail')}
+        proposed_assignment_edges =  { g['id']['head']: g['values'] for g in self.client.get_grouped_edges(invitation=self.conference.get_paper_assignment_id(self.match_group.id),
+            label=assignment_title, groupby='head', select=None)}
+        assignment_edges = []
+        assignment_invitation_id = self.conference.get_paper_assignment_id(self.match_group.id, deployed=True)
 
         ac_groups = {g.id:g for g in openreview.tools.iterget_groups(self.client, regex=self.conference.get_area_chairs_id('.*'))}
 
@@ -1223,7 +1225,7 @@ class Matching(object):
                     raise openreview.OpenReviewException('AC assignments must be deployed first')
 
                 for ac in ac_group.members:
-                    sac_assignments = assignment_edges.get(ac, [])
+                    sac_assignments = proposed_assignment_edges.get(ac, [])
 
                     for sac_assignment in sac_assignments:
                         sac=sac_assignment['tail']
@@ -1234,8 +1236,19 @@ class Matching(object):
                         sac_group.members.append(sac)
                         self.client.post_group(sac_group)
 
-        ac_group=self.client.get_group(self.conference.get_area_chairs_id())
-        self.conference.webfield_builder.edit_web_value(ac_group, 'ASSIGNMENT_LABEL', assignment_title)
+                        assignment_edges.append(openreview.Edge(
+                            invitation=assignment_invitation_id,
+                            head=ac,
+                            tail=sac_assignment['tail'],
+                            readers=sac_assignment['readers'],
+                            nonreaders=sac_assignment['nonreaders'],
+                            writers=sac_assignment['writers'],
+                            signatures=sac_assignment['signatures'],
+                            weight=sac_assignment.get('weight')
+                        ))
+
+        print('POsting assignments edges', len(assignment_edges))
+        openreview.tools.post_bulk_edges(client=self.client, edges=assignment_edges)
 
 
     def deploy(self, assignment_title, overwrite=False, enable_reviewer_reassignment=False):
@@ -1251,11 +1264,11 @@ class Matching(object):
             return self.deploy_reviewers(assignment_title, overwrite)
 
 
-        if self.match_group.id == self.conference.get_senior_area_chairs_id():
-            return self.deploy_sac_assignments(assignment_title, overwrite)
-
         ## Deploy assingments creating groups and assignment edges
-        self.deploy_assignments(assignment_title, overwrite)
+        if self.match_group.id == self.conference.get_senior_area_chairs_id():
+            self.deploy_sac_assignments(assignment_title, overwrite)
+        else:
+            self.deploy_assignments(assignment_title, overwrite)
 
         ## Add sync process function
         self.conference.invitation_builder.set_paper_group_invitation(self.conference, self.match_group.id)

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -15,7 +15,6 @@ var REVIEW_RATING_NAME = 'rating';
 var REVIEW_CONFIDENCE_NAME = 'confidence';
 var OFFICIAL_META_REVIEW_NAME = '';
 var SENIOR_AREA_CHAIRS_ID = '';
-var ASSIGNMENT_LABEL = '';
 var ENABLE_REVIEWER_REASSIGNMENT = false;
 var ENABLE_REVIEWER_REASSIGNMENT_TO_OUTSIDE_REVIEWERS = false;
 
@@ -255,7 +254,7 @@ var loadData = function(paperNums) {
   });
 
   if (SENIOR_AREA_CHAIRS_ID) {
-    assignedSACP = Webfield.get('/edges', { invitation: SENIOR_AREA_CHAIRS_ID + '/-/Proposed_Assignment', label: ASSIGNMENT_LABEL, head: user.profile.id })
+    assignedSACP = Webfield.get('/edges', { invitation: SENIOR_AREA_CHAIRS_ID + '/-/Assignment', head: user.profile.id })
     .then(function(result) {
       if (result && result.edges.length) {
         return result.edges[0].tail;

--- a/openreview/conference/templates/assignment_post_process.py
+++ b/openreview/conference/templates/assignment_post_process.py
@@ -6,6 +6,7 @@ def process_update(client, edge, invitation, existing_edge):
     GROUP_NAME = ''
     PAPER_GROUP_ID = ''
     SYNC_SAC_ID = ''
+    SAC_ASSIGNMENT_INVITATION_ID = ''
     print(edge.id)
     print(invitation.id)
     print(existing_edge)
@@ -29,7 +30,7 @@ def process_update(client, edge, invitation, existing_edge):
 
         if SYNC_SAC_ID:
             print('Add the SAC to the paper group')
-            assignments = client.get_edges(invitation=CONFERENCE_ID + '/Senior_Area_Chairs/-/Assignment', head=edge.tail)
+            assignments = client.get_edges(invitation=SAC_ASSIGNMENT_INVITATION_ID, head=edge.tail)
             if assignments:
                 client.add_members_to_group(SYNC_SAC_ID.format(number=note.number), assignments[0].tail)
             else:

--- a/openreview/conference/templates/assignment_post_process.py
+++ b/openreview/conference/templates/assignment_post_process.py
@@ -5,6 +5,7 @@ def process_update(client, edge, invitation, existing_edge):
     GROUP_ID = ''
     GROUP_NAME = ''
     PAPER_GROUP_ID = ''
+    SYNC_SAC_ID = ''
     print(edge.id)
     print(invitation.id)
     print(existing_edge)
@@ -13,12 +14,26 @@ def process_update(client, edge, invitation, existing_edge):
     group=client.get_group(PAPER_GROUP_ID.format(number=note.number))
     if edge.ddate and edge.tail in group.members:
         print(f'Remove member {edge.tail} from {group.id}')
-        return client.remove_members_from_group(group.id, edge.tail)
+        client.remove_members_from_group(group.id, edge.tail)
+
+        if SYNC_SAC_ID:
+            print(f'Remove member from SAC group')
+            group = client.get_group(SYNC_SAC_ID.format(number=note.number))
+            group.members = []
+            client.post_group(group)
 
     if not edge.ddate and edge.tail not in group.members:
         print(f'Add member {edge.tail} to {group.id}')
         client.add_members_to_group(group.id, edge.tail)
         client.add_members_to_group(GROUP_ID, edge.tail)
+
+        if SYNC_SAC_ID:
+            print('Add the SAC to the paper group')
+            assignments = client.get_edges(invitation=CONFERENCE_ID + '/Senior_Area_Chairs/-/Assignment', head=edge.tail)
+            if assignments:
+                client.add_members_to_group(SYNC_SAC_ID.format(number=note.number), assignments[0].tail)
+            else:
+                print('No SAC assignments found')
 
         signature=f'{openreview.tools.pretty_id(edge.signatures[0])}({edge.tauthor})'
 

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -24,13 +24,12 @@ var REVIEWERS_ID = '';
 var AREA_CHAIRS_ID = '';
 var SENIOR_AREA_CHAIRS_ID = '';
 var PROGRAM_CHAIRS_ID = '';
-var SAC_ASSIGNMENT_LABEL = null;
 var REQUEST_FORM_ID = '';
 var EMAIL_SENDER = null;
 
 var WILDCARD_INVITATION = CONFERENCE_ID + '.*';
 var PC_PAPER_TAG_INVITATION = PROGRAM_CHAIRS_ID + '/-/Paper_Assignment';
-var SAC_ASSIGNMENT_INVITATION = SENIOR_AREA_CHAIRS_ID + '/-/Proposed_Assignment';
+var SAC_ASSIGNMENT_INVITATION = SENIOR_AREA_CHAIRS_ID + '/-/Assignment';
 var REVIEWERS_INVITED_ID = REVIEWERS_ID + '/Invited';
 var AREA_CHAIRS_INVITED_ID = AREA_CHAIRS_ID ? AREA_CHAIRS_ID + '/Invited' : '';
 var SENIOR_AREA_CHAIRS_INVITED_ID = SENIOR_AREA_CHAIRS_ID ? SENIOR_AREA_CHAIRS_ID + '/Invited' : '';
@@ -271,8 +270,7 @@ var main = function() {
 var getSACEdges = function() {
   if (SENIOR_AREA_CHAIRS_ID) {
     return Webfield.getAll('/edges', {
-      invitation: SAC_ASSIGNMENT_INVITATION,
-      label: SAC_ASSIGNMENT_LABEL
+      invitation: SAC_ASSIGNMENT_INVITATION
     });
   }
   return $.Deferred().resolve([]);

--- a/openreview/conference/templates/sac_assignment_post_process.py
+++ b/openreview/conference/templates/sac_assignment_post_process.py
@@ -1,0 +1,24 @@
+def process_update(client, edge, invitation, existing_edge):
+
+    CONFERENCE_ID = ''
+    PAPER_GROUP_ID = ''
+    AC_ASSIGNMENT_INVITATION_ID = ''
+
+    if edge.ddate:
+        print(f'Remove assignments from {edge.head}')
+        ac_assignments = client.get_edges(invitation=AC_ASSIGNMENT_INVITATION_ID, tail=edge.head)
+
+        for ac_assignment in ac_assignments:
+
+            submission = client.get_note(ac_assignment.head)
+
+            client.remove_members_from_group(PAPER_GROUP_ID.format(number=submission.number), edge.tail)
+    else:
+        print(f'Add assignments from {edge.head}')
+        ac_assignments = client.get_edges(invitation=AC_ASSIGNMENT_INVITATION_ID, tail=edge.head)
+
+        for ac_assignment in ac_assignments:
+
+            submission = client.get_note(ac_assignment.head)
+
+            client.add_members_to_group(PAPER_GROUP_ID.format(number=submission.number), edge.tail)

--- a/openreview/conference/templates/seniorAreaChairWebfield.js
+++ b/openreview/conference/templates/seniorAreaChairWebfield.js
@@ -14,7 +14,7 @@ var HEADER = {};
 var SENIOR_AREA_CHAIR_NAME = '';
 var AREA_CHAIRS_ID = '';
 var REVIEWERS_ID = '';
-var ASSIGNMENT_INVITATION = CONFERENCE_ID + '/' + SENIOR_AREA_CHAIR_NAME + '/-/Proposed_Assignment';
+var ASSIGNMENT_INVITATION = CONFERENCE_ID + '/' + SENIOR_AREA_CHAIR_NAME + '/-/Assignment';
 var ASSIGNMENT_LABEL = null;
 var EMAIL_SENDER = null;
 

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -940,7 +940,7 @@ class TestNeurIPSConference():
         assert ['~SeniorArea_NeurIPSChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper2/Senior_Area_Chairs').members
         assert ['~SeniorArea_NeurIPSChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper1/Senior_Area_Chairs').members
 
-        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 5
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 3
 
         ## Check if the SAC can edit the AC assignments
         print('http://localhost:3030/edges/browse?traverse=NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment&edit=NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment&browse=NeurIPS.cc/2021/Conference/Area_Chairs/-/Affinity_Score&hide=NeurIPS.cc/2021/Conference/Area_Chairs/-/Conflict&maxColumns=2')
@@ -1006,6 +1006,9 @@ class TestNeurIPSConference():
         pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
         submissions=conference.get_submissions()
 
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 3
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment')) == 5
+
         ac_assignment = pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment', head=submissions[0].id)[0]
 
         ## Remove AC assignment
@@ -1013,6 +1016,9 @@ class TestNeurIPSConference():
         pc_client.post_edge(ac_assignment)
 
         helpers.await_queue()
+
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 3
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment')) == 4
 
         assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
         assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
@@ -1022,6 +1028,9 @@ class TestNeurIPSConference():
         pc_client.post_edge(ac_assignment)
 
         helpers.await_queue()
+
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 3
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment')) == 5
 
         assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
         assert ['~SeniorArea_GoogleChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
@@ -1035,6 +1044,9 @@ class TestNeurIPSConference():
 
         helpers.await_queue()
 
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 2
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment')) == 5
+
         assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
         assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
 
@@ -1046,6 +1058,9 @@ class TestNeurIPSConference():
         pc_client.post_edge(sac_assignment)
 
         helpers.await_queue()
+
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 3
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment')) == 5
 
         assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
         assert ['~SeniorArea_GoogleChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -940,7 +940,11 @@ class TestNeurIPSConference():
         assert ['~SeniorArea_NeurIPSChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper2/Senior_Area_Chairs').members
         assert ['~SeniorArea_NeurIPSChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper1/Senior_Area_Chairs').members
 
-        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 0
+        assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 5
+
+        ## Check if the SAC can edit the AC assignments
+        print('http://localhost:3030/edges/browse?traverse=NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment&edit=NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment&browse=NeurIPS.cc/2021/Conference/Area_Chairs/-/Affinity_Score&hide=NeurIPS.cc/2021/Conference/Area_Chairs/-/Conflict&maxColumns=2')
+        #assert False
 
         ## Reviewer assignments
         # Paper 5
@@ -996,6 +1000,32 @@ class TestNeurIPSConference():
 
         # print(url)
         # assert False
+
+    def test_ac_reassignment(self, conference, helpers, client):
+
+        pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
+        submissions=conference.get_submissions()
+
+        ac_assignment = pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment', head=submissions[0].id)[0]
+
+        ## Remove assignment
+        ac_assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        pc_client.post_edge(ac_assignment)
+
+        helpers.await_queue()
+
+        assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
+        assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
+
+        ## Add assignment
+        ac_assignment.ddate = None
+        pc_client.post_edge(ac_assignment)
+
+        helpers.await_queue()
+
+        assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
+        assert ['~SeniorArea_GoogleChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
+
 
     def test_reassignment_stage(self, conference, helpers, client, selenium, request_page):
 

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -1008,7 +1008,7 @@ class TestNeurIPSConference():
 
         ac_assignment = pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment', head=submissions[0].id)[0]
 
-        ## Remove assignment
+        ## Remove AC assignment
         ac_assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
         pc_client.post_edge(ac_assignment)
 
@@ -1017,7 +1017,7 @@ class TestNeurIPSConference():
         assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
         assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
 
-        ## Add assignment
+        ## Add AC assignment
         ac_assignment.ddate = None
         pc_client.post_edge(ac_assignment)
 
@@ -1025,6 +1025,33 @@ class TestNeurIPSConference():
 
         assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
         assert ['~SeniorArea_GoogleChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
+
+        sac_assignment = pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment', head='~Area_IBMChair1')[0]
+        assert sac_assignment.tail == '~SeniorArea_GoogleChair1'
+
+        ## Add SAC assignment
+        sac_assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        pc_client.post_edge(sac_assignment)
+
+        helpers.await_queue()
+
+        assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
+        assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
+
+        assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper4/Area_Chairs').members
+        assert [] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper4/Senior_Area_Chairs').members
+
+        ## Add SAC assignment
+        sac_assignment.ddate = None
+        pc_client.post_edge(sac_assignment)
+
+        helpers.await_queue()
+
+        assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Area_Chairs').members
+        assert ['~SeniorArea_GoogleChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper5/Senior_Area_Chairs').members
+
+        assert ['~Area_IBMChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper4/Area_Chairs').members
+        assert ['~SeniorArea_GoogleChair1'] == pc_client.get_group('NeurIPS.cc/2021/Conference/Paper4/Senior_Area_Chairs').members
 
 
     def test_reassignment_stage(self, conference, helpers, client, selenium, request_page):


### PR DESCRIPTION
- Create Assignment edges when SAC are deployed so the PCs can make reassignments using the edge browser.
- Sync SAC group when a AC assignment changes.
- Sync SAC groups when a SAC assignment changes. 