### PR TITLE
request form paper matching fixes

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -849,10 +849,10 @@ class Matching(object):
                         'hidden': True
                     },
                     'allow_zero_score_assignments': {
-                        'description': 'Select "Yes" only if you want to allow assignments with 0 scores',
+                        'description': 'Select "No" only if you do not want to allow assignments with 0 scores. Note that if there are any users without publications, you need to select "Yes" in order to run a paper matching.',
                         'value-radio': ['Yes', 'No'],
                         'required': False,
-                        'default': 'No',
+                        'default': 'Yes',
                         'order': 20
                     },
                     'randomized_probability_limits': {

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -325,72 +325,66 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
         signatures=['~Super_User1']
     ))
 
-    if (forum.content.get('Submission Deadline') and forum.content.get('Paper Matching')):
-        activation_date = forum.content.get('Submission Deadline').strip()
-        try:
-            activation_date = datetime.strptime(activation_date, '%Y/%m/%d %H:%M')
-        except ValueError:
-            activation_date = datetime.strptime(activation_date, '%Y/%m/%d')
-        matching_group_ids = [conference.get_committee_id(r) for r in conference.reviewer_roles]
-        if conference.use_area_chairs:
-            matching_group_ids.append(conference.get_area_chairs_id())
-        if conference.use_senior_area_chairs:
-            matching_group_ids.append(conference.get_senior_area_chairs_id())
-        matching_invitation = openreview.Invitation(
-            id = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Paper_Matching_Setup',
-            super = SUPPORT_GROUP + '/-/Paper_Matching_Setup',
-            invitees = readers,
-            cdate = openreview.tools.datetime_millis(activation_date),
-            reply = {
-                'forum': forum.id,
-                'replyto': forum.id,
-                'readers' : {
-                    'description': 'The users who will be allowed to read the above content.',
-                    'values' : readers
-                },
-                'writers': {
-                    'values':[],
-                },
-                'content': {
-                    'title': {
-                        'value': 'Paper Matching Setup',
-                        'required': True,
-                        'order': 1
-                    },
-                    'matching_group': {
-                        'description': 'Please select the group you want to set up matching for.',
-                        'value-dropdown' : matching_group_ids,
-                        'required': True,
-                        'order': 2
-                    },
-                    'compute_conflicts': {
-                        'description': 'Please select whether you want to compute conflicts of interest between the matching group and submissions. By default, conflicts will be computed.',
-                        'value-radio': ['Yes', 'No'],
-                        'default': 'Yes',
-                        'required': True,
-                        'order': 3
-                    },
-                    'compute_affinity_scores': {
-                        'description': 'Please select whether you would like affinity scores to be computed by our expertise API and uploaded automatically.',
-                        'order': 4,
-                        'value-radio': ['Yes', 'No'],
-                        'required': True,
-                    },
-                    'upload_affinity_scores': {
-                        'description': 'If you would like to use your own affinity scores, upload a CSV file containing affinity scores for reviewer-paper pairs (one reviewer-paper pair per line in the format: submission_id, reviewer_id, affinity_score)',
-                        'order': 4,
-                        'value-file': {
-                            'fileTypes': ['csv'],
-                            'size': 50
-                        },
-                        'required': False
-                    }
-                }
+    # always post Paper_Matching_Setup invitation
+    matching_group_ids = [conference.get_committee_id(r) for r in conference.reviewer_roles]
+    if conference.use_area_chairs:
+        matching_group_ids.append(conference.get_area_chairs_id())
+    if conference.use_senior_area_chairs:
+        matching_group_ids.append(conference.get_senior_area_chairs_id())
+    matching_invitation = openreview.Invitation(
+        id = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Paper_Matching_Setup',
+        super = SUPPORT_GROUP + '/-/Paper_Matching_Setup',
+        invitees = readers,
+        reply = {
+            'forum': forum.id,
+            'replyto': forum.id,
+            'readers' : {
+                'description': 'The users who will be allowed to read the above content.',
+                'values' : readers
             },
-            signatures = ['~Super_User1']
-        )
-
-        client.post_invitation(matching_invitation)
+            'writers': {
+                'values':[],
+            },
+            'content': {
+                'title': {
+                    'value': 'Paper Matching Setup',
+                    'required': True,
+                    'order': 1
+                },
+                'matching_group': {
+                    'description': 'Please select the group you want to set up matching for.',
+                    'value-dropdown' : matching_group_ids,
+                    'required': True,
+                    'order': 2
+                },
+                'compute_conflicts': {
+                    'description': 'Please select whether you want to compute conflicts of interest between the matching group and submissions. By default, conflicts will be computed.',
+                    'value-radio': ['Yes', 'No'],
+                    'default': 'Yes',
+                    'required': True,
+                    'order': 3
+                },
+                'compute_affinity_scores': {
+                    'description': 'Please select whether you would like affinity scores to be computed by our expertise API and uploaded automatically.',
+                    'order': 4,
+                    'value-radio': ['Yes', 'No'],
+                    'required': True,
+                },
+                'upload_affinity_scores': {
+                    'description': 'If you would like to use your own affinity scores, upload a CSV file containing affinity scores for reviewer-paper pairs (one reviewer-paper pair per line in the format: submission_id, reviewer_id, affinity_score)',
+                    'order': 4,
+                    'value-file': {
+                        'fileTypes': ['csv'],
+                        'size': 50
+                    },
+                    'required': False
+                }
+            }
+        },
+        signatures = ['~Super_User1']
+    )
+    print('posting paper matching setup invitation!!')
+    client.post_invitation(matching_invitation)
 
     client.post_invitation(openreview.Invitation(
         id=SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Comment',

--- a/openreview/venue_request/process/matchingProcess.py
+++ b/openreview/venue_request/process/matchingProcess.py
@@ -62,9 +62,11 @@ To check references for the note: https://api.openreview.net/references?id={note
             profiles_status=f'''
 {len(no_profiles_status)} {role_name} without a profile: {no_profiles_status}
 
-Affinity scores and/or conflicts could not be computed for these users. Please ask these users to sign up in OpenReview and upload their papers. Alternatively, you can remove these users from the {role_name} group.
+Affinity scores and/or conflicts could not be computed for these users. You will not be able to run the matcher until all {role_name} have profiles. You have two options:
 
-Please check the {role_name} group to see more details: https://openreview.net/group?id={matching_group}'''
+1. You can ask these users to sign up in OpenReview and upload their papers. After all {role_name} have done this, you will need to rerun the paper matching setup to recompute conflicts and/or affinity scores for all users.
+2. You can remove these users from the {role_name} group: https://openreview.net/group/edit?id={matching_group}. You can find all users without a profile by searching for the '@' character in the search box.
+'''
         else:
             profiles_status=f'''Affinity scores and/or conflicts were successfully computed. To run the matcher, click on the '{role_name} Paper Assignment' link in the PC console: https://openreview.net/group?id={conference.get_program_chairs_id()}
 

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -823,9 +823,11 @@ class TestVenueRequest():
         assert matching_status.content['comment'] == '''
 1 Reviewers without a profile: ['some_user@mail.com']
 
-Affinity scores and/or conflicts could not be computed for these users. Please ask these users to sign up in OpenReview and upload their papers. Alternatively, you can remove these users from the Reviewers group.
+Affinity scores and/or conflicts could not be computed for these users. You will not be able to run the matcher until all Reviewers have profiles. You have two options:
 
-Please check the Reviewers group to see more details: https://openreview.net/group?id=TEST.cc/2030/Conference/Reviewers'''
+1. You can ask these users to sign up in OpenReview and upload their papers. After all Reviewers have done this, you will need to rerun the paper matching setup to recompute conflicts and/or affinity scores for all users.
+2. You can remove these users from the Reviewers group: https://openreview.net/group/edit?id=TEST.cc/2030/Conference/Reviewers. You can find all users without a profile by searching for the '@' character in the search box.
+'''
 
         scores_invitation = client.get_invitation(conference.get_invitation_id('Affinity_Score', prefix=reviewer_group.id))
         assert scores_invitation


### PR DESCRIPTION
- Always creates Paper_Matching_Setup invitation on deployment
- Include instructions on what to do if there are users with no profiles
- Fix link to reviewers group
- Set allow_zero_score_assignements == Yes as default