### PR TITLE
Feature/ethics review stage

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -624,12 +624,6 @@ class Conference(object):
     def has_senior_area_chairs(self, has_senior_area_chairs):
         self.use_senior_area_chairs = has_senior_area_chairs
 
-    def has_ethics_chairs(self, has_ethics_chairs):
-        self.use_ethics_chairs = has_ethics_chairs
-
-    def has_ethics_reviewers(self, has_ethics_reviewers):
-        self.use_ethics_reviewers = has_ethics_reviewers                
-
     def has_secondary_area_chairs(self, has_secondary_area_chairs):
         self.use_secondary_area_chairs = has_secondary_area_chairs
 
@@ -2430,10 +2424,10 @@ class ConferenceBuilder(object):
         self.conference.has_senior_area_chairs(has_senior_area_chairs)
 
     def has_ethics_chairs(self, has_ethics_chairs):
-        self.conference.has_ethics_chairs(has_ethics_chairs)  
+        self.conference.use_ethics_chairs = has_ethics_chairs
 
     def has_ethics_reviewers(self, has_ethics_reviewers):
-        self.conference.has_ethics_reviewers(has_ethics_reviewers)                
+        self.conference.use_ethics_reviewers = has_ethics_reviewers
 
     def enable_reviewer_reassignment(self, enable):
         self.conference.enable_reviewer_reassignment = enable

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -211,6 +211,7 @@ class Conference(object):
     def __create_ethics_review_stage(self):
 
         self.set_ethics_reviewers()
+        self.set_ethics_chairs()
         
         numbers = ','.join(map(str, self.ethics_review_stage.submission_numbers))
         notes = list(self.get_submissions(number=numbers))
@@ -1197,6 +1198,18 @@ class Conference(object):
             additional_readers = readers)
 
         return self.webfield_builder.set_ethics_reviewer_page(self, ethics_reviewer_group)        
+
+    def set_ethics_chairs(self, emails = []):
+        readers = [self.id, self.get_ethics_chairs_id()]
+
+        ethics_reviewer_group = self.__create_group(
+            group_id = self.get_ethics_chairs_id(),
+            group_owner_id = self.id,
+            members = emails,
+            additional_readers = readers)
+
+        return self.webfield_builder.set_ethics_chairs_page(self, ethics_reviewer_group)        
+
 
     def set_authors(self):
         # Creating venue level authors group

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -365,6 +365,10 @@ class Conference(object):
         self.bid_stages[stage.committee_id] = stage
         return self.__create_bid_stage(stage)
 
+    def set_review_stage(self, stage):
+        self.review_stage = stage
+        self.create_review_stage()
+
     def create_review_stage(self):
         if self.review_stage:
             return self.__create_review_stage()

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1234,7 +1234,7 @@ class Conference(object):
 
         ethics_reviewer_group = self.__create_group(
             group_id = self.get_ethics_reviewers_id(),
-            group_owner_id = self.id,
+            group_owner_id = self.get_ethics_chairs_id(),
             members = emails,
             additional_readers = readers)
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -210,6 +210,8 @@ class Conference(object):
 
     def __create_ethics_review_stage(self):
 
+        self.set_ethics_reviewers()
+        
         numbers = ','.join(map(str, self.ethics_review_stage.submission_numbers))
         notes = list(self.get_submissions(number=numbers))
         
@@ -1184,6 +1186,17 @@ class Conference(object):
             additional_readers = readers)
 
         return self.__set_reviewer_page()
+
+    def set_ethics_reviewers(self, emails = []):
+        readers = [self.id, self.get_ethics_chairs_id()]
+
+        ethics_reviewer_group = self.__create_group(
+            group_id = self.get_ethics_reviewers_id(),
+            group_owner_id = self.id,
+            members = emails,
+            additional_readers = readers)
+
+        return self.webfield_builder.set_ethics_reviewer_page(self, ethics_reviewer_group)        
 
     def set_authors(self):
         # Creating venue level authors group

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -54,6 +54,8 @@ class Conference(object):
         self.use_area_chairs = False
         self.use_senior_area_chairs = False
         self.use_secondary_area_chairs = False
+        self.use_ethics_chairs = False
+        self.use_ethics_reviewers = False
         self.legacy_anonids = False
         self.legacy_invitation_id = False
         self.groups = []
@@ -75,6 +77,8 @@ class Conference(object):
         self.area_chairs_name = 'Area_Chairs'
         self.senior_area_chairs_name = 'Senior_Area_Chairs'
         self.secondary_area_chairs_name = 'Secondary_Area_Chair'
+        self.ethics_chairs_name = 'Ethics_Chairs'
+        self.ethics_reviewers_name = 'Ethics_Reviewers'
         self.program_chairs_name = 'Program_Chairs'
         self.recommendation_name = 'Recommendation'
         self.submission_stage = SubmissionStage()
@@ -404,6 +408,12 @@ class Conference(object):
     def get_senior_area_chairs_id(self, number = None):
         return self.get_committee_id(self.senior_area_chairs_name, number)
 
+    def get_ethics_chairs_id(self, number = None):
+        return self.get_committee_id(self.ethics_chairs_name, number)
+
+    def get_ethics_reviewers_id(self, number = None):
+        return self.get_committee_id(self.ethics_reviewers_name, number)
+
     def get_secondary_area_chairs_id(self, number=None):
         return self.get_committee_id(self.secondary_area_chairs_name, number)
 
@@ -462,6 +472,11 @@ class Conference(object):
             roles = self.reviewer_roles + self.area_chair_roles
         if self.use_senior_area_chairs:
             roles = roles + self.senior_area_chair_roles
+        if self.use_ethics_chairs:
+            roles = roles + [self.ethics_chairs_name]
+        if self.use_ethics_reviewers:
+            roles = roles + [self.ethics_reviewers_name]
+
         return roles
 
     def get_submission_id(self):
@@ -574,6 +589,12 @@ class Conference(object):
 
     def has_senior_area_chairs(self, has_senior_area_chairs):
         self.use_senior_area_chairs = has_senior_area_chairs
+
+    def has_ethics_chairs(self, has_ethics_chairs):
+        self.use_ethics_chairs = has_ethics_chairs
+
+    def has_ethics_reviewers(self, has_ethics_reviewers):
+        self.use_ethics_reviewers = has_ethics_reviewers                
 
     def has_secondary_area_chairs(self, has_secondary_area_chairs):
         self.use_secondary_area_chairs = has_secondary_area_chairs
@@ -1022,6 +1043,7 @@ class Conference(object):
         else:
             raise openreview.OpenReviewException('Conference "has_secondary_area_chairs" setting is disabled')
 
+    ## Deprecated
     def set_senior_area_chair_recruitment_groups(self):
         if self.use_senior_area_chairs:
             parent_group_id = self.get_senior_area_chairs_id()
@@ -1040,6 +1062,7 @@ class Conference(object):
             raise openreview.OpenReviewException('Conference "has_senior_area_chairs" setting is disabled')
 
 
+    ## Deprecated
     def set_area_chair_recruitment_groups(self):
         if self.use_area_chairs:
             parent_group_id = self.get_area_chairs_id()
@@ -1056,6 +1079,19 @@ class Conference(object):
             self.__create_group(parent_group_invited_id, pcs_id, exclude_self_reader=True)
         else:
             raise openreview.OpenReviewException('Conference "has_area_chairs" setting is disabled')
+
+    def set_recruitment_groups(self, parent_group_id):
+        parent_group_declined_id = parent_group_id + '/Declined'
+        parent_group_invited_id = parent_group_id + '/Invited'
+        parent_group_accepted_id = parent_group_id
+
+        pcs_id = self.get_program_chairs_id()
+        # parent_group_accepted_group
+        self.__create_group(parent_group_accepted_id, pcs_id)
+        # parent_group_declined_group
+        self.__create_group(parent_group_declined_id, pcs_id, exclude_self_reader=True)
+        # parent_group_invited_group
+        self.__create_group(parent_group_invited_id, pcs_id, exclude_self_reader=True)
 
     def set_reviewer_recruitment_groups(self):
         parent_group_id = self.get_reviewers_id()
@@ -2219,6 +2255,12 @@ class ConferenceBuilder(object):
     def has_senior_area_chairs(self, has_senior_area_chairs):
         self.conference.has_senior_area_chairs(has_senior_area_chairs)
 
+    def has_ethics_chairs(self, has_ethics_chairs):
+        self.conference.has_ethics_chairs(has_ethics_chairs)  
+
+    def has_ethics_reviewers(self, has_ethics_reviewers):
+        self.conference.has_ethics_reviewers(has_ethics_reviewers)                
+
     def enable_reviewer_reassignment(self, enable):
         self.conference.enable_reviewer_reassignment = enable
 
@@ -2375,6 +2417,10 @@ class ConferenceBuilder(object):
             self.conference.set_senior_area_chair_recruitment_groups()
         if self.conference.use_area_chairs:
             self.conference.set_area_chair_recruitment_groups()
+        if self.conference.use_ethics_chairs:
+            self.conference.set_recruitment_groups(self.conference.get_ethics_chairs_id())
+        if self.conference.use_ethics_reviewers:
+            self.conference.set_recruitment_groups(self.conference.get_ethics_reviewers_id())                       
         self.conference.set_reviewer_recruitment_groups()
 
         for s in self.bid_stages:

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -210,9 +210,6 @@ class Conference(object):
 
     def __create_ethics_review_stage(self):
 
-        self.set_ethics_reviewers()
-        self.set_ethics_chairs()
-        
         numbers = ','.join(map(str, self.ethics_review_stage.submission_numbers))
         notes = list(self.get_submissions(number=numbers))
         
@@ -1080,7 +1077,6 @@ class Conference(object):
         else:
             raise openreview.OpenReviewException('Conference "has_secondary_area_chairs" setting is disabled')
 
-    ## Deprecated
     def set_senior_area_chair_recruitment_groups(self):
         if self.use_senior_area_chairs:
             parent_group_id = self.get_senior_area_chairs_id()
@@ -1099,7 +1095,6 @@ class Conference(object):
             raise openreview.OpenReviewException('Conference "has_senior_area_chairs" setting is disabled')
 
 
-    ## Deprecated
     def set_area_chair_recruitment_groups(self):
         if self.use_area_chairs:
             parent_group_id = self.get_area_chairs_id()
@@ -1117,18 +1112,25 @@ class Conference(object):
         else:
             raise openreview.OpenReviewException('Conference "has_area_chairs" setting is disabled')
 
-    def set_recruitment_groups(self, parent_group_id):
+    def set_ethics_reviewer_recruitment_groups(self):
+        parent_group_id = self.get_ethics_reviewers_id()
         parent_group_declined_id = parent_group_id + '/Declined'
         parent_group_invited_id = parent_group_id + '/Invited'
-        parent_group_accepted_id = parent_group_id
+
+        pcs_id = self.get_ethics_chairs_id()
+        self.set_ethics_reviewers()
+        self.__create_group(parent_group_declined_id, pcs_id, exclude_self_reader=True)
+        self.__create_group(parent_group_invited_id, pcs_id, exclude_self_reader=True) 
+
+    def set_ethics_chair_recruitment_groups(self):
+        parent_group_id = self.get_ethics_chairs_id()
+        parent_group_declined_id = parent_group_id + '/Declined'
+        parent_group_invited_id = parent_group_id + '/Invited'
 
         pcs_id = self.get_program_chairs_id()
-        # parent_group_accepted_group
-        self.__create_group(parent_group_accepted_id, pcs_id)
-        # parent_group_declined_group
+        self.set_ethics_chairs()
         self.__create_group(parent_group_declined_id, pcs_id, exclude_self_reader=True)
-        # parent_group_invited_group
-        self.__create_group(parent_group_invited_id, pcs_id, exclude_self_reader=True)
+        self.__create_group(parent_group_invited_id, pcs_id, exclude_self_reader=True)                
 
     def set_reviewer_recruitment_groups(self):
         parent_group_id = self.get_reviewers_id()
@@ -2589,9 +2591,9 @@ class ConferenceBuilder(object):
         if self.conference.use_area_chairs:
             self.conference.set_area_chair_recruitment_groups()
         if self.conference.use_ethics_chairs:
-            self.conference.set_recruitment_groups(self.conference.get_ethics_chairs_id())
+            self.conference.set_ethics_chair_recruitment_groups()
         if self.conference.use_ethics_reviewers:
-            self.conference.set_recruitment_groups(self.conference.get_ethics_reviewers_id())                       
+            self.conference.set_ethics_reviewer_recruitment_groups()                       
         self.conference.set_reviewer_recruitment_groups()
 
         for s in self.bid_stages:

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1715,8 +1715,10 @@ class SubmissionStage(object):
             submission_readers.append(conference.get_reviewers_id(number=number))
 
         if conference.ethics_review_stage and number in conference.ethics_review_stage.submission_numbers:
-            submission_readers.append(conference.get_ethics_chairs_id())
-            submission_readers.append(conference.get_ethics_reviewers_id(number=number))            
+            if conference.use_ethics_chairs:
+                submission_readers.append(conference.get_ethics_chairs_id())
+            if conference.use_ethics_reviewers:
+                submission_readers.append(conference.get_ethics_reviewers_id(number=number))            
 
         submission_readers.append(conference.get_authors_id(number=number))
         return submission_readers
@@ -1931,8 +1933,10 @@ class ReviewStage(object):
         readers.append(self._get_reviewer_readers(conference, number))
 
         if conference.ethics_review_stage and number in conference.ethics_review_stage.submission_numbers:
