### PR TITLE
Feature/speed up revision invitation

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -1671,13 +1671,12 @@ class InvitationBuilder(object):
         return invitations
 
     def set_revise_submission_invitation(self, conference, notes, content):
-
-        invitations = []
         self.client.post_invitation(SubmissionRevisionInvitation(conference, content))
-        for note in tqdm(notes, total=len(notes), desc='set_revise_submission_invitation'):
-            invitations.append(self.client.post_invitation(PaperSubmissionRevisionInvitation(conference, note, content)))
-
-        return invitations
+        return tools.concurrent_requests(
+            lambda note : self.client.post_invitation(PaperSubmissionRevisionInvitation(conference, note, content)),
+            notes,
+            desc='set_revise_submission_invitation'
+        )
 
     def set_reviewer_reduced_load_invitation(self, conference, options = {}):
 

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -70,7 +70,7 @@ def format_params(params):
 
     return params
 
-def concurrent_requests(request_func, params, max_workers=min(6, cpu_count() - 1)):
+def concurrent_requests(request_func, params, desc='Gathering Responses'):
     """
     Returns a list of results given for each request_func param execution. It shows a progress bar to know the progress of the task.
 
@@ -84,8 +84,9 @@ def concurrent_requests(request_func, params, max_workers=min(6, cpu_count() - 1
     :return: A list of results given for each func value execution
     :rtype: list
     """
+    max_workers = min(6, cpu_count() - 1)
     futures = []
-    gathering_responses = tqdm(total=len(params), desc='Gathering Responses')
+    gathering_responses = tqdm(total=len(params), desc=desc)
     results = []
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:


### PR DESCRIPTION
This PR reduced the amount of time from 10 min to 3 min in NeurIPS 2022 when posting revision invitations.