### PR TITLE
Submission readers: add an option to make the submissions readable to…

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1106,7 +1106,7 @@ class Conference(object):
 
         if self.submission_stage.second_due_date:
             if self.submission_stage.due_date < now and now < self.submission_stage.second_due_date:
-                self.setup_first_deadline_stage(force, hide_fields)
+                self.setup_first_deadline_stage(force, hide_fields, self.submission_stage.author_reorder_after_first_deadline)
             elif self.submission_stage.second_due_date < now:
                 self.setup_final_deadline_stage(force, hide_fields)
             elif force:
@@ -1952,7 +1952,8 @@ class SubmissionStage(object):
             desk_rejected_submission_reveal_authors=False,
             email_pcs_on_desk_reject=True,
             author_names_revealed=False,
-            papers_released=False
+            papers_released=False,
+            author_reorder_after_first_deadline=False
         ):
 
         self.start_date = start_date
@@ -1977,6 +1978,7 @@ class SubmissionStage(object):
         self.author_names_revealed = author_names_revealed
         self.papers_released = papers_released
         self.public = self.Readers.EVERYONE in self.readers
+        self.author_reorder_after_first_deadline = author_reorder_after_first_deadline
 
     def get_readers(self, conference, number, decision_note=None):
 
@@ -2839,7 +2841,8 @@ class ConferenceBuilder(object):
             email_pcs_on_desk_reject=True,
             author_names_revealed=False,
             papers_released=False,
-            readers=None
+            readers=None,
+            author_reorder_after_first_deadline=False
         ):
 
         submissions_readers=[SubmissionStage.Readers.SENIOR_AREA_CHAIRS_ASSIGNED, SubmissionStage.Readers.AREA_CHAIRS_ASSIGNED, SubmissionStage.Readers.REVIEWERS_ASSIGNED]
@@ -2871,7 +2874,8 @@ class ConferenceBuilder(object):
             desk_rejected_submission_reveal_authors,
             email_pcs_on_desk_reject,
             author_names_revealed,
-            papers_released
+            papers_released,
+            author_reorder_after_first_deadline
         )
 
     def set_expertise_selection_stage(self, start_date = None, due_date = None, include_option=False):

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -105,6 +105,7 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
 
     readers_map = {
         'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)': [openreview.SubmissionStage.Readers.SENIOR_AREA_CHAIRS, openreview.SubmissionStage.Readers.AREA_CHAIRS, openreview.SubmissionStage.Readers.REVIEWERS],
+        'All area chairs only': [openreview.SubmissionStage.Readers.AREA_CHAIRS],
         'Assigned program committee (assigned reviewers, assigned area chairs, assigned senior area chairs if applicable)': [openreview.SubmissionStage.Readers.SENIOR_AREA_CHAIRS_ASSIGNED, openreview.SubmissionStage.Readers.AREA_CHAIRS_ASSIGNED, openreview.SubmissionStage.Readers.REVIEWERS_ASSIGNED],
         'Program chairs and paper authors only': [],
         'Everyone (submissions are public)': [openreview.SubmissionStage.Readers.EVERYONE],

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -157,6 +157,8 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
 
     name = note.content.get('submission_name', 'Submission').strip()
 
+    author_reorder_after_first_deadline = note.content.get('submission_deadline_author_reorder', 'No') == 'Yes'
+
     builder.set_submission_stage(
         name=name,
         double_blind=double_blind,
@@ -177,7 +179,8 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
         desk_rejected_submission_reveal_authors=desk_rejected_submission_reveal_authors,
         author_names_revealed=author_names_revealed,
         papers_released=papers_released,
-        readers=readers)
+        readers=readers,
+        author_reorder_after_first_deadline=author_reorder_after_first_deadline)
 
     paper_matching_options = note.content.get('Paper Matching', [])
     include_expertise_selection = note.content.get('include_expertise_selection', '') == 'Yes'

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -204,6 +204,7 @@ def process(client, note, invitation):
                     'description': 'Please select who should have access to the submissions after the submission deadline. Note that program chairs and paper authors are always readers of submissions.',
                     'value-radio': [
                         'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)',
+                        'All area chairs only',
                         'Assigned program committee (assigned reviewers, assigned area chairs, assigned senior area chairs if applicable)',
                         'Program chairs and paper authors only',
                         'Everyone (submissions are public)',

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1143,6 +1143,13 @@ class VenueRequest():
                 'order': 38,
                 'required': False,
                 'hidden': True # Change this value on exception request from the PCs.
+            },
+            'submission_deadline_author_reorder': {
+                'value-radio': ['Yes', 'No'],
+                'default': 'No',
+                'order': 39,
+                'required': False,
+                'hidden': True # Change this value on exception request from the PCs.
             }
         }
 

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1012,6 +1012,7 @@ class VenueRequest():
                 'description': 'Please select who should have access to the submissions after the abstract deadline (if your venue had one) or the submission deadline. Note that program chairs and paper authors are always readers of submissions.',
                 'value-radio': [
                     'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)',
+                    'All area chairs only',
                     'Assigned program committee (assigned reviewers, assigned area chairs, assigned senior area chairs if applicable)',
                     'Program chairs and paper authors only',
                     'Everyone (submissions are public)'
@@ -1270,6 +1271,7 @@ class VenueRequest():
                 'description': 'Please select who should have access to the submissions after the submission deadline. Note that program chairs and paper authors are always readers of submissions.',
                 'value-radio': [
                     'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)',
+                    'All area chairs only',
                     'Assigned program committee (assigned reviewers, assigned area chairs, assigned senior area chairs if applicable)',
                     'Program chairs and paper authors only',
                     'Everyone (submissions are public)'


### PR DESCRIPTION
After abstract deadline:

- set submissions readers to be All Chairs 
- restrict author edition to be order only.