-            readers.append(conference.get_ethics_chairs_id())
-            readers.append(conference.get_ethics_reviewers_id(number=number))
+            if conference.use_ethics_chairs:
+                readers.append(conference.get_ethics_chairs_id())
+            if conference.use_ethics_reviewers:
+                readers.append(conference.get_ethics_reviewers_id(number=number))  
 
         if self.release_to_authors:
             readers.append(conference.get_authors_id(number = number))

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -213,6 +213,7 @@ class Conference(object):
         numbers = ','.join(map(str, self.ethics_review_stage.submission_numbers))
         notes = list(self.get_submissions(number=numbers))
         
+        ## Make submissions visible to the ethics committee
         self.create_blind_submissions(number=numbers)
 
         ## Create ethics paper groups
@@ -230,8 +231,13 @@ class Conference(object):
                     signatories=[self.id],
                     anonids=True,
                     members=group.members if group else [])
-                )           
+                )
 
+        ## Setup paper matching
+        self.setup_committee_matching(self.get_ethics_reviewers_id(), compute_affinity_scores=False, compute_conflicts=True)
+        self.invitation_builder.set_assignment_invitation(self, self.get_ethics_reviewers_id())      
+
+        ## Make reviews visible to the ethics committee
         self.invitation_builder.set_review_invitation(self, notes)
         invitations = self.invitation_builder.set_ethics_review_invitation(self, notes)
         return invitations 
@@ -418,6 +424,12 @@ class Conference(object):
             name=self.reviewers_name.replace('_', ' ')
             return name[:-1] if name.endswith('s') else name
         return self.reviewers_name
+
+    def get_ethics_reviewers_name(self, pretty=True):
+        if pretty:
+            name=self.ethics_reviewers_name.replace('_', ' ')
+            return name[:-1] if name.endswith('s') else name
+        return self.ethics_reviewers_name
 
     def get_area_chairs_name(self, pretty=True):
         if pretty:

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -304,8 +304,8 @@ def get_ethics_review_stage(request_forum):
     release_to_reviewers = readers_map.get(request_forum.content.get('release_ethics_reviews_to_reviewers', ''), openreview.EthicsReviewStage.Readers.ETHICS_REVIEWER_SIGNATURE)
 
     flagged_submissions = []
-    if request_forum.content.get('flagged_submissions'):
-        flagged_submissions = [int(number) for number in request_forum.content['flagged_submissions'].split(',')]
+    if request_forum.content.get('ethics_review_submissions'):
+        flagged_submissions = [int(number) for number in request_forum.content['ethics_review_submissions'].split(',')]
     
     return openreview.EthicsReviewStage(
         start_date = review_start_date,

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -96,6 +96,13 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
     if note.content.get('senior_area_chairs') == 'Yes, our venue has Senior Area Chairs':
         builder.has_senior_area_chairs(True)
 
+    if note.content.get('ethics_chairs_and_reviewers') == 'Yes, our venue has Ethics Chairs and Reviewers':
+        builder.has_ethics_chairs(True)
+        builder.has_ethics_reviewers(True)
+
+    if note.content.get('ethics_chairs_and_reviewers') == 'Yes, our venue has Ethics Reviewers only':
+        builder.has_ethics_reviewers(True)
+
     double_blind = (note.content.get('Author and Reviewer Anonymity', '') == 'Double-blind')
 
     readers_map = {

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -100,9 +100,6 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
         builder.has_ethics_chairs(True)
         builder.has_ethics_reviewers(True)
 
-    if note.content.get('ethics_chairs_and_reviewers') == 'Yes, our venue has Ethics Reviewers only':
-        builder.has_ethics_reviewers(True)
-
     double_blind = (note.content.get('Author and Reviewer Anonymity', '') == 'Double-blind')
 
     readers_map = {

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -200,6 +200,8 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
     builder.set_reviewer_roles(note.content.get('reviewer_roles', ['Reviewers']))
     builder.set_area_chair_roles(note.content.get('area_chair_roles', ['Area_Chairs']))
     builder.set_senior_area_chair_roles(note.content.get('senior_area_chair_roles', ['Senior_Area_Chairs']))
+    builder.set_review_stage(get_review_stage(note))
+    builder.set_ethics_review_stage(get_ethics_review_stage(note))
 
     return builder
 
@@ -224,7 +226,7 @@ def get_bid_stage(client, request_forum, committee_id):
 
     return openreview.BidStage(committee_id if committee_id else request_forum.content['venue_id'] + '/Reviewers', start_date = bid_start_date, due_date = bid_due_date, request_count = int(request_forum.content.get('bid_count', 50)))
 
-def get_review_stage(client, request_forum):
+def get_review_stage(request_forum):
     review_start_date = request_forum.content.get('review_start_date', '').strip()
     if review_start_date:
         try:
@@ -273,7 +275,7 @@ def get_review_stage(client, request_forum):
         remove_fields = review_form_remove_options
     )
 
-def get_ethics_review_stage(client, request_forum):
+def get_ethics_review_stage(request_forum):
     review_start_date = request_forum.content.get('ethics_review_start_date', '').strip()
     if review_start_date:
         try:
@@ -304,7 +306,9 @@ def get_ethics_review_stage(client, request_forum):
     }
     release_to_reviewers = readers_map.get(request_forum.content.get('release_ethics_reviews_to_reviewers', ''), openreview.EthicsReviewStage.Readers.ETHICS_REVIEWER_SIGNATURE)
 
-    flagged_submissions = request_forum.content.get('flagged_submissions', '').split(',')
+    flagged_submissions = []
+    if request_forum.content.get('flagged_submissions'):
+        flagged_submissions = [int(number) for number in request_forum.content['flagged_submissions'].split(',')]
     
     return openreview.EthicsReviewStage(
         start_date = review_start_date,

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -831,7 +831,7 @@ class ReviewInvitation(openreview.Invitation):
             file_content = file_content.replace("var AUTHORS_NAME = '';", "var AUTHORS_NAME = '" + conference.authors_name + "';")
             file_content = file_content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + conference.reviewers_name + "';")
             file_content = file_content.replace("var AREA_CHAIRS_NAME = '';", "var AREA_CHAIRS_NAME = '" + conference.area_chairs_name + "';")
-            file_content = file_content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + review_stage.name + "';")
+            file_content = file_content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + ('Review' if 'Official' in review_stage.name else review_stage.name) + "';")
             file_content = file_content.replace("var ADD_SUBMITED = false;", "var ADD_SUBMITED = true;")
 
 

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -831,6 +831,9 @@ class ReviewInvitation(openreview.Invitation):
             file_content = file_content.replace("var AUTHORS_NAME = '';", "var AUTHORS_NAME = '" + conference.authors_name + "';")
             file_content = file_content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + conference.reviewers_name + "';")
             file_content = file_content.replace("var AREA_CHAIRS_NAME = '';", "var AREA_CHAIRS_NAME = '" + conference.area_chairs_name + "';")
+            file_content = file_content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + review_stage.name + "';")
+            file_content = file_content.replace("var ADD_SUBMITED = false;", "var ADD_SUBMITED = true;")
+
 
             if conference.use_area_chairs:
                 file_content = file_content.replace("var USE_AREA_CHAIRS = false;", "var USE_AREA_CHAIRS = true;")
@@ -917,8 +920,9 @@ class EthicsReviewInvitation(openreview.Invitation):
             file_content = file_content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference.id + "';")
             file_content = file_content.replace("var SHORT_PHRASE = '';", f'var SHORT_PHRASE = "{conference.get_short_name()}";')
             file_content = file_content.replace("var AUTHORS_NAME = '';", "var AUTHORS_NAME = '" + conference.authors_name + "';")
-            file_content = file_content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + conference.reviewers_name + "';")
+            file_content = file_content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + conference.ethics_reviewers_name + "';")
             file_content = file_content.replace("var AREA_CHAIRS_NAME = '';", "var AREA_CHAIRS_NAME = '" + conference.area_chairs_name + "';")
