### PR TITLE
allow for custom recruitment template

### DIFF
--- a/openreview/journal/journal_request/journal_request.py
+++ b/openreview/journal/journal_request/journal_request.py
@@ -174,11 +174,23 @@ class JournalRequest():
                         invitation = invitation
                     )
 
-    def setup_recruitment_invitations(self, note_id):
+    def setup_recruitment_invitations(self, note_id, ae_template=None, reviewer_template=None):
 
         note = self.client.get_note(note_id)
         short_name = note.content['abbreviated_venue_name']['value']
         venue_id = note.content['venue_id']['value']
+
+        default_recruitment_template = '''Dear {name},
+
+You have been nominated by the program chair committee of {short_name} to serve as {role}.
+
+ACCEPT LINK:
+{accept_url}
+
+DECLINE LINK:
+{decline_url}
+
+Cheers!'''.replace('{short_name}', short_name)
 
         recruitment_content = {
             'title': {
@@ -201,7 +213,7 @@ class JournalRequest():
                     'value-regex': '.*'
                 },
                 'presentation': {
-                    'default': None
+                    'default': '[{short_name}] Invitation to serve as {role} for {short_name}'.replace('{short_name}', short_name)
                 }
             },
             'email_content': {
@@ -211,45 +223,15 @@ class JournalRequest():
                     'value-regex': '[\\S\\s]{1,10000}'
                 },
                 'presentation': {
-                    'default': None,
+                    'default': default_recruitment_template,
                     'markdown': True
                 }
             }
         }
 
         #setup ae recruitment
-        recruitment_email_template = '''Hi {name},
-
-The [Transactions on Machine Learning Research](https://jmlr.org/tmlr/) is a journal for ML research that:
-- Uses OpenReview
-- Focuses on conference-length publications
-- Has no submission deadlines
-- Aims for a fast turnaround
-- Has acceptance based on matched claims and evidence, not potential impact
-You can learn more about TMLR in [our founding blog post](https://medium.com/@hugo_larochelle_65309/announcing-the-transactions-on-machine-learning-research-3ea6101c936f) and on [jmlr.org/tmlr](https://jmlr.org/tmlr/). 
-
-We are reaching out to you as we'd like to invite you to serve as an Action Editor (AE) for the journal. 
-
-In terms of workload, we will be capping the number of assigned submissions to 12 per year. Note also that we are aiming for a short review period, of about 2 months, with most of your direct involvement being needed in the first week to assign reviewers and in the last two weeks for submitting a decision. We also hope to spread that workload across the year, so that you only have 2 or 3 active submissions at any given time. Within these limits, we otherwise expect AEs to handle all papers assigned to then, so as to have the fastest turnaround possible. You can learn more about the AE role at [jmlr.org/tmlr/ae-guide.html](https://jmlr.org/tmlr/ae-guide.html). 
-
-AEs will play a crucial role in building the credibility of TMLR. For example, much like for JMLR, the identity of the AE in charge of each submission will be made visible during and after the review process. Hence, TMLR will only be successful if experts such as yourself are willing to give their support and their time. 
-
-To ACCEPT the invitation, please click on the following link:
-
-{accept_url}
-
-To DECLINE the invitation, please click on the following link:
-
-{decline_url}
-
-If you have any questions, simply reach out to us at tmlr-editors@jmlr.org.
-
-Hope we can count on you!
-
-The TMLR Editors-in-Chief
-'''
-        recruitment_content['email_content']['presentation']['default'] = recruitment_email_template
-        recruitment_content['email_subject']['presentation']['default'] = f'[{short_name}] Invitation to serve as Action Editor for {short_name}'
+        if ae_template:
+            recruitment_content['email_content']['presentation']['default'] = ae_template
 
         with open(os.path.join(os.path.dirname(__file__), 'process/recruitment_process.py')) as f:
             content = f.read()
@@ -284,38 +266,8 @@ The TMLR Editors-in-Chief
             )
 
         #setup rev recruitment
-        recruitment_email_template = '''Hi {name},
-
-The [Transactions on Machine Learning Research](https://jmlr.org/tmlr/) is a journal for ML research that:
-- Uses OpenReview
-- Focuses on conference-length publications
-- Has no submission deadlines
-- Aims for a fast turnaround
-- Has acceptance based on matched claims and evidence, not potential impact
-You can learn more about TMLR in [our founding blog post](https://medium.com/@hugo_larochelle_65309/announcing-the-transactions-on-machine-learning-research-3ea6101c936f) and on [jmlr.org/tmlr](https://jmlr.org/tmlr/). 
-
-We are reaching out to you as we'd like to invite you to serve as a reviewer for the journal. For each paper, we are aiming for a short review period, of about 2 months. The TMLR review process works as follows. 
-- After receiving an assignment, an initial review must be submitted within 2 weeks. Exceptions on this deadline can be made for submissions longer than twelve pages of main content. 
-- Then, two weeks after all reviewers have submitted their initial review (and no later than 1 month after), each reviewer is asked to submit a final decision recommendation to the Action Editor in charge of the submission, based on their discussion with the authors since the initial review. 
-
-In terms of workload, we are capping the number of assigned submissions to 6 per year. We also aim to spread workload across the year, so that you only have to review 1 active submission at any given time. Within these limits, we otherwise expect reviewers to handle all papers assigned to then, so as to have the fastest turnaround possible. You can learn more about the reviewer role at [jmlr.org/tmlr/reviewer-guide.html](https://jmlr.org/tmlr/reviewer-guide.html). 
-
-To ACCEPT the invitation, please click on the following link:
-
-{accept_url}
-
-To DECLINE the invitation, please click on the following link:
-
-{decline_url}
-
-If you have any questions, simply reach out to us at tmlr-editors@jmlr.org.
-
-Hope we can count on you!
-
-The TMLR Editors-in-Chief
-'''
-        recruitment_content['email_content']['presentation']['default'] = recruitment_email_template
-        recruitment_content['email_subject']['presentation']['default'] = f'[{short_name}] Invitation to serve as Reviewer for {short_name}'
+        if reviewer_template:
+            recruitment_content['email_content']['presentation']['default'] = reviewer_template
 
         with open(os.path.join(os.path.dirname(__file__), 'process/recruitment_process.py')) as f:
             content = f.read()


### PR DESCRIPTION
Allows for a custom recruitment email to be chosen when setting up recruitment invitations. 