### PR TITLE
use a checkbox instead of a dropdown so description can be available

### DIFF
--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1149,8 +1149,8 @@ class VenueRequest():
             },
             'api_version': {
                 'description': 'Which API version would you like to use? API 2 is still in the experimental phase, contact us if you would like more information.',
-                'value-dropdown': ['1', '2'],
-                'default': ['1'],
+                'value-checkbox': ['1', '2'],
+                'default': '1',
                 'order': 39
             },
             'include_expertise_selection': {


### PR DESCRIPTION
Users should be able to read the description easily:

<img width="789" alt="Screen Shot 2022-12-20 at 11 27 13 AM" src="https://user-images.githubusercontent.com/545506/208690315-4b175542-30c7-4eb7-9bbf-72192c90e240.png">

This change is already in the live site.
