### PR TITLE
split journal recruitment

### DIFF
--- a/openreview/journal/journal_request/journal_request.py
+++ b/openreview/journal/journal_request/journal_request.py
@@ -174,35 +174,17 @@ class JournalRequest():
                         invitation = invitation
                     )
 
-    def setup_recruitment_invitation(self, note_id):
+    def setup_recruitment_invitations(self, note_id):
 
         note = self.client.get_note(note_id)
         short_name = note.content['abbreviated_venue_name']['value']
         venue_id = note.content['venue_id']['value']
-        recruitment_email_template = '''Dear {name},
-
-You have been nominated by the program chair committee of {short_name} to serve as {invitee_role}.
-
-ACCEPT LINK:
-{accept_url}
-
-DECLINE LINK:
-{decline_url}
-
-Cheers!'''.replace('{short_name}', short_name)
 
         recruitment_content = {
             'title': {
                 'order': 1,
                 'value': {
                     'value': 'Recruitment'
-                }
-            },
-            'invitee_role': {
-                'description': 'Please select the role of the invitees in the journal,',
-                'order': 2,
-                'value' : {
-                    'value-radio': ['action editor', 'reviewer']
                 }
             },
             'invitee_details': {
@@ -219,7 +201,7 @@ Cheers!'''.replace('{short_name}', short_name)
                     'value-regex': '.*'
                 },
                 'presentation': {
-                    'default': '[{short_name}] Invitation to serve as {invitee_role}'.replace('{short_name}', short_name)
+                    'default': None
                 }
             },
             'email_content': {
@@ -229,16 +211,117 @@ Cheers!'''.replace('{short_name}', short_name)
                     'value-regex': '[\\S\\s]{1,10000}'
                 },
                 'presentation': {
-                    'default': recruitment_email_template
+                    'default': None,
+                    'markdown': True
                 }
             }
         }
