### PR TITLE
fix affinity scores upload, make the SAC reader of the scores

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -597,8 +597,8 @@ class Matching(object):
         for row in tqdm(score_handle, desc='_build_scores'):
             edges.append(Edge(
                 invitation=invitation.id,
-                head=row[1],
-                tail=row[0],
+                head=row[0],
+                tail=row[1],
                 weight=str(max(round(float(row[2]), 4), 0)),
                 readers=self._get_edge_readers(tail=row[1]),
                 writers=[self.conference.id],
@@ -684,7 +684,7 @@ class Matching(object):
                 matching_status['no_publications'] = result['metadata']['no_publications']
 
                 if self.alternate_matching_group:
-                    scores = [[entry['match_member'], entry['submission_member'], entry['score']] for entry in result['results']]
+                    scores = [[entry['submission_member'], entry['match_member'], entry['score']] for entry in result['results']]
                     return self._build_profile_scores(score_invitation_id, scores=scores), matching_status
 
                 scores = [[entry['submission'], entry['user'], entry['score']] for entry in result['results']]

--- a/openreview/conference/templates/profileBidWebfield.js
+++ b/openreview/conference/templates/profileBidWebfield.js
@@ -302,7 +302,7 @@ function updateNotes(notes) {
   var loadingContent = Handlebars.templates.spinner({ extraClasses: 'spinner-inline' });
   sections = [
     {
-      heading: 'All Papers  <span class="glyphicon glyphicon-search"></span>',
+      heading: 'All Area Chairs  <span class="glyphicon glyphicon-search"></span>',
       id: 'allPapers',
       content: null
     },

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -169,7 +169,7 @@ class WebfieldBuilder(object):
                     Papers can be also sorted by TPMS score, change the sorting criteria using the 'Sort By' dropdown.
                 </li>'''
 
-        default_instructions = '''
+        paper_default_instructions = '''
             <p class="dark"><strong>Instructions:</strong></p>
             <ul>
                 <li>
@@ -203,6 +203,28 @@ class WebfieldBuilder(object):
             </ul>
             <br>'''
 
+        profile_default_instructions = '''
+            <p class="dark"><strong>Instructions:</strong></p>
+            <ul>
+                <li>
+                    Please indicate your <strong>level of interest</strong> in the list of Area Chairs below, on a scale from "Very Low" interest to "Very High" interest. Area Chairs were automatically pre-ranked using the expertise information in your profile.
+                </li>
+                <li>
+                    Bid on as many Area Chairs as possible to correct errors of this automatic procedure.
+                </li>
+                <li>
+                    Bidding on the top ranked Area Chairs removes false positives.
+                </li>
+                <li>
+                    You can use the search field to find Area Chairs by keywords from the position, institution or expertise to reduce false negatives.
+                </li>                
+                <li>
+                    Ensure that you have at least <strong>{request_count} bids</strong>.
+                </li>
+            </ul>
+            <br>'''            
+
+        default_instructions = profile_default_instructions if stage.committee_id == conference.get_senior_area_chairs_id() else paper_default_instructions
         instructions_html = stage.instructions if stage.instructions else default_instructions
 
         header = {

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -338,6 +338,10 @@ If you would like to change your decision, please follow the link in the previou
         assert notes
         assert len(notes.find_elements_by_class_name('note')) == 3
 
+        header = selenium.find_element_by_id('header')
+        instruction = header.find_element_by_tag_name('li')
+        assert 'Please indicate your level of interest in the list of Area Chairs below, on a scale from "Very Low" interest to "Very High" interest. Area Chairs were automatically pre-ranked using the expertise information in your profile.' == instruction.text
+
         sac_client.post_edge(openreview.Edge(
             invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Bid',
             readers = [conference.id, '~SeniorArea_GoogleChair1'],

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -322,6 +322,9 @@ If you would like to change your decision, please follow the link in the previou
         sac_client=openreview.Client(username='sac1@google.com', password='1234')
         assert sac_client.get_group(id='NeurIPS.cc/2021/Conference/Area_Chairs')
 
+        edges=sac_client.get_edges(invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Affinity_Score', tail='~SeniorArea_GoogleChair1')
+        assert len(edges) == 3
+
         tasks_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Senior_Area_Chairs#senior-areachair-tasks'
         request_page(selenium, tasks_url, sac_client.token, by=By.LINK_TEXT, wait_for_element='Senior Area Chair Bid')
 
@@ -331,7 +334,9 @@ If you would like to change your decision, please follow the link in the previou
         bid_url = 'http://localhost:3030/invitation?id=NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Bid'
         request_page(selenium, bid_url, sac_client.token, wait_for_element='notes')
 
-        assert selenium.find_element_by_id('notes')
+        notes = selenium.find_element_by_id('notes')
+        assert notes
+        assert len(notes.find_elements_by_class_name('note')) == 3
 
         sac_client.post_edge(openreview.Edge(
             invitation='NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Bid',


### PR DESCRIPTION
Fix: SAC can not read SAC affinity scores.

Reading the scores from a file or from the expertise API should be the following format:

AC, SAC, weight

AC are treated as submissions and SAC as reviewers. This follow the same format than paper reviewer scores. 