### PR TITLE
Fix/recruitment-email-templates

### DIFF
--- a/openreview/conference/templates/paper_recruitment_process.py
+++ b/openreview/conference/templates/paper_recruitment_process.py
@@ -58,7 +58,7 @@ def process(client, note, invitation):
 
         print('Invitation accepted', edge.tail, submission.number)
 
-        decline_instructions = 'If you would like to change your decision, please follow link in the previous invitation email and click on the "Decline" button.' if USE_RECRUITMENT_TEMPLATE else 'If you would like to change your decision, please click the Decline link in the previous invitation email.'
+        decline_instructions = 'If you would like to change your decision, please follow the link in the previous invitation email and click on the "Decline" button.' if USE_RECRUITMENT_TEMPLATE else 'If you would like to change your decision, please click the Decline link in the previous invitation email.'
 
         if not user_profile or user_profile.active == False:
             edge.label='Pending Sign Up'
@@ -198,7 +198,7 @@ OpenReview Team'''
     elif (note.content['response'] == 'No'):
 
         print('Invitation declined', edge.tail, submission.number)
-        accept_instructions = 'If you would like to change your decision, please follow link in the previous invitation email and click on the "Accept" button.' if USE_RECRUITMENT_TEMPLATE else 'If you would like to change your decision, please click the Accept link in the previous invitation email.'
+        accept_instructions = 'If you would like to change your decision, please follow the link in the previous invitation email and click on the "Accept" button.' if USE_RECRUITMENT_TEMPLATE else 'If you would like to change your decision, please click the Accept link in the previous invitation email.'
 
         ## I'm not sure if we should remove it because they could have been invite to more than one paper
         #client.remove_members_from_group(EXTERNAL_COMMITTEE_ID, edge.tail)

--- a/openreview/conference/templates/recruit_reviewers_post_process.py
+++ b/openreview/conference/templates/recruit_reviewers_post_process.py
@@ -14,7 +14,7 @@ def process_update(client, note, invitation, existing_note):
 
     note = client.get_note(note.id)
 
-    if note.ddate:
+    if note.ddate or 'message' in note.content:
         return
     
     user = urllib.parse.unquote(note.content['user'])
@@ -49,7 +49,7 @@ You have selected a reduced load of {reduced_load} submissions to review.''' if 
 
 The {SHORT_PHRASE} program chairs will be contacting you with more information regarding next steps soon. In the meantime, please add noreply@openreview.net to your email contacts to ensure that you receive all communications.
 
-If you would like to change your decision, please follow link in the previous invitation email and click on the "Decline" button.'''
+If you would like to change your decision, please follow the link in the previous invitation email and click on the "Decline" button.'''
 
             client.post_message(subject, [user], message, parentGroup=REVIEWERS_ACCEPTED_ID)
             return
@@ -61,7 +61,7 @@ If you would like to change your decision, please follow link in the previous in
             subject = f'[{SHORT_PHRASE}] {REVIEWER_NAME} Invitation declined'
             message = f'''You have declined the invitation to become a {REVIEWER_NAME} for {SHORT_PHRASE}.
 
-If you would like to change your decision, please follow link in the previous invitation email and click on the "Accept" button.'''
+If you would like to change your decision, please follow the link in the previous invitation email and click on the "Accept" button.'''
 
             client.post_message(subject, [user], message, parentGroup=REVIEWERS_DECLINED_ID)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='openreview-py',
-    version='1.4.0',
+    version='1.5.0',
     description='OpenReview API Python client library',
     url='https://github.com/openreview/openreview-py',
     author='OpenReview Team',

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -163,7 +163,7 @@ class TestNeurIPSConference():
         assert messages and len(messages) == 1
         assert messages[0]['content']['text'] == '''<p>Thank you for accepting the invitation to be a Senior Area Chair for NeurIPS 2021.</p>
 <p>The NeurIPS 2021 program chairs will be contacting you with more information regarding next steps soon. In the meantime, please add <a href=\"mailto:noreply@openreview.net\">noreply@openreview.net</a> to your email contacts to ensure that you receive all communications.</p>
