### PR TITLE
Fix/journal conflicts

### DIFF
--- a/openreview/api/__init__.py
+++ b/openreview/api/__init__.py
@@ -3,3 +3,4 @@ from .client import Edit
 from .client import Note
 from .client import Invitation
 from .client import Edge
+from .client import Group

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -362,10 +362,12 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return [Profile.from_json(p) for p in response.json()['profiles']]
 
-    def search_profiles(self, emails = None, ids = None, term = None, first = None, middle = None, last = None):
+    def search_profiles(self, confirmedEmails = None, emails = None, ids = None, term = None, first = None, middle = None, last = None):
         """
         Gets a list of profiles using either their ids or corresponding emails
 
+        :param confirmedEmails: List of confirmed emails registered in OpenReview
+        :type confirmedEmails: list, optional
         :param emails: List of emails registered in OpenReview
         :type emails: list, optional
         :param ids: List of OpenReview username ids
@@ -379,7 +381,7 @@ class OpenReviewClient(object):
         :param last: Last name of user
         :type last: str, optional
 
-        :return: List of profiles
+        :return: List of profiles, if emails is present then a dictionary of { email: profiles } is returned. If confirmedEmails is present then a dictionary of { email: profile } is returned
         :rtype: list[Profile]
         """
 
@@ -407,7 +409,28 @@ class OpenReviewClient(object):
                 response = self.__handle_response(response)
                 full_response.extend(response.json()['profiles'])
 
-            return {p['email']: Profile.from_json(p) for p in full_response}
+            profiles_by_email = {}
+            for p in full_response:
+                if p['email'] not in profiles_by_email:
+                    profiles_by_email[p['email']] = []
+                profiles_by_email[p['email']].append(Profile.from_json(p))
+            return profiles_by_email
+
+        if confirmedEmails:
+            full_response = []
+            for email_batch in batches(confirmedEmails):
+                response = requests.post(self.profiles_search_url, json = {'emails': email_batch}, headers = self.headers)
+                response = self.__handle_response(response)
+                full_response.extend(response.json()['profiles'])
+
+            profiles_by_email = {}
+            for p in full_response:
+                profile = Profile.from_json(p)
+                if p['email'] in profile.content['emailsConfirmed']:
+                    profiles_by_email[p['email']] = profile
+            return profiles_by_email
+
+
 
         if ids:
             full_response = []

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -16,6 +16,7 @@ import re
 from tqdm import tqdm
 from .. import tools
 import time
+from deprecated.sphinx import deprecated
 
 def _jaccard_similarity(list1, list2):
     '''
@@ -27,6 +28,7 @@ def _jaccard_similarity(list1, list2):
     union = set1.union(set2)
     return len(intersection) / len(union)
 
+@deprecated(version='1.1.1', reason="Use tools.get_profiles instead")
 def _get_profiles(client, ids_or_emails, with_publications=False):
     '''
     Helper function that repeatedly queries for profiles, given IDs and emails.
@@ -253,7 +255,7 @@ class Matching(object):
     def _build_conflicts(self, submissions, user_profiles, get_profile_info):
         if self.alternate_matching_group:
             other_matching_group = self.client.get_group(self.alternate_matching_group)
-            other_matching_profiles = _get_profiles(self.client, other_matching_group.members)
+            other_matching_profiles = tools.get_profiles(self.client, other_matching_group.members)
             return self._build_profile_conflicts(other_matching_profiles, user_profiles)
         return self._build_note_conflicts(submissions, user_profiles, get_profile_info)
 
@@ -264,7 +266,7 @@ class Matching(object):
 
         # Adapt single profile to multi-profile code
         user_profiles = [profile_id]
-        user_profiles = _get_profiles(self.client, user_profiles, with_publications=build_conflicts)
+        user_profiles = tools.get_profiles(self.client, user_profiles, with_publications=build_conflicts)
         # Check for existing OpenReview profile - perform dummy check
         if user_profiles[0].active == None:
             raise openreview.OpenReviewException('No profile exists')
@@ -293,7 +295,7 @@ class Matching(object):
                 authorids = submission.details['original']['content']['authorids']
 
             # Extract domains from each profile
-            author_profiles = _get_profiles(self.client, authorids, with_publications=True)
+            author_profiles = tools.get_profiles(self.client, authorids, with_publications=True)
             author_domains = set()
             author_emails = set()
             author_relations = set()
@@ -358,7 +360,7 @@ class Matching(object):
                 authorids = submission.details['original']['content']['authorids']
 
             # Extract domains from each profile
-            author_profiles = _get_profiles(self.client, authorids, with_publications=True)
+            author_profiles = tools.get_profiles(self.client, authorids, with_publications=True)
             author_domains = set()
             author_emails = set()
             author_relations = set()
@@ -536,7 +538,7 @@ class Matching(object):
                     deleted_papers.add(paper_note_id)
 
         print('deleted papers', deleted_papers)
-        
+
         ## Delete previous scores
         self.client.delete_edges(invitation.id, wait_to_finish=True)
 
@@ -918,7 +920,7 @@ class Matching(object):
                 'WARNING: not all reviewers have been converted to profile IDs.',
                 'Members without profiles will not have metadata created.')
 
-        user_profiles = _get_profiles(self.client, self.match_group.members, with_publications=build_conflicts)
+        user_profiles = tools.get_profiles(self.client, self.match_group.members, with_publications=build_conflicts)
 
         invitation = self._create_edge_invitation(self.conference.get_paper_assignment_id(self.match_group.id))
         if not self.is_senior_area_chair:

--- a/openreview/conference/templates/invite_assignment_pre_process.py
+++ b/openreview/conference/templates/invite_assignment_pre_process.py
@@ -17,7 +17,7 @@ def process(client, edge, invitation):
         ## - Get profile
         user = edge.tail
         print(f'Get profile for {user}')
-        user_profile=openreview.conference.matching._get_profiles(client, [user])[0]
+        user_profile=openreview.tools.get_profiles(client, [user])[0]
 
         if user_profile:
             if user_profile.id != user:
@@ -60,7 +60,7 @@ def process(client, edge, invitation):
         authorids = submission.content['authorids']
         if submission.details and submission.details.get('original'):
             authorids = submission.details['original']['content']['authorids']
-        author_profiles = openreview.conference.matching._get_profiles(client, authorids)
+        author_profiles = openreview.tools.get_profiles(client, authorids)
         conflicts=openreview.tools.get_conflicts(author_profiles, user_profile)
         if conflicts:
             print('Conflicts detected', conflicts)

--- a/openreview/conference/templates/paper_recruitment_process.py
+++ b/openreview/conference/templates/paper_recruitment_process.py
@@ -97,8 +97,8 @@ OpenReview Team'''
         authorids = submission.content['authorids']
         if submission.details and submission.details.get('original'):
             authorids = submission.details['original']['content']['authorids']
-        author_profiles = openreview.conference.matching._get_profiles(client, authorids, with_publications=True)
-        profiles=openreview.conference.matching._get_profiles(client, [edge.tail], with_publications=True)
+        author_profiles = openreview.tools.get_profiles(client, authorids, with_publications=True)
+        profiles=openreview.tools.get_profiles(client, [edge.tail], with_publications=True)
         conflicts=openreview.tools.get_conflicts(author_profiles, profiles[0])
         if conflicts:
             print('Conflicts detected', conflicts)

--- a/openreview/journal/assignment.py
+++ b/openreview/journal/assignment.py
@@ -1,0 +1,91 @@
+from .. import openreview
+from .. import tools
+
+from openreview.api import Edge
+
+import random
+
+class Assignment(object):
+
+    def __init__(self, journal):
+        self.client = journal.client
+        self.journal = journal
+
+
+    def setup_ae_assignment(self, note):
+        venue_id=self.journal.venue_id
+        action_editors_id=self.journal.get_action_editors_id()
+        authors_id=self.journal.get_authors_id(number=note.number)
+
+        ## Create conflict and affinity score edges
+        for ae in self.journal.get_action_editors():
+            edge = Edge(invitation = self.journal.get_ae_affinity_score_id(),
+                readers = [venue_id, authors_id, ae],
+                writers = [venue_id],
+                signatures = [venue_id],
+                head = note.id,
+                tail = ae,
+                weight=round(random.random(), 2)
+            )
+            self.client.post_edge(edge)
+
+            random_number=round(random.random(), 2)
+            if random_number <= 0.3:
+                edge = Edge(invitation = self.journal.get_ae_conflict_id(),
+                    readers = [venue_id, authors_id, ae],
+                    writers = [venue_id],
+                    signatures = [venue_id],
+                    head = note.id,
+                    tail = ae,
+                    weight=-1,
+                    label='Conflict'
+                )
+                self.client.post_edge(edge)
+
+    def setup_reviewer_assignment(self, note):
+        venue_id=self.journal.venue_id
+        reviewers_id=self.journal.get_reviewers_id()
+        action_editors_id=self.journal.get_action_editors_id(number=note.number)
+        authors_id = self.journal.get_authors_id(number=note.number)
+        note=self.client.get_notes(invitation=self.journal.get_author_submission_id(), number=note.number)[0]
+
+        ## Create conflict and affinity score edges
+        for r in self.journal.get_reviewers():
+            edge = Edge(invitation = self.journal.get_reviewer_affinity_score_id(),
+                readers = [venue_id, action_editors_id, r],
+                nonreaders = [authors_id],
+                writers = [venue_id],
+                signatures = [venue_id],
+                head = note.id,
+                tail = r,
+                weight=round(random.random(), 2)
+            )
+            self.client.post_edge(edge)
+
+            random_number=round(random.random(), 2)
+            if random_number <= 0.3:
+                edge = Edge(invitation = self.journal.get_reviewer_conflict_id(),
+                    readers = [venue_id, action_editors_id, r],
+                    nonreaders = [authors_id],
+                    writers = [venue_id],
+                    signatures = [venue_id],
+                    head = note.id,
+                    tail = r,
+                    weight=-1,
+                    label='Conflict'
+                )
+                self.client.post_edge(edge)
+
+    def assign_reviewer(self, note, reviewer):
+
+        profile = self.client.get_profile(reviewer)
+        ## Check conflicts again?
+        self.client.post_edge(Edge(invitation=self.journal.get_reviewer_assignment_id(),
+            readers=[self.journal.venue_id, self.journal.get_action_editors_id(number=note.number), profile.id],
+            nonreaders=[self.journal.get_authors_id(number=note.number)],
+            writers=[self.journal.venue_id, self.journal.get_action_editors_id(number=note.number)],
+            signatures=[self.journal.venue_id],
+            head=note.id,
+            tail=profile.id,
+            weight=1
+        ))

--- a/openreview/journal/assignment.py
+++ b/openreview/journal/assignment.py
@@ -88,8 +88,9 @@ class Assignment(object):
             conflicts = tools.get_conflicts(author_profiles, reviewer_profile, policy='neurips')
             print('Compute Reviewer conflict', note.id, reviewer_profile.id, conflicts)
             if conflicts:
-                edge = Edge(invitation = self.journal.get_ae_conflict_id(),
+                edge = Edge(invitation = self.journal.get_reviewer_conflict_id(),
                     readers = [venue_id, action_editors_id],
+                    nonreaders = [authors_id],
                     writers = [venue_id],
                     signatures = [venue_id],
                     head = note.id,

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -1,0 +1,185 @@
+from .. import openreview
+from openreview.api import Group
+
+import os
+import json
+
+class GroupBuilder(object):
+
+    def __init__(self, client):
+        self.client = client
+
+
+    def set_groups(self, journal, support_role, editors):
+        header = journal.header
+        venue_id=journal.venue_id
+        editor_in_chief_id=journal.get_editors_in_chief_id()
+        ## venue group
+        venue_group=self.client.post_group(Group(id=venue_id,
+                        readers=['everyone'],
+                        writers=[venue_id],
+                        signatures=['~Super_User1'],
+                        signatories=[venue_id],
+                        members=[support_role]
+                        ))
+
+        self.client.add_members_to_group('host', venue_id)
+
+        ## editor in chief
+        editor_in_chief_group = openreview.tools.get_group(self.client, editor_in_chief_id)
+        if not editor_in_chief_group:
+            editor_in_chief_group=self.client.post_group(Group(id=editor_in_chief_id,
+                            readers=['everyone'],
+                            writers=[editor_in_chief_id],
+                            signatures=[venue_id],
+                            signatories=[editor_in_chief_id, venue_id],
+                            members=editors
+                            ))
+        with open(os.path.join(os.path.dirname(__file__), 'webfield/editorsInChiefWebfield.js')) as f:
+            content = f.read()
+            editor_in_chief_group.web = content
+            self.client.post_group(editor_in_chief_group)
+
+        editors=""
+        for m in editor_in_chief_group.members:
+            name=m.replace('~', ' ').replace('_', ' ')[:-1]
+            editors+=f'<a href="https://openreview.net/profile?id={m}">{name}</a></br>'
+
+        header['instructions'] = '''
+        <p>
+            <strong>Editors-in-chief:</strong></br>
+            {editors}
+            <strong>Managing Editors:</strong></br>
+            <a href=\"https://openreview.net/profile?id=~Fabian_Pedregosa1\"> Fabian Pedregosa</a>
+        </p>
+        <p>
+            Transactions on Machine Learning Research (TMLR) is a venue for dissemination of machine learning research that is intended to complement JMLR while supporting the unmet needs of a growing ML community.
+        </p>
+        <ul>
+            <li>
+                <p>TMLR emphasizes technical correctness over subjective significance, in order to ensure we facilitate scientific discourses on topics that are deemed less significant by contemporaries but may be so in the future.</p>
+            </li>
+            <li>
+                <p>TMLR caters to the shorter format manuscripts that are usually submitted to conferences, providing fast turnarounds and double blind reviewing. </p>
+            </li>
+            <li>
+                <p>TMLR employs a rolling submission process, shortened review period, flexible timelines, and variable manuscript length, to enable deep and sustained interactions among authors, reviewers, editors and readers.</p>
+            </li>
+            <li>
+                <p>TMLR does not accept submissions that have any overlap with previously published work.</p>
+            </li>
+        </ul>
+        <p>
+            For more information on TMLR, visit
+            <a href="http://jmlr.org/tmlr" target="_blank" rel="nofollow">jmlr.org/tmlr</a>.
+        </p>
+        '''.format(editors=editors)
+
+        with open(os.path.join(os.path.dirname(__file__), 'webfield/homepage.js')) as f:
+            content = f.read()
+            content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
+            content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
+            content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + venue_id + "/-/Author_Submission';")
+            content = content.replace("var SUBMITTED_ID = '';", "var SUBMITTED_ID = '" + venue_id + "/Submitted';")
+            content = content.replace("var UNDER_REVIEW_ID = '';", "var UNDER_REVIEW_ID = '" + venue_id + "/Under_Review';")
+            content = content.replace("var DESK_REJECTED_ID = '';", "var DESK_REJECTED_ID = '" + venue_id + "/Desk_Rejection';")
+            content = content.replace("var WITHDRAWN_ID = '';", "var WITHDRAWN_ID = '" + venue_id + "/Withdrawn_Submission';")
+            content = content.replace("var REJECTED_ID = '';", "var REJECTED_ID = '" + venue_id + "/Rejection';")
+            venue_group.web = content
+            self.client.post_group(venue_group)
+
+        ## Add editors in chief to have all the permissions
+        self.client.add_members_to_group(venue_group, editor_in_chief_id)
+
+        ## action editors group
+        action_editors_id = journal.get_action_editors_id()
+        action_editor_group = openreview.tools.get_group(self.client, action_editors_id)
+        if not action_editor_group:
+            action_editor_group=self.client.post_group(Group(id=action_editors_id,
+                            readers=['everyone'],
+                            writers=[venue_id],
+                            signatures=[venue_id],
+                            signatories=[venue_id],
+                            members=[]))
+        with open(os.path.join(os.path.dirname(__file__), 'webfield/actionEditorWebfield.js')) as f:
+            content = f.read()
+            action_editor_group.web = content
+            self.client.post_group(action_editor_group)
+
+        ## action editors invited group
+        action_editors_invited_id = f'{action_editors_id}/Invited'
+        action_editors_invited_group = openreview.tools.get_group(self.client, action_editors_invited_id)
+        if not action_editors_invited_group:
+            self.client.post_group(Group(id=action_editors_invited_id,
+                            readers=[venue_id],
+                            writers=[venue_id],
+                            signatures=[venue_id],
+                            signatories=[],
+                            members=[]))
+
+        ## action editors declined group
+        action_editors_declined_id = f'{action_editors_id}/Declined'
+        action_editors_declined_group = openreview.tools.get_group(self.client, action_editors_declined_id)
+        if not action_editors_declined_group:
+            self.client.post_group(Group(id=action_editors_declined_id,
+                            readers=[venue_id],
+                            writers=[venue_id],
+                            signatures=[venue_id],
+                            signatories=[],
+                            members=[]))
+
+        ## reviewers group
+        reviewers_id = journal.get_reviewers_id()
+        reviewer_group = openreview.tools.get_group(self.client, reviewers_id)
+        if not reviewer_group:
+            reviewer_group = Group(id=reviewers_id,
+                            readers=[venue_id, action_editors_id, reviewers_id],
+                            writers=[venue_id],
+                            signatures=[venue_id],
+                            signatories=[venue_id],
+                            members=[]
+                            )
+        with open(os.path.join(os.path.dirname(__file__), 'webfield/reviewersWebfield.js')) as f:
+            content = f.read()
+            content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
+            reviewer_group.web = content
+            self.client.post_group(reviewer_group)
+
+        ## reviewers invited group
+        reviewers_invited_id = f'{reviewers_id}/Invited'
+        reviewers_invited_group = openreview.tools.get_group(self.client, reviewers_invited_id)
+        if not reviewers_invited_group:
+            self.client.post_group(Group(id=reviewers_invited_id,
+                            readers=[venue_id],
+                            writers=[venue_id],
+                            signatures=[venue_id],
+                            signatories=[],
+                            members=[]))
+
+        ## reviewers declined group
+        reviewers_declined_id = f'{reviewers_id}/Declined'
+        reviewers_declined_group = openreview.tools.get_group(self.client, reviewers_declined_id)
+        if not reviewers_declined_group:
+            self.client.post_group(Group(id=reviewers_declined_id,
+                            readers=[venue_id],
+                            writers=[venue_id],
+                            signatures=[venue_id],
+                            signatories=[],
+                            members=[]))
+
+        ## authors group
+        authors_id = journal.get_authors_id()
+        authors_group = openreview.tools.get_group(self.client, authors_id)
+        if not authors_group:
+            authors_group = Group(id=authors_id,
+                            readers=[venue_id, authors_id],
+                            writers=[venue_id],
+                            signatures=[venue_id],
+                            signatories=[venue_id],
+                            members=[])
+
+        with open(os.path.join(os.path.dirname(__file__), 'webfield/authorsWebfield.js')) as f:
+            content = f.read()
+            content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
+            authors_group.web = content
+            self.client.post_group(authors_group)

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -11,6 +11,17 @@ class InvitationBuilder(object):
     def __init__(self, client):
         self.client = client
 
+    def set_invitations(self, journal):
+        self.set_submission_invitation(journal)
+        self.set_under_review_invitation(journal)
+        self.set_desk_rejection_invitation(journal)
+        self.set_rejection_invitation(journal)
+        self.set_withdrawn_invitation(journal)
+        self.set_acceptance_invitation(journal)
+        self.set_authors_release_invitation(journal)
+        self.set_ae_assignment(journal)
+        self.set_reviewer_assignment(journal)
+
     def expire_invitation(self, journal, invitation_id, expdate=None):
         venue_id=journal.venue_id
         invitation = self.client.get_invitation(invitation_id)

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -396,7 +396,7 @@ class InvitationBuilder(object):
                     'nullable': True
                 },
                 'readers': {
-                    'values': [venue_id, paper_authors_id, '${tail}']
+                    'values': [venue_id, paper_authors_id]
                 },
                 'writers': {
                     'values': [venue_id]
@@ -619,7 +619,7 @@ class InvitationBuilder(object):
                     'nullable': True
                 },
                 'readers': {
-                    'values': [venue_id, paper_action_editors_id, '${tail}']
+                    'values': [venue_id, paper_action_editors_id]
                 },
                 'nonreaders': {
                     'values': [paper_authors_id]

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -230,11 +230,11 @@ class InvitationBuilder(object):
             invitees=['~'],
             readers=['everyone'],
             writers=[venue_id],
-            signatures=[venue_id],
+            signatures=[editor_in_chief_id],
             edit={
                 'signatures': { 'values-regex': '~.*' },
                 'readers': { 'values': [ venue_id, action_editors_value, authors_value]},
-                'writers': { 'values': [ venue_id, ]},
+                'writers': { 'values': [ venue_id ]},
                 'note': {
                     'signatures': { 'values': [authors_value] },
                     'readers': { 'values': [ venue_id, action_editors_value, authors_value]},

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -12,6 +12,8 @@ class InvitationBuilder(object):
         self.client = client
 
     def set_invitations(self, journal):
+        self.set_ae_recruitment_invitation(journal)
+        self.set_reviewer_recruitment_invitation(journal)
         self.set_submission_invitation(journal)
         self.set_under_review_invitation(journal)
         self.set_desk_rejection_invitation(journal)
@@ -56,7 +58,7 @@ class InvitationBuilder(object):
                 invitation=invitation
             )
 
-    def set_ae_recruitment_invitation(self, journal, hash_seed, header):
+    def set_ae_recruitment_invitation(self, journal):
 
         venue_id=journal.venue_id
         action_editors_id = journal.get_action_editors_id()
@@ -70,17 +72,17 @@ class InvitationBuilder(object):
             process_content = process_content.replace("ACTION_EDITOR_INVITED_ID = ''", f"ACTION_EDITOR_INVITED_ID = '{action_editors_invited_id}'")
             process_content = process_content.replace("ACTION_EDITOR_ACCEPTED_ID = ''", f"ACTION_EDITOR_ACCEPTED_ID = '{action_editors_id}'")
             process_content = process_content.replace("ACTION_EDITOR_DECLINED_ID = ''", f"ACTION_EDITOR_DECLINED_ID = '{action_editors_declined_id}'")
-            process_content = process_content.replace("HASH_SEED = ''", f"HASH_SEED = '{hash_seed}'")
+            process_content = process_content.replace("HASH_SEED = ''", f"HASH_SEED = '{journal.secret_key}'")
 
             with open(os.path.join(os.path.dirname(__file__), 'webfield/recruitResponseWebfield.js')) as webfield_reader:
                 webfield_content = webfield_reader.read()
                 webfield_content = webfield_content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
-                webfield_content = webfield_content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
+                webfield_content = webfield_content.replace("var HEADER = {};", "var HEADER = " + json.dumps(journal.header) + ";")
 
                 invitation=self.client.post_invitation_edit(readers=[venue_id],
                     writers=[venue_id],
                     signatures=[venue_id],
-                    invitation=Invitation(id=f'{action_editors_id}/-/Recruitment',
+                    invitation=Invitation(id=journal.get_ae_recruitment_id(),
                         invitees = ['everyone'],
                         readers = ['everyone'],
                         writers = [venue_id],
@@ -132,7 +134,7 @@ class InvitationBuilder(object):
                 )
                 return invitation
 
-    def set_reviewer_recruitment_invitation(self, journal, hash_seed, header):
+    def set_reviewer_recruitment_invitation(self, journal):
 
         venue_id=journal.venue_id
         reviewers_id = journal.get_reviewers_id()
@@ -146,17 +148,17 @@ class InvitationBuilder(object):
             process_content = process_content.replace("ACTION_EDITOR_INVITED_ID = ''", f"ACTION_EDITOR_INVITED_ID = '{reviewers_invited_id}'")
             process_content = process_content.replace("ACTION_EDITOR_ACCEPTED_ID = ''", f"ACTION_EDITOR_ACCEPTED_ID = '{reviewers_id}'")
             process_content = process_content.replace("ACTION_EDITOR_DECLINED_ID = ''", f"ACTION_EDITOR_DECLINED_ID = '{reviewers_declined_id}'")
-            process_content = process_content.replace("HASH_SEED = ''", f"HASH_SEED = '{hash_seed}'")
+            process_content = process_content.replace("HASH_SEED = ''", f"HASH_SEED = '{journal.secret_key}'")
 
             with open(os.path.join(os.path.dirname(__file__), 'webfield/recruitResponseWebfield.js')) as webfield_reader:
                 webfield_content = webfield_reader.read()
                 webfield_content = webfield_content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
-                webfield_content = webfield_content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
+                webfield_content = webfield_content.replace("var HEADER = {};", "var HEADER = " + json.dumps(journal.header) + ";")
 
                 invitation=self.client.post_invitation_edit(readers=[venue_id],
                     writers=[venue_id],
                     signatures=[venue_id],
-                    invitation=Invitation(id=f'{reviewers_id}/-/Recruitment',
+                    invitation=Invitation(id=journal.get_reviewer_recruitment_id(),
                         invitees = ['everyone'],
                         readers = ['everyone'],
                         writers = [venue_id],

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -1,9 +1,10 @@
 from .. import openreview
 from .. import tools
 from . import invitation
+from . import group
 from openreview.api import Edge
 from openreview.api import Group
-import os
+
 import re
 import json
 import datetime
@@ -32,9 +33,10 @@ class Journal(object):
         self.desk_rejected_venue_id = f'{venue_id}/Desk_Rejection'
         self.accepted_venue_id = venue_id
         self.invitation_builder = invitation.InvitationBuilder(client)
+        self.group_builder = group.GroupBuilder(client)
         self.header = {
             "title": "Transactions of Machine Learning Research",
-            "short": short_name,
+            "short": self.short_name,
             "subtitle": "To be defined",
             "location": "Everywhere",
             "date": "Ongoing",
@@ -181,16 +183,8 @@ class Journal(object):
         return self.__get_invitation_id(name='Submission_Editable', number=number)
 
     def setup(self, support_role, editors=[]):
-        self.setup_groups(support_role, editors)
-        self.invitation_builder.set_submission_invitation(self)
-        self.invitation_builder.set_under_review_invitation(self)
-        self.invitation_builder.set_desk_rejection_invitation(self)
-        self.invitation_builder.set_rejection_invitation(self)
-        self.invitation_builder.set_withdrawn_invitation(self)
-        self.invitation_builder.set_acceptance_invitation(self)
-        self.invitation_builder.set_authors_release_invitation(self)
-        self.invitation_builder.set_ae_assignment(self)
-        self.invitation_builder.set_reviewer_assignment(self)
+        self.group_builder.set_groups(self, support_role, editors)
+        self.invitation_builder.set_invitations(self)
 
     def set_action_editors(self, editors, custom_papers):
         venue_id=self.venue_id
@@ -216,178 +210,6 @@ class Journal(object):
     def get_reviewers(self):
         return self.client.get_group(self.get_reviewers_id()).members
 
-    def setup_groups(self, support_role, editors):
-        venue_id=self.venue_id
-        editor_in_chief_id=self.get_editors_in_chief_id()
-        ## venue group
-        venue_group=self.client.post_group(Group(id=venue_id,
-                        readers=['everyone'],
-                        writers=[venue_id],
-                        signatures=['~Super_User1'],
-                        signatories=[venue_id],
-                        members=[support_role]
-                        ))
-
-        self.client.add_members_to_group('host', venue_id)
-
-        ## editor in chief
-        editor_in_chief_group = openreview.tools.get_group(self.client, editor_in_chief_id)
-        if not editor_in_chief_group:
-            editor_in_chief_group=self.client.post_group(Group(id=editor_in_chief_id,
-                            readers=['everyone'],
-                            writers=[editor_in_chief_id],
-                            signatures=[venue_id],
-                            signatories=[editor_in_chief_id, venue_id],
-                            members=editors
-                            ))
-        with open(os.path.join(os.path.dirname(__file__), 'webfield/editorsInChiefWebfield.js')) as f:
-            content = f.read()
-            editor_in_chief_group.web = content
-            self.client.post_group(editor_in_chief_group)
-
-        editors=""
-        for m in editor_in_chief_group.members:
-            name=m.replace('~', ' ').replace('_', ' ')[:-1]
-            editors+=f'<a href="https://openreview.net/profile?id={m}">{name}</a></br>'
-
-        self.header['instructions'] = '''
-        <p>
-            <strong>Editors-in-chief:</strong></br>
-            {editors}
-            <strong>Managing Editors:</strong></br>
-            <a href=\"https://openreview.net/profile?id=~Fabian_Pedregosa1\"> Fabian Pedregosa</a>
-        </p>
-        <p>
-            Transactions on Machine Learning Research (TMLR) is a venue for dissemination of machine learning research that is intended to complement JMLR while supporting the unmet needs of a growing ML community.
-        </p>
-        <ul>
-            <li>
-                <p>TMLR emphasizes technical correctness over subjective significance, in order to ensure we facilitate scientific discourses on topics that are deemed less significant by contemporaries but may be so in the future.</p>
-            </li>
-            <li>
-                <p>TMLR caters to the shorter format manuscripts that are usually submitted to conferences, providing fast turnarounds and double blind reviewing. </p>
-            </li>
-            <li>
-                <p>TMLR employs a rolling submission process, shortened review period, flexible timelines, and variable manuscript length, to enable deep and sustained interactions among authors, reviewers, editors and readers.</p>
-            </li>
-            <li>
-                <p>TMLR does not accept submissions that have any overlap with previously published work.</p>
-            </li>
-        </ul>
-        <p>
-            For more information on TMLR, visit
-            <a href="http://jmlr.org/tmlr" target="_blank" rel="nofollow">jmlr.org/tmlr</a>.
-        </p>
-        '''.format(editors=editors)
-
-        with open(os.path.join(os.path.dirname(__file__), 'webfield/homepage.js')) as f:
-            content = f.read()
-            content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(self.header) + ";")
-            content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
-            content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + venue_id + "/-/Author_Submission';")
-            content = content.replace("var SUBMITTED_ID = '';", "var SUBMITTED_ID = '" + venue_id + "/Submitted';")
-            content = content.replace("var UNDER_REVIEW_ID = '';", "var UNDER_REVIEW_ID = '" + venue_id + "/Under_Review';")
-            content = content.replace("var DESK_REJECTED_ID = '';", "var DESK_REJECTED_ID = '" + venue_id + "/Desk_Rejection';")
-            content = content.replace("var WITHDRAWN_ID = '';", "var WITHDRAWN_ID = '" + venue_id + "/Withdrawn_Submission';")
-            content = content.replace("var REJECTED_ID = '';", "var REJECTED_ID = '" + venue_id + "/Rejection';")
-            venue_group.web = content
-            self.client.post_group(venue_group)
-
-        ## Add editors in chief to have all the permissions
-        self.client.add_members_to_group(venue_group, editor_in_chief_id)
-
-        ## action editors group
-        action_editors_id = self.get_action_editors_id()
-        action_editor_group = openreview.tools.get_group(self.client, action_editors_id)
-        if not action_editor_group:
-            action_editor_group=self.client.post_group(Group(id=action_editors_id,
-                            readers=['everyone'],
-                            writers=[venue_id],
-                            signatures=[venue_id],
-                            signatories=[venue_id],
-                            members=[]))
-        with open(os.path.join(os.path.dirname(__file__), 'webfield/actionEditorWebfield.js')) as f:
-            content = f.read()
-            action_editor_group.web = content
-            self.client.post_group(action_editor_group)
-
-        ## action editors invited group
-        action_editors_invited_id = f'{action_editors_id}/Invited'
-        action_editors_invited_group = openreview.tools.get_group(self.client, action_editors_invited_id)
-        if not action_editors_invited_group:
-            self.client.post_group(Group(id=action_editors_invited_id,
-                            readers=[venue_id],
-                            writers=[venue_id],
-                            signatures=[venue_id],
-                            signatories=[],
-                            members=[]))
-
-        ## action editors declined group
-        action_editors_declined_id = f'{action_editors_id}/Declined'
-        action_editors_declined_group = openreview.tools.get_group(self.client, action_editors_declined_id)
-        if not action_editors_declined_group:
-            self.client.post_group(Group(id=action_editors_declined_id,
-                            readers=[venue_id],
-                            writers=[venue_id],
-                            signatures=[venue_id],
-                            signatories=[],
-                            members=[]))
-
-        ## reviewers group
-        reviewers_id = self.get_reviewers_id()
-        reviewer_group = openreview.tools.get_group(self.client, reviewers_id)
-        if not reviewer_group:
-            reviewer_group = Group(id=reviewers_id,
-                            readers=[venue_id, action_editors_id, reviewers_id],
-                            writers=[venue_id],
-                            signatures=[venue_id],
-                            signatories=[venue_id],
-                            members=[]
-                            )
-        with open(os.path.join(os.path.dirname(__file__), 'webfield/reviewersWebfield.js')) as f:
-            content = f.read()
-            content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
-            reviewer_group.web = content
-            self.client.post_group(reviewer_group)
-
-        ## reviewers invited group
-        reviewers_invited_id = f'{reviewers_id}/Invited'
-        reviewers_invited_group = openreview.tools.get_group(self.client, reviewers_invited_id)
-        if not reviewers_invited_group:
-            self.client.post_group(Group(id=reviewers_invited_id,
-                            readers=[venue_id],
-                            writers=[venue_id],
-                            signatures=[venue_id],
-                            signatories=[],
-                            members=[]))
-
-        ## reviewers declined group
-        reviewers_declined_id = f'{reviewers_id}/Declined'
-        reviewers_declined_group = openreview.tools.get_group(self.client, reviewers_declined_id)
-        if not reviewers_declined_group:
-            self.client.post_group(Group(id=reviewers_declined_id,
-                            readers=[venue_id],
-                            writers=[venue_id],
-                            signatures=[venue_id],
-                            signatories=[],
-                            members=[]))
-
-        ## authors group
-        authors_id = self.get_authors_id()
-        authors_group = openreview.tools.get_group(self.client, authors_id)
-        if not authors_group:
-            authors_group = Group(id=authors_id,
-                            readers=[venue_id, authors_id],
-                            writers=[venue_id],
-                            signatures=[venue_id],
-                            signatories=[venue_id],
-                            members=[])
-
-        with open(os.path.join(os.path.dirname(__file__), 'webfield/authorsWebfield.js')) as f:
-            content = f.read()
-            content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
-            authors_group.web = content
-            self.client.post_group(authors_group)
 
     def setup_ae_assignment(self, note):
         venue_id=self.venue_id

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -2,7 +2,7 @@ from .. import openreview
 from .. import tools
 from . import invitation
 from . import group
-from . import recruitment
+from .recruitment import Recruitment
 from .assignment import Assignment
 from openreview.api import Edge
 from openreview.api import Group
@@ -48,6 +48,7 @@ class Journal(object):
             "contact": self.contact_info
         }
         self.assignment = Assignment(self)
+        self.recruitment = Recruitment(self)
 
     def __get_group_id(self, name, number=None):
         if number:
@@ -229,10 +230,10 @@ class Journal(object):
         return self.assignment.setup_reviewer_assignment(note)
 
     def invite_action_editors(self, message, subject, invitees, invitee_names=None):
-        return recruitment.Recruitment(self).invite_action_editors(message, subject, invitees, invitee_names)
+        return self.recruitment.invite_action_editors(message, subject, invitees, invitee_names)
 
     def invite_reviewers(self, message, subject, invitees, invitee_names=None):
-        return recruitment.Recruitment(self).invite_reviewers(message, subject, invitees, invitee_names)
+        return self.recruitment.invite_reviewers(message, subject, invitees, invitee_names)
 
     def setup_author_submission(self, note):
         self.group_builder.setup_submission_groups(self, note)

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -219,6 +219,9 @@ class Journal(object):
     def get_reviewers(self):
         return self.client.get_group(self.get_reviewers_id()).members
 
+    def get_authors(self, number):
+        return self.client.get_group(self.get_authors_id(number=number)).members
+
     def setup_ae_assignment(self, note):
         return self.assignment.setup_ae_assignment(note)
 

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -2,7 +2,7 @@ from .. import openreview
 from .. import tools
 from . import invitation
 from openreview.api import Edge
-from openreview import Group
+from openreview.api import Group
 import os
 import re
 import json
@@ -220,7 +220,7 @@ class Journal(object):
         venue_id=self.venue_id
         editor_in_chief_id=self.get_editors_in_chief_id()
         ## venue group
-        venue_group=self.client.post_group(openreview.Group(id=venue_id,
+        venue_group=self.client.post_group(Group(id=venue_id,
                         readers=['everyone'],
                         writers=[venue_id],
                         signatures=['~Super_User1'],
@@ -233,7 +233,7 @@ class Journal(object):
         ## editor in chief
         editor_in_chief_group = openreview.tools.get_group(self.client, editor_in_chief_id)
         if not editor_in_chief_group:
-            editor_in_chief_group=self.client.post_group(openreview.Group(id=editor_in_chief_id,
+            editor_in_chief_group=self.client.post_group(Group(id=editor_in_chief_id,
                             readers=['everyone'],
                             writers=[editor_in_chief_id],
                             signatures=[venue_id],
@@ -300,7 +300,7 @@ class Journal(object):
         action_editors_id = self.get_action_editors_id()
         action_editor_group = openreview.tools.get_group(self.client, action_editors_id)
         if not action_editor_group:
-            action_editor_group=self.client.post_group(openreview.Group(id=action_editors_id,
+            action_editor_group=self.client.post_group(Group(id=action_editors_id,
                             readers=['everyone'],
                             writers=[venue_id],
                             signatures=[venue_id],
@@ -315,7 +315,7 @@ class Journal(object):
         action_editors_invited_id = f'{action_editors_id}/Invited'
         action_editors_invited_group = openreview.tools.get_group(self.client, action_editors_invited_id)
         if not action_editors_invited_group:
-            self.client.post_group(openreview.Group(id=action_editors_invited_id,
+            self.client.post_group(Group(id=action_editors_invited_id,
                             readers=[venue_id],
                             writers=[venue_id],
                             signatures=[venue_id],
@@ -326,7 +326,7 @@ class Journal(object):
         action_editors_declined_id = f'{action_editors_id}/Declined'
         action_editors_declined_group = openreview.tools.get_group(self.client, action_editors_declined_id)
         if not action_editors_declined_group:
-            self.client.post_group(openreview.Group(id=action_editors_declined_id,
+            self.client.post_group(Group(id=action_editors_declined_id,
                             readers=[venue_id],
                             writers=[venue_id],
                             signatures=[venue_id],
@@ -337,7 +337,7 @@ class Journal(object):
         reviewers_id = self.get_reviewers_id()
         reviewer_group = openreview.tools.get_group(self.client, reviewers_id)
         if not reviewer_group:
-            reviewer_group = openreview.Group(id=reviewers_id,
+            reviewer_group = Group(id=reviewers_id,
                             readers=[venue_id, action_editors_id, reviewers_id],
                             writers=[venue_id],
                             signatures=[venue_id],
@@ -354,7 +354,7 @@ class Journal(object):
         reviewers_invited_id = f'{reviewers_id}/Invited'
         reviewers_invited_group = openreview.tools.get_group(self.client, reviewers_invited_id)
         if not reviewers_invited_group:
-            self.client.post_group(openreview.Group(id=reviewers_invited_id,
+            self.client.post_group(Group(id=reviewers_invited_id,
                             readers=[venue_id],
                             writers=[venue_id],
                             signatures=[venue_id],
@@ -365,7 +365,7 @@ class Journal(object):
         reviewers_declined_id = f'{reviewers_id}/Declined'
         reviewers_declined_group = openreview.tools.get_group(self.client, reviewers_declined_id)
         if not reviewers_declined_group:
-            self.client.post_group(openreview.Group(id=reviewers_declined_id,
+            self.client.post_group(Group(id=reviewers_declined_id,
                             readers=[venue_id],
                             writers=[venue_id],
                             signatures=[venue_id],
@@ -376,7 +376,7 @@ class Journal(object):
         authors_id = self.get_authors_id()
         authors_group = openreview.tools.get_group(self.client, authors_id)
         if not authors_group:
-            authors_group = openreview.Group(id=authors_id,
+            authors_group = Group(id=authors_id,
                             readers=[venue_id, authors_id],
                             writers=[venue_id],
                             signatures=[venue_id],

--- a/openreview/journal/recruitment.py
+++ b/openreview/journal/recruitment.py
@@ -1,0 +1,64 @@
+from .. import openreview
+from .. import tools
+
+from tqdm import tqdm
+import re
+
+class Recruitment(object):
+
+    def __init__(self, journal):
+        self.client = journal.client
+        self.journal = journal
+
+    def invite_action_editors(self, message, subject, invitees, invitee_names=None):
+
+        action_editors_id = self.journal.get_action_editors_id()
+        action_editors_declined_id = action_editors_id + '/Declined'
+        action_editors_invited_id = action_editors_id + '/Invited'
+        hash_seed = self.journal.secret_key
+
+        invited_members = self.client.get_group(action_editors_invited_id).members
+
+        for index, invitee in enumerate(tqdm(invitees, desc='send_invitations')):
+            profile=openreview.tools.get_profile(self.client, invitee)
+            invitee = profile.id if profile else invitee
+            if invitee not in invited_members:
+                name = invitee_names[index] if (invitee_names and index < len(invitee_names)) else None
+                if not name:
+                    name = re.sub('[0-9]+', '', invitee.replace('~', '').replace('_', ' ')) if invitee.startswith('~') else 'invitee'
+                r=tools.recruit_reviewer(self.client, invitee, name,
+                    hash_seed,
+                    self.journal.get_ae_recruitment_id(),
+                    message,
+                    subject,
+                    action_editors_invited_id,
+                    verbose = False)
+
+        return self.client.get_group(id = action_editors_invited_id)
+
+    def invite_reviewers(self, message, subject, invitees, invitee_names=None):
+
+        reviewers_id = self.journal.get_reviewers_id()
+        reviewers_declined_id = reviewers_id + '/Declined'
+        reviewers_invited_id = reviewers_id + '/Invited'
+        hash_seed = self.journal.secret_key
+
+        invited_members = self.client.get_group(reviewers_invited_id).members
+
+        for index, invitee in enumerate(tqdm(invitees, desc='send_invitations')):
+            memberships = [g.id for g in self.client.get_groups(member=invitee, regex=reviewers_id)] if (invitee.startswith('~') or tools.get_group(self.client, invitee)) else []
+            profile=openreview.tools.get_profile(self.client, invitee)
+            invitee = profile.id if profile else invitee
+            if invitee not in invited_members:
+                name = invitee_names[index] if (invitee_names and index < len(invitee_names)) else None
+                if not name:
+                    name = re.sub('[0-9]+', '', invitee.replace('~', '').replace('_', ' ')) if invitee.startswith('~') else 'invitee'
+                r=tools.recruit_reviewer(self.client, invitee, name,
+                    hash_seed,
+                    self.journal.get_reviewer_recruitment_id(),
+                    message,
+                    subject,
+                    reviewers_invited_id,
+                    verbose = False)
+
+        return self.client.get_group(id = reviewers_invited_id)

--- a/openreview/journal/webfield/recruitResponseWebfield.js
+++ b/openreview/journal/webfield/recruitResponseWebfield.js
@@ -40,7 +40,7 @@ function render() {
           '<ol>',
             '<li><p>Log in to your OpenReview account. If you do not already have an account, you can sign up <a style="font-weight:bold;" href="/signup">here</a>.</p></li>',
             '<li><p>Ensure that the email address ' + email + ' that received this invitation is linked to your <a style="font-weight:bold;" href="/profile?mode=edit">profile page</a> and has been confirmed.</p></li>',
-            '<li><p>Complete your pending <a style="font-weight:bold;" href="/tasks">tasks</a> (if any) for ' + HEADER.subtitle + '.</p></li>',
+            '<li><p>Complete your pending <a style="font-weight:bold;" href="/tasks">tasks</a> (if any) for ' + HEADER.short + '.</p></li>',
           '</ol>',
         '</div>',
       ].join('\n'));

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -69,6 +69,49 @@ def get_profile(client, value, with_publications=False):
             raise e
     return profile
 
+def get_profiles(client, ids_or_emails, with_publications=False):
+    '''
+    Helper function that repeatedly queries for profiles, given IDs and emails.
+    Useful for getting more Profiles than the server will return by default (1000)
+    '''
+    ids = []
+    emails = []
+    for member in ids_or_emails:
+        if '~' in member:
+            ids.append(member)
+        else:
+            emails.append(member)
+
+    profiles = []
+    profile_by_email = {}
+
+    batch_size = 100
+    for i in range(0, len(ids), batch_size):
+        batch_ids = ids[i:i+batch_size]
+        batch_profiles = client.search_profiles(ids=batch_ids)
+        profiles.extend(batch_profiles)
+
+    for j in range(0, len(emails), batch_size):
+        batch_emails = emails[j:j+batch_size]
+        batch_profile_by_email = client.search_profiles(confirmedEmails=batch_emails)
+        profile_by_email.update(batch_profile_by_email)
+
+    for email in emails:
+        profiles.append(profile_by_email.get(email, openreview.Profile(
+            id=email,
+            content={
+                'emails': [email],
+                'preferredEmail': email,
+                'emailsConfirmed': [email],
+                'names': []
+            })))
+
+    if with_publications:
+        for profile in profiles:
+            profile.content['publications'] = list(iterget_notes(client, content={'authorids': profile.id}))
+
+    return profiles
+
 def get_group(client, id):
     """
     Get a single Group by id if available
@@ -1722,7 +1765,7 @@ def pretty_id(group_id):
 
 def export_committee(client, committee_id, file_name):
     members=client.get_group(committee_id).members
-    profiles=openreview.matching._get_profiles(client, members)
+    profiles=get_profiles(client, members)
     with open(file_name, 'w') as outfile:
         csvwriter = csv.writer(outfile, delimiter=',')
         for profile in tqdm(profiles):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='openreview-py',
-    version='1.1.0',
+    version='1.1.1',
     description='OpenReview API Python client library',
     url='https://github.com/openreview/openreview-py',
     author='OpenReview Team',

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -17,6 +17,7 @@ class TestJournal():
     def journal(self):
         venue_id = '.TMLR'
         fabian_client=OpenReviewClient(username='fabian@mail.com', password='1234')
+        fabian_client.impersonate('.TMLR/Editors_In_Chief')
         journal=Journal(fabian_client, venue_id, '1234', contact_info='tmlr@jmlr.org', full_name='Transactions of Machine Learning Research', short_name='TMLR')
         return journal
 


### PR DESCRIPTION
- create new journal modules: groups, recruitment and assignment
- deprecate `_getprofiles` in the matching module of the conference, move the implementation to tools.
- compute conflicts for action editors and reviewers. 