### PR TITLE
remove homepage from create_profile

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -344,8 +344,7 @@ def create_profile(client, email, first, last, middle=None, allow_duplicates=Fal
                         'last': last,
                         'username': tilde_id
                     }
-                ],
-                'homepage': 'http://no_url'
+                ]
             }
             client.post_group(tilde_group)
             client.post_group(email_group)


### PR DESCRIPTION
Homepage is preferably empty when creating a profile.