### PR TITLE
use new bibtex generation function and deprecate old

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -833,7 +833,7 @@ class Conference(object):
             blind_note = self.client.post_note(blind_note)
 
             if self.submission_stage.public and 'venue' not in blind_content:
-                blind_content['_bibtex'] = tools.get_bibtex(
+                blind_content['_bibtex'] = tools.generate_bibtex(
                     note=note,
                     venue_fullname=self.name,
                     url_forum=blind_note.id,
@@ -1500,12 +1500,12 @@ Program Chairs
             if self.submission_stage.double_blind:
                 release_authors = is_release_authors(note_accepted)
                 submission.content = {
-                    '_bibtex': tools.get_bibtex(
+                    '_bibtex': tools.generate_bibtex(
                         openreview.Note.from_json(submission.details['original']),
                         venue_fullname=self.name,
                         year=str(self.year),
                         url_forum=submission.forum,
-                        accepted=note_accepted,
+                        paper_status = 'accepted' if note_accepted else 'rejected',
                         anonymous=(not release_authors)
                     )
                 }
@@ -1514,12 +1514,12 @@ Program Chairs
                     submission.content['authorids'] = [self.get_authors_id(number=submission.number)]
             #single-blind
             else:
-                submission.content['_bibtex'] = tools.get_bibtex(
+                submission.content['_bibtex'] = tools.generate_bibtex(
                     submission,
                     venue_fullname=self.name,
                     year=str(self.year),
                     url_forum=submission.forum,
-                    accepted=note_accepted,
+                    paper_status = 'accepted' if note_accepted else 'rejected',
                     anonymous=False
                 )
             #add venue_id if note accepted

--- a/openreview/conference/templates/desk_reject_process.py
+++ b/openreview/conference/templates/desk_reject_process.py
@@ -63,10 +63,11 @@ def process_update(client, note, invitation, existing_note):
         else:
             forum_note.readers = committee
 
-        bibtex = openreview.tools.get_bibtex(
+        bibtex = openreview.tools.generate_bibtex(
             note=original_note if original_note is not None else forum_note,
             venue_fullname=CONFERENCE_NAME,
             url_forum=forum_note.id,
+            paper_status='rejected',
             year=CONFERENCE_YEAR,
             anonymous=not(REVEAL_AUTHORS_ON_DESK_REJECT),
             baseurl='https://openreview.net')

--- a/openreview/conference/templates/submission_revision_process.py
+++ b/openreview/conference/templates/submission_revision_process.py
@@ -47,12 +47,12 @@ To view your submission, click here: https://openreview.net/forum?id={}'''.forma
                 bibtex_note.content['authors'] = ['Anonymous']
                 bibtex_note.content['authorids'] = [CONFERENCE_ID + '/Paper' + str(bibtex_note.number) + '/' + AUTHORS_NAME]
 
-        bibtex_note.content['_bibtex'] = openreview.tools.get_bibtex(
+        bibtex_note.content['_bibtex'] = openreview.tools.generate_bibtex(
             note,
             venue_fullname=CONFERENCE_NAME,
             year=CONFERENCE_YEAR,
             url_forum=bibtex_note.id,
-            accepted=True,
+            paper_status='accepted',
             anonymous=bibtex_note.content.get('authors', []) == ['Anonymous']
         )
         client.post_note(bibtex_note)

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -64,10 +64,11 @@ def process_update(client, note, invitation, existing_note):
         else:
             forum_note.readers = committee
 
-        bibtex = openreview.tools.get_bibtex(
+        bibtex = openreview.tools.generate_bibtex(
             note=original_note if original_note is not None else forum_note,
             venue_fullname=CONFERENCE_NAME,
             url_forum=forum_note.id,
+            paper_status='rejected',
             year=CONFERENCE_YEAR,
             anonymous=not(REVEAL_AUTHORS_ON_WITHDRAW),
             baseurl='https://openreview.net')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='openreview-py',
-    version='1.2.1',
+    version='1.2.2',
     description='OpenReview API Python client library',
     url='https://github.com/openreview/openreview-py',
     author='OpenReview Team',

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -1500,14 +1500,12 @@ Please refer to the FAQ for pointers on how to run the matcher: https://openrevi
         assert 'venue' in submissions[1].content and 'TestVenue@OR\'2030' in submissions[1].content['venue']
 
         note_id = submissions[0].id
-        assert '_bibtex' in submissions[0].content and submissions[0].content['_bibtex'] == '''@inproceedings{
+        assert '_bibtex' in submissions[0].content and submissions[0].content['_bibtex'] == '''@misc{
 anonymous2022test,
 title={test submission},
 author={Anonymous},
-booktitle={Submitted to Test 2030 Venue Updated},
 year={2022},
-url={https://openreview.net/forum?id=''' + note_id + '''},
-note={under review}
+url={https://openreview.net/forum?id='''+ note_id + '''}
 }'''
         
         # Post another revision stage note
@@ -1566,14 +1564,12 @@ note={under review}
         assert 'venue' in submissions[1].content and 'TestVenue@OR\'2030' in submissions[1].content['venue']
 
         note_id = submissions[0].id
-        assert '_bibtex' in submissions[0].content and submissions[0].content['_bibtex'] == '''@inproceedings{
+        assert '_bibtex' in submissions[0].content and submissions[0].content['_bibtex'] == '''@misc{
 anonymous2022test,
 title={test submission},
 author={Anonymous},
-booktitle={Submitted to Test 2030 Venue Updated},
 year={2022},
-url={https://openreview.net/forum?id=''' + note_id + '''},
-note={under review}
+url={https://openreview.net/forum?id='''+ note_id + '''}
 }'''
 
         # Post revision note for a submission


### PR DESCRIPTION
- Uses new `generate_bibtex()` function, which takes a param `paper_status` from the set {'accepted', 'rejected', 'under review'}
- Deprecated `get_bibtex()`