### PR TITLE
updates paper matching and assignment invites

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -2210,8 +2210,8 @@ class InvitationBuilder(object):
     def set_assignment_invitation(self, conference, committee_id):
 
         invitation = self.client.get_invitation(conference.get_paper_assignment_id(committee_id, deployed=True))
-        is_area_chair = committee_id == conference.get_area_chairs_id()
-        is_senior_area_chair = committee_id == conference.get_senior_area_chairs_id()
+        is_area_chair = committee_id == conference.get_area_chairs_id() or committee_id.split("/")[-1] in conference.area_chair_roles
+        is_senior_area_chair = committee_id == conference.get_senior_area_chairs_id() or committee_id.split("/")[-1] in conference.senior_area_chair_roles
         is_reviewer = committee_id == conference.get_reviewers_id()
         is_ethics_reviewer = committee_id == conference.get_ethics_reviewers_id()
 

--- a/openreview/venue_request/process/deployProcess.py
+++ b/openreview/venue_request/process/deployProcess.py
@@ -364,9 +364,11 @@ Program Chairs'''.replace('{Abbreviated_Venue_Name}', conference.get_short_name(
     # always post Paper_Matching_Setup invitation
     matching_group_ids = [conference.get_committee_id(r) for r in conference.reviewer_roles]
     if conference.use_area_chairs:
-        matching_group_ids.append(conference.get_area_chairs_id())
+        area_chairs = [conference.get_committee_id(r) for r in conference.area_chair_roles]
+        matching_group_ids = matching_group_ids + area_chairs
     if conference.use_senior_area_chairs:
-        matching_group_ids.append(conference.get_senior_area_chairs_id())
+        senior_area_chairs = [conference.get_committee_id(r) for r in conference.senior_area_chair_roles]
+        matching_group_ids = matching_group_ids + senior_area_chairs
     matching_invitation = openreview.Invitation(
         id = SUPPORT_GROUP + '/-/Request' + str(forum.number) + '/Paper_Matching_Setup',
         super = SUPPORT_GROUP + '/-/Paper_Matching_Setup',


### PR DESCRIPTION
Venues with multiple roles reported the issue that the paper matching setup invitation was created without the area chair roles listed in the committee group dropdown. Then, they reported that for their multiple AC role assignment invitations, the process functions were adding the ACs to the reviewers groups. This PR addresses those issues. 