+
+        #setup ae recruitment
+        recruitment_email_template = '''Hi {name},
+
+The Transactions on Machine Learning Research is a journal for ML research that:
+- Uses OpenReview
+- Focuses on conference-length publications
+- Has no submission deadlines
+- Aims for a fast turnaround
+- Has acceptance based on matched claims and evidence, not potential impact
+You can learn more about TMLR in our founding blog post and on jmlr.org/tmlr. 
+
+We are reaching out to you as we'd like to invite you to serve as an Action Editor (AE) for the journal. 
+
+In terms of workload, we will be capping the number of assigned submissions to 12 per year. Note also that we are aiming for a short review period, of about 2 months, with most of your direct involvement being needed in the first week to assign reviewers and in the last two weeks for submitting a decision. We also hope to spread that workload across the year, so that you only have 2 or 3 active submissions at any given time. Within these limits, we otherwise expect AEs to handle all papers assigned to then, so as to have the fastest turnaround possible. You can learn more about the AE role at jmlr.org/tmlr/ae-guide.html. 
+
+AEs will play a crucial role in building the credibility of TMLR. For example, much like for JMLR, the identity of the AE in charge of each submission will be made visible during and after the review process. Hence, TMLR will only be successful if experts such as yourself are willing to give their support and their time. 
+
+To ACCEPT the invitation, please click on the following link:
+
+{accept_url}
+
+To DECLINE the invitation, please click on the following link:
+
+{decline_url}
+
+If you have any questions, simply reach out to us at tmlr-editors@jmlr.org.
+
+Hope we can count on you!
+
+The TMLR Editors-in-Chief
+'''
+        recruitment_content['email_content']['presentation']['default'] = recruitment_email_template
+        recruitment_content['email_subject']['presentation']['default'] = f'[{short_name}] Invitation to serve as Action Editor for {short_name}'
 
         with open(os.path.join(os.path.dirname(__file__), 'process/recruitment_process.py')) as f:
             content = f.read()
             content = content.replace("SUPPORT_GROUP = ''", "SUPPORT_GROUP = '" + self.support_group_id + "'")
             invitation = openreview.api.Invitation(
-                id = f'{self.support_group_id}/Journal_Request' + str(note.number) + '/-/Recruitment',
+                id = f'{self.support_group_id}/Journal_Request' + str(note.number) + '/-/Action_Editor_Recruitment',
+                invitees = [venue_id],
+                readers = ['everyone'],
+                writers = [],
+                signatures = ['~Super_User1'],
+                edit = {
+                    'signatures': { 'values-regex': f'~.*|{self.support_group_id}' },
+                    'writers': { 'values': [self.support_group_id, venue_id] },
+                    'readers': { 'values': [self.support_group_id, venue_id] },
+                    'note': {
+                        'forum': { 'value': note.id },
+                        'replyto': {'value': note.id },
+                        'signatures': { 'values': ['${signatures}'] },
+                        'readers': { 'values': [self.support_group_id, venue_id] },
+                        'writers': { 'values': [self.support_group_id, venue_id]},
+                        'content': recruitment_content
+                    }
+                },
+                process_string = content
+            )
+
+            self.client.post_invitation_edit(
+                readers = ['~Super_User1'],
+                writers = ['~Super_User1'],
+                signatures = ['~Super_User1'],
+                invitation = invitation
+            )
+
+        #setup rev recruitment
+        recruitment_email_template = '''Hi {name},
+
+The Transactions on Machine Learning Research is a journal for ML research that:
+- Uses OpenReview
+- Focuses on conference-length publications
+- Has no submission deadlines
+- Aims for a fast turnaround
+- Has acceptance based on matched claims and evidence, not potential impact
+You can learn more about TMLR in our founding blog post and on jmlr.org/tmlr. 
+
+We are reaching out to you as we'd like to invite you to serve as a reviewer for the journal. For each paper, we are aiming for a short review period, of about 2 months. The TMLR review process works as follows. 
+- After receiving an assignment, an initial review must be submitted within 2 weeks. Exceptions on this deadline can be made for submissions longer than twelve pages of main content. 
+- Then, two weeks after all reviewers have submitted their initial review (and no later than 1 month after), each reviewer is asked to submit a final decision recommendation to the Action Editor in charge of the submission, based on their discussion with the authors since the initial review. 
+
+In terms of workload, we are capping the number of assigned submissions to 6 per year. We also aim to spread workload across the year, so that you only have to review 1 active submission at any given time. Within these limits, we otherwise expect reviewers to handle all papers assigned to then, so as to have the fastest turnaround possible. You can learn more about the reviewer role at jmlr.org/tmlr/reviewer-guide.html . 
+
+To ACCEPT the invitation, please click on the following link:
+
+{accept_url}
+
+To DECLINE the invitation, please click on the following link:
+
+{decline_url}
+
+If you have any questions, simply reach out to us at tmlr-editors@jmlr.org.
+
+Hope we can count on you!
+
+The TMLR Editors-in-Chief
+'''
+        recruitment_content['email_content']['presentation']['default'] = recruitment_email_template
+        recruitment_content['email_subject']['presentation']['default'] = f'[{short_name}] Invitation to serve as Reviewer for {short_name}'
+
+        with open(os.path.join(os.path.dirname(__file__), 'process/recruitment_process.py')) as f:
+            content = f.read()
+            content = content.replace("SUPPORT_GROUP = ''", "SUPPORT_GROUP = '" + self.support_group_id + "'")
+            invitation = openreview.api.Invitation(
+                id = f'{self.support_group_id}/Journal_Request' + str(note.number) + '/-/Reviewer_Recruitment',
                 invitees = [venue_id],
                 readers = ['everyone'],
                 writers = [],
@@ -299,7 +382,7 @@ Cheers!
                     'value-regex': '.*'
                 },
                 'presentation': {
-                    'default': '[{short_name}] Invitation to serve as reviewer'
+                    'default': f'[{short_name}] Invitation to serve as reviewer'
                 }
             },
             'email_content': {
@@ -318,7 +401,7 @@ Cheers!
             content = f.read()
             content = content.replace("SUPPORT_GROUP = ''", "SUPPORT_GROUP = '" + self.support_group_id + "'")
             invitation = openreview.api.Invitation(
-                id = f'{self.support_group_id}/Journal_Request' + str(note.number) + '/-/Reviewer_Recruitment',
+                id = f'{self.support_group_id}/Journal_Request' + str(note.number) + '/-/Reviewer_Recruitment_by_AE',
                 invitees = [venue_id, f'{venue_id}/Action_Editors'],
                 readers = ['everyone'],
                 writers = [],

--- a/openreview/journal/journal_request/journal_request.py
+++ b/openreview/journal/journal_request/journal_request.py
@@ -220,17 +220,17 @@ class JournalRequest():
         #setup ae recruitment
         recruitment_email_template = '''Hi {name},
 
-The Transactions on Machine Learning Research is a journal for ML research that:
+The [Transactions on Machine Learning Research](https://jmlr.org/tmlr/) is a journal for ML research that:
 - Uses OpenReview
 - Focuses on conference-length publications
 - Has no submission deadlines
 - Aims for a fast turnaround
 - Has acceptance based on matched claims and evidence, not potential impact
-You can learn more about TMLR in our founding blog post and on jmlr.org/tmlr. 
+You can learn more about TMLR in [our founding blog post](https://medium.com/@hugo_larochelle_65309/announcing-the-transactions-on-machine-learning-research-3ea6101c936f) and on [jmlr.org/tmlr](https://jmlr.org/tmlr/). 
 
 We are reaching out to you as we'd like to invite you to serve as an Action Editor (AE) for the journal. 
 
-In terms of workload, we will be capping the number of assigned submissions to 12 per year. Note also that we are aiming for a short review period, of about 2 months, with most of your direct involvement being needed in the first week to assign reviewers and in the last two weeks for submitting a decision. We also hope to spread that workload across the year, so that you only have 2 or 3 active submissions at any given time. Within these limits, we otherwise expect AEs to handle all papers assigned to then, so as to have the fastest turnaround possible. You can learn more about the AE role at jmlr.org/tmlr/ae-guide.html. 
+In terms of workload, we will be capping the number of assigned submissions to 12 per year. Note also that we are aiming for a short review period, of about 2 months, with most of your direct involvement being needed in the first week to assign reviewers and in the last two weeks for submitting a decision. We also hope to spread that workload across the year, so that you only have 2 or 3 active submissions at any given time. Within these limits, we otherwise expect AEs to handle all papers assigned to then, so as to have the fastest turnaround possible. You can learn more about the AE role at [jmlr.org/tmlr/ae-guide.html](https://jmlr.org/tmlr/ae-guide.html). 
 
 AEs will play a crucial role in building the credibility of TMLR. For example, much like for JMLR, the identity of the AE in charge of each submission will be made visible during and after the review process. Hence, TMLR will only be successful if experts such as yourself are willing to give their support and their time. 
 
@@ -286,19 +286,19 @@ The TMLR Editors-in-Chief
         #setup rev recruitment
         recruitment_email_template = '''Hi {name},
 
-The Transactions on Machine Learning Research is a journal for ML research that:
+The [Transactions on Machine Learning Research](https://jmlr.org/tmlr/) is a journal for ML research that:
 - Uses OpenReview
 - Focuses on conference-length publications
 - Has no submission deadlines
 - Aims for a fast turnaround
 - Has acceptance based on matched claims and evidence, not potential impact
-You can learn more about TMLR in our founding blog post and on jmlr.org/tmlr. 
+You can learn more about TMLR in [our founding blog post](https://medium.com/@hugo_larochelle_65309/announcing-the-transactions-on-machine-learning-research-3ea6101c936f) and on [jmlr.org/tmlr](https://jmlr.org/tmlr/). 
 
 We are reaching out to you as we'd like to invite you to serve as a reviewer for the journal. For each paper, we are aiming for a short review period, of about 2 months. The TMLR review process works as follows. 
 - After receiving an assignment, an initial review must be submitted within 2 weeks. Exceptions on this deadline can be made for submissions longer than twelve pages of main content. 
 - Then, two weeks after all reviewers have submitted their initial review (and no later than 1 month after), each reviewer is asked to submit a final decision recommendation to the Action Editor in charge of the submission, based on their discussion with the authors since the initial review. 
 
-In terms of workload, we are capping the number of assigned submissions to 6 per year. We also aim to spread workload across the year, so that you only have to review 1 active submission at any given time. Within these limits, we otherwise expect reviewers to handle all papers assigned to then, so as to have the fastest turnaround possible. You can learn more about the reviewer role at jmlr.org/tmlr/reviewer-guide.html . 
+In terms of workload, we are capping the number of assigned submissions to 6 per year. We also aim to spread workload across the year, so that you only have to review 1 active submission at any given time. Within these limits, we otherwise expect reviewers to handle all papers assigned to then, so as to have the fastest turnaround possible. You can learn more about the reviewer role at [jmlr.org/tmlr/reviewer-guide.html](https://jmlr.org/tmlr/reviewer-guide.html). 
 
 To ACCEPT the invitation, please click on the following link:
 

--- a/openreview/journal/journal_request/process/ae_recruitment_process.py
+++ b/openreview/journal/journal_request/process/ae_recruitment_process.py
@@ -57,7 +57,7 @@ Please check the invitee group to see more details: https://openreview.net/group
         comment_content += f'''
 Error: {error_status}'''
 
-    comment_note = client.post_note_edit(invitation=recruitment_note.invitations[0].replace('Reviewer_Recruitment', 'Comment'),
+    comment_note = client.post_note_edit(invitation=recruitment_note.invitations[0].replace('Reviewer_Recruitment_by_AE', 'Comment'),
         signatures=[SUPPORT_GROUP],
         note = openreview.api.Note(
             content = {

--- a/openreview/journal/journal_request/process/deploy_process.py
+++ b/openreview/journal/journal_request/process/deploy_process.py
@@ -19,5 +19,5 @@ def process(client, edit, invitation):
     journal_request = openreview.journal.JournalRequest(client, SUPPORT_GROUP)
     journal_request.setup_journal_group(edit.note.id)
     journal_request.setup_comment_invitation(edit.note.id, journal.get_action_editors_id())
-    journal_request.setup_recruitment_invitation(edit.note.id)
+    journal_request.setup_recruitment_invitations(edit.note.id)
     journal_request.setup_recruitment_by_action_editors(edit.note.id)

--- a/openreview/journal/journal_request/process/recruitment_process.py
+++ b/openreview/journal/journal_request/process/recruitment_process.py
@@ -15,16 +15,10 @@ def process(client, edit, invitation):
     journal = openreview.journal.Journal(client, venue_id, secret_key, contact_info, full_name, short_name, website)
 
     recruitment_note = client.get_note(edit.note.id)
-
-    role = recruitment_note.content['invitee_role']['value']
-
     role_map={
-        'reviewer': 'Reviewers',
-        'action editor': 'Action_Editor',
+        'Reviewer': 'Reviewers',
+        'Action Editor': 'Action_Editors',
     }
-
-    subject = recruitment_note.content['email_subject']['value'].replace('{invitee_role}', role)
-    content = recruitment_note.content['email_content']['value'].replace('{invitee_role}', role)
 
     invitee_details_str = recruitment_note.content['invitee_details']['value']
     invitee_emails = []
@@ -43,10 +37,16 @@ def process(client, edit, invitation):
                 invitee_emails.append(email)
                 invitee_names.append(name)
 
-    if role == 'reviewer':
-        status = journal.invite_reviewers(content, subject, invitee_emails, invitee_names)
-    else:
+    subject = recruitment_note.content['email_subject']['value']
+    content = recruitment_note.content['email_content']['value']
+    if 'Action_Editor' in invitation.id:
+        role = 'Action Editor'
+        subject.replace('{role}', role)
         status = journal.invite_action_editors(content, subject, invitee_emails, invitee_names)
+    else:
+        role = 'Reviewer'
+        subject.replace('{role}', role)
+        status = journal.invite_reviewers(content, subject, invitee_emails, invitee_names)
 
     non_invited_status = f'''No recruitment invitation was sent to the following users because they have already been invited as {role}:
 {status.get('already_invited')}''' if status.get('already_invited') else ''
@@ -59,7 +59,7 @@ def process(client, edit, invitation):
 {status.get('errors')}''' if status.get('errors') else ''
 
     comment_content = f'''
-Invited: {len(status.get('invited'))} {role}s.
+Invited: {len(status.get('invited'))} {role}(s).
 
 {non_invited_status}
 {already_member_status}
@@ -73,7 +73,8 @@ Please check the invitee group to see more details: https://openreview.net/group
         comment_content += f'''
 Error: {error_status}'''
 
-    comment_note = client.post_note_edit(invitation=recruitment_note.invitations[0].replace('Recruitment', 'Comment'),
+    invitation = recruitment_note.invitations[0].split('/-/')[0]
+    comment_note = client.post_note_edit(invitation=invitation + '/-/Comment',
         signatures=[SUPPORT_GROUP],
         note = openreview.api.Note(
             content = {

--- a/tests/test_journal_request.py
+++ b/tests/test_journal_request.py
@@ -107,7 +107,7 @@ class TestJournalRequest():
         reply_row = recruitment_div.find_element_by_class_name('reply_row')
         assert reply_row
         buttons = reply_row.find_elements_by_class_name('btn-xs')
-        assert [btn for btn in buttons if btn.text == 'Recruitment']
+        assert [btn for btn in buttons if btn.text == 'Reviewer Recruitment']
 
         helpers.create_user('reviewer_journal2@mail.com', 'Second', 'Reviewer')
 
@@ -116,15 +116,14 @@ class TestJournalRequest():
 
         reviewer_details = { 'value': '''reviewer_journal1@mail.com, First Reviewer\n~Second_Reviewer1\nreviewer_journal3@mail.com'''}
         recruitment_note = test_client.post_note_edit(
-            invitation = '{}/Journal_Request{}/-/Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number']),
+            invitation = '{}/Journal_Request{}/-/Reviewer_Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number']),
             signatures = ['~Support_Role1'],
             note = Note(
                 content = {
                     'title': { 'value': 'Recruitment' },
-                    'invitee_role': { 'value': 'reviewer' },
                     'invitee_details': reviewer_details,
-                    'email_subject': { 'value': '[' + journal['journal_request_note']['content']['abbreviated_venue_name']['value'] + '] Invitation to serve as {invitee_role}' },
-                    'email_content': {'value': 'Dear {name},\n\nYou have been nominated by the program chair committee of TJ22 to serve as {invitee_role}.\n\nACCEPT LINK:\n{accept_url}\n\nDECLINE LINK:\n{decline_url}\n\nCheers!'}
+                    'email_subject': { 'value': '[' + journal['journal_request_note']['content']['abbreviated_venue_name']['value'] + '] Invitation to serve as Reviewer for ' +  journal['journal_request_note']['content']['abbreviated_venue_name']['value']},
+                    'email_content': {'value': 'Dear {name},\n\nYou have been nominated by the program chair committee of TJ22 to serve as reviewer.\n\nACCEPT LINK:\n{accept_url}\n\nDECLINE LINK:\n{decline_url}\n\nCheers!'}
                 },
                 forum = journal['journal_request_note']['forum'],
                 replyto = journal['journal_request_note']['forum'],
@@ -136,7 +135,7 @@ class TestJournalRequest():
         process_logs = openreview_client.get_process_logs(id = recruitment_note['id'])
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
-        assert process_logs[0]['invitation'] == '{}/Journal_Request{}/-/Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number'])
+        assert process_logs[0]['invitation'] == '{}/Journal_Request{}/-/Reviewer_Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number'])
 
         invited_group = openreview_client.get_group('{}/Reviewers/Invited'.format(journal['journal_request_note']['content']['venue_id']['value']))
         assert invited_group
@@ -145,11 +144,11 @@ class TestJournalRequest():
         assert '~Second_Reviewer1' in invited_group.members
         assert 'reviewer_journal3@mail.com' in invited_group.members
 
-        messages = openreview_client.get_messages(to = 'reviewer_journal1@mail.com', subject = '[TJ22] Invitation to serve as reviewer')
+        messages = openreview_client.get_messages(to = 'reviewer_journal1@mail.com', subject = '[TJ22] Invitation to serve as Reviewer for TJ22')
         assert len(messages) == 1
         assert messages[0]['content']['text'].startswith('<p>Dear First Reviewer,</p>\n<p>You have been nominated by the program chair committee of TJ22 to serve as reviewer.</p>')
 
-        messages = openreview_client.get_messages(to = 'reviewer_journal2@mail.com', subject = '[TJ22] Invitation to serve as reviewer')
+        messages = openreview_client.get_messages(to = 'reviewer_journal2@mail.com', subject = '[TJ22] Invitation to serve as Reviewer for TJ22')
         assert len(messages) == 1
         assert messages[0]['content']['text'].startswith('<p>Dear Second Reviewer,</p>\n<p>You have been nominated by the program chair committee of TJ22 to serve as reviewer.</p>')
 
@@ -161,7 +160,7 @@ class TestJournalRequest():
 
         assert recruitment_status
         assert recruitment_status[0].content['title']['value'] == 'Recruitment Status'
-        assert 'Invited: 2 reviewers.' in recruitment_status[0].content['comment']['value']
+        assert 'Invited: 2 Reviewer(s).' in recruitment_status[0].content['comment']['value']
 
     def test_journal_action_editor_recruitment(self, openreview_client, selenium, request_page, helpers, journal):
 
@@ -175,15 +174,14 @@ class TestJournalRequest():
 
         ae_details = { 'value': '''ae_journal1@mail.com, First AE\nae_journal2@mail.com, Second AE\nae_journal3@mail.com, Third AE\nalready_actioneditor@mail.com, Action Editor'''}
         recruitment_note = test_client.post_note_edit(
-            invitation = '{}/Journal_Request{}/-/Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number']),
+            invitation = '{}/Journal_Request{}/-/Action_Editor_Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number']),
             signatures = ['~Support_Role1'],
             note = Note(
                 content = {
                     'title': { 'value': 'Recruitment' },
-                    'invitee_role': { 'value': 'action editor' },
                     'invitee_details': ae_details,
-                    'email_subject': { 'value': '[' + journal['journal_request_note']['content']['abbreviated_venue_name']['value'] + '] Invitation to serve as {invitee_role}' },
-                    'email_content': {'value': 'Dear {name},\n\nYou have been nominated by the program chair committee of TJ22 to serve as {invitee_role}.\n\nACCEPT LINK:\n{accept_url}\n\nDECLINE LINK:\n{decline_url}\n\nCheers!'}
+                    'email_subject': { 'value': '[' + journal['journal_request_note']['content']['abbreviated_venue_name']['value'] + '] Invitation to serve as Action Editor for ' + journal['journal_request_note']['content']['abbreviated_venue_name']['value'] },
+                    'email_content': {'value': 'Dear {name},\n\nYou have been nominated by the program chair committee of TJ22 to serve as action editor.\n\nACCEPT LINK:\n{accept_url}\n\nDECLINE LINK:\n{decline_url}\n\nCheers!'}
                 },
                 forum = journal['journal_request_note']['forum'],
                 replyto = journal['journal_request_note']['forum'],
@@ -195,7 +193,7 @@ class TestJournalRequest():
         process_logs = openreview_client.get_process_logs(id = recruitment_note['id'])
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
-        assert process_logs[0]['invitation'] == '{}/Journal_Request{}/-/Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number'])
+        assert process_logs[0]['invitation'] == '{}/Journal_Request{}/-/Action_Editor_Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number'])
 
         messages = openreview_client.get_messages(to = 'ae_journal1@mail.com')
         assert len(messages) == 0
@@ -203,11 +201,11 @@ class TestJournalRequest():
         messages = openreview_client.get_messages(to = 'already_actioneditor@mail.com')
         assert len(messages) == 0
 
-        messages = openreview_client.get_messages(to = 'ae_journal2@mail.com', subject = '[TJ22] Invitation to serve as action editor')
+        messages = openreview_client.get_messages(to = 'ae_journal2@mail.com', subject = '[TJ22] Invitation to serve as Action Editor for TJ22')
         assert len(messages) == 1
         assert messages[0]['content']['text'].startswith('<p>Dear Second AE,</p>\n<p>You have been nominated by the program chair committee of TJ22 to serve as action editor.</p>')
 
-        messages = openreview_client.get_messages(to = 'ae_journal3@mail.com', subject = '[TJ22] Invitation to serve as action editor')
+        messages = openreview_client.get_messages(to = 'ae_journal3@mail.com', subject = '[TJ22] Invitation to serve as Action Editor for TJ22')
         assert len(messages) == 1
         assert messages[0]['content']['text'].startswith('<p>Dear Third AE,</p>\n<p>You have been nominated by the program chair committee of TJ22 to serve as action editor.</p>')
 
@@ -216,8 +214,8 @@ class TestJournalRequest():
 
         assert recruitment_status
         assert recruitment_status[0].content['title']['value'] == 'Recruitment Status'
-        assert 'Invited: 2 action editors.' in recruitment_status[0].content['comment']['value']
-        assert 'No recruitment invitation was sent to the following users because they are already members of the action editor group:'
+        assert 'Invited: 2 Action Editor(s).' in recruitment_status[0].content['comment']['value']
+        assert 'No recruitment invitation was sent to the following users because they are already members of the Action Editor group:'
 
     def test_journal_reviewer_recruitment_by_ae(self, openreview_client, selenium, request_page, helpers, journal):
 
@@ -233,11 +231,11 @@ class TestJournalRequest():
         reply_row = recruitment_div.find_element_by_class_name('reply_row')
         assert reply_row
         buttons = reply_row.find_elements_by_class_name('btn-xs')
-        assert [btn for btn in buttons if btn.text == 'Reviewer Recruitment']
+        assert [btn for btn in buttons if btn.text == 'Reviewer Recruitment by AE']
 
         reviewer_details = { 'value': '''new_reviewer@mail.com, New Reviewer'''}
         recruitment_note = ae_client.post_note_edit(
-            invitation = '{}/Journal_Request{}/-/Reviewer_Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number']),
+            invitation = '{}/Journal_Request{}/-/Reviewer_Recruitment_by_AE'.format(journal['suppot_group_id'],journal['journal_request_note']['number']),
             signatures = ['~First_AE1'],
             note = Note(
                 content = {
@@ -255,7 +253,7 @@ class TestJournalRequest():
         process_logs = openreview_client.get_process_logs(id = recruitment_note['id'])
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
-        assert process_logs[0]['invitation'] == '{}/Journal_Request{}/-/Reviewer_Recruitment'.format(journal['suppot_group_id'],journal['journal_request_note']['number'])
+        assert process_logs[0]['invitation'] == '{}/Journal_Request{}/-/Reviewer_Recruitment_by_AE'.format(journal['suppot_group_id'],journal['journal_request_note']['number'])
 
         messages = openreview_client.get_messages(to = 'new_reviewer@mail.com', subject = '[TJ22] Invitation to serve as reviewer')
         assert len(messages) == 1


### PR DESCRIPTION
-Separates AE and reviewer recruitment invitations
-Renamed Reviewer_Recruitment to Reviewer_Recruitment_by_AE (the invitation for AEs to invite reviewers), but open to other invitation ids

I am still using one process function, but I can split it into two if that would be better and easier to understand. 

Note:  I added the TMLR template as default, but I did not add it to the test (it's a long email template) but I can add it if necessary. 