-<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Decline&quot; button.</p>
+<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Decline&quot; button.</p>
 '''
         
         messages = client.get_messages(to='sac2@gmail.com', subject='[NeurIPS 2021] Invitation to serve as Senior Area Chair')
@@ -269,7 +269,7 @@ class TestNeurIPSConference():
         assert messages[0]['content']['text'] == '''<p>Thank you for accepting the invitation to be a Area Chair for NeurIPS 2021.<br>
 You have selected a reduced load of 3 submissions to review.</p>
 <p>The NeurIPS 2021 program chairs will be contacting you with more information regarding next steps soon. In the meantime, please add <a href=\"mailto:noreply@openreview.net\">noreply@openreview.net</a> to your email contacts to ensure that you receive all communications.</p>
-<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Decline&quot; button.</p>
+<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Decline&quot; button.</p>
 '''
 
 
@@ -501,7 +501,7 @@ You have selected a reduced load of 3 submissions to review.</p>
         messages = client.get_messages(to='reviewer1@umass.edu', subject='[NeurIPS 2021] Reviewer Invitation declined')
         assert messages
         assert len(messages)
-        assert messages[0]['content']['text'] == '<p>You have declined the invitation to become a Reviewer for NeurIPS 2021.</p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n'
+        assert messages[0]['content']['text'] == '<p>You have declined the invitation to become a Reviewer for NeurIPS 2021.</p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n'
 
         notes = client.get_notes(invitation='NeurIPS.cc/2021/Conference/Reviewers/-/Recruitment', content={'user': 'reviewer1@umass.edu'})
         assert notes
@@ -532,7 +532,7 @@ You have selected a reduced load of 3 submissions to review.</p>
         assert messages[0]['content']['text'] == '''<p>Thank you for accepting the invitation to be a Reviewer for NeurIPS 2021.<br>
 You have selected a reduced load of 4 submissions to review.</p>
 <p>The NeurIPS 2021 program chairs will be contacting you with more information regarding next steps soon. In the meantime, please add <a href=\"mailto:noreply@openreview.net\">noreply@openreview.net</a> to your email contacts to ensure that you receive all communications.</p>
