### PR TITLE
Fix/Enable download pdf button

### DIFF
--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -694,7 +694,7 @@ var renderStatusTable = function(conferenceStatusData, container) {
       '</ul>' +
     '</div>' +
     '<div class="btn-group"><button class="btn btn-export-data" type="button">Export</button></div>' +
-    // '<div class="btn-group"><button class="btn btn-export-pdf" type="button">Download PDF</button></div>' +
+    '<div class="btn-group"><button class="btn btn-export-pdf" type="button">Download PDF</button></div>' +
     '<div class="pull-right">' +
       '<strong style="vertical-align: middle;">Search:</strong>' +
       '<input type="text" class="form-search form-control" class="form-control" placeholder="Enter search term or type + to start a query and press enter" style="width:380px; margin-right: 0.5rem; line-height: 34px;">' +


### PR DESCRIPTION
Download pdf button in AC console was disabled in #1490 as API and Web are not ready yet.
The changes have been deployed so this button can be enabled now.