### PR TITLE
Fix/request-form

### DIFF
--- a/openreview/venue_request/process/request_form_pre_process.py
+++ b/openreview/venue_request/process/request_form_pre_process.py
@@ -17,5 +17,5 @@ def process(client, note, invitation):
     if 'Yes, our venue has Senior Area Chairs' in note.content.get('senior_area_chairs', '') and 'All Senior Area Chairs' not in note.content['reviewer_identity'] and 'Assigned Senior Area Chair' not in note.content['reviewer_identity']:
         raise openreview.OpenReviewException('Assigned senior area chairs must see the reviewer identity')
 
-    if ('Reviewer Bid Scores' in note.content.get('Paper Matching', '') or 'Reviewer Recommendation Scores' in note.content.get('Paper Matching', '')) and 'Assigned program committee' in note.content.get('submission_readers', ''):
-        raise openreview.OpenReviewException('Papers should be visible to all program committee if bidding or reviewer recommendation is enabled')
+    if 'Reviewer Bid Scores' in note.content.get('Paper Matching', '') and 'Assigned program committee' in note.content.get('submission_readers', ''):
+        raise openreview.OpenReviewException('Papers should be visible to all program committee if bidding is enabled')

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -75,7 +75,7 @@ class TestVenueRequest():
 
         request_form_note.content['reviewer_identity'] = ['Program Chairs', 'Assigned Area Chair', 'Assigned Senior Area Chair']
 
-        with pytest.raises(openreview.OpenReviewException, match=r'Papers should be visible to all program committee if bidding or reviewer recommendation is enabled'):
+        with pytest.raises(openreview.OpenReviewException, match=r'Papers should be visible to all program committee if bidding is enabled'):
             request_form_note=test_client.post_note(request_form_note)
 
         request_form_note.content['submission_readers'] = 'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)'


### PR DESCRIPTION
- remove reviewer recommendation check from preprocess

- the changes to the Support group webfield were already made here: https://github.com/openreview/openreview-py/blob/master/openreview/venue_request/webfield/supportRequestsWeb.js. If this seems fine, I can make this change on the live site