### PR TITLE
Fix tests: add sort option to all the get_notes calls

### DIFF
--- a/openreview/agora/webfield/homepage.js
+++ b/openreview/agora/webfield/homepage.js
@@ -68,7 +68,8 @@ function load() {
   if (user && !_.startsWith(user.id, 'guest_')) {
     activityNotesP = Webfield.api.getSubmissions(WILDCARD_INVITATION, {
       pageSize: PAGE_SIZE,
-      details: 'forumContent,invitation,writable'
+      details: 'forumContent,invitation,writable',
+      sort: 'tmdate:desc'
     });
   }
 

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -219,7 +219,8 @@ var loadData = function(paperNums) {
       invitation: BLIND_SUBMISSION_ID,
       number: noteNumbersStr,
       select: 'id,number,forum,content,details,invitation',
-      details: 'invitation,replyCount,directReplies'
+      details: 'invitation,replyCount,directReplies',
+      sort: 'number:asc'
     }).then(function(notes) {
       return _.sortBy(notes, 'number');
     });

--- a/openreview/conference/templates/authorWebfield.js
+++ b/openreview/conference/templates/authorWebfield.js
@@ -46,7 +46,8 @@ function main() {
 function load() {
   var query = {
     invitation: SUBMISSION_ID,
-    details: 'invitation,overwriting,directReplies'
+    details: 'invitation,overwriting,directReplies',
+    sort: 'number:asc'
   }
   query[AUTHOR_SUBMISSION_FIELD] = user.profile.id;
   var notesP = Webfield.get('/notes', query).then(function(result) {
@@ -62,7 +63,8 @@ function load() {
     if (blindNoteIds.length) {
       return Webfield.get('/notes', {
         ids: blindNoteIds,
-        details: 'directReplies'
+        details: 'directReplies',
+        sort: 'number:asc'
       })
       .then(function(result) {
         return (result.notes || []).filter(function(note) {

--- a/openreview/conference/templates/liteAuthorWebfield.js
+++ b/openreview/conference/templates/liteAuthorWebfield.js
@@ -46,7 +46,8 @@ function load() {
   return Webfield.get('/notes', {
     'content.authorids': user.profile.id,
     invitation: SUBMISSION_ID,
-    details: 'overwriting'
+    details: 'overwriting',
+    sort: 'number:asc'
   }).then(function(result) {
     // Get the blind submissions to have backward compatibility with the paper number
     var originalNotes = result.notes;
@@ -58,7 +59,7 @@ function load() {
     });
 
     if (blindNoteIds.length) {
-      return Webfield.get('/notes', { ids: blindNoteIds })
+      return Webfield.get('/notes', { ids: blindNoteIds, sort: 'number:asc' })
         .then(function(result) {
           return (result.notes || []).filter(function(note) {
             return note.invitation === BLIND_SUBMISSION_ID;

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -366,7 +366,8 @@ var getBlindedNotes = function() {
   return Webfield.getAll('/notes', {
     invitation: BLIND_SUBMISSION_ID,
     details: 'invitation,tags,original,replyCount,directReplies',
-    select: 'id,number,forum,content,details'
+    select: 'id,number,forum,content,details',
+    sort: 'number:asc'
   })
 };
 

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -178,7 +178,8 @@ var getBlindedNotes = function(noteNumbers) {
     invitation: BLIND_SUBMISSION_ID,
     number: noteNumbers.join(','),
     select: 'id,number,forum,content.title,content.authors,content.authorDomains,content.pdf',
-    details: 'invitation'
+    details: 'invitation',
+    sort: 'number:asc'
   }).then(function(result) {
     return result.notes || [];
   });

--- a/openreview/conference/templates/tabsConferenceWebfield.js
+++ b/openreview/conference/templates/tabsConferenceWebfield.js
@@ -99,7 +99,8 @@ function load() {
   if (user && !_.startsWith(user.id, 'guest_')) {
     activityNotesP = Webfield.api.getSubmissions(WILDCARD_INVITATION, {
       pageSize: PAGE_SIZE,
-      details: 'forumContent,invitation,writable'
+      details: 'forumContent,invitation,writable',
+      sort: 'tmdate:desc'
     });
 
     userGroupsP = Webfield.getAll('/groups', { regex: CONFERENCE_ID + '/.*', member: user.id, web: true });

--- a/openreview/journal/webfield/authorsWebfield.js
+++ b/openreview/journal/webfield/authorsWebfield.js
@@ -45,7 +45,8 @@ var loadData = function() {
   var notesP = Webfield2.getAll('/notes', {
     'content.authorids': user.profile.id,
     invitation: SUBMISSION_ID,
-    details: 'replies'
+    details: 'replies',
+    sort: 'number:asc'
   });
 
   return $.when(

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -209,7 +209,7 @@ class VenueStages():
                 'order': 28
             },
             'participants': {
-                'description': 'Select who should be allowed to post comments on submissions.',
+                'description': 'Select who should be allowed to post and view comments on submissions.',
                 'values-checkbox' : [
                     'Program Chairs',
                     'Paper Area Chairs',

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -410,7 +410,7 @@ class TestNeurIPSConference():
 
         venue.set_area_chairs(['~Area_CMUChair1', '~Area_MITChair1', '~Area_AmazonChair1'])
 
-        submissions=venue.get_submissions()
+        submissions=venue.get_submissions(sort='tmdate')
 
         with open(os.path.join(os.path.dirname(__file__), 'data/ac_affinity_scores.csv'), 'w') as file_handle:
             writer = csv.writer(file_handle)

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -14,7 +14,7 @@ class TestNeurIPSConference():
     @pytest.fixture(scope="class")
     def venue(self, client):
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password='1234')
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
 
         conference=openreview.helpers.get_conference(pc_client, request_form.id)
         return conference
@@ -97,7 +97,7 @@ class TestNeurIPSConference():
     def test_recruit_actions_editors(self, client, helpers, request_page, selenium):
 
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password='1234')
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
 
         ## Invite ~Area_CMUChair1 as AC
         reviewer_details = '''~Area_CMUChair1'''
@@ -291,7 +291,7 @@ class TestNeurIPSConference():
     def test_registration_tasks(self, client):
 
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password='1234')
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
         conference=openreview.helpers.get_conference(pc_client, request_form.id)
 
         fields = {}
@@ -378,7 +378,7 @@ class TestNeurIPSConference():
     def test_submit_papers(self, test_client, client, helpers):
 
         ## Need super user permission to add the venue to the active_venues group
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
         conference=openreview.helpers.get_conference(client, request_form.id)
 
         domains = ['gmail.com', 'facebook.com', 'yahoo.com', 'ucla.edu', 'mdu.edu', 'cornell.edu']

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -820,7 +820,7 @@ class TestDoubleBlindConference():
 
         conference.setup_post_submission_stage(force=True)
 
-        blind_submissions = conference.get_submissions()
+        blind_submissions = conference.get_submissions(sort='tmdate')
         assert blind_submissions
         assert len(blind_submissions) == 1
         assert blind_submissions[0].content['authors'] == ['Anonymous']
@@ -852,7 +852,7 @@ class TestDoubleBlindConference():
 
         conference.setup_post_submission_stage(force=True)
 
-        blind_submissions_2 = conference.get_submissions()
+        blind_submissions_2 = conference.get_submissions(sort='tmdate')
         assert blind_submissions_2
         assert len(blind_submissions_2) == 2
         assert blind_submissions_2[0].readers == ['everyone']
@@ -880,7 +880,7 @@ class TestDoubleBlindConference():
 
         conference.setup_post_submission_stage(force=True)
 
-        blind_submissions_3 = conference.get_submissions()
+        blind_submissions_3 = conference.get_submissions(sort='tmdate')
         assert blind_submissions_3
         assert len(blind_submissions_3) == 3
         assert blind_submissions[0].id == blind_submissions_3[2].id
@@ -1161,7 +1161,7 @@ class TestDoubleBlindConference():
         conference.set_area_chairs(emails = ['ac@mail.com'])
         conference.set_reviewers(emails = ['reviewer2@mail.com'])
 
-        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
+        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
 
         reviews = test_client.get_notes(invitation='AKBC.ws/2019/Conference/Paper.*/-/Official_Review')
@@ -1231,7 +1231,7 @@ class TestDoubleBlindConference():
         builder.use_legacy_anonids(True)
         builder.get_result()
 
-        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
+        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
 
         note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Meta_Review',
@@ -1278,7 +1278,7 @@ class TestDoubleBlindConference():
         })
         conference = builder.get_result()
 
-        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
+        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
 
         conference.set_assignment('meta_additional@mail.com', submission.number, is_area_chair = True)
@@ -1321,7 +1321,7 @@ class TestDoubleBlindConference():
         }, remove_fields = ['confidence'])
         conference = builder.get_result()
 
-        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
+        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
 
         note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Meta_Review',
@@ -1374,7 +1374,7 @@ class TestDoubleBlindConference():
         assert accepted_author_group
         assert accepted_author_group.members == []
 
-        notes = pc_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
+        notes = pc_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
         print(submission.readers)
         note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Decision',
@@ -1568,7 +1568,7 @@ class TestDoubleBlindConference():
         builder.has_area_chairs(True)
         conference = builder.get_result()
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 3
 
@@ -1615,7 +1615,7 @@ class TestDoubleBlindConference():
         conference = builder.get_result()
         conference.setup_post_submission_stage(force=True)
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 3
 
@@ -1637,7 +1637,7 @@ class TestDoubleBlindConference():
 
         helpers.await_queue()
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 2
 
@@ -1702,7 +1702,7 @@ class TestDoubleBlindConference():
         conference = builder.get_result()
         conference.setup_post_submission_stage(force=True)
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 2
 
@@ -1726,7 +1726,7 @@ class TestDoubleBlindConference():
 
         helpers.await_queue()
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
 
@@ -1807,7 +1807,7 @@ class TestDoubleBlindConference():
         builder.set_conference_year(2019)
         conference = builder.get_result()
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]
@@ -1953,7 +1953,7 @@ class TestDoubleBlindConference():
         conference = builder.get_result()
 
         conference.set_submission_revision_stage(openreview.SubmissionRevisionStage(only_accepted=True))
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]
@@ -1984,7 +1984,7 @@ class TestDoubleBlindConference():
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]
@@ -2043,7 +2043,7 @@ url={'''
         assert tabs.find_element_by_id('accepted-oral-papers')
         assert tabs.find_element_by_id('reject')
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]
@@ -2102,7 +2102,7 @@ url={'''
         assert tabs.find_element_by_id('accepted-oral-papers')
         assert tabs.find_element_by_id('reject')
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]
@@ -2167,7 +2167,7 @@ url={'''
 
         conference.set_submission_revision_stage(openreview.SubmissionRevisionStage(name='Camera_Ready_Revision', only_accepted=True))
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]
@@ -2198,7 +2198,7 @@ url={'''
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -509,7 +509,7 @@ Please contact info@openreview.net with any questions or concerns about this int
 
     def test_submission_edit(self, conference, client, helpers, test_client):
 
-        existing_notes = client.get_notes(invitation = conference.get_submission_id())
+        existing_notes = client.get_notes(invitation = conference.get_submission_id(), sort='tmdate')
         assert len(existing_notes) == 5
 
         helpers.await_queue()

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -559,7 +559,7 @@ Please contact info@openreview.net with any questions or concerns about this int
 
         conference.setup_post_submission_stage(force=True, hide_fields=['pdf', 'supplementary_material'])
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
         assert len(submissions) == 5
         note = submissions[0]
@@ -671,7 +671,7 @@ Please contact info@openreview.net with any questions or concerns about this int
         conference.set_reviewers(['~Reviewer_ECCV_One1', '~Reviewer_ECCV_Two1', '~Reviewer_ECCV_Three1', '~Reviewer_ECCV_Four1'])
         conference.set_area_chairs(['~AreaChair_ECCV_One1', '~AreaChair_ECCV_Two1'])
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
 
         with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w') as file_handle:
             writer = csv.writer(file_handle)
@@ -960,7 +960,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
         conference.setup_post_submission_stage(force=True)
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
         assert len(blinded_notes) == 5
 
         desk_reject_note = openreview.Note(
@@ -990,7 +990,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         assert logs
         assert logs[0]['status'] == 'ok'
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
         assert len(blinded_notes) == 4
 
         desk_rejected_notes = client.get_notes(invitation = conference.submission_stage.get_desk_rejected_submission_id(conference))
@@ -1025,7 +1025,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
         conference.setup_post_submission_stage(force=True, hide_fields=['_bibtex'])
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
         assert len(blinded_notes) == 4
 
         withdrawal_note = openreview.Note(
@@ -1055,7 +1055,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         assert logs
         assert logs[0]['status'] == 'ok'
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
         assert len(blinded_notes) == 3
 
         withdrawn_notes = client.get_notes(invitation = conference.submission_stage.get_withdrawn_submission_id(conference))
@@ -1158,7 +1158,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         r2_client = openreview.Client(username='reviewer2@google.com', password='1234')
 
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
         assert len(blinded_notes) == 3
 
         signatory = r1_client.get_groups(regex='thecvf.com/ECCV/2020/Conference/Paper1/Reviewer_.*', signatory='reviewer1@fb.com')[0].id
@@ -1282,7 +1282,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
         r2_client = openreview.Client(username='reviewer2@google.com', password='1234')
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
 
         signatory = r2_client.get_groups(regex='thecvf.com/ECCV/2020/Conference/Paper1/Reviewer_.*', signatory='reviewer2@google.com')[0].id
 
@@ -1424,7 +1424,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         assert options
         assert len(options) == 3
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
 
         signatory = ac_client.get_groups(regex='thecvf.com/ECCV/2020/Conference/Paper1/Area_Chair_.*', signatory='ac1@eccv.org')[0].id
 
@@ -1480,7 +1480,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
     def test_rebuttal_stage(self, conference, client, test_client, selenium, request_page, helpers):
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
 
         now = datetime.datetime.utcnow()
 
@@ -1537,7 +1537,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
     def test_revise_review_stage(self, conference, client, test_client, selenium, request_page, helpers):
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
 
         now = datetime.datetime.utcnow()
 
@@ -1637,7 +1637,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
         ac_client = openreview.Client(username='ac1@eccv.org', password='1234')
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
 
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , ac_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
         notes = selenium.find_elements_by_class_name('note_with_children')

--- a/tests/test_eswc_conference.py
+++ b/tests/test_eswc_conference.py
@@ -341,7 +341,7 @@ url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
 
         helpers.await_queue()
 
-        withdrawn_notes = client.get_notes(invitation='eswc-conferences.org/ESWC/2021/Conference/-/Withdrawn_Special_Submission')
+        withdrawn_notes = client.get_notes(invitation='eswc-conferences.org/ESWC/2021/Conference/-/Withdrawn_Special_Submission', sort='tmdate')
         assert len(withdrawn_notes) == 2
         withdrawn_notes[0].readers == [
             'everyone'

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -634,7 +634,7 @@ Naila, Katja, Alice, and Ivan
         conference.submission_stage.readers = [openreview.SubmissionStage.Readers.EVERYONE]
         conference.setup_final_deadline_stage(force=True)
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert len(submissions) == 4
         assert submissions[0].readers == ['everyone']
         assert submissions[1].readers == ['everyone']
@@ -675,7 +675,7 @@ Naila, Katja, Alice, and Ivan
         now = datetime.datetime.utcnow()
         conference.set_submission_revision_stage(openreview.SubmissionRevisionStage(due_date=now + datetime.timedelta(minutes = 40), allow_author_reorder=True))
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
 
         print(submissions[0])
 

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -509,7 +509,7 @@ Naila, Katja, Alice, and Ivan
 
         conference.setup_first_deadline_stage(force=True)
 
-        blinded_notes = test_client.get_notes(invitation='ICLR.cc/2021/Conference/-/Blind_Submission')
+        blinded_notes = test_client.get_notes(invitation='ICLR.cc/2021/Conference/-/Blind_Submission', sort='tmdate')
         assert len(blinded_notes) == 5
 
         assert blinded_notes[0].readers == [
@@ -657,7 +657,7 @@ Naila, Katja, Alice, and Ivan
 
         helpers.await_queue()
 
-        withdrawn_notes = client.get_notes(invitation='ICLR.cc/2021/Conference/-/Withdrawn_Submission')
+        withdrawn_notes = client.get_notes(invitation='ICLR.cc/2021/Conference/-/Withdrawn_Submission', sort='tmdate')
         assert len(withdrawn_notes) == 2
         withdrawn_notes[0].readers == [
             'everyone'

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -168,7 +168,7 @@ class TestMatching():
         conference.setup_matching(committee_id=conference.get_area_chairs_id())
         conference.setup_matching(committee_id=conference.get_reviewers_id(), build_conflicts=True)
 
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
 
         ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(conference.get_area_chairs_id()),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
@@ -368,7 +368,7 @@ class TestMatching():
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'Conflict'
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
         assert 3 == len(submissions)
 
@@ -407,7 +407,7 @@ class TestMatching():
 
     def test_setup_matching_with_recommendations(self, conference, pc_client, test_client, helpers):
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         ## Open reviewer recommendations
         now = datetime.datetime.utcnow()
@@ -517,7 +517,7 @@ class TestMatching():
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'Conflict'
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
         assert 3 == len(submissions)
 
@@ -556,7 +556,7 @@ class TestMatching():
 
     def test_setup_matching_with_subject_areas(self, conference, pc_client, test_client, helpers):
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         registration_notes = pc_client.get_notes(invitation = 'auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Registration_Form')
         assert registration_notes
@@ -647,7 +647,7 @@ class TestMatching():
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'Conflict'
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
         assert 3 == len(submissions)
 
@@ -719,7 +719,7 @@ class TestMatching():
 
         conference.client = pc_client
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         edges = pc_client.get_edges(
             invitation='auai.org/UAI/2019/Conference/Program_Committee/-/Proposed_Assignment',
@@ -825,7 +825,7 @@ class TestMatching():
 
     def test_redeploy_assigments(self, conference, client, pc_client, test_client, helpers):
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         #Reviewer assignments
         pc_client.post_edge(openreview.Edge(invitation = conference.get_paper_assignment_id(conference.get_reviewers_id()),
@@ -1097,7 +1097,7 @@ class TestMatching():
 
         conference.client = pc2_client
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         pc2_client.post_edge(openreview.Edge(invitation = conference.get_paper_assignment_id(conference.get_reviewers_id()),
             readers = [conference.id, '~Reviewer_One1'],
@@ -1136,7 +1136,7 @@ class TestMatching():
     def test_set_ac_assigments(self, conference, pc_client, test_client, helpers):
 
         conference.set_area_chairs(['ac1@cmu.edu', 'ac2@umass.edu'])
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         edges = pc_client.get_edges(
             invitation='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Proposed_Assignment',

--- a/tests/test_matching_anonids.py
+++ b/tests/test_matching_anonids.py
@@ -149,7 +149,7 @@ class TestMatchingWithAnonIds():
 
         ## Create blind submissions
         conference.setup_post_submission_stage(force=True)
-        blinded_notes = conference.get_submissions()
+        blinded_notes = conference.get_submissions(sort='tmdate')
 
         # Set up reviewer matching
         conference.setup_matching(build_conflicts=True)
@@ -351,7 +351,7 @@ class TestMatchingWithAnonIds():
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'Conflict'
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
         assert 3 == len(submissions)
 
@@ -390,7 +390,7 @@ class TestMatchingWithAnonIds():
 
     def test_setup_matching_with_recommendations(self, conference, pc_client, test_client, helpers):
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         ## Open reviewer recommendations
         now = datetime.datetime.utcnow()
@@ -500,7 +500,7 @@ class TestMatchingWithAnonIds():
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'Conflict'
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
         assert 3 == len(submissions)
 
@@ -539,7 +539,7 @@ class TestMatchingWithAnonIds():
 
     def test_setup_matching_with_subject_areas(self, conference, pc_client, test_client, helpers):
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         registration_notes = pc_client.get_notes(invitation = 'auai.org/UAI/2021/Conference/Senior_Program_Committee/-/Registration_Form')
         assert registration_notes
@@ -630,7 +630,7 @@ class TestMatchingWithAnonIds():
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'Conflict'
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
         assert 3 == len(submissions)
 
@@ -702,7 +702,7 @@ class TestMatchingWithAnonIds():
 
         conference.client = pc_client
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         edges = pc_client.get_edges(
             invitation='auai.org/UAI/2021/Conference/Program_Committee/-/Proposed_Assignment',
@@ -846,7 +846,7 @@ class TestMatchingWithAnonIds():
 
     def test_redeploy_assigments(self, conference, client, pc_client, test_client, helpers):
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         #Reviewer assignments
         pc_client.post_edge(openreview.Edge(invitation = conference.get_paper_assignment_id(conference.get_reviewers_id()),
@@ -1139,7 +1139,7 @@ class TestMatchingWithAnonIds():
 
         conference.client = pc2_client
 
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         pc2_client.post_edge(openreview.Edge(invitation = conference.get_paper_assignment_id(conference.get_reviewers_id()),
             readers = [conference.id, '~Reviewer_MITOne1'],
@@ -1178,7 +1178,7 @@ class TestMatchingWithAnonIds():
     def test_set_ac_assigments(self, conference, pc_client, test_client, helpers):
 
         conference.set_area_chairs(['ac2@cmu.edu', 'ac2@umass.edu'])
-        blinded_notes = list(conference.get_submissions())
+        blinded_notes = list(conference.get_submissions(sort='tmdate'))
 
         edges = pc_client.get_edges(
             invitation='auai.org/UAI/2021/Conference/Senior_Program_Committee/-/Proposed_Assignment',

--- a/tests/test_multiple_roles.py
+++ b/tests/test_multiple_roles.py
@@ -19,7 +19,7 @@ class TestMultipleRoles():
     @pytest.fixture(scope="class")
     def conference(self, client):
         pc_client=openreview.Client(username='pc@lifelong-ml.cc', password='1234')
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
 
         conference=openreview.helpers.get_conference(pc_client, request_form.id)
         return conference
@@ -153,7 +153,7 @@ class TestMultipleRoles():
 
         ## Need super user permission to add the venue to the active_venues group
         pc_client=openreview.Client(username='pc@lifelong-ml.cc', password='1234')
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
         conference=openreview.helpers.get_conference(client, request_form.id)
 
         domains = ['umass.edu', 'amazon.com', 'fb.com', 'cs.umass.edu', 'google.com', 'mit.edu']
@@ -197,7 +197,7 @@ class TestMultipleRoles():
     def test_setup_matching(self, conference, client, helpers):
 
         pc_client=openreview.Client(username='pc@lifelong-ml.cc', password='1234')
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
 
         ## Setup Matching for Program Committee
         matching_setup_note = client.post_note(openreview.Note(

--- a/tests/test_multiple_roles.py
+++ b/tests/test_multiple_roles.py
@@ -235,7 +235,7 @@ class TestMultipleRoles():
         assert matching_setup_note
         helpers.await_queue()
 
-        submissions=conference.get_submissions()
+        submissions=conference.get_submissions(sort='tmdate')
 
         ## Program Committee
         client.post_edge(openreview.Edge(

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -725,7 +725,7 @@ class TestNeurIPSConference():
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert len(submissions) == 5
 
         assert submissions[0].content['keywords'] == ''
@@ -811,7 +811,7 @@ class TestNeurIPSConference():
         now = datetime.datetime.utcnow()
 
         pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
-        submissions=conference.get_submissions()
+        submissions=conference.get_submissions(sort='tmdate')
 
         with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w') as file_handle:
             writer = csv.writer(file_handle)
@@ -1031,7 +1031,7 @@ class TestNeurIPSConference():
     def test_ac_reassignment(self, conference, helpers, client):
 
         pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
-        submissions=conference.get_submissions()
+        submissions=conference.get_submissions(sort='tmdate')
 
         assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Assignment')) == 3
         assert len(pc_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Area_Chairs/-/Assignment')) == 5
@@ -1134,7 +1134,7 @@ Thank you,
         print(url)
 
         ac_client=openreview.Client(username='ac1@mit.edu', password='1234')
-        submission=conference.get_submissions()[0]
+        submission=conference.get_submissions(sort='tmdate')[0]
         signatory_group=ac_client.get_groups(regex='NeurIPS.cc/2021/Conference/Paper5/Area_Chair_')[0]
 
         ## Invite external reviewer 1
@@ -1585,7 +1585,7 @@ Thank you,
     def test_deployment_stage(self, conference, client, helpers):
 
         pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
-        submissions=conference.get_submissions()
+        submissions=conference.get_submissions(sort='tmdate')
 
         conference.set_assignments(assignment_title='reviewer-matching', committee_id='NeurIPS.cc/2021/Conference/Reviewers', overwrite=True, enable_reviewer_reassignment=True)
 
@@ -1898,7 +1898,7 @@ Thank you,
         print(url)
 
         ac_client=openreview.Client(username='ac1@mit.edu', password='1234')
-        submission=conference.get_submissions()[1]
+        submission=conference.get_submissions(sort='tmdate')[1]
         signatory_group=ac_client.get_groups(regex='NeurIPS.cc/2021/Conference/Paper4/Area_Chair_')[0]
 
         ## Invite external reviewer 1

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -19,7 +19,7 @@ class TestNeurIPSConference():
     @pytest.fixture(scope="class")
     def conference(self, client):
         pc_client=openreview.Client(username='pc@neurips.cc', password='1234')
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
 
         conference=openreview.helpers.get_conference(pc_client, request_form.id)
         return conference
@@ -549,7 +549,7 @@ class TestNeurIPSConference():
     def test_recruit_ethics_reviewers(self, client, request_page, selenium, helpers):
 
         ## Need super user permission to add the venue to the active_venues group
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
         conference=openreview.helpers.get_conference(client, request_form.id)
 
         result = conference.recruit_reviewers(invitees = ['reviewer2@mit.edu'], title = 'Ethics Review invitation', message = '{accept_url}, {decline_url}', reviewers_name = 'Ethics_Reviewers')
@@ -584,7 +584,7 @@ class TestNeurIPSConference():
     def test_submit_papers(self, test_client, client, helpers):
 
         ## Need super user permission to add the venue to the active_venues group
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
         conference=openreview.helpers.get_conference(client, request_form.id)
 
         domains = ['umass.edu', 'amazon.com', 'fb.com', 'cs.umass.edu', 'google.com', 'mit.edu']
@@ -2397,7 +2397,7 @@ Thank you,
 
     def test_add_impersonator(self, client, request_page, selenium):
         ## Need super user permission to add the venue to the active_venues group
-        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
         conference=openreview.helpers.get_conference(client, request_form.id)
 
         conference.set_impersonators(group_ids=['pc@neurips.cc'])

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -611,7 +611,7 @@ class TestNeurIPSConference():
 
         conference.setup_first_deadline_stage(force=True)
 
-        blinded_notes = test_client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Blind_Submission')
+        blinded_notes = test_client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Blind_Submission', sort='tmdate')
         assert len(blinded_notes) == 5
 
         assert blinded_notes[0].readers == ['NeurIPS.cc/2021/Conference', 'NeurIPS.cc/2021/Conference/Paper5/Authors']
@@ -2199,7 +2199,7 @@ Thank you,
 
         helpers.await_queue()
 
-        reviews=client.get_notes(invitation='NeurIPS.cc/2021/Conference/Paper.*/-/Official_Review')
+        reviews=client.get_notes(invitation='NeurIPS.cc/2021/Conference/Paper.*/-/Official_Review', sort='tmdate')
         assert len(reviews) == 1
         reviews[0].readers = [
             'NeurIPS.cc/2021/Conference/Program_Chairs',
@@ -2413,7 +2413,7 @@ Thank you,
 
     def test_withdraw_after_review(self, conference, helpers, test_client, client, selenium, request_page):
 
-        submissions = test_client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Blind_Submission')
+        submissions = test_client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Blind_Submission', sort='tmdate')
         assert len(submissions) == 5
 
         withdrawn_note = test_client.post_note(openreview.Note(
@@ -2471,7 +2471,7 @@ Thank you,
 
     def test_desk_reject_after_review(self, conference, helpers, test_client, client, selenium, request_page):
 
-        submissions = test_client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Blind_Submission')
+        submissions = test_client.get_notes(invitation='NeurIPS.cc/2021/Conference/-/Blind_Submission', sort='tmdate')
         assert len(submissions) == 4
 
         pc_client=openreview.Client(username='pc@neurips.cc', password='1234')

--- a/tests/test_open_submissions.py
+++ b/tests/test_open_submissions.py
@@ -94,7 +94,7 @@ class TestOpenSubmissions():
 
         ## call post submission stage and keep the submissions public
         conference.setup_post_submission_stage(force=True)
-        submissions=conference.get_submissions()
+        submissions=conference.get_submissions(sort='tmdate')
         assert submissions
         assert submissions[0].readers == ['everyone']
         assert submissions[0].tcdate == submissions[0].tmdate
@@ -139,7 +139,7 @@ class TestOpenSubmissions():
 
     def test_post_comments(self, client, conference, test_client, helpers):
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
 
         conference.open_comments()
@@ -170,7 +170,7 @@ class TestOpenSubmissions():
 
     def test_post_decisions(self, client, conference, helpers):
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert submissions
 
         conference.open_decisions()

--- a/tests/test_open_submissions.py
+++ b/tests/test_open_submissions.py
@@ -111,7 +111,7 @@ class TestOpenSubmissions():
 
         reviewer_client=helpers.create_user('reviewer@aclweb.org', 'Reviewer', 'ACL')
 
-        submissions=reviewer_client.get_notes(invitation='aclweb.org/ACL/2020/Workshop/NLP-COVID/-/Submission')
+        submissions=reviewer_client.get_notes(invitation='aclweb.org/ACL/2020/Workshop/NLP-COVID/-/Submission', sort='tmdate')
         assert submissions
 
         note = openreview.Note(invitation = conference.get_invitation_id(name = 'Official_Review', number = 1),

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -210,7 +210,7 @@ class TestSingleBlindConference():
 
         conference.setup_final_deadline_stage()
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert len(submissions) == 1
         assert submissions[0].readers == ['everyone']
 
@@ -673,7 +673,7 @@ class TestSingleBlindConference():
         }
         conference.set_decision_stage(openreview.DecisionStage(public=True, additional_fields=decision_additional_fields))
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert len(submissions) == 1
         note = openreview.Note(invitation = 'NIPS.cc/2018/Workshop/MLITS/Paper1/-/Decision',
             forum = submissions[0].id,
@@ -691,7 +691,7 @@ class TestSingleBlindConference():
 
         conference.post_decision_stage(release_notes_accepted=True)
 
-        submissions = conference.get_submissions()
+        submissions = conference.get_submissions(sort='tmdate')
         assert len(submissions) == 1
 
         valid_bibtex = '''@inproceedings{
@@ -720,7 +720,7 @@ url={https://openreview.net/forum?id='''
 
         conference.set_submission_revision_stage(openreview.SubmissionRevisionStage(name='Camera_Ready_Revision', only_accepted=True))
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]
@@ -749,7 +749,7 @@ url={https://openreview.net/forum?id='''
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
 
-        notes = conference.get_submissions()
+        notes = conference.get_submissions(sort='tmdate')
         assert notes
         assert len(notes) == 1
         note = notes[0]

--- a/tests/test_single_blind_private_conference.py
+++ b/tests/test_single_blind_private_conference.py
@@ -80,7 +80,7 @@ class TestSingleBlindPrivateConference():
 
         conference.setup_post_submission_stage(force=True)
 
-        notes = test_client.get_notes(invitation='MICCAI.org/2021/Challenges/-/Submission')
+        notes = test_client.get_notes(invitation='MICCAI.org/2021/Challenges/-/Submission', sort='tmdate')
         assert len(notes) == 5
         assert notes[0].readers == ['MICCAI.org/2021/Challenges', 'MICCAI.org/2021/Challenges/Area_Chairs', 'MICCAI.org/2021/Challenges/Paper5/Reviewers', 'MICCAI.org/2021/Challenges/Paper5/Authors']
 
@@ -95,7 +95,7 @@ class TestSingleBlindPrivateConference():
         assert 'MICCAI.org/2021/Challenges/Paper5/-/Withdraw' in invitation_ids
 
     def test_public_comments(self, conference, helpers, test_client, client):
-        notes = test_client.get_notes(invitation='MICCAI.org/2021/Challenges/-/Submission')
+        notes = test_client.get_notes(invitation='MICCAI.org/2021/Challenges/-/Submission', sort='tmdate')
         assert len(notes) == 5
 
         conference.set_comment_stage(openreview.CommentStage(unsubmitted_reviewers=True, reader_selection=True, email_pcs=True, authors=True, allow_public_comments=True))
@@ -182,7 +182,7 @@ class TestSingleBlindPrivateConference():
         assert tabs.find_element_by_id('poster')
 
     def test_enable_public_comments(self, conference, helpers, test_client, client):
-        notes = test_client.get_notes(invitation='MICCAI.org/2021/Challenges/-/Submission')
+        notes = test_client.get_notes(invitation='MICCAI.org/2021/Challenges/-/Submission', sort='tmdate')
         assert len(notes) == 5
 
         conference.submission_stage.papers_released=True

--- a/tests/test_single_blind_private_conference.py
+++ b/tests/test_single_blind_private_conference.py
@@ -106,7 +106,7 @@ class TestSingleBlindPrivateConference():
 
         conference.set_decision_stage(openreview.DecisionStage(release_to_area_chairs=True))
 
-        submissions=conference.get_submissions()
+        submissions=conference.get_submissions(sort='tmdate')
         assert len(submissions) == 5
 
         client.post_note(openreview.Note(

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -250,7 +250,7 @@ class TestVenueRequest():
 
         comment_invitation = '{}/-/Request{}/Comment'.format(venue.support_group_id,
                                                              request_form_note.number)
-        last_comment = client.get_notes(invitation=comment_invitation)[-1]
+        last_comment = client.get_notes(invitation=comment_invitation, sort='tmdate')[-1]
         assert 'TEST.cc/2021/Conference/Program_Chairs' in last_comment.readers
 
     def test_venue_revision_error(self, client, test_client, selenium, request_page, venue, helpers):
@@ -314,7 +314,7 @@ class TestVenueRequest():
 
         comment_invitation = '{}/-/Request{}/Stage_Error_Status'.format(venue['support_group_id'],
                                                              venue['request_form_note'].number)
-        last_comment = client.get_notes(invitation=comment_invitation)[0]
+        last_comment = client.get_notes(invitation=comment_invitation, sort='tmdate')[0]
         error = last_comment.content['error']
         assert 'InvalidFieldError' in error
         assert 'The field value-regexx is not allowed' in error
@@ -434,7 +434,7 @@ class TestVenueRequest():
 
         recruitment_status_invitation = '{}/-/Request{}/Recruitment_Status'.format(venue['support_group_id'],
                                                              venue['request_form_note'].number)
-        last_comment = client.get_notes(invitation=recruitment_status_invitation)[0]
+        last_comment = client.get_notes(invitation=recruitment_status_invitation, sort='tmdate')[0]
         error_string = '{\n ' \
                        ' "KeyError(\'program\')": [\n' \
                        '    "reviewer_candidate1@email.com",\n' \
@@ -494,7 +494,7 @@ class TestVenueRequest():
 
         recruitment_status_invitation = '{}/-/Request{}/Recruitment_Status'.format(venue['support_group_id'],
                                                                                    venue['request_form_note'].number)
-        last_comment = client.get_notes(invitation=recruitment_status_invitation)[0]
+        last_comment = client.get_notes(invitation=recruitment_status_invitation, sort='tmdate')[0]
         assert '2 users' in last_comment.content['invited']
 
         last_message = client.get_messages(to='support@openreview.net')[-1]
@@ -550,7 +550,7 @@ class TestVenueRequest():
 
         recruitment_status_invitation = '{}/-/Request{}/Recruitment_Status'.format(venue['support_group_id'],
                                                                                    venue['request_form_note'].number)
-        last_comment = client.get_notes(invitation=recruitment_status_invitation)[0]
+        last_comment = client.get_notes(invitation=recruitment_status_invitation, sort='tmdate')[0]
         assert '2 users' in last_comment.content['invited']
 
     def test_venue_remind_recruitment(self, client, test_client, selenium, request_page, venue, helpers):
@@ -598,7 +598,7 @@ class TestVenueRequest():
 
         remind_recruitment_status_invitation = '{}/-/Request{}/Remind_Recruitment_Status'.format(venue['support_group_id'],
                                                                                    venue['request_form_note'].number)
-        last_comment = client.get_notes(invitation=remind_recruitment_status_invitation)[0]
+        last_comment = client.get_notes(invitation=remind_recruitment_status_invitation, sort='tmdate')[0]
         assert '4 users' in last_comment.content['reminded']
 
         last_message = client.get_messages(to='support@openreview.net')[-1]
@@ -631,7 +631,7 @@ class TestVenueRequest():
 
         comment_invitation = '{}/-/Request{}/Stage_Error_Status'.format(venue['support_group_id'],
                                                              venue['request_form_note'].number)
-        last_comment = client.get_notes(invitation=comment_invitation)[0]
+        last_comment = client.get_notes(invitation=comment_invitation, sort='tmdate')[0]
         error_string = '\n```python\nValueError(\'day is out of range for month\')'
         assert error_string in last_comment.content['error']
 
@@ -762,13 +762,13 @@ class TestVenueRequest():
         helpers.await_queue()
 
         comment_invitation_id = '{}/-/Request{}/Paper_Matching_Setup_Status'.format(venue['support_group_id'], venue['request_form_note'].number)
-        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum)[0]
+        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum, sort='tmdate')[0]
         assert matching_status
         assert 'Could not compute affinity scores and conflicts since no submissions were found. Make sure the submission deadline has passed and you have started the review stage using the \'Review Stage\' button.' in matching_status.content['error']
 
         conference.setup_post_submission_stage(force=True)
 
-        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']))
+        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']), sort='tmdate')
         assert blind_submissions and len(blind_submissions) == 2
 
         reviewer_group = client.get_group('{}/Reviewers'.format(venue['venue_id']))
@@ -793,7 +793,7 @@ class TestVenueRequest():
         helpers.await_queue()
 
         comment_invitation_id = '{}/-/Request{}/Paper_Matching_Setup_Status'.format(venue['support_group_id'], venue['request_form_note'].number)
-        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum)[0]
+        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum, sort='tmdate')[0]
         assert matching_status
         assert 'Could not compute affinity scores and conflicts since there are no Reviewers. You can use the \'Recruitment\' button to recruit Reviewers.' in matching_status.content['error']
 
@@ -820,7 +820,7 @@ class TestVenueRequest():
         helpers.await_queue()
 
         comment_invitation_id = '{}/-/Request{}/Paper_Matching_Setup_Status'.format(venue['support_group_id'], venue['request_form_note'].number)
-        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum)[0]
+        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum, sort='tmdate')[0]
         assert matching_status
         assert 'There was an error connecting with the expertise API' in matching_status.content['error']
 
@@ -888,7 +888,7 @@ class TestVenueRequest():
         helpers.await_queue()
 
         comment_invitation_id = '{}/-/Request{}/Paper_Matching_Setup_Status'.format(venue['support_group_id'], venue['request_form_note'].number)
-        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum)[0]
+        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum, sort='tmdate')[0]
         assert matching_status
         assert matching_status.content['without_profile'] == ['some_user@mail.com']
         assert '''
@@ -927,7 +927,7 @@ Affinity scores and/or conflicts could not be computed for the users listed unde
         helpers.await_queue()
 
         comment_invitation_id = '{}/-/Request{}/Paper_Matching_Setup_Status'.format(venue['support_group_id'], venue['request_form_note'].number)
-        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum)[0]
+        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=venue['request_form_note'].forum, sort='tmdate')[0]
         assert matching_status
         assert matching_status.content['comment'] == '''Affinity scores and/or conflicts were successfully computed. To run the matcher, click on the 'Reviewers Paper Assignment' link in the PC console: https://openreview.net/group?id=TEST.cc/2030/Conference/Program_Chairs
 
@@ -1026,7 +1026,7 @@ Please refer to the FAQ for pointers on how to run the matcher: https://openrevi
         conference = openreview.get_conference(client, request_form_id=venue['request_form_note'].forum)
         conference.setup_post_submission_stage(force=True)
 
-        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']))
+        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']), sort='tmdate')
         assert blind_submissions and len(blind_submissions) == 2
 
         # Assert that ACs do not see the Submit button for meta reviews at this point
@@ -1112,7 +1112,7 @@ Please refer to the FAQ for pointers on how to run the matcher: https://openrevi
     def test_venue_comment_stage(self, client, test_client, selenium, request_page, helpers, venue):
 
         conference = openreview.get_conference(client, request_form_id=venue['request_form_note'].forum)
-        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']))
+        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']), sort='tmdate')
         assert blind_submissions and len(blind_submissions) == 2
 
         # Assert that official comment invitation is not available already
@@ -1185,7 +1185,7 @@ Please refer to the FAQ for pointers on how to run the matcher: https://openrevi
 
     def test_venue_decision_stage(self, client, test_client, selenium, request_page, venue, helpers):
 
-        submissions = test_client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']))
+        submissions = test_client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']), sort='tmdate')
         assert submissions and len(submissions) == 2
         submission = submissions[0]
 
@@ -1298,7 +1298,7 @@ Please refer to the FAQ for pointers on how to run the matcher: https://openrevi
         conference.setup_post_submission_stage(force=True)
 
         blind_submissions = author_client.get_notes(
-            invitation='{}/-/Blind_Submission'.format(venue['venue_id']))
+            invitation='{}/-/Blind_Submission'.format(venue['venue_id']), sort='tmdate')
         assert blind_submissions and len(blind_submissions) == 1
 
         # Post a revision stage note
@@ -1376,7 +1376,7 @@ Please refer to the FAQ for pointers on how to run the matcher: https://openrevi
         #assert messages[0]['content']['to'] == 'venue_author3@mail.com'
 
     def test_post_decision_stage(self, client, test_client, selenium, request_page, helpers, venue):
-        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']))
+        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']), sort='tmdate')
         assert blind_submissions and len(blind_submissions) == 3
 
         # Assert that submissions are still blind
@@ -1523,7 +1523,7 @@ Please refer to the FAQ for pointers on how to run the matcher: https://openrevi
     def test_venue_public_comment_stage(self, client, test_client, selenium, request_page, helpers, venue):
 
         conference = openreview.get_conference(client, request_form_id=venue['request_form_note'].forum)
-        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']))
+        blind_submissions = client.get_notes(invitation='{}/-/Blind_Submission'.format(venue['venue_id']), sort='tmdate')
         assert blind_submissions and len(blind_submissions) == 3
 
         # Post an official comment stage note

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -256,7 +256,7 @@ class TestWorkshop():
 
     def test_open_reviews(self, client, conference, test_client, selenium, request_page, helpers):
 
-        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
+        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
 
         # Reviewer
@@ -317,7 +317,7 @@ class TestWorkshop():
 
         conference.set_comment_stage(openreview.CommentStage(unsubmitted_reviewers = True, email_pcs = True, reader_selection=True, allow_public_comments = True, authors=True))
 
-        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
+        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
 
         reviews = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review')
@@ -389,10 +389,10 @@ class TestWorkshop():
 
     def test_open_revise_reviews(self, client, conference, test_client, selenium, request_page, helpers):
 
-        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
+        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
 
-        reviews = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review')
+        reviews = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review', sort='tmdate')
         assert reviews
         review = reviews[0]
 
@@ -441,7 +441,7 @@ class TestWorkshop():
 
         conference.open_meta_reviews()
 
-        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
+        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission', sort='tmdate')
         submission = notes[2]
 
         note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Meta_Review',
@@ -467,7 +467,7 @@ class TestWorkshop():
 
         pc_client = openreview.Client(username = 'program_chairs@hsdip.org', password = '1234')
 
-        notes = pc_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
+        notes = pc_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission', sort='tmdate')
         assert len(notes) == 3
         submission = notes[2]
 
@@ -609,7 +609,7 @@ class TestWorkshop():
         notes = conference.get_submissions(accepted=True, sort='number:asc')
         assert len(notes) == 1
 
-        withdrawn_notes = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Withdrawn_Submission')
+        withdrawn_notes = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Withdrawn_Submission', sort='tmdate')
         assert len(withdrawn_notes) == 1
         assert withdrawn_notes[0].readers == [
             'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/Authors',

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -170,7 +170,7 @@ class TestWorkshop():
 
         conference.setup_post_submission_stage(force=True)
 
-        blind_submissions = conference.get_submissions()
+        blind_submissions = conference.get_submissions(sort='tmdate')
         assert blind_submissions
         assert len(blind_submissions) == 1
 
@@ -191,7 +191,7 @@ class TestWorkshop():
 
         conference.setup_post_submission_stage(force=True)
 
-        blind_submissions_2 = conference.get_submissions()
+        blind_submissions_2 = conference.get_submissions(sort='tmdate')
         assert blind_submissions_2
         assert len(blind_submissions_2) == 2
         assert blind_submissions[0].id == blind_submissions_2[1].id
@@ -216,7 +216,7 @@ class TestWorkshop():
 
         conference.setup_post_submission_stage(force=True)
 
-        blind_submissions_3 = conference.get_submissions()
+        blind_submissions_3 = conference.get_submissions(sort='tmdate')
         assert blind_submissions_3
         assert len(blind_submissions_3) == 3
         assert blind_submissions[0].id == blind_submissions_3[2].id


### PR DESCRIPTION
- Add the sort parameters to all the get_notes calls from the tests.
- Add the sort parameters to all the get_notes calls from the webfields.