### PR TITLE
Fix/ Bidding webfield:  prevent counts from getting out of sync

### DIFF
--- a/openreview/conference/templates/paperBidWebfield.js
+++ b/openreview/conference/templates/paperBidWebfield.js
@@ -211,9 +211,10 @@ function renderContent(notes, conflicts, bidEdges) {
 
     // If not on the All Papers tab, fade out note when bid is changed
     if (activeTab !== 0) {
+      $(e.currentTarget).find('.btn-group').addClass('disabled');
       setTimeout(function() {
-        $(e.currentTarget).closest('.note').fadeOut();
-      }, 500);
+        $(e.currentTarget).closest('.note').fadeOut('fast');
+      }, 100);
     }
 
     updateCounts();

--- a/openreview/conference/templates/profileBidWebfield.js
+++ b/openreview/conference/templates/profileBidWebfield.js
@@ -231,9 +231,10 @@ function renderContent(notes, conflicts, bidEdges) {
 
     // If not on the All Papers tab, fade out note when bid is changed
     if (activeTab !== 0) {
+      $(e.currentTarget).find('.btn-group').addClass('disabled');
       setTimeout(function() {
-        $(e.currentTarget).closest('.note').fadeOut();
-      }, 500);
+        $(e.currentTarget).closest('.note').fadeOut('fast');
+      }, 100);
     }
 
     updateCounts();


### PR DESCRIPTION
Disable bid widget when fading out to prevent count from getting out of sync.