### PR TITLE
always update PC console

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -991,9 +991,7 @@ class Conference(object):
 
     def set_program_chairs(self, emails = []):
         pcs = self.__create_group(self.get_program_chairs_id(), self.id, emails)
-        # if first time, add PC console
-        if not pcs.web:
-            self.webfield_builder.set_program_chair_page(self, pcs)
+        self.webfield_builder.set_program_chair_page(self, pcs)
         ## Give program chairs admin permissions
         self.__create_group(self.id, '~Super_User1', [self.get_program_chairs_id()])
         return pcs

--- a/tests/test_builder_console.py
+++ b/tests/test_builder_console.py
@@ -43,6 +43,9 @@ class TestBuilderConsoles():
         # update web manually
         pc_group.web = pc_group.web.replace("PC Console TEST Conf 2020",
                                             "PC Console TEST Conf YEAR")
+        # we make manual change so we don't want it overwritten
+        pc_group.web = pc_group.web.replace("// webfield_template",
+                                            "")
         pc_group = client.post_group(pc_group)
         customized_web = pc_group.web
 


### PR DESCRIPTION
PC console is not getting updated when the request form is revised, this is a problem when the submission name is changed. 

I think we should always update the PC console (unless we remove the `// webfield_template` line)