### PR TITLE
Post Decision Stage: use active submissions to get decision notes

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1759,7 +1759,7 @@ Program Chairs
         def send_notification(note):
             decision_note = None
             for reply in note.details['directReplies']:
-                if reply['invitation'].endswith(self.decision_stage.name):
+                if reply['invitation'].endswith('/-/' + self.decision_stage.name):
                     decision_note = reply
                     break
             subject = "[{SHORT_NAME}] Decision notification for your submission {submission_number}: {submission_title}".format(

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1754,24 +1754,27 @@ Program Chairs
         self.expire_recruitment_invitations()
 
     def send_decision_notifications(self, decision_options, messages):
-        decision_notes = self.client.get_all_notes(
-            invitation=self.get_invitation_id(self.decision_stage.name, '.*'),
-        )
-        paper_notes = {n.forum: n for n in self.get_submissions()}
+        paper_notes = self.get_submissions(details='directReplies')
 
         def send_notification(note):
-            paper_note = paper_notes[note.forum]
-            message = messages[note.content['decision']]
+            decision_note = None
+            for reply in note.details['directReplies']:
+                if reply['invitation'].endswith(self.decision_stage.name):
+                    decision_note = reply
+                    break
             subject = "[{SHORT_NAME}] Decision notification for your submission {submission_number}: {submission_title}".format(
                 SHORT_NAME=self.get_short_name(),
-                submission_number=paper_note.number,
-                submission_title=paper_note.content['title']
+                submission_number=note.number,
+                submission_title=note.content['title']
             )
-            final_message = message.replace("{{submission_title}}", paper_note.content['title'])
-            final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={paper_note.id}')
-            self.client.post_message(subject, recipients=paper_note.content['authorids'], message=final_message)
 
-        tools.concurrent_requests(send_notification, decision_notes)
+            if decision_note and not self.client.get_messages(subject=subject):
+                message = messages[decision_note['content']['decision']]
+                final_message = message.replace("{{submission_title}}", note.content['title'])
+                final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={note.id}')
+                self.client.post_message(subject, recipients=note.content['authorids'], message=final_message)
+
+        tools.concurrent_requests(send_notification, paper_notes)
 
     def post_decisions(self, decisions_file):
         decisions_data = list(csv.reader(StringIO(decisions_file.decode()), delimiter=","))

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -1984,6 +1984,12 @@ Best,
         assert "Dear Venue Author,</p>\n<p>Thank you for submitting your paper, test submission, to TestVenue@OR'2030." in last_message['content']['text']
         assert f"https://openreview.net/forum?id={blind_submissions[0].id}" in last_message['content']['text']
 
+        test_client.post_note(post_decision_stage_note)
+        helpers.await_queue()
+
+        decision_messages = client.get_messages(subject="[TestVenue@OR'2030] Decision notification for your submission 1: test submission")
+        assert len(decision_messages) == 1
+
         # Assert that submissions are public
         assert blind_submissions[0].readers == ['everyone']
         assert blind_submissions[1].readers == ['everyone']


### PR DESCRIPTION
Also, check if the authors have already been notified to avoid multiple messages