### PR TITLE
Fix/PC console paper status export file name should show 'filtered'

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -3366,7 +3366,7 @@ var buildDeskrejectedWithdrawnCSV = function(){
 
 $('#group-container').on('click', 'button.btn.btn-export-data', function(e) {
   var blob = new Blob(buildCSV(), {type: 'text/csv;charset=utf-8'});
-  var fileName = conferenceStatusData.filteredNotes ? SHORT_PHRASE.replace(/\s/g, '_') + '_paper_status(Filtered).csv' : SHORT_PHRASE.replace(/\s/g, '_') + '_paper_status.csv'
+  var fileName = conferenceStatusData.filteredRows ? SHORT_PHRASE.replace(/\s/g, '_') + '_paper_status(Filtered).csv' : SHORT_PHRASE.replace(/\s/g, '_') + '_paper_status.csv'
   saveAs(blob, fileName);
 });
 


### PR DESCRIPTION
this pr should fix the issue that exported csv file name does not contain "(Filtered)" even if the data exported is filtered