### PR TITLE
don't update comment invitation when the request form is updated

### DIFF
--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -10,12 +10,30 @@ def process(client, note, invitation):
     client.add_members_to_group(conference_group, SUPPORT_GROUP)
 
     forum = client.get_note(id=note.forum)
-    comment_readers = forum.content.get('Contact Emails', []) + forum.content.get('program_chair_emails', []) + [SUPPORT_GROUP]
+    forum.writers = []
+    forum = client.post_note(forum)
+
+    readers = [conference.get_program_chairs_id(), SUPPORT_GROUP]
+
+    comment_invitation = client.post_invitation(openreview.Invitation(
+        id=SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Comment',
+        super=SUPPORT_GROUP + '/-/Comment',
+        reply={
+            'forum': forum.id,
+            'replyto': None,
+            'readers': {
+                'description': 'The users who will be allowed to read the above content.',
+                'values': [conference.get_program_chairs_id(), SUPPORT_GROUP]
+            }
+        },
+        signatures=['~Super_User1']
+    ))
+
     comment_note = openreview.Note(
         invitation = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Comment',
         forum = forum.id,
         replyto = forum.id,
-        readers = comment_readers,
+        readers = readers,
         writers = [SUPPORT_GROUP],
         signatures = [SUPPORT_GROUP],
         content = {
@@ -45,11 +63,6 @@ The OpenReview Team
         }
     )
     client.post_note(comment_note)
-
-    forum.writers = []
-    forum = client.post_note(forum)
-
-    readers = [conference.get_program_chairs_id(), SUPPORT_GROUP]
 
     client.post_invitation(openreview.Invitation(
         id = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Revision',
@@ -408,20 +421,6 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
     )
     print('posting paper matching setup invitation!!')
     client.post_invitation(matching_invitation)
-
-    client.post_invitation(openreview.Invitation(
-        id=SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Comment',
-        super=SUPPORT_GROUP + '/-/Comment',
-        reply={
-            'forum': forum.id,
-            'replyto': None,
-            'readers': {
-                'description': 'The users who will be allowed to read the above content.',
-                'values': readers
-            }
-        },
-        signatures=['~Super_User1']
-    ))
 
     replies = client.get_notes(forum=forum.id, invitation=SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Comment')
     for reply in replies:

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -23,7 +23,7 @@ def process(client, note, invitation):
             'replyto': None,
             'readers': {
                 'description': 'The users who will be allowed to read the above content.',
-                'values': [conference.get_program_chairs_id(), SUPPORT_GROUP]
+                'values': readers
             }
         },
         signatures=['~Super_User1']

--- a/openreview/venue_request/process/support_process.py
+++ b/openreview/venue_request/process/support_process.py
@@ -6,6 +6,9 @@ def process_update(client, note, invitation, existing_note):
     SUPER_USER = '~Super_User1'
     baseurl = 'https://openreview.net'
 
+    if 'venue_id' in note.content:
+        return
+
     if existing_note is None:
         admin_subject = "A request for service has been submitted by {venue_name}".format(venue_name=note.content['Abbreviated Venue Name'])
         admin_message = "A request for service has been submitted by {venue_name}. Check it here: {baseurl}/forum?id={forum} \n".format(venue_name=note.content['Abbreviated Venue Name'], baseurl=baseurl, forum=note.forum)


### PR DESCRIPTION
I'm having a test failing because the comment invitation of the request from is being updated twice: when the deploy process updates it and when the process function of the request form runs when the writers are removed from the request note. 

To fix this, the update of the request form doesn't update the comment invitation if there is already a 'venue_id'.