### PR TITLE
Fix: update support group webfield

### DIFF
--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -791,19 +791,12 @@ class VenueRequest():
         self.client = client
         self.super_user = super_user
 
-        if not self.support_group:
+        if self.support_group:
             with open(os.path.join(os.path.dirname(__file__), 'webfield/supportRequestsWeb.js')) as f:
                 file_content = f.read()
                 file_content = file_content.replace("var GROUP_PREFIX = '';", "var GROUP_PREFIX = '" + super_user + "';")
-                support_group = openreview.Group(
-                    id=self.support_group_id,
-                    readers=['everyone'],
-                    writers=[self.support_group_id],
-                    signatures=[super_user],
-                    signatories=[self.support_group_id],
-                    members=[],
-                    web_string=file_content)
-                self.support_group = client.post_group(support_group)
+                self.support_group.web = file_content
+                self.support_group = client.post_group(self.support_group)
 
         self.support_process = os.path.join(os.path.dirname(__file__), 'process/support_process.py')
         self.support_pre_process = os.path.join(os.path.dirname(__file__), 'process/request_form_pre_process.py')

--- a/openreview/venue_request/webfield/supportRequestsWeb.js
+++ b/openreview/venue_request/webfield/supportRequestsWeb.js
@@ -83,7 +83,7 @@ var paperDisplayOptions = {
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
-  Webfield.ui.setup('#group-container', GROUP_PREFIX);  // required
+  Webfield.ui.setup('#group-container', SUPPORT_GROUP);  // required
 
   renderConferenceHeader();
 

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -135,6 +135,11 @@ class TestVenueRequest():
 
         helpers.await_queue()
         request_page(selenium, 'http://localhost:3030/group?id={}&mode=default'.format(support_group_id), client.token)
+        header_div = selenium.find_element_by_id('header')
+        assert header_div
+        title_tag = header_div.find_element_by_tag_name('h1')
+        assert title_tag
+        assert title_tag.text == 'Host a Venue'
 
         pc_client = helpers.create_user('new_test_user@mail.com', 'NewFirstName', 'User')
 


### PR DESCRIPTION
- Update the support group webfield every time we update the request form
- **Note**: the webfield is slightly different from what is on the live site (live site stil has things like TPMS)
- I noticed that the support group created in the setup script of the API creates this group slightly different than how it is in the live site: https://github.com/openreview/openreview-api-v1/blob/214dcd1b1e9971afee20bce13351f7aecbab57c1/scripts/mongo_database.js#L316 (for example, it is not visible to everyone, not sure if we want to change this)