### PR TITLE
Change group scoring edge format

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -587,8 +587,8 @@ class Matching(object):
         for row in tqdm(score_handle, desc='_build_scores'):
             edges.append(Edge(
                 invitation=invitation.id,
-                head=row[0],
-                tail=row[1],
+                head=row[1],
+                tail=row[0],
                 weight=str(max(round(float(row[2]), 4), 0)),
                 readers=self._get_edge_readers(tail=row[1]),
                 writers=[self.conference.id],

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -674,7 +674,7 @@ class Matching(object):
                 matching_status['no_publications'] = result['metadata']['no_publications']
 
                 if self.alternate_matching_group:
-                    scores = [[entry['submission_member'], entry['match_member'], entry['score']] for entry in result['results']]
+                    scores = [[entry['match_member'], entry['submission_member'], entry['score']] for entry in result['results']]
                     return self._build_profile_scores(score_invitation_id, scores=scores), matching_status
 
                 scores = [[entry['submission'], entry['user'], entry['score']] for entry in result['results']]


### PR DESCRIPTION
Expertise scores between groups are formatted as (tail,head,score). This PR fixes that format for both expertise API calls and CSV uploads.