-<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Decline&quot; button.</p>
+<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Decline&quot; button.</p>
 '''        
 
         ## Check reviewers console load
@@ -579,7 +579,7 @@ You have selected a reduced load of 4 submissions to review.</p>
         messages = client.get_messages(to='reviewer2@mit.edu', subject='[NeurIPS 2021] Reviewer Invitation declined')
         assert messages
         assert len(messages)
-        assert messages[0]['content']['text'] =='<p>You have declined the invitation to become a Reviewer for NeurIPS 2021.</p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n'
+        assert messages[0]['content']['text'] =='<p>You have declined the invitation to become a Reviewer for NeurIPS 2021.</p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n'
 
         client.add_members_to_group('NeurIPS.cc/2021/Conference/Reviewers', ['reviewer2@mit.edu', 'reviewer3@ibm.com', 'reviewer4@fb.com', 'reviewer5@google.com', 'reviewer6@amazon.com'])
 
@@ -1458,7 +1458,7 @@ Thank you,
         # Confirmation email to the reviewer
         messages = client.get_messages(to='external_reviewer1@amazon.com', subject='[NeurIPS 2021] Reviewer Invitation accepted for paper 5')
         assert messages and len(messages) == 1
-        assert messages[0]['content']['text'] == '<p>Hi External Reviewer Amazon,<br>\nThank you for accepting the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>The NeurIPS 2021 program chairs will be contacting you with more information regarding next steps soon. In the meantime, please add <a href=\"mailto:noreply@openreview.net\">noreply@openreview.net</a> to your email contacts to ensure that you receive all communications.</p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Decline&quot; button.</p>\n<p>OpenReview Team</p>\n'
+        assert messages[0]['content']['text'] == '<p>Hi External Reviewer Amazon,<br>\nThank you for accepting the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>The NeurIPS 2021 program chairs will be contacting you with more information regarding next steps soon. In the meantime, please add <a href=\"mailto:noreply@openreview.net\">noreply@openreview.net</a> to your email contacts to ensure that you receive all communications.</p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Decline&quot; button.</p>\n<p>OpenReview Team</p>\n'
 
         # Confirmation email to the ac
         messages = client.get_messages(to='ac1@mit.edu', subject='[NeurIPS 2021] Reviewer External Reviewer Amazon accepted to review paper 5')
@@ -1494,7 +1494,7 @@ Thank you,
 
         messages = client.get_messages(to='external_reviewer1@amazon.com', subject='[NeurIPS 2021] Reviewer Invitation declined for paper 5')
         assert messages and len(messages) == 1
-        assert messages[0]['content']['text'] == '<p>Hi External Reviewer Amazon,<br>\nYou have declined the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n<p>OpenReview Team</p>\n'
+        assert messages[0]['content']['text'] == '<p>Hi External Reviewer Amazon,<br>\nYou have declined the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n<p>OpenReview Team</p>\n'
 
         response_note=client.get_notes(invitation='NeurIPS.cc/2021/Conference/Reviewers/-/Proposed_Assignment_Recruitment', content={ 'submission_id': submission.id, 'user': '~External_Reviewer_Amazon1', 'response': 'No'})[0]
         messages = client.get_messages(to='ac1@mit.edu', subject='[NeurIPS 2021] Reviewer External Reviewer Amazon declined to review paper 5')
@@ -1616,7 +1616,7 @@ Thank you,
 
         messages = client.get_messages(to='external_reviewer3@adobe.com', subject='[NeurIPS 2021] Reviewer Invitation declined for paper 5')
         assert messages and len(messages) == 1
-        assert messages[0]['content']['text'] == '<p>Hi External Reviewer Adobe,<br>\nYou have declined the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n<p>OpenReview Team</p>\n'
+        assert messages[0]['content']['text'] == '<p>Hi External Reviewer Adobe,<br>\nYou have declined the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n<p>OpenReview Team</p>\n'
 
         assert client.get_groups('NeurIPS.cc/2021/Conference/Paper5/External_Reviewers/Invited', member='~External_Reviewer_Adobe1')
         assert client.get_groups('NeurIPS.cc/2021/Conference/External_Reviewers/Invited', member='~External_Reviewer_Adobe1')
@@ -1679,7 +1679,7 @@ Thank you,
 
         messages = client.get_messages(to='external_reviewer4@gmail.com', subject='[NeurIPS 2021] Reviewer Invitation accepted for paper 5, assignment pending')
         assert messages and len(messages) == 1
-        assert messages[0]['content']['text'] == '<p>Hi <a href=\"mailto:external_reviewer4@gmail.com\">external_reviewer4@gmail.com</a>,<br>\nThank you for accepting the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>Please signup in OpenReview using the email address <a href=\"mailto:external_reviewer4@gmail.com\">external_reviewer4@gmail.com</a> and complete your profile.<br>\nConfirmation of the assignment is pending until your profile is active and no conflicts of interest are detected.</p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Decline&quot; button.</p>\n<p>OpenReview Team</p>\n'
+        assert messages[0]['content']['text'] == '<p>Hi <a href=\"mailto:external_reviewer4@gmail.com\">external_reviewer4@gmail.com</a>,<br>\nThank you for accepting the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>Please signup in OpenReview using the email address <a href=\"mailto:external_reviewer4@gmail.com\">external_reviewer4@gmail.com</a> and complete your profile.<br>\nConfirmation of the assignment is pending until your profile is active and no conflicts of interest are detected.</p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Decline&quot; button.</p>\n<p>OpenReview Team</p>\n'
 
         messages = client.get_messages(to='ac1@mit.edu', subject='[NeurIPS 2021] Reviewer external_reviewer4@gmail.com accepted to review paper 5, assignment pending')
         assert messages and len(messages) == 1
@@ -1767,7 +1767,7 @@ Thank you,
 
         messages = client.get_messages(to='external_reviewer5@gmail.com', subject='[NeurIPS 2021] Reviewer Invitation declined for paper 5')
         assert messages and len(messages) == 1
-        assert messages[0]['content']['text'] == '<p>Hi <a href=\"mailto:external_reviewer5@gmail.com\">external_reviewer5@gmail.com</a>,<br>\nYou have declined the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n<p>OpenReview Team</p>\n'
+        assert messages[0]['content']['text'] == '<p>Hi <a href=\"mailto:external_reviewer5@gmail.com\">external_reviewer5@gmail.com</a>,<br>\nYou have declined the invitation to review the paper number: 5, title: Paper title 5.</p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Accept&quot; button.</p>\n<p>OpenReview Team</p>\n'
         ## Invite external reviewer with wrong tilde id
         with pytest.raises(openreview.OpenReviewException) as openReviewError:
             posted_edge=ac_client.post_edge(openreview.Edge(
@@ -2207,7 +2207,7 @@ Thank you,
 
         messages = client.get_messages(to='external_reviewer2@mit.edu', subject='[NeurIPS 2021] Reviewer Invitation accepted for paper 4')
         assert messages and len(messages) == 1
-        assert messages[0]['content']['text'] == '<p>Hi External Reviewer MIT,<br>\nThank you for accepting the invitation to review the paper number: 4, title: Paper title 4.</p>\n<p>Please go to the NeurIPS 2021 Reviewers Console and check your pending tasks: <a href=\"https://openreview.net/group?id=NeurIPS.cc/2021/Conference/Reviewers\">https://openreview.net/group?id=NeurIPS.cc/2021/Conference/Reviewers</a></p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Decline&quot; button.</p>\n<p>OpenReview Team</p>\n'
+        assert messages[0]['content']['text'] == '<p>Hi External Reviewer MIT,<br>\nThank you for accepting the invitation to review the paper number: 4, title: Paper title 4.</p>\n<p>Please go to the NeurIPS 2021 Reviewers Console and check your pending tasks: <a href=\"https://openreview.net/group?id=NeurIPS.cc/2021/Conference/Reviewers\">https://openreview.net/group?id=NeurIPS.cc/2021/Conference/Reviewers</a></p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Decline&quot; button.</p>\n<p>OpenReview Team</p>\n'
 
         messages = client.get_messages(to='external_reviewer2@mit.edu', subject='[NeurIPS 2021] You have been assigned as a Reviewer for paper number 4')
         assert messages and len(messages) == 1
@@ -2300,7 +2300,7 @@ Thank you,
 
         messages = client.get_messages(to='reviewer6@amazon.com', subject='[NeurIPS 2021] Reviewer Invitation accepted for paper 4')
         assert messages and len(messages) == 1
-        assert messages[0]['content']['text'] == '<p>Hi Reviewer Amazon,<br>\nThank you for accepting the invitation to review the paper number: 4, title: Paper title 4.</p>\n<p>Please go to the NeurIPS 2021 Reviewers Console and check your pending tasks: <a href=\"https://openreview.net/group?id=NeurIPS.cc/2021/Conference/Reviewers\">https://openreview.net/group?id=NeurIPS.cc/2021/Conference/Reviewers</a></p>\n<p>If you would like to change your decision, please follow link in the previous invitation email and click on the &quot;Decline&quot; button.</p>\n<p>OpenReview Team</p>\n'
+        assert messages[0]['content']['text'] == '<p>Hi Reviewer Amazon,<br>\nThank you for accepting the invitation to review the paper number: 4, title: Paper title 4.</p>\n<p>Please go to the NeurIPS 2021 Reviewers Console and check your pending tasks: <a href=\"https://openreview.net/group?id=NeurIPS.cc/2021/Conference/Reviewers\">https://openreview.net/group?id=NeurIPS.cc/2021/Conference/Reviewers</a></p>\n<p>If you would like to change your decision, please follow the link in the previous invitation email and click on the &quot;Decline&quot; button.</p>\n<p>OpenReview Team</p>\n'
 
         assert client.get_groups('NeurIPS.cc/2021/Conference/Emergency_Reviewers/Invited', member='~Reviewer_Amazon1')
         assert client.get_groups('NeurIPS.cc/2021/Conference/Emergency_Reviewers', member='~Reviewer_Amazon1')


### PR DESCRIPTION
- don't send email if user is posting comment and add missing `the`