### PR TITLE
Fix: submission template short name

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -46,6 +46,7 @@ class SubmissionInvitation(openreview.Invitation):
 
                 if submission_stage.submission_email:
                     email_template = submission_stage.submission_email
+                    email_template = email_template.replace('{{Abbreviated_Venue_Name}}', conference.get_short_name())
                     email_template = email_template.replace('{{action}}', '{action}')
                     email_template = email_template.replace('{{note_title}}', '{note.content[\'title\']}')
                     email_template = email_template.replace('{{note_abstract}}', '{note_abstract}')

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -33,7 +33,7 @@ class VenueStages():
         revision_content['submission_email'] = {
             'order': 20,
             'description': 'Please review the email sent to authors when a submission is posted. Make sure not to remove the parenthesized tokens.',
-            'default': f'''Your submission to ${self.venue_request.request_content['Abbreviated Venue Name']} has been {{action}}.\n\nSubmission Number: {{note_number}} \n\nTitle: {{note_title}} {{note_abstract}} \n\nTo view your submission, click here: https://openreview.net/forum?id={{note_forum}}''',
+            'default': '''Your submission to {{Abbreviated_Venue_Name}} has been {{action}}.\n\nSubmission Number: {{note_number}} \n\nTitle: {{note_title}} {{note_abstract}} \n\nTo view your submission, click here: https://openreview.net/forum?id={{note_forum}}''',
             'value-regex':'[\\S\\s]{1,10000}',
             'hidden': True
         }

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -427,7 +427,7 @@ class TestVenueRequest():
                         'value-regex': '.*'
                     }
                 },
-                'submission_email': 'Your submission to TestVenue@OR\'2030 has been {{action}}.\n\nSubmission Number: {{note_number}}\n\nTitle: {{note_title}} {{note_abstract}}\n\nTo view your submission, click here: https://openreview.net/forum?id={{note_forum}}\n\nThis is some extra information to be added at the end of the email template.',
+                'submission_email': 'Your submission to {{Abbreviated_Venue_Name}} has been {{action}}.\n\nSubmission Number: {{note_number}}\n\nTitle: {{note_title}} {{note_abstract}}\n\nTo view your submission, click here: https://openreview.net/forum?id={{note_forum}}\n\nThis is some extra information to be added at the end of the email template.',
                 'reviewer_roles': ['Reviewers', 'Expert_Reviewers']
             },
             forum=venue['request_form_note'].forum,
@@ -930,6 +930,7 @@ class TestVenueRequest():
         assert messages and len(messages) == 1
         assert 'This is some extra information to be added at the end of the email template.' in messages[0]['content']['text']
         assert 'Title: test submission' in messages[0]['content']['text']
+        assert 'Your submission to TestVenue@OR\'2030 has been posted.'
 
         messages = client.get_messages(subject='{} has received a new submission titled {}'.format(venue['request_form_note'].content['Abbreviated Venue Name'], submission.content['title']))
         assert messages and len(messages) == 3


### PR DESCRIPTION
There was an issue with how I was replacing the abbreviated venue name, since when we create the revision invitation we just get the content from the super invitation. I am making the replacement in `invitation.py` instead

This is fixed on the dev site's request form.