### PR TITLE
Fix/ EIC console: logging out triggers error

### DIFF
--- a/openreview/journal/webfield/editorsInChiefWebfield.js
+++ b/openreview/journal/webfield/editorsInChiefWebfield.js
@@ -133,6 +133,11 @@ var main = function() {
     referrer: args && args.referrer,
     fullWidth: true
   });
+  
+  if (!user || user.isGuest) {
+    Webfield2.ui.errorMessage('You must be logged in to access this page.');
+    return;
+  }  
 
   loadData()
     .then(formatData)


### PR DESCRIPTION
Fix bug with logging out while on the EIC console page. Previously this would trigger a JS error.

Fixes https://github.com/openreview/openreview-web/issues/1052