### PR TITLE
fix manifest: add journal files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,5 @@ include openreview/agora/webfield/*.js
 include openreview/agora/process/*.js
 include openreview/agora/process/*.py
 include openreview/duplicate_domains.json
+include openreview/journal/process/*.py
+include openreview/journal/webfield/*.js

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='openreview-py',
 
-    version='1.9.0',
+    version='1.10.0',
 
     description='OpenReview API Python client library',
     url='https://github.com/openreview/openreview-py',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='openreview-py',
 
-    version='1.10.0',
+    version='1.9.0',
 
     description='OpenReview API Python client library',
     url='https://github.com/openreview/openreview-py',


### PR DESCRIPTION
Export journal files so they can be accessed when installing the library from pip. 