+            file_content = file_content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + ethics_review_stage.name + "';")
 
             super(EthicsReviewInvitation, self).__init__(id = conference.get_invitation_id(ethics_review_stage.name),
                 cdate = tools.datetime_millis(ethics_review_stage.start_date),

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -100,6 +100,7 @@ class Matching(object):
         self.is_reviewer = conference.get_reviewers_id() == match_group.id
         self.is_area_chair = conference.get_area_chairs_id() == match_group.id
         self.is_senior_area_chair = conference.get_senior_area_chairs_id() == match_group.id
+        self.is_ethics_reviewer = conference.get_ethics_reviewers_id() == match_group.id
         self.should_read_by_area_chair = conference.get_reviewers_id() == match_group.id and conference.use_area_chairs
 
 
@@ -128,6 +129,7 @@ class Matching(object):
 
         edge_invitees = [self.conference.get_id(), self.conference.support_user]
         edge_readers = [self.conference.get_id()]
+        invitation_readers = [self.conference.get_id()]
         edge_writers = [self.conference.get_id()]
         edge_signatures = [self.conference.get_id() + '$', self.conference.get_program_chairs_id()]
         edge_nonreaders = {
@@ -136,8 +138,10 @@ class Matching(object):
         if self.is_reviewer:
             if self.conference.use_senior_area_chairs:
                 edge_readers.append(self.conference.get_senior_area_chairs_id(number=paper_number))
+                invitation_readers.append(self.conference.get_senior_area_chairs_id())
             if self.conference.use_area_chairs:
                 edge_readers.append(self.conference.get_area_chairs_id(number=paper_number))
+                invitation_readers.append(self.conference.get_area_chairs_id())
 
             if is_assignment_invitation:
                 if self.conference.use_senior_area_chairs:
@@ -157,6 +161,8 @@ class Matching(object):
         if self.is_area_chair:
             if self.conference.use_senior_area_chairs:
                 edge_readers.append(self.conference.get_senior_area_chairs_id(number=paper_number))
+                invitation_readers.append(self.conference.get_senior_area_chairs_id())
+
 
             if is_assignment_invitation:
                 if self.conference.use_senior_area_chairs:
@@ -167,6 +173,21 @@ class Matching(object):
                 edge_nonreaders = {
                     'values': [self.conference.get_authors_id(number=paper_number)]
                 }
+
+        if self.is_ethics_reviewer:
+            if self.conference.use_ethics_chairs:
+                edge_readers.append(self.conference.get_ethics_chairs_id())
+                invitation_readers.append(self.conference.get_ethics_chairs_id())
+
+            if is_assignment_invitation:
+                if self.conference.use_ethics_chairs:
+                    edge_invitees.append(self.conference.get_ethics_chairs_id())
+                    edge_writers.append(self.conference.get_ethics_chairs_id())
+                    edge_signatures.append(self.conference.get_ethics_chairs_id())
+
+                edge_nonreaders = {
+                    'values': [self.conference.get_authors_id(number=paper_number)]
+                }                               
 
         readers = {
             'values-copied': edge_readers + ['{tail}']
@@ -233,7 +254,7 @@ class Matching(object):
         invitation = openreview.Invitation(
             id=edge_id,
             invitees=edge_invitees,
-            readers=[self.conference.get_id(), self.conference.get_senior_area_chairs_id(), self.conference.get_area_chairs_id()],
+            readers=invitation_readers,
             writers=[self.conference.get_id()],
             signatures=[self.conference.get_id()],
             reply={

--- a/openreview/conference/templates/ethicsChairsWebfield.js
+++ b/openreview/conference/templates/ethicsChairsWebfield.js
@@ -486,7 +486,16 @@ var buildPaperTableRow = function(note) {
     showActivityModal: false,
     expandReviewerList: false,
     enableReviewerReassignment : false,
-    referrer: paperTableReferrerUrl
+    referrer: paperTableReferrerUrl,
+    actions: [
+      {
+        name: 'Edit Assignments',
+        url: '/edges/browse?start=staticList,type:head,ids:' + note.id +
+        '&traverse=' + ETHICS_REVIEWERS_ID + '/-/Assignment' +
+        '&edit=' + ETHICS_REVIEWERS_ID + '/-/Assignment' +
+        '&browse=' + ETHICS_REVIEWERS_ID + '/-/Affinity_Score' + ';' + ETHICS_REVIEWERS_ID + '/-/Conflict'
+      }
+    ]
   };
 
   return {
@@ -568,13 +577,9 @@ var displayPaperStatusTable = function() {
       paperNumbers.push(d.note.number);
 
       var numberHtml = '<strong class="note-number">' + d.note.number + '</strong>';
-      var checked = '<label><input type="checkbox" class="select-note-reviewers" data-note-id="' +
-        d.note.id + '" ' + (selectedNotesById[d.note.id] ? 'checked="checked"' : '') + '></label>';
       var numberHtml = '<strong class="note-number">' + d.note.number + '</strong>';
       var summaryHtml = Handlebars.templates.noteSummary(d.note);
       var reviewHtml = Handlebars.templates.noteReviewers(d.reviewProgressData);
-      var areachairHtml = Handlebars.templates.noteAreaChairs(d.areachairProgressData);
-      var decisionHtml = '<h4>' + (d.decision ? d.decision.content.decision : 'No Decision') + '</h4>';
 
       var rows = [numberHtml, summaryHtml, reviewHtml];
       return rows;

--- a/openreview/conference/templates/ethicsChairsWebfield.js
+++ b/openreview/conference/templates/ethicsChairsWebfield.js
@@ -1,0 +1,876 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
+// Constants
+var CONFERENCE_ID = '';
+var SHORT_PHRASE = '';
+var BLIND_SUBMISSION_ID = '';
+var OFFICIAL_REVIEW_NAME = '';
+var REVIEW_RATING_NAME = 'recommendation';
+var REVIEW_CONFIDENCE_NAME = 'confidence';
+var HEADER = {};
+var ETHICS_CHAIRS_NAME = '';
+var ETHICS_REVIEWERS_NAME = '';
+var ETHICS_CHAIRS_ID = CONFERENCE_ID + '/' + ETHICS_CHAIRS_NAME;
+var ETHICS_REVIEWERS_ID = CONFERENCE_ID + '/' + ETHICS_REVIEWERS_NAME;
+var WILDCARD_INVITATION = CONFERENCE_ID + '.*';
+var PAGE_SIZE = 25;
+var EMAIL_SENDER = null;
+
+var singularReviewersName = ETHICS_REVIEWERS_NAME.endsWith('s') ? ETHICS_REVIEWERS_NAME.slice(0, -1) : ETHICS_REVIEWERS_NAME;
+var conferenceStatusData = {};
+var selectedNotesById = {};
+
+var filterOperators = ['!=','>=','<=','>','<','=']; // sequence matters
+var propertiesAllowed = {
+    number:['note.number'],
+    id:['note.id','summary.id'],// multi tab same prop
+    title:['note.content.title'],
+    author:['note.content.authors','note.content.authorids'], // multi props
+    keywords:['note.content.keywords'],
+    reviewer:['reviewProgressData.reviewers'],
+    numReviewersAssigned:['reviewProgressData.numReviewers'],
+    numReviewsDone:['reviewProgressData.numSubmittedReviews'],
+    replyCount:['reviewProgressData.forumReplyCount']
+}
+
+// Main function is the entry point to the webfield code
+var main = function() {
+  if (args && args.referrer) {
+    OpenBanner.referrerLink(args.referrer);
+  } else {
+    OpenBanner.venueHomepageLink(CONFERENCE_ID);
+  }
+
+  renderHeader();
+
+  loadData()
+  .then(formatData)
+  .then(renderTableAndTasks)
+  .fail(function() {
+    Webfield.ui.errorMessage();
+  });
+};
+
+var renderHeader = function() {
+  Webfield.ui.setup('#group-container', CONFERENCE_ID);
+  Webfield.ui.header(HEADER.title, HEADER.instructions);
+
+  var loadingMessage = '<p class="empty-message">No information to display at this time.</p>';
+  var tabsList = [
+    {
+      heading: 'Overview',
+      id: 'overview',
+      content: loadingMessage,
+      extraClasses: 'horizontal-scroll',
+      active: true
+    },
+    {
+      heading: 'Paper Status',
+      id: 'paper-status',
+      content: loadingMessage,
+      extraClasses: 'horizontal-scroll'
+    },
+    {
+      heading: 'Ethics Chair Tasks',
+      id: 'ethic-review-chair-tasks',
+      content: loadingMessage
+    }
+  ];
+
+  Webfield.ui.tabPanel(tabsList);
+};
+
+var getGroups = function() {
+    return Webfield.getAll('/groups', {
+      id: CONFERENCE_ID + '/Paper.*',
+      select: 'id,members'
+    }).then(function(groups) {
+      var reviewerGroups = [];
+      var anonReviewerGroups = [];
+      var areaChairGroups = [];
+      var anonAreaChairGroups = [];
+      var seniorAreaChairGroups = [];
+      for (var groupIdx = 0; groupIdx < groups.length; groupIdx++) {
+        var group = groups[groupIdx];
+        if (group.id.endsWith('/' + ETHICS_REVIEWERS_NAME)) {
+          reviewerGroups.push(group);
+        } else if (_.includes(group.id, '/' + singularReviewersName + '_')) {
+          anonReviewerGroups.push(group);
+        } else if (group.id.endsWith('/Area_Chairs')) {
+          areaChairGroups.push(group);
+        } else if (_.includes(group.id, 'Area_Chair_')) {
+          anonAreaChairGroups.push(group);
+        } else if (group.id.endsWith('/Senior_Area_Chairs')) {
+          seniorAreaChairGroups.push(group);
+        }
+      }
+      return {
+        anonReviewerGroups: anonReviewerGroups,
+        reviewerGroups: reviewerGroups,
+        anonAreaChairGroups: anonAreaChairGroups,
+        areaChairGroups: areaChairGroups,
+        seniorAreaChairGroups: seniorAreaChairGroups
+      };
+    });
+  };
+
+var loadData = function(papers) {
+
+  var recruitmentGroupsP = Webfield.getAll('/groups', {
+    regex: CONFERENCE_ID + '/' + ETHICS_REVIEWERS_NAME + '.*'
+  })
+
+  var submissionsP = Webfield.getAll('/notes', {
+    invitation: BLIND_SUBMISSION_ID,
+    details: 'invitation,tags,original,replyCount,directReplies',
+    sort: 'number:asc'
+  });
+
+  return $.when(
+    getGroups(),
+    submissionsP,
+    getAllInvitations(),
+    recruitmentGroupsP
+  );
+};
+
+// Util functions
+var getNumberfromGroup = function(groupId, name) {
+  var tokens = groupId.split('/');
+  var paper = _.find(tokens, function(token) {
+    return _.startsWith(token, name);
+  });
+
+  return paper ? paper.replace(name, '') : null;
+};
+
+var getPaperNumbersfromGroups = function(groups) {
+  return _.map(groups, function(group) {
+    return parseInt(getNumberfromGroup(group.id, 'Paper'));
+  });
+};
+
+var getInvitationId = function(name, number) {
+  return CONFERENCE_ID + '/Paper' + number + '/-/' + name;
+};
+
+var findProfile = function(id) {
+  if (conferenceStatusData.profiles[id]) {
+    return conferenceStatusData.profiles[id];
+  }
+  var profile = _.find(conferenceStatusData.profiles, function(p) {
+    return _.includes(p.allNames, id) || _.includes(p.allEmails, id);
+  });
+  return profile || {
+    id: id,
+    name: id.indexOf('~') === 0 ? view.prettyId(id) : id,
+    email: id,
+    allEmails: [id],
+    allNames: [id]
+  }
+};
+
+var buildNoteMap = function(noteNumbers) {
+  var noteMap = Object.create(null);
+  for (var i = 0; i < noteNumbers.length; i++) {
+    noteMap[noteNumbers[i]] = Object.create(null);
+  }
+  return noteMap;
+};
+
+var buildReviewerGroupMaps = function(noteNumbers, reviewerGroups, anonReviewerGroups) {
+  var noteMap = buildNoteMap(noteNumbers);
+  var reviewerMap = {};
+  var profileIds = [];
+
+  reviewerGroups.forEach(function(g) {
+    var num = getNumberfromGroup(g.id, 'Paper');
+
+    if(num in noteMap) {
+      g.members.forEach(function(member, index) {
+        var anonGroup = anonReviewerGroups.find(function(grp) {
+          return grp.id.startsWith(CONFERENCE_ID + '/Paper' + num + '/' + singularReviewersName + '_') && grp.members.length && grp.members[0] == member;
+        });
+        if (anonGroup) {
+          var anonId = getNumberfromGroup(anonGroup.id, singularReviewersName + '_')
+          noteMap[num][anonId] = member;
+          if (!(member in reviewerMap)) {
+            reviewerMap[member] = [];
+          }
+          reviewerMap[member].push(num);
+          profileIds.push(member);
+        }
+      })
+    }
+  });
+
+  return {
+    byNotes: noteMap,
+    byReviewers: reviewerMap,
+    profileIds: profileIds
+  };
+};
+
+var buildAreaChairGroupMaps = function(noteNumbers, areaChairGroups, anonAreaChairGroups) {
+  var noteMap = buildNoteMap(noteNumbers);
+  var areaChairMap = {};
+  var profileIds = [];
+
+  areaChairGroups.forEach(function(g) {
+    var num = getNumberfromGroup(g.id, 'Paper');
+    if (num in noteMap) {
+      g.members.forEach(function(member, index) {
+        var anonGroup = anonAreaChairGroups.find(function(grp) {
+          return grp.id.startsWith(CONFERENCE_ID + '/Paper' + num + '/Area_Chair_') && grp.members.length && grp.members[0] == member;
+        });
+        if (anonGroup) {
+          var anonId = getNumberfromGroup(anonGroup.id, 'Area_Chair_')
+          noteMap[num][anonId] = member;
+          if (!(member in areaChairMap)) {
+            areaChairMap[member] = [];
+          }
+          areaChairMap[member].push(num);
+          profileIds.push(member);
+        }
+      })
+    }
+  });
+
+  return {
+    byNotes: noteMap,
+    byAreaChairs: areaChairMap,
+    profileIds: profileIds
+  };
+};
+
+var buildSeniorAreaChairGroupMaps = function(noteNumbers, seniorAreaChairGroups) {
+  var noteMap = buildNoteMap(noteNumbers);
+  var seniorAreaChairMap = {};
+
+  seniorAreaChairGroups.forEach(function(g) {
+    var num = getNumberfromGroup(g.id, 'Paper');
+    if (num in noteMap) {
+      g.members.forEach(function(member, index) {
+        noteMap[num] = member;
+        if (!(member in seniorAreaChairMap)) {
+          seniorAreaChairMap[member] = [];
+        }
+        seniorAreaChairMap[member].push(num);
+      })
+    }
+  });
+
+  return {
+    byNotes: noteMap,
+    bySeniorAreaChairs: seniorAreaChairMap
+  };
+};
+
+var getOfficialReviews = function(notes) {
+  var ratingExp = /^(\d+): .*/;
+
+  var reviewByAnonId = {};
+
+  _.forEach(notes, function(n) {
+    var anonId = getNumberfromGroup(n.signatures[0], singularReviewersName + '_');
+    // Need to parse rating and confidence strings into ints
+    ratingNumber = n.content[REVIEW_RATING_NAME] ? n.content[REVIEW_RATING_NAME].substring(0, n.content[REVIEW_RATING_NAME].indexOf(':')) : null;
+    n.rating = ratingNumber ? parseInt(ratingNumber, 10) : null;
+    confidenceMatch = n.content[REVIEW_CONFIDENCE_NAME] && n.content[REVIEW_CONFIDENCE_NAME].match(ratingExp);
+    n.confidence = confidenceMatch ? parseInt(confidenceMatch[1], 10) : null;
+    reviewByAnonId[anonId] = n;
+  });
+
+  return reviewByAnonId;
+};
+
+
+var getUserProfiles = function(userIds) {
+  var ids = _.filter(userIds, function(id) { return _.startsWith(id, '~');});
+  var emails = _.filter(userIds, function(id) { return id.match(/.+@.+/);});
+
+  var profileSearch = [];
+  if (ids.length) {
+    profileSearch.push(Webfield.post('/profiles/search', {ids: ids}),);
+  }
+  if (emails.length) {
+    profileSearch.push(Webfield.post('/profiles/search', {emails: emails}));
+  }
+
+  return $.when.apply($, profileSearch)
+  .then(function() {
+    var searchResults = _.toArray(arguments);
+    var profileMap = {};
+    if (!searchResults) {
+      return profileMap;
+    }
+    var addProfileToMap = function(profile) {
+      var name = _.find(profile.content.names, ['preferred', true]) || _.first(profile.content.names);
+      profile.name = _.isEmpty(name) ? view.prettyId(profile.id) : name.first + ' ' + name.last;
+      profile.email = profile.content.preferredEmail || profile.content.emails[0];
+      profile.allEmails = profile.content.emailsConfirmed;
+      profileMap[profile.id] = profile;
+    };
+    _.forEach(searchResults, function(result) {
+      _.forEach(result.profiles, addProfileToMap);
+    });
+    return profileMap;
+  })
+  .fail(function(error) {
+    displayError();
+    return null;
+  });
+};
+
+var getAllInvitations = function() {
+
+  var invitationsP = Webfield.getAll('/invitations', {
+    regex: WILDCARD_INVITATION,
+    invitee: true,
+    duedate: true,
+    replyto: true,
+    type: 'notes',
+    details: 'replytoNote,repliedNotes'
+  });
+
+  var edgeInvitationsP = Webfield.getAll('/invitations', {
+    regex: WILDCARD_INVITATION,
+    invitee: true,
+    duedate: true,
+    type: 'edges',
+    details: 'repliedEdges'
+  });
+
+  var tagInvitationsP = Webfield.getAll('/invitations', {
+    regex: WILDCARD_INVITATION,
+    invitee: true,
+    duedate: true,
+    type: 'tags',
+    details: 'repliedTags'
+  });
+
+  var filterInvitee = function(inv) {
+    return _.some(inv.invitees, function(invitee) { return invitee.indexOf(ETHICS_REVIEW_CHAIR_NAME) !== -1; });
+  };
+
+  return $.when(
+    invitationsP,
+    edgeInvitationsP,
+    tagInvitationsP
+  ).then(function(noteInvitations, edgeInvitations, tagInvitations) {
+    var invitations = noteInvitations.concat(edgeInvitations).concat(tagInvitations);
+    return _.filter(invitations, filterInvitee);
+  });
+};
+
+var formatData = function(groups, submissions, invitations, recruitmentGroups) {
+
+  var noteNumbers = getPaperNumbersfromGroups(groups.seniorAreaChairGroups);
+  submissions = submissions.filter(function(s) { return noteNumbers.indexOf(s.number) >= 0; });
+  var reviewerGroupMaps = buildReviewerGroupMaps(noteNumbers, groups.reviewerGroups, groups.anonReviewerGroups);
+  var allProfileIds = _.uniq(reviewerGroupMaps.profileIds).concat(areaChairGroupMaps.profileIds);
+
+  return getUserProfiles(allProfileIds)
+  .then(function(profiles) {
+    submissions.forEach(function(submission) {
+      selectedNotesById[submission.id] = false;
+      submission.details.reviews = getOfficialReviews(_.filter(submission.details.directReplies, ['invitation', getInvitationId(OFFICIAL_REVIEW_NAME, submission.number)]));
+      submission.details.reviewers = reviewerGroupMaps.byNotes[submission.number];
+    })
+
+    conferenceStatusData = {
+      profiles: profiles,
+      reviewerGroups: reviewerGroupMaps,
+      submissions: submissions,
+      invitations: invitations,
+      recruitmentGroups: recruitmentGroups
+    };
+  })
+
+};
+
+var renderTasks = function(invitations) {
+  //  My Tasks tab
+  var tasksOptions = {
+    container: '#ethics-chair-tasks',
+    emptyMessage: 'No outstanding tasks for this conference',
+    referrer: encodeURIComponent('[Ethics Chair Console](/group?id=' + CONFERENCE_ID + '/' + ETHICS_CHAIR_NAME + '#ethics-chair-tasks)')
+  }
+  $(tasksOptions.container).empty();
+
+  Webfield.ui.newTaskList(invitations, [], tasksOptions);
+  $('.tabs-container a[href="#ethics-chair-tasks"]').parent().show();
+}
+
+var renderTableAndTasks = function() {
+
+  displayOverview();
+  displayPaperStatusTable();
+  renderTasks(conferenceStatusData.invitations);
+
+  Webfield.ui.done();
+}
+
+var displayOverview = function() {
+
+  var reviewerGroup = _.find(conferenceStatusData.recruitmentGroups, ['id', CONFERENCE_ID + '/' + ETHICS_REVIEWERS_NAME])
+  var invitedReviewerGroup = _.find(conferenceStatusData.recruitmentGroups, ['id', CONFERENCE_ID + '/' + ETHICS_REVIEWERS_NAME + '/Invited'])
+
+  var renderStatContainer = function(title, stat, hint) {
+    return '<div class="col-md-4 col-xs-6">' +
+      '<h4>' + title + '</h4>' +
+      (hint ? '<p class="hint">' + hint + '</p>' : '') + stat +
+      '</div>';
+  };
+
+  // Conference statistics
+  var html = '<div class="row" style="margin-top: .5rem;">';
+  html += renderStatContainer(
+    'Ethics Reviewer Recruitment:',
+    '<h3>' + (reviewerGroup && reviewerGroup.members.length) + ' / ' + (invitedReviewerGroup && invitedReviewerGroup.members.length) + '</h3>',
+    'accepted / invited'
+  );
+  html += '</div>';
+  html += '<hr class="spacer" style="margin-bottom: 1rem;">';
+
+  // Official Committee
+  html += '<div class="row" style="margin-top: .5rem;">';
+  html += '<div class="col-md-4 col-xs-6">'
+  html += '<h4>Ethics Review Roles:</h4><ul style="padding-left: 15px">' +
+    '<li><a href="/group?id=' + ETHICS_CHAIRS_ID + '&mode=info">' + view.prettyId(ETHICS_CHAIRS_NAME) + '</a></li>';
+  html += '<li><a href="/group?id=' + ETHICS_REVIEWERS_ID + '&mode=info">' + view.prettyId(ETHICS_REVIEWERS_NAME) + '</a> (' +
+    '<a href="/group?id=' + ETHICS_REVIEWERS_ID + '/Invited&mode=info">Invited</a>, ' +
+    '<a href="/group?id=' + ETHICS_REVIEWERS_ID + '/Declined&mode=info">Declined</a>)</li></ul>';
+  html += '</div>';
+  html += '</div>';
+
+//   html += '<hr class="spacer" style="margin-bottom: 1rem;">';
+//   html += '<div class="row" style="margin-top: .5rem;">';
+//   html += '<div class="col-md-4 col-xs-6">'
+//   html += '<h4>Ethics Review Assignments:</h4>' +
+//     '<a href="/assignments?group=' + ETHICS_REVIEWERS_ID + '">See Assignments</a>';
+//   html += '</div>';
+//   html += '</div>';
+
+  $('#overview').html(html);
+};
+
+var buildPaperTableRow = function(note) {
+
+  var paperTableReferrerUrl = encodeURIComponent('[Ethics Chair Console](/group?id=' + CONFERENCE_ID + '/' + ETHICS_CHAIRS_NAME + '#paper-status)');
+  var reviewerIds = note.details.reviewers;
+  var completedReviews = note.details.reviews;
+
+  // Checkbox for selecting each row
+  var cellCheck = { selected: false, noteId: note.id };
+
+  // Build Note Summary Cell
+  var cell1 = note;
+  cell1.referrer = paperTableReferrerUrl;
+
+  // Build Review Progress Cell
+  var reviewObj;
+  var combinedObj = {};
+  var ratings = [];
+  var confidences = [];
+  for (var reviewerNum in reviewerIds) {
+    var reviewer = findProfile(reviewerIds[reviewerNum]);
+    if (reviewerNum in completedReviews || reviewer.id in completedReviews) {
+      reviewObj = completedReviews[reviewerNum] || completedReviews[reviewer.id];
+      combinedObj[reviewerNum] = _.assign({}, reviewer, {
+        id: reviewer.id,
+        name: reviewer.name,
+        email: reviewer.email,
+        completedReview: true,
+        forum: reviewObj.forum,
+        note: reviewObj.id,
+        rating: reviewObj.rating,
+        confidence: reviewObj.confidence,
+        reviewLength: reviewObj.content.review && reviewObj.content.review.length,
+      });
+      ratings.push(reviewObj.rating);
+      confidences.push(reviewObj.confidence);
+    } else {
+      var forumUrl = 'https://openreview.net/forum?' + $.param({
+        id: note.forum,
+        noteId: note.id,
+        invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, note.number)
+      });
+      var lastReminderSent = localStorage.getItem(forumUrl + '|' + reviewer.id);
+      combinedObj[reviewerNum] = _.assign({}, reviewer, {
+        id: reviewer.id,
+        name: reviewer.name,
+        email: reviewer.email,
+        forum: note.forum,
+        forumUrl: forumUrl,
+        paperNumber: note.number,
+        reviewerNumber: reviewerNum,
+        lastReminderSent: lastReminderSent ?
+          new Date(parseInt(lastReminderSent)).toLocaleDateString() :
+          lastReminderSent
+      });
+    }
+  }
+  var averageRating = 'N/A';
+  var minRating = 'N/A';
+  var maxRating = 'N/A';
+  if (ratings.length) {
+    averageRating = _.round(_.sum(ratings) / ratings.length, 2);
+    minRating = _.min(ratings);
+    maxRating = _.max(ratings);
+  }
+
+  var averageConfidence = 'N/A';
+  var minConfidence = 'N/A';
+  var maxConfidence = 'N/A';
+  if (confidences.length) {
+    averageConfidence = _.round(_.sum(confidences) / confidences.length, 2);
+    minConfidence = _.min(confidences);
+    maxConfidence = _.max(confidences);
+  }
+
+  var reviewProgressData = {
+    noteId: note.id,
+    paperNumber: note.number,
+    forumReplyCount: note.details['replyCount'],
+    numSubmittedReviews: Object.keys(completedReviews).length,
+    numReviewers: Object.keys(reviewerIds).length,
+    reviewers: combinedObj,
+    sendReminder: true,
+    showActivityModal: false,
+    expandReviewerList: false,
+    enableReviewerReassignment : false,
+    referrer: paperTableReferrerUrl
+  };
+
+  return {
+    cellCheck: cellCheck,
+    note: cell1,
+    reviewProgressData: reviewProgressData
+  }
+};
+
+var displayPaperStatusTable = function() {
+
+  var container = '#paper-status';
+
+  var rowData = _.map(conferenceStatusData.submissions, function(submission) {
+    return buildPaperTableRow(submission);
+  });
+  var filteredRows = null;
+  var toNumber = function(value) {
+    return value === 'N/A' ? 0 : value;
+  }
+  var order = 'desc';
+  var sortOptions = {
+    Paper_Number: function(row) { return row.note.number; },
+    Paper_Title: function(row) { return _.trim(row.note.content.title).toLowerCase(); },
+    Reviewers_Assigned: function(row) { return row.reviewProgressData.numReviewers; },
+    Reviews_Submitted: function(row) { return row.reviewProgressData.numSubmittedReviews; },
+    Reviews_Missing: function(row) { return row.reviewProgressData.numReviewers - row.reviewProgressData.numSubmittedReviews; },
+    Number_of_Forum_Replies: function(row) { return row.reviewProgressData.forumReplyCount; },
+  };
+
+  var sortResults = function(newOption, switchOrder) {
+    if (switchOrder) {
+      order = order === 'asc' ? 'desc' : 'asc';
+    }
+    var rowDataToRender = _.orderBy(filteredRows === null ? rowData : filteredRows, sortOptions[newOption], order);
+    renderTable(container, rowDataToRender);
+  };
+
+  var searchResults = function(searchText, isQueryMode) {
+    $(container).data('lastPageNum', 1);
+    $(container + ' .form-sort').val('Paper_Number');
+
+    // Currently only searching on note number and note title
+    var filterFunc = function(row) {
+      return (
+        (row.note.number + '').indexOf(searchText) === 0 ||
+        row.note.content.title.toLowerCase().indexOf(searchText) !== -1
+      );
+    };
+
+    if (searchText) {
+        if (isQueryMode) {
+            var filterResult = Webfield.filterCollections(rowData, searchText.slice(1), filterOperators, propertiesAllowed, 'note.id');
+            filteredRows = filterResult.filteredRows;
+            queryIsInvalid = filterResult.queryIsInvalid;
+            if (queryIsInvalid) $(container + ' .form-search').addClass('invalid-value');
+        } else {
+            filteredRows = _.filter(rowData, filterFunc);
+        }
+
+        filteredRows = _.orderBy(filteredRows, sortOptions['Paper_Number'], 'asc');
+        matchingNoteIds = filteredRows.map(function (row) {
+            return row.note.id;
+        });
+        order = 'asc'
+    } else {
+        filteredRows = rowData;
+        matchingNoteIds = [];
+    }
+    if (rowData.length !== filteredRows.length) {
+        conferenceStatusData.filteredRows = filteredRows
+      }
+    renderTable(container, filteredRows);
+  };
+
+  var renderTable = function(container, data) {
+    var paperNumbers = [];
+    var rowData = _.map(data, function(d) {
+      paperNumbers.push(d.note.number);
+
+      var numberHtml = '<strong class="note-number">' + d.note.number + '</strong>';
+      var checked = '<label><input type="checkbox" class="select-note-reviewers" data-note-id="' +
+        d.note.id + '" ' + (selectedNotesById[d.note.id] ? 'checked="checked"' : '') + '></label>';
+      var numberHtml = '<strong class="note-number">' + d.note.number + '</strong>';
+      var summaryHtml = Handlebars.templates.noteSummary(d.note);
+      var reviewHtml = Handlebars.templates.noteReviewers(d.reviewProgressData);
+      var areachairHtml = Handlebars.templates.noteAreaChairs(d.areachairProgressData);
+      var decisionHtml = '<h4>' + (d.decision ? d.decision.content.decision : 'No Decision') + '</h4>';
+
+      var rows = [numberHtml, summaryHtml, reviewHtml];
+      return rows;
+    });
+
+    var headings = ['#', 'Paper Summary', 'Ethics Review Progress'];
+
+    var $container = $(container);
+    var tableData = {
+      headings: headings,
+      rows: rowData,
+      extraClasses: 'console-table paper-table'
+    };
+    var pageNum = $container.data('lastPageNum') || 1;
+    renderPaginatedTable($container, tableData, pageNum);
+    postRenderTable(data, pageNum);
+
+    $container.off('click', 'ul.pagination > li > a').on('click', 'ul.pagination > li > a', function(e) {
+      paginationOnClick($(this).parent(), $container, tableData);
+
+      var newPageNum = parseInt($(this).parent().data('pageNumber'), 10);
+      postRenderTable(data, newPageNum);
+      return false;
+    });
+  
+
+  };
+
+  var postRenderTable = function(data, pageNum) {
+    $('#paper-status .console-table th').eq(0).css('width', '5%');
+    $('#paper-status .console-table th').eq(1).css('width', '50%');
+    $('#paper-status .console-table th').eq(2).css('width', '45%');
+
+    var offset = (pageNum - 1) * PAGE_SIZE;
+    var pageData = data.slice(offset, offset + PAGE_SIZE);
+
+    $(container + ' .console-table > tbody > tr .select-note-reviewers').each(function() {
+      var noteId = $(this).data('noteId');
+      $(this).prop('checked', selectedNotesById[noteId]);
+    });
+
+    var allSelected = _.every(Object.values(selectedNotesById));
+    $(container + ' .console-table #select-all-papers').prop('checked', allSelected);
+  };
+
+  if (rowData.length) {
+    displaySortPanel(container, sortOptions, sortResults, searchResults, true);
+    renderTable(container, rowData);
+  } else {
+    $(container).empty().append('<p class="empty-message">No papers have been submitted. ' +
+      'Check back later or contact info@openreview.net if you believe this to be an error.</p>');
+  }
+  paperStatusNeedsRerender = false;
+
+};
+
+var displaySortPanel = function(container, sortOptions, sortResults, searchResults, enableQuery) {
+  var searchType = container.substring(1).split('-')[0] + 's';
+  var placeHolder = enableQuery ? 'Enter search term or type + to start a query and press enter' : 'Search all ' + searchType + '...'
+  var searchBarWidth = enableQuery ? '440px' : '300px'
+  var searchBarHtml = _.isFunction(searchResults) ?
+    '<strong style="vertical-align: middle;">Search:</strong> ' +
+    '<input type="text" class="form-search form-control" class="form-control" placeholder="' + placeHolder + '" ' +
+      'style="width: ' + searchBarWidth + '; margin-right: 1.5rem; line-height: 34px;">' :
+    '';
+  var sortOptionsHtml = _.map(_.keys(sortOptions), function(option) {
+    return '<option class="' + option.replace(/_/g, '-') + '-' + container.substring(1) + '" value="' + option + '">' + option.replace(/_/g, ' ') + '</option>';
+  });
+  var sortDropdownHtml = sortOptionsHtml.length && _.isFunction(sortResults) ?
+    '<strong style="vertical-align: middle;">Sort By:</strong> ' +
+    '<select class="form-sort form-control" style="width: 250px; line-height: 1rem;">' + sortOptionsHtml + '</select>' +
+    '<button class="form-order btn btn-icon" type="button"><span class="glyphicon glyphicon-sort"></span></button>' :
+    '';
+
+  $(container).html(
+    '<form class="form-inline search-form clearfix" role="search">' +
+      '<div class="pull-left"></div>' +
+      '<div class="pull-right">' +
+        searchBarHtml +
+        sortDropdownHtml +
+      '</div>' +
+    '</form>'
+  );
+
+  $(container + ' select.form-sort').on('change', function(event) {
+    sortResults($(event.target).val(), false);
+  });
+  $(container + ' .form-order').on('click', function(event) {
+    sortResults($(container).find('.form-sort').val(), true);
+    return false;
+  });
+  $(container + ' .form-search').on('keyup', function (e) {
+    var searchText = $(container + ' .form-search').val().trim();
+    var searchLabel = $(container + ' .form-search').prevAll('strong:first').text();
+    if (enableQuery){
+      conferenceStatusData.filteredRows = null
+    }
+    $(container + ' .form-search').removeClass('invalid-value');
+
+    if (enableQuery && searchText.startsWith('+')) {
+      // filter query mode
+      if (searchLabel === 'Search:') {
+        $(container + ' .form-search').prevAll('strong:first').text('Query:');
+        $(container + ' .form-search').prevAll('strong:first').after($('<span/>', {
+          class: 'glyphicon glyphicon-info-sign'
+        }).hover(function (e) {
+          $(e.target).tooltip({
+            title: "<strong class='tooltip-title'>Query Mode Help</strong>\n<p>In Query mode, you can enter an expression and hit ENTER to search.<br/> The expression consists of property of a paper and a value you would like to search.</p><p>e.g. +number=5 will return the paper 5</p><p>Expressions may also be combined with AND/OR.<br>e.g. +number=5 OR number=6 OR number=7 will return paper 5,6 and 7.<br>If the value has multiple words, it should be enclosed in double quotes.<br>e.g. +title=\"some title to search\"</p><p>Braces can be used to organize expressions.<br>e.g. +number=1 OR ((number=5 AND number=7) OR number=8) will return paper 1 and 8.</p><p>Operators available:".concat(filterOperators.join(', '), "</p><p>Properties available:").concat(Object.keys(propertiesAllowed).join(', '), "</p>"),
+            html: true,
+            placement: 'bottom'
+          });
+        }));
+      }
+
+      if (e.key === 'Enter') {
+        searchResults(searchText, true);
+      }
+    } else {
+      if (enableQuery && searchLabel !== 'Search:') {
+        $(container + ' .form-search').prev().remove(); // remove info icon
+
+        $(container + ' .form-search').prev().text('Search:');
+      }
+
+      _.debounce(function () {
+        searchResults(searchText.toLowerCase(), false);
+      }, 300)();
+    }
+  });
+  $(container + ' form.search-form').on('submit', function() {
+    return false;
+  });
+};
+
+var renderPaginatedTable = function($container, tableData, pageNumber) {
+  if (!tableData.rows) {
+    tableData.rows = [];
+  }
+
+  $container.find('.table-container, .pagination-container').remove();
+
+  var offset = (pageNumber - 1) * PAGE_SIZE;
+  var tableHtml = Handlebars.templates['components/table']({
+    headings: tableData.headings,
+    rows: tableData.rows.slice(offset, offset + PAGE_SIZE),
+    extraClasses: tableData.extraClasses
+  });
+
+  var paginationHtml = null;
+  if (tableData.rows.length > PAGE_SIZE) {
+    paginationHtml = view.paginationLinks(tableData.rows.length, PAGE_SIZE, pageNumber);
+  }
+
+  $container.append(tableHtml, paginationHtml);
+
+  if (paginationHtml) {
+    $('ul.pagination', $container).css({ marginTop: '2.5rem', marginBottom: '0' });
+  }
+};
+
+var paginationOnClick = function($target, $container, tableData) {
+  if ($target.hasClass('disabled') || $target.hasClass('active')) {
+    return;
+  }
+
+  var pageNum = parseInt($target.data('pageNumber'), 10);
+  if (isNaN(pageNum)) {
+    return;
+  }
+
+  // Only way to get fresh data after doing reviewer re-assignment is to re-compute
+  // the whole table
+  if (paperStatusNeedsRerender) {
+    $('#paper-status').data('lastPageNum', pageNum);
+    displayPaperStatusTable();
+  } else {
+    renderPaginatedTable($container, tableData, pageNum);
+  }
+
+  var scrollPos = $container.offset().top - 104;
+  $('html, body').animate({scrollTop: scrollPos}, 400);
+
+  $container.data('lastPageNum', pageNum);
+};
+
+var postReviewerEmails = function(postData) {
+  var formttedData = _.pick(postData, ['groups', 'subject', 'message', 'parentGroup']);
+  formttedData.message = postData.message.replace('[[SUBMIT_REVIEW_LINK]]', postData.forumUrl);
+  if (EMAIL_SENDER) {
+    formttedData.from = EMAIL_SENDER;
+  }
+
+  return Webfield.post('/messages', formttedData)
+  .then(function() {
+    // Save the timestamp in the local storage
+    for (var i = 0; i < postData.groups.length; i++) {
+      var userId = postData.groups[i];
+      localStorage.setItem(postData.forumUrl + '|' + userId, Date.now());
+    }
+  });
+};
+
+$('#group-container').on('click', 'a.send-reminder-link', function(e) {
+  var $link = $(this);
+  var userId = $link.data('userId');
+  var forumUrl = $link.data('forumUrl');
+
+  var sendReviewerReminderEmails = function(e) {
+    var postData = {
+      groups: [userId],
+      forumUrl: forumUrl,
+      subject: $('#message-reviewers-modal input[name="subject"]').val().trim(),
+      message: $('#message-reviewers-modal textarea[name="message"]').val().trim(),
+    };
+
+    $('#message-reviewers-modal').modal('hide');
+    postReviewerEmails(postData);
+    promptMessage('A reminder email has been sent to ' + view.prettyId(userId), { overlay: true });
+    $link.after(' (Last sent: ' + (new Date()).toLocaleDateString() + ')');
+
+    return false;
+  };
+
+  var modalHtml = Handlebars.templates.messageReviewersModalFewerOptions({
+    singleRecipient: true,
+    reviewerId: userId,
+    forumUrl: forumUrl,
+    defaultSubject: SHORT_PHRASE + ' Reminder',
+    defaultBody: 'This is a reminder to please submit your ethics review for ' + SHORT_PHRASE + '. ' +
+      'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
+      '\n\nThank you,\n' + SHORT_PHRASE + ' ' + view.prettyId(ETHICS_CHAIRS_NAME),
+  });
+  $('#message-reviewers-modal').remove();
+  $('body').append(modalHtml);
+
+  $('#message-reviewers-modal .btn-primary').on('click', sendReviewerReminderEmails);
+  $('#message-reviewers-modal form').on('submit', sendReviewerReminderEmails);
+
+  $('#message-reviewers-modal').modal();
+  return false;
+});
+
+
+main();

--- a/openreview/conference/templates/ethicsChairsWebfield.js
+++ b/openreview/conference/templates/ethicsChairsWebfield.js
@@ -212,61 +212,6 @@ var buildReviewerGroupMaps = function(noteNumbers, reviewerGroups, anonReviewerG
   };
 };
 
-var buildAreaChairGroupMaps = function(noteNumbers, areaChairGroups, anonAreaChairGroups) {
-  var noteMap = buildNoteMap(noteNumbers);
-  var areaChairMap = {};
-  var profileIds = [];
-
-  areaChairGroups.forEach(function(g) {
-    var num = getNumberfromGroup(g.id, 'Paper');
-    if (num in noteMap) {
-      g.members.forEach(function(member, index) {
-        var anonGroup = anonAreaChairGroups.find(function(grp) {
-          return grp.id.startsWith(CONFERENCE_ID + '/Paper' + num + '/Area_Chair_') && grp.members.length && grp.members[0] == member;
-        });
-        if (anonGroup) {
-          var anonId = getNumberfromGroup(anonGroup.id, 'Area_Chair_')
-          noteMap[num][anonId] = member;
-          if (!(member in areaChairMap)) {
-            areaChairMap[member] = [];
-          }
-          areaChairMap[member].push(num);
-          profileIds.push(member);
-        }
-      })
-    }
-  });
-
-  return {
-    byNotes: noteMap,
-    byAreaChairs: areaChairMap,
-    profileIds: profileIds
-  };
-};
-
-var buildSeniorAreaChairGroupMaps = function(noteNumbers, seniorAreaChairGroups) {
-  var noteMap = buildNoteMap(noteNumbers);
-  var seniorAreaChairMap = {};
-
-  seniorAreaChairGroups.forEach(function(g) {
-    var num = getNumberfromGroup(g.id, 'Paper');
-    if (num in noteMap) {
-      g.members.forEach(function(member, index) {
-        noteMap[num] = member;
-        if (!(member in seniorAreaChairMap)) {
-          seniorAreaChairMap[member] = [];
-        }
-        seniorAreaChairMap[member].push(num);
-      })
-    }
-  });
-
-  return {
-    byNotes: noteMap,
-    bySeniorAreaChairs: seniorAreaChairMap
-  };
-};
-
 var getOfficialReviews = function(notes) {
   var ratingExp = /^(\d+): .*/;
 
@@ -366,10 +311,10 @@ var getAllInvitations = function() {
 
 var formatData = function(groups, submissions, invitations, recruitmentGroups) {
 
-  var noteNumbers = getPaperNumbersfromGroups(groups.seniorAreaChairGroups);
+  var noteNumbers = getPaperNumbersfromGroups(groups.reviewerGroups);
   submissions = submissions.filter(function(s) { return noteNumbers.indexOf(s.number) >= 0; });
   var reviewerGroupMaps = buildReviewerGroupMaps(noteNumbers, groups.reviewerGroups, groups.anonReviewerGroups);
-  var allProfileIds = _.uniq(reviewerGroupMaps.profileIds).concat(areaChairGroupMaps.profileIds);
+  var allProfileIds = _.uniq(reviewerGroupMaps.profileIds);
 
   return getUserProfiles(allProfileIds)
   .then(function(profiles) {
@@ -395,7 +340,7 @@ var renderTasks = function(invitations) {
   var tasksOptions = {
     container: '#ethics-chair-tasks',
     emptyMessage: 'No outstanding tasks for this conference',
-    referrer: encodeURIComponent('[Ethics Chair Console](/group?id=' + CONFERENCE_ID + '/' + ETHICS_CHAIR_NAME + '#ethics-chair-tasks)')
+    referrer: encodeURIComponent('[Ethics Chair Console](/group?id=' + CONFERENCE_ID + '/' + ETHICS_CHAIRS_NAME + '#ethics-chair-tasks)')
   }
   $(tasksOptions.container).empty();
 

--- a/openreview/conference/templates/reviewProcess.js
+++ b/openreview/conference/templates/reviewProcess.js
@@ -3,17 +3,20 @@ function(){
 
     var CONFERENCE_ID = '';
     var SHORT_PHRASE = '';
+    var OFFICIAL_REVIEW_NAME = '';
     var AUTHORS_NAME = '';
     var REVIEWERS_NAME = '';
     var AREA_CHAIRS_NAME = '';
     var PROGRAM_CHAIRS_ID = '';
     var USE_AREA_CHAIRS = false;
+    var ADD_SUBMITED = false;
 
     var forumNote = or3client.or3request(or3client.notesUrl+'?id='+note.forum, {}, 'GET', token);
 
     forumNote.then(function(result) {
       var forum = result.notes[0];
       var promises = [];
+      var reviewName = OFFICIAL_REVIEW_NAME.replace('_', ' ').toLocaleLowerCase();
 
       var AUTHORS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/' + AUTHORS_NAME;
       //TODO: use the variable instead, when we have anonymous groups integrated
@@ -22,13 +25,13 @@ function(){
       var ignoreGroups = note.nonreaders || [];
       ignoreGroups.push(note.tauthor);
 
-      var content = 'To view the review, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id;
+      var content = 'To view the ' + reviewName + ', click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id;
 
       if (PROGRAM_CHAIRS_ID) {
         var program_chair_mail = {
           groups: [PROGRAM_CHAIRS_ID],
           ignoreGroups: ignoreGroups,
-          subject: '[' + SHORT_PHRASE + '] A review has been received on Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject: '[' + SHORT_PHRASE + '] A ' + reviewName + ' has been received on Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'We have received a review on a submission to ' + SHORT_PHRASE + '.\n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, program_chair_mail, 'POST', token ));
@@ -36,8 +39,8 @@ function(){
 
       var review_writer_mail = {
         groups: note.signatures,
-        subject: '[' + SHORT_PHRASE + '] Your review has been received on your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
-        message: 'We have received your review on a submission to ' + SHORT_PHRASE + '.\n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\n' + content
+        subject: '[' + SHORT_PHRASE + '] Your ' + reviewName + ' has been received on your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+        message: 'We have received your ' + reviewName + ' on a submission to ' + SHORT_PHRASE + '.\n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\n' + content
       };
       promises.push(or3client.or3request( or3client.mailUrl, review_writer_mail, 'POST', token ));
 
@@ -45,7 +48,7 @@ function(){
         var areachair_mail = {
           groups: [AREA_CHAIRS_ID],
           ignoreGroups: ignoreGroups,
-          subject : '[' + SHORT_PHRASE + '] Review posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject : '[' + SHORT_PHRASE + '] ' + reviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'A submission to ' + SHORT_PHRASE + ', for which you are an official area chair, has received a review. \n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, areachair_mail, 'POST', token ));
@@ -56,7 +59,7 @@ function(){
         var reviewer_mail = {
           groups: [REVIEWERS_ID],
           ignoreGroups: ignoreGroups,
-          subject: '[' + SHORT_PHRASE + '] Review posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject: '[' + SHORT_PHRASE + '] ' + reviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'A submission to ' + SHORT_PHRASE + ', for which you are a reviewer, has received a review. \n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, reviewer_mail, 'POST', token ));
@@ -64,7 +67,7 @@ function(){
         var reviewer_mail = {
           groups: [reviewers_submitted],
           ignoreGroups: ignoreGroups,
-          subject: '[' + SHORT_PHRASE + '] Review posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject: '[' + SHORT_PHRASE + '] ' + reviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'A submission to ' + SHORT_PHRASE + ', for which you are a reviewer, has received a review. \n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, reviewer_mail, 'POST', token ));
@@ -74,7 +77,7 @@ function(){
         var author_mail = {
           groups: [AUTHORS_ID],
           ignoreGroups: ignoreGroups,
-          subject: '[' + SHORT_PHRASE + '] Review posted to your submission - Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject: '[' + SHORT_PHRASE + '] ' + reviewName +' posted to your submission - Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'Your submission to ' + SHORT_PHRASE + ' has received a review. \n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, author_mail, 'POST', token ));
@@ -82,7 +85,9 @@ function(){
 
       return Promise.all(promises)
       .then(function(result) {
-        return or3client.addGroupMember(reviewers_submitted, note.signatures[0], token);
+        if (ADD_SUBMITED) {
+          return or3client.addGroupMember(reviewers_submitted, note.signatures[0], token);
+        }
       })
     })
     .then(result => done())

--- a/openreview/conference/templates/reviewProcess.js
+++ b/openreview/conference/templates/reviewProcess.js
@@ -16,7 +16,8 @@ function(){
     forumNote.then(function(result) {
       var forum = result.notes[0];
       var promises = [];
-      var reviewName = OFFICIAL_REVIEW_NAME.replace('_', ' ').toLocaleLowerCase();
+      var capitalReviewName = OFFICIAL_REVIEW_NAME.replace('_', ' ');
+      var reviewName = capitalReviewName.toLocaleLowerCase();
 
       var AUTHORS_ID = CONFERENCE_ID + '/Paper' + forum.number + '/' + AUTHORS_NAME;
       //TODO: use the variable instead, when we have anonymous groups integrated
@@ -48,7 +49,7 @@ function(){
         var areachair_mail = {
           groups: [AREA_CHAIRS_ID],
           ignoreGroups: ignoreGroups,
-          subject : '[' + SHORT_PHRASE + '] ' + reviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject : '[' + SHORT_PHRASE + '] ' + capitalReviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'A submission to ' + SHORT_PHRASE + ', for which you are an official area chair, has received a review. \n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, areachair_mail, 'POST', token ));
@@ -59,7 +60,7 @@ function(){
         var reviewer_mail = {
           groups: [REVIEWERS_ID],
           ignoreGroups: ignoreGroups,
-          subject: '[' + SHORT_PHRASE + '] ' + reviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject: '[' + SHORT_PHRASE + '] ' + capitalReviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'A submission to ' + SHORT_PHRASE + ', for which you are a reviewer, has received a review. \n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, reviewer_mail, 'POST', token ));
@@ -67,7 +68,7 @@ function(){
         var reviewer_mail = {
           groups: [reviewers_submitted],
           ignoreGroups: ignoreGroups,
-          subject: '[' + SHORT_PHRASE + '] ' + reviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject: '[' + SHORT_PHRASE + '] ' + capitalReviewName + ' posted to your assigned Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'A submission to ' + SHORT_PHRASE + ', for which you are a reviewer, has received a review. \n\nPaper number: ' + forum.number + '\n\nPaper title: ' + forum.content.title + '\n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, reviewer_mail, 'POST', token ));
@@ -77,7 +78,7 @@ function(){
         var author_mail = {
           groups: [AUTHORS_ID],
           ignoreGroups: ignoreGroups,
-          subject: '[' + SHORT_PHRASE + '] ' + reviewName +' posted to your submission - Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
+          subject: '[' + SHORT_PHRASE + '] ' + capitalReviewName +' posted to your submission - Paper number: ' + forum.number + ', Paper title: "' + forum.content.title + '"',
           message: 'Your submission to ' + SHORT_PHRASE + ' has received a review. \n\n' + content
         };
         promises.push(or3client.or3request( or3client.mailUrl, author_mail, 'POST', token ));

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -128,18 +128,19 @@ var buildNoteMap = function(noteNumbers) {
 
 // AJAX functions
 var getReviewerNoteNumbers = function() {
+  var singularName = REVIEWER_NAME.endsWith('s') ? REVIEWER_NAME.slice(0, -1) : REVIEWER_NAME;
   return Webfield.getAll('/groups', {
     regex: WILDCARD_INVITATION,
     member: user.id
   }).then(function(groups) {
 
-    var anonGroups = _.filter(groups, function(g) { return g.id.includes('/Reviewer_'); });
+    var anonGroups = _.filter(groups, function(g) { return g.id.includes('/' + singularName + '_'); });
     var reviewerGroups = _.filter(groups, function(g) { return g.id.endsWith('/' + REVIEWER_NAME); });
 
     var groupByNumber = {};
     _.forEach(reviewerGroups, function(reviewerGroup) {
       var num = getNumberFromGroup(reviewerGroup.id, 'Paper');
-      var anonGroup = anonGroups.find(function(anonGroup) { return anonGroup.id.startsWith(CONFERENCE_ID + '/Paper' + num + '/Reviewer_'); });
+      var anonGroup = anonGroups.find(function(anonGroup) { return anonGroup.id.startsWith(CONFERENCE_ID + '/Paper' + num + '/' + singularName + '_'); });
       if (anonGroup) {
         groupByNumber[num] = anonGroup.id;
       }

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -418,6 +418,31 @@ class WebfieldBuilder(object):
             return self.__update_group(group, content)
 
 
+    def set_ethics_reviewer_page(self, conference, group):
+
+        reviewers_name = conference.ethics_reviewers_name
+
+        header = {
+            'title': reviewers_name.replace('_', ' ') + ' Console',
+            'instructions': '<p class="dark">This page provides information and status \
+            updates for the ' + conference.get_short_name() + '. It will be regularly updated as the conference \
+            progresses, so please check back frequently.</p>',
+            'schedule': ''
+        }
+
+        with open(os.path.join(os.path.dirname(__file__), f'templates/reviewerWebfield.js')) as f:
+            content = f.read()
+            content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference.get_id() + "';")
+            content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + conference.get_submission_id() + "';")
+            content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
+            content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
+            content = content.replace("var REVIEWER_NAME = '';", "var REVIEWER_NAME = '" + conference.ethics_reviewers_name + "';")
+            content = content.replace("var AREACHAIR_NAME = '';", "var AREACHAIR_NAME = '" + conference.area_chairs_name + "';")
+            content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.ethics_review_stage.name + "';")
+            content = content.replace("var CUSTOM_LOAD_INVITATION = '';", "var CUSTOM_LOAD_INVITATION = '" + conference.id + '/' + reviewers_name + '/-/Reduced_Load' + "';")
+            return self.__update_group(group, content)
+
+
     def set_area_chair_page(self, conference, group):
 
         area_chair_name = conference.area_chairs_name

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -440,6 +440,7 @@ class WebfieldBuilder(object):
             content = content.replace("var AREACHAIR_NAME = '';", "var AREACHAIR_NAME = '" + conference.area_chairs_name + "';")
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.ethics_review_stage.name + "';")
             content = content.replace("var CUSTOM_LOAD_INVITATION = '';", "var CUSTOM_LOAD_INVITATION = '" + conference.id + '/' + reviewers_name + '/-/Reduced_Load' + "';")
+            content = content.replace("var REVIEW_RATING_NAME = 'rating';", "var REVIEW_RATING_NAME = 'recommendation';")
             return self.__update_group(group, content)
 
 
@@ -514,6 +515,33 @@ class WebfieldBuilder(object):
             content = content.replace("var REVIEWERS_ID = '';", "var REVIEWERS_ID = '" + conference.get_reviewers_id() + "';")
             content = content.replace("var AREA_CHAIRS_ID = '';", "var AREA_CHAIRS_ID = '" + conference.get_area_chairs_id() + "';")
             return self.__update_group(group, content)
+
+
+    def set_ethics_chairs_page(self, conference, group):
+
+        ethics_chairs_name = conference.ethics_chairs_name
+
+        header = {
+            'title': ethics_chairs_name.replace('_', ' ') + ' Console',
+            'instructions': '<p class="dark">This page provides information and status \
+            updates for the ' + conference.get_short_name() + '. It will be regularly updated as the conference \
+            progresses, so please check back frequently.</p>',
+            'schedule': '<h4>Coming Soon</h4>\
+            <p>\
+                <em><strong>Please check back later for updates.</strong></em>\
+            </p>'
+        }
+
+        with open(os.path.join(os.path.dirname(__file__), f'templates/ethicsChairsWebfield.js')) as f:
+            content = f.read()
+            content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference.get_id() + "';")
+            content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
+            content = content.replace("var SHORT_PHRASE = '';", f'var SHORT_PHRASE = "{conference.get_short_name()}";')
+            content = content.replace("var ETHICS_CHAIRS_NAME = '';", "var ETHICS_CHAIRS_NAME = '" + conference.ethics_chairs_name + "';")
+            content = content.replace("var ETHICS_REVIEWERS_NAME = '';", "var ETHICS_REVIEWERS_NAME = '" + conference.ethics_reviewers_name + "';")
+            content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.ethics_review_stage.name + "';")
+            content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
+            return self.__update_group(group, content)            
 
     def set_program_chair_page(self, conference, group):
 

--- a/openreview/invitations/content.py
+++ b/openreview/invitations/content.py
@@ -115,6 +115,26 @@ review = {
     }
 }
 
+ethics_review = {
+    "recommendation": {
+        "order": 1,
+        "value-radio": [
+            "1: No serious ethical issues",
+            "2: Serious ethical issues that need to be addressed in the final version",
+            "3: Paper should be rejected due to ethical issues"
+      ],
+      "description": "Please select your ethical recommendation",
+      "required": True
+    },
+    "ethics_review": {
+      "order": 2,
+      "value-regex": "[\\S\\s]{1,200000}",
+      "description": "Provide justification for your suggested ethics issues. Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.",
+      "required": False,
+      "markdown": True
+    }
+}
+
 meta_review = {
     'metareview': {
         'order': 1,

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -246,6 +246,22 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
         signatures = ['~Super_User1']
     ))
 
+    if (forum.content.get('ethics_chairs_and_reviewers')):
+        client.post_invitation(openreview.Invitation(
+            id = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Ethics_Review_Stage',
+            super = SUPPORT_GROUP + '/-/Ethics_Review_Stage',
+            invitees = readers,
+            reply = {
+                'forum': forum.id,
+                'referent': forum.id,
+                'readers': {
+                    'description': 'The users who will be allowed to read the above content.',
+                    'values' : readers
+                }
+            },
+            signatures = ['~Super_User1']
+        ))    
+
     if (forum.content.get('Area Chairs (Metareviewers)') == "Yes, our venue has Area Chairs") :
         client.post_invitation(openreview.Invitation(
             id = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Meta_Review_Stage',

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -246,7 +246,7 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
         signatures = ['~Super_User1']
     ))
 
-    if (forum.content.get('ethics_chairs_and_reviewers')):
+    if (forum.content.get('ethics_chairs_and_reviewers') == 'Yes, our venue has Ethics Chairs and Reviewers'):
         client.post_invitation(openreview.Invitation(
             id = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Ethics_Review_Stage',
             super = SUPPORT_GROUP + '/-/Ethics_Review_Stage',

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -37,6 +37,9 @@ def process(client, note, invitation):
         elif invitation_type == 'Review_Stage':
             conference.set_review_stage(openreview.helpers.get_review_stage(client, forum_note))
 
+        elif invitation_type == 'Ethics_Review_Stage':
+            conference.set_ethics_review_stage(openreview.helpers.get_ethics_review_stage(client, forum_note))
+
         elif invitation_type == 'Meta_Review_Stage':
             conference.set_meta_review_stage(openreview.helpers.get_meta_review_stage(client, forum_note))
 

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -35,10 +35,10 @@ def process(client, note, invitation):
                 conference.set_bid_stage(openreview.helpers.get_bid_stage(client, forum_note, conference.get_area_chairs_id()))
 
         elif invitation_type == 'Review_Stage':
-            conference.set_review_stage(openreview.helpers.get_review_stage(client, forum_note))
+            conference.create_review_stage()
 
         elif invitation_type == 'Ethics_Review_Stage':
-            conference.set_ethics_review_stage(openreview.helpers.get_ethics_review_stage(client, forum_note))
+            conference.create_ethics_review_stage()
 
         elif invitation_type == 'Meta_Review_Stage':
             conference.set_meta_review_stage(openreview.helpers.get_meta_review_stage(client, forum_note))

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -29,6 +29,33 @@ def process(client, note, invitation):
                     matching_invitation.cdate = openreview.tools.datetime_millis(submission_deadline)
                     client.post_invitation(matching_invitation)
 
+            if conference.use_ethics_chairs or conference.use_ethics_reviewers:
+                client.post_invitation(openreview.Invitation(
+                    id = SUPPORT_GROUP + '/-/Request' + str(forum_note.number) + '/Ethics_Review_Stage',
+                    super = SUPPORT_GROUP + '/-/Ethics_Review_Stage',
+                    invitees = [conference.get_program_chairs_id(), SUPPORT_GROUP],
+                    reply = {
+                        'forum': forum_note.id,
+                        'referent': forum_note.id,
+                        'readers': {
+                            'description': 'The users who will be allowed to read the above content.',
+                            'values' : [conference.get_program_chairs_id(), SUPPORT_GROUP]
+                        }
+                    },
+                    signatures = ['~Super_User1']
+                ))
+
+                recruitment_invitation = openreview.tools.get_invitation(client, SUPPORT_GROUP + '/-/Request' + str(forum_note.number) + '/Recruitment')
+                if recruitment_invitation:
+                    recruitment_invitation.reply['content']['invitee_role']['value-dropdown'] = conference.get_roles()
+                    client.post_invitation(recruitment_invitation)
+
+                remind_recruitment_invitation = openreview.tools.get_invitation(client, SUPPORT_GROUP + '/-/Request' + str(forum_note.number) + '/Remind_Recruitment')
+                if remind_recruitment_invitation:
+                    remind_recruitment_invitation.reply['content']['invitee_role']['value-dropdown'] = conference.get_roles()
+                    client.post_invitation(remind_recruitment_invitation)
+
+
         elif invitation_type == 'Bid_Stage':
             conference.set_bid_stage(openreview.helpers.get_bid_stage(client, forum_note, conference.get_reviewers_id()))
             if forum_note.content.get('Area Chairs (Metareviewers)', '') == 'Yes, our venue has Area Chairs':

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -195,6 +195,107 @@ class VenueStages():
             }
         ))
 
+    def setup_ethics_review_stage(self):
+
+        ethics_review_stage_content = {
+            'ethics_review_start_date': {
+                'description': 'When does reviewing of submissions begin? Please use the following format: YYYY/MM/DD HH:MM (e.g. 2019/01/31 23:59)',
+                'value-regex': r'^[0-9]{4}\/([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[1-2][0-9]|3[0-1])(\s+)?((2[0-3]|[01][0-9]|[0-9]):[0-5][0-9])?(\s+)?$',
+                'order': 1
+            },
+            'ethics_review_deadline': {
+                'description': 'When does reviewing of submissions end? Please use the following format: YYYY/MM/DD HH:MM (e.g. 2019/01/31 23:59)',
+                'value-regex': r'^[0-9]{4}\/([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[1-2][0-9]|3[0-1])(\s+)?((2[0-3]|[01][0-9]|[0-9]):[0-5][0-9])?(\s+)?$',
+                'required': True,
+                'order': 2
+            },
+            'make_ethics_reviews_public': {
+                'description': "Should the ethics reviews be made public immediately upon posting? Note that selecting 'Yes' will automatically release any posted ethics reviews to the public if the submission is also public.",
+                'value-radio': [
+                    'Yes, ethics reviews should be revealed publicly when they are posted',
+                    'No, ethics reviews should NOT be revealed publicly when they are posted'
+                ],
+                'required': True,
+                'default': 'Yes, ethics reviews should be revealed publicly when they are posted',
+                'order': 3
+            },
+            'release_ethics_reviews_to_authors': {
+                'description': 'Should the ethics reviews be visible to paper\'s authors immediately upon posting? Default is "No, ethics reviews should NOT be revealed when they are posted to the paper\'s authors".',
+                'value-radio': [
+                    'Yes, ethics reviews should be revealed when they are posted to the paper\'s authors',
+                    'No, ethics reviews should NOT be revealed when they are posted to the paper\'s authors'
+                ],
+                'required': True,
+                'default': 'No, ethics reviews should NOT be revealed when they are posted to the paper\'s authors',
+                'order': 4
+            },
+            'release_ethics_reviews_to_reviewers': {
+                'description': 'Should the reviews be visible to all reviewers, all assigned reviewers, assigned reviewers who have already submitted their own review or only the author of the review immediately upon posting?',
+                'value-radio': [
+                    'Ethics reviews should be immediately revealed to all reviewers and ethics reviewers',
+                    'Ethics reviews should be immediately revealed to the paper\'s reviewers and ethics reviewers',
+                    'Ethics reviews should be immediately revealed to the paper\'s ethics reviewers',
+                    'Ethics Review should not be revealed to any reviewer, except to the author of the ethics review'
+                ],
+                'required': True,
+                'default': 'Review should not be revealed to any reviewer, except to the author of the review',
+                'order': 5
+            },
+            'flagged_submissions': {
+                'order' : 6,
+                'value-regex': '.*',
+                'required': True,
+                'description': 'Comma separated values of submission numbers that ethics reviews must be enabled.'
+            },
+            'additional_ethics_review_form_options': {
+                'order' : 7,
+                'value-dict': {},
+                'required': False,
+                'description': 'Configure additional options in the ethics review form. Use lowercase for the field names and underscores to represent spaces. The UI will auto-format the names, for example: supplementary_material -> Supplementary Material. Valid JSON expected.'
+            },
+            'remove_ethics_review_form_options': {
+                'order': 8,
+                'value-regex': r'^[^,]+(,\s*[^,]*)*$',
+                'required': False,
+                'description': 'Comma separated list of fields (recommendation, ethics_review) that you want removed from the review form.'
+            },
+            "release_submissions_to_ethics_reviewers": {
+                "description": "Confirm that you want to release the submissions to the ethics reviewers if they are no currently released.",
+                "order": 9,
+                "value-radio": [
+                    "We confirm we want to release the submissions to the ethics reviewers",
+                    "We confirm we want to release the submissions and reviews to the ethics reviewers"
+                ],
+                "required": True
+            }           
+        }
+
+        return self.venue_request.client.post_invitation(openreview.Invitation(
+            id='{}/-/Ethics_Review_Stage'.format(self.venue_request.support_group.id),
+            readers=['everyone'],
+            writers=[self.venue_request.support_group.id],
+            signatures=[self.venue_request.super_user],
+            invitees=['everyone'],
+            multiReply=True,
+            process_string=self.file_content,
+            reply={
+                'readers': {
+                    'values-copied': [
+                        self.venue_request.support_group.id,
+                        '{content["program_chair_emails"]}'
+                    ]
+                },
+                'writers': {
+                    'values':[],
+                },
+                'signatures': {
+                    'values-regex': '~.*|{}'.format(self.venue_request.support_group.id)
+                },
+                'content': ethics_review_stage_content
+            }
+        ))
+
+
     def setup_comment_stage(self):
 
         comment_stage_content = {
@@ -620,6 +721,7 @@ class VenueRequest():
         self.venue_revision_invitation = venue_stages.setup_venue_revision()
         self.bid_stage_super_invitation = venue_stages.setup_bidding_stage()
         self.review_stage_super_invitation = venue_stages.setup_review_stage()
+        self.ethics_review_stage_super_invitation = venue_stages.setup_ethics_review_stage()
         self.comment_stage_super_invitation = venue_stages.setup_comment_stage()
         self.meta_review_stage_super_invitation = venue_stages.setup_meta_review_stage()
         self.submission_revision_stage_super_invitation = venue_stages.setup_submission_revision_stage()

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -241,11 +241,11 @@ class VenueStages():
                 'default': 'Review should not be revealed to any reviewer, except to the author of the review',
                 'order': 5
             },
-            'flagged_submissions': {
+            'ethics_review_submissions': {
                 'order' : 6,
                 'value-regex': '.*',
                 'required': True,
-                'description': 'Comma separated values of submission numbers that ethics reviews must be enabled.'
+                'description': 'Comma separated values of submission numbers that need ethics reviews.'
             },
             'additional_ethics_review_form_options': {
                 'order' : 7,

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -682,6 +682,16 @@ class VenueRequest():
                 'required': False,
                 'order': 8
             },
+            'ethics_chairs_and_reviewers': {
+                'description': 'Are you going to have Ethics reviews?. In case of yes, you need to recruit Ethics Chair and Reviewers',
+                'value-radio': [
+                    'Yes, our venue has Ethics Chairs and Reviewers',
+                    'Yes, our venue has Ethics Reviewers only'
+                    'No, our venue does not have Ethics Chairs and Reviewers'
+                ],
+                'required': False,
+                'order': 9
+            },
             'Submission Start Date': {
                 'description': 'When would you (ideally) like to have your OpenReview submission portal opened? Please specify the date and time in GMT using the following format: YYYY/MM/DD HH:MM(e.g. 2019/01/31 23:59). (Skip this if only requesting paper matching service)',
                 'value-regex': '.*',

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -788,7 +788,6 @@ class VenueRequest():
                 'description': 'Are you going to have Ethics reviews?. In case of yes, you need to recruit Ethics Chair and Reviewers',
                 'value-radio': [
                     'Yes, our venue has Ethics Chairs and Reviewers',
-                    'Yes, our venue has Ethics Reviewers only'
                     'No, our venue does not have Ethics Chairs and Reviewers'
                 ],
                 'required': False,

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -266,10 +266,7 @@ class VenueStages():
             "release_submissions_to_ethics_reviewers": {
                 "description": "Confirm that you want to release the submissions to the ethics reviewers if they are no currently released.",
                 "order": 9,
-                "value-radio": [
-                    "We confirm we want to release the submissions to the ethics reviewers",
-                    "We confirm we want to release the submissions and reviews to the ethics reviewers"
-                ],
+                "value-checkbox": "We confirm we want to release the submissions and reviews to the ethics reviewers",
                 "required": True
             }           
         }

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -991,6 +991,15 @@ The Reviewer Reviewer ARR MIT(<a href=\"mailto:reviewer_arr2@mit.edu\">reviewer_
 
         submissions=venue.get_submissions(number=5)
 
+        submission = ethics_reviewer_client.get_note(submissions[0].id)
+        assert 'aclweb.org/ACL/ARR/2021/September/Paper5/Ethics_Reviewers' in submission.readers
+        assert 'aclweb.org/ACL/ARR/2021/September/Ethics_Chairs' in submission.readers
+
+        reviews = ethics_reviewer_client.get_notes(forum=submission.id, invitation='aclweb.org/ACL/ARR/2021/September/Paper5/-/Official_Review')
+        assert len(reviews) == 1
+        assert 'aclweb.org/ACL/ARR/2021/September/Paper5/Ethics_Reviewers' in reviews[0].readers
+        assert 'aclweb.org/ACL/ARR/2021/September/Ethics_Chairs' in reviews[0].readers
+
         signatory_groups=client.get_groups(regex='aclweb.org/ACL/ARR/2021/September/Paper5/Ethics_Reviewer_', signatory='ethic_reviewer@arr.org')
         assert len(signatory_groups) == 1        
 
@@ -1006,5 +1015,9 @@ The Reviewer Reviewer ARR MIT(<a href=\"mailto:reviewer_arr2@mit.edu\">reviewer_
                 'ethics_concerns': 'This paper is ok',
                 'recommendation': '1: No serious ethical issues'
             }
-
         ))
+
+        helpers.await_queue()
+
+        messages = client.get_messages(to='ethic_reviewer@arr.org', subject="[ARR 2021 - September] Your ethics review has been received on your assigned Paper number: 5, Paper title: \"Paper title 5\"")
+        assert len(messages) == 1

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -962,7 +962,7 @@ The Reviewer Reviewer ARR MIT(<a href=\"mailto:reviewer_arr2@mit.edu\">reviewer_
                         "required": True
                     }                    
                 },
-                'flagged_submissions': '1,5',
+                'ethics_review_submissions': '1,5',
                 'release_submissions_to_ethics_reviewers': 'We confirm we want to release the submissions and reviews to the ethics reviewers'
             },
             forum=request_form.forum,

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -985,6 +985,9 @@ The Reviewer Reviewer ARR MIT(<a href=\"mailto:reviewer_arr2@mit.edu\">reviewer_
 
         helpers.await_queue()
 
+        ## ethics chairs should be able to add ethics reviewers manually
+        ethics_chair_client.add_members_to_group('aclweb.org/ACL/ARR/2021/September/Ethics_Reviewers', 'another@ethics_reviewer.org')
+
         groups = client.get_groups(regex='aclweb.org/ACL/ARR/2021/September/Paper.*/Ethics_Reviewers')
         assert len(groups) == 2
         assert client.get_group('aclweb.org/ACL/ARR/2021/September/Paper1/Ethics_Reviewers')

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -37,6 +37,7 @@ class TestARRVenue():
         helpers.create_user('reviewer_arr3@ibm.com', 'Reviewer ARR', 'IBM', institution='ibm.com')
         helpers.create_user('reviewer_arr4@fb.com', 'Reviewer ARR', 'Facebook', institution='fb.com')
         helpers.create_user('reviewer_arr5@google.com', 'Reviewer ARR', 'Google', institution='google.com')
+        helpers.create_user('ethic_chair@arr.org', 'Ethics', 'Chair', institution='google.com')
 
         request_form_note = pc_client.post_note(openreview.Note(
             invitation='openreview.net/Support/-/Request_Form',

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -949,6 +949,7 @@ The Reviewer Reviewer ARR MIT(<a href=\"mailto:reviewer_arr2@mit.edu\">reviewer_
     def test_ethics_review_stage(self, venue, client, helpers):
 
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password='1234')
+        ethics_chair_client=openreview.Client(username='ethic_chair@arr.org', password='1234')
         ## Need super user permission to add the venue to the active_venues group
         request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form', sort='tmdate')[0]
 
@@ -999,13 +1000,14 @@ The Reviewer Reviewer ARR MIT(<a href=\"mailto:reviewer_arr2@mit.edu\">reviewer_
         ## Assign ethics reviewer
         ethics_reviewer_client = helpers.create_user('ethic_reviewer@arr.org', 'Ethics', 'Reviewer')
         
-        pc_client.post_edge(openreview.Edge(
+        ethics_chair_client.post_edge(openreview.Edge(
             invitation='aclweb.org/ACL/ARR/2021/September/Ethics_Reviewers/-/Assignment',
-            readers=['aclweb.org/ACL/ARR/2021/September', '~Ethics_Reviewer1'],
-            writers=['aclweb.org/ACL/ARR/2021/September'],
+            readers=['aclweb.org/ACL/ARR/2021/September', 'aclweb.org/ACL/ARR/2021/September/Ethics_Chairs', '~Ethics_Reviewer1'],
+            nonreaders=['aclweb.org/ACL/ARR/2021/September/Paper5/Authors'],
+            writers=['aclweb.org/ACL/ARR/2021/September', 'aclweb.org/ACL/ARR/2021/September/Ethics_Chairs'],
             head=submissions[0].id,
             tail='~Ethics_Reviewer1',
-            signatures=['aclweb.org/ACL/ARR/2021/September/Program_Chairs']
+            signatures=['aclweb.org/ACL/ARR/2021/September/Ethics_Chairs']
         ))
         
         helpers.await_queue()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -193,10 +193,10 @@ class TestClient():
         assert len(invitations) == 5
 
         invitations = client.get_invitations(invitee = True, duedate = True, details = 'replytoNote,repliedNotes')
-        assert len(invitations) == 11
+        assert len(invitations) == 22
 
         invitations = client.get_invitations(invitee = True, duedate = True, replyto = True, details = 'replytoNote,repliedNotes')
-        assert len(invitations) == 3
+        assert len(invitations) == 10
 
         invitations = client.get_invitations(invitee = True, duedate = True, tags = True, details = 'repliedTags')
         assert len(invitations) == 0

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import openreview
+from openreview.conference.builder import ReviewStage
 import pytest
 import requests
 import datetime
@@ -334,7 +335,7 @@ class TestCommentNotification():
             "Algorithms: Exact Inference",
         ])
         builder.set_comment_stage(email_pcs = True, unsubmitted_reviewers = False, authors=True)
-        builder.set_review_stage(release_to_authors=True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED)
+        builder.set_review_stage(openreview.ReviewStage(release_to_authors=True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED))
         builder.has_area_chairs(True)
         builder.use_legacy_anonids(True)
         conference = builder.get_result()

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -339,6 +339,7 @@ class TestCommentNotification():
         builder.has_area_chairs(True)
         builder.use_legacy_anonids(True)
         conference = builder.get_result()
+        conference.create_review_stage()
 
         note = openreview.Note(invitation = conference.get_submission_id(),
             readers = [conference.id, '~SomeFirstName_User1', 'author@mail.com', 'author2@mail.com'],

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -988,13 +988,13 @@ class TestDoubleBlindConference():
         conference.set_area_chairs(emails = ['ac@mail.com'])
         conference.set_reviewers(emails = ['reviewer2@mail.com', 'reviewer@domain.com'])
 
-        request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token, by=By.CLASS_NAME, wait_for_element='note')
+        request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tabs-containe')
         tabs = selenium.find_element_by_class_name('tabs-container')
         assert tabs
         notes = selenium.find_elements_by_class_name('note')
         assert len(notes) == 3
 
-        request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token, by=By.CLASS_NAME, wait_for_element='note')
+        request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token, by=By.CLASS_NAME, wait_for_element='tabs-containe')
         tabs = selenium.find_element_by_class_name('tabs-container')
         assert tabs
         notes = selenium.find_elements_by_class_name('note')
@@ -1067,6 +1067,7 @@ class TestDoubleBlindConference():
         conference = builder.get_result()
         conference.set_area_chairs(emails = ['ac@mail.com'])
         conference.set_reviewers(emails = ['reviewer2@mail.com'])
+        conference.create_review_stage()
 
         notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission', sort='numbers:asc')
         submission = notes[0]
@@ -1848,7 +1849,8 @@ class TestDoubleBlindConference():
         builder.get_result()
 
         builder.set_review_stage(openreview.ReviewStage(public=True))
-        builder.get_result()
+        conference = builder.get_result()
+        conference.create_review_stage()
 
         reviews = client.get_notes(invitation='AKBC.ws/2019/Conference/Paper.*/-/Official_Review')
         assert(reviews)

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1062,7 +1062,7 @@ class TestDoubleBlindConference():
         builder.set_submission_stage(double_blind = True, public = True)
         builder.has_area_chairs(True)
         builder.set_conference_short_name('AKBC 2019')
-        builder.set_review_stage(due_date = now + datetime.timedelta(minutes = 10), release_to_authors = True, release_to_reviewers = openreview.ReviewStage.Readers.REVIEWERS_ASSIGNED, email_pcs = True)
+        builder.set_review_stage(openreview.ReviewStage(due_date = now + datetime.timedelta(minutes = 10), release_to_authors = True, release_to_reviewers = openreview.ReviewStage.Readers.REVIEWERS_ASSIGNED, email_pcs = True))
         builder.use_legacy_anonids(True)
         conference = builder.get_result()
         conference.set_area_chairs(emails = ['ac@mail.com'])
@@ -1847,7 +1847,7 @@ class TestDoubleBlindConference():
         builder.set_conference_year(2019)
         builder.get_result()
 
-        builder.set_review_stage(public=True)
+        builder.set_review_stage(openreview.ReviewStage(public=True))
         builder.get_result()
 
         reviews = client.get_notes(invitation='AKBC.ws/2019/Conference/Paper.*/-/Official_Review')

--- a/tests/test_legacy_invitations.py
+++ b/tests/test_legacy_invitations.py
@@ -38,6 +38,7 @@ class TestLegacyInvitations():
         builder.set_review_stage(openreview.ReviewStage(due_date = now + datetime.timedelta(minutes = 40)))
         builder.set_meta_review_stage(due_date = now + datetime.timedelta(minutes = 40))
         conference = builder.get_result()
+        conference.create_review_stage()
 
         note = openreview.Note(invitation = conference.get_submission_id(),
             readers = ['~SomeFirstName_User1', 'peter@mail.com', 'andrew@mail.com'],

--- a/tests/test_legacy_invitations.py
+++ b/tests/test_legacy_invitations.py
@@ -35,7 +35,7 @@ class TestLegacyInvitations():
             withdrawn_submission_reveal_authors=True,
             desk_rejected_submission_public=True,
             desk_rejected_submission_reveal_authors=True)
-        builder.set_review_stage(due_date = now + datetime.timedelta(minutes = 40))
+        builder.set_review_stage(openreview.ReviewStage(due_date = now + datetime.timedelta(minutes = 40)))
         builder.set_meta_review_stage(due_date = now + datetime.timedelta(minutes = 40))
         conference = builder.get_result()
 

--- a/tests/test_open_submissions.py
+++ b/tests/test_open_submissions.py
@@ -36,7 +36,7 @@ class TestOpenSubmissions():
             withdrawn_submission_reveal_authors=True,
             desk_rejected_submission_reveal_authors=True
         )
-        builder.set_review_stage(public=True, due_date=now + datetime.timedelta(minutes = 40), email_pcs=True)
+        builder.set_review_stage(openreview.ReviewStage(public=True, due_date=now + datetime.timedelta(minutes = 40), email_pcs=True))
         builder.set_comment_stage(allow_public_comments=True, email_pcs=True, reader_selection=True, authors=True)
         builder.set_decision_stage(public=True, due_date=now + datetime.timedelta(minutes = 40), options = ['Accept', 'Reject'], email_authors=True)
         builder.enable_reviewer_reassignment(enable = True)

--- a/tests/test_open_submissions.py
+++ b/tests/test_open_submissions.py
@@ -42,6 +42,7 @@ class TestOpenSubmissions():
         builder.enable_reviewer_reassignment(enable = True)
         conference = builder.get_result()
         conference.set_program_chairs(['pc@aclweb.org'])
+        conference.create_review_stage()
         return conference
 
 

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -88,7 +88,7 @@ class TestReviewersConference():
         })
         now = datetime.datetime.utcnow()
         builder.set_submission_stage(due_date = now + datetime.timedelta(minutes = 40), public=True, withdrawn_submission_reveal_authors=True, desk_rejected_submission_reveal_authors=True)
-        builder.set_review_stage(openeview.ReviewStage(due_date = now + datetime.timedelta(minutes = 10), allow_de_anonymization = True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED))
+        builder.set_review_stage(openreview.ReviewStage(due_date = now + datetime.timedelta(minutes = 10), allow_de_anonymization = True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED))
         conference = builder.get_result()
         conference.create_review_stage()
 

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -90,6 +90,7 @@ class TestReviewersConference():
         builder.set_submission_stage(due_date = now + datetime.timedelta(minutes = 40), public=True, withdrawn_submission_reveal_authors=True, desk_rejected_submission_reveal_authors=True)
         builder.set_review_stage(openeview.ReviewStage(due_date = now + datetime.timedelta(minutes = 10), allow_de_anonymization = True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED))
         conference = builder.get_result()
+        conference.create_review_stage()
 
         note = openreview.Note(invitation = conference.get_submission_id(),
             readers = [conference.id, '~SomeFirstName_User1', 'author@mail.com', 'author2@mail.com'],

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -88,7 +88,7 @@ class TestReviewersConference():
         })
         now = datetime.datetime.utcnow()
         builder.set_submission_stage(due_date = now + datetime.timedelta(minutes = 40), public=True, withdrawn_submission_reveal_authors=True, desk_rejected_submission_reveal_authors=True)
-        builder.set_review_stage(due_date = now + datetime.timedelta(minutes = 10), allow_de_anonymization = True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED)
+        builder.set_review_stage(openeview.ReviewStage(due_date = now + datetime.timedelta(minutes = 10), allow_de_anonymization = True, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED))
         conference = builder.get_result()
 
         note = openreview.Note(invitation = conference.get_submission_id(),

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -402,6 +402,7 @@ class TestSingleBlindConference():
         conference.set_program_chairs(emails = ['pc2@mail.com'])
         conference.set_area_chairs(emails = ['ac2@mail.com'])
         conference.set_reviewers(emails = ['reviewer@mail.com', 'reviewer3@mail.com'])
+        conference.create_review_stage()
 
         conference.set_assignment('ac2@mail.com', submission.number, is_area_chair = True)
         conference.set_assignment('reviewer@mail.com', submission.number)
@@ -523,6 +524,7 @@ class TestSingleBlindConference():
             }
         }, release_to_reviewers = openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED))
         conference = builder.get_result()
+        conference.create_review_stage()
 
         # Author user
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", test_client.token, wait_for_element='your-consoles')

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -385,7 +385,7 @@ class TestSingleBlindConference():
         builder.set_conference_short_name('MLITS 2018')
         builder.has_area_chairs(True)
         builder.use_legacy_anonids(True)
-        builder.set_review_stage(due_date = now + datetime.timedelta(minutes = 100), additional_fields = {
+        builder.set_review_stage(openreview.ReviewStage(due_date = now + datetime.timedelta(minutes = 100), additional_fields = {
             'rating': {
                 'order': 3,
                 'value-dropdown': [
@@ -397,7 +397,7 @@ class TestSingleBlindConference():
                 ],
                 'required': True
             }
-        }, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED)
+        }, release_to_reviewers=openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED))
         conference = builder.get_result()
         conference.set_program_chairs(emails = ['pc2@mail.com'])
         conference.set_area_chairs(emails = ['ac2@mail.com'])
@@ -509,7 +509,7 @@ class TestSingleBlindConference():
         builder.set_conference_short_name('MLITS 2018')
         builder.has_area_chairs(True)
         builder.use_legacy_anonids(True)
-        builder.set_review_stage(due_date = now + datetime.timedelta(minutes = 100), additional_fields = {
+        builder.set_review_stage(openreview.ReviewStage(due_date = now + datetime.timedelta(minutes = 100), additional_fields = {
             'rating': {
                 'order': 3,
                 'value-dropdown': [
@@ -521,7 +521,7 @@ class TestSingleBlindConference():
                 ],
                 'required': True
             }
-        }, release_to_reviewers = openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED)
+        }, release_to_reviewers = openreview.ReviewStage.Readers.REVIEWERS_SUBMITTED))
         conference = builder.get_result()
 
         # Author user


### PR DESCRIPTION
Fixes https://github.com/openreview/openreview-py/issues/1182

- Use the request form to enable ethics reviewers and chairs
- Use the Ethics Review stage to setup the ethics review form and pass the flagged papers
- Ethics Reviewers should see their assigned papers in the Ethics Reviewer console. They should have access to the submission and official reviews.
- Ethics Chairs should see all the flagged papers in the Ethics Chair console. They can manually assignment reviewers using the "Edits Assignments" link shown below each paper row. 