### PR TITLE
soft delete existing assignments,  create new archive assignments edges

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -1251,6 +1251,61 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
         self.save_invitation(invitation)
 
         invitation = Invitation(
+            id=self.journal.get_ae_assignment_id(archived=True),
+            invitees=[venue_id, editor_in_chief_id],
+            readers=[venue_id, action_editors_id],
+            writers=[venue_id],
+            signatures=[editor_in_chief_id], ## EIC have permission to check conflicts
+            minReplies=1,
+            maxReplies=1,
+            type='Edge',
+            edit={
+                'id': {
+                    'param': {
+                        'withInvitation': self.journal.get_ae_assignment_id(archived=True),
+                        'optional': True
+                    }
+                },                
+                'ddate': {
+                    'param': {
+                        'range': [ 0, 9999999999999 ],
+                        'optional': True,
+                        'deletable': True
+                    }
+                },
+                'readers': [venue_id, editor_in_chief_id, '${2/tail}'],
+                'nonreaders': [],
+                'writers': [venue_id, editor_in_chief_id],
+                'signatures': [editor_in_chief_id],
+                'head': {
+                    'param': {
+                        'type': 'note',
+                        'withInvitation': author_submission_id
+                    }
+                },
+                'tail': {
+                    'param': {
+                        'type': 'profile',
+                        'inGroup' : action_editors_id
+                    }
+                },
+                'weight': {
+                    'param': {
+                        'minimum': -1
+                    }
+                },
+                'label': {
+                    'param': {
+                        'optional': True,
+                        'minLength': 1
+                    }
+                }
+            }
+        )
+
+        self.save_invitation(invitation)        
+
+        invitation = Invitation(
             id=self.journal.get_ae_assignment_id(proposed=True),
             invitees=[venue_id, editor_in_chief_id],
             readers=[venue_id, action_editors_id],
@@ -1696,6 +1751,66 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
         )
 
         self.save_invitation(invitation)
+
+        invitation = Invitation(
+            id=self.journal.get_reviewer_assignment_id(archived=True),
+            invitees=[venue_id],
+            readers=[venue_id, action_editors_id],
+            writers=[venue_id],
+            signatures=[self.journal.get_editors_in_chief_id()],
+            minReplies=1,
+            maxReplies=1,
+            type='Edge',
+            edit={
+                'id': {
+                    'param': {
+                        'withInvitation': self.journal.get_reviewer_assignment_id(archived=True),
+                        'optional': True
+                    }
+                },                 
+                'ddate': {
+                    'param': {
+                        'range': [ 0, 9999999999999 ],
+                        'optional': True,
+                        'deletable': True
+                    }
+                },
+                'readers': [venue_id, self.journal.get_action_editors_id(number='${{2/head}/number}'), '${2/tail}'],
+                'nonreaders': [self.journal.get_authors_id(number='${{2/head}/number}')],
+                'writers': [venue_id],
+                'signatures': {
+                    'param': {
+                        'regex': venue_id + '|' + editor_in_chief_id
+                    }
+                },
+                'head': {
+                    'param': {
+                        'type': 'note',
+                        'withInvitation': author_submission_id
+                    }
+                },
+                'tail': {
+                    'param': {
+                        'type': 'profile',
+                        #'inGroup' : reviewers_id,
+                         'options': { 'group': reviewers_id }
+                    }
+                },
+                'weight': {
+                    'param': {
+                        'minimum': -1
+                    }
+                },
+                'label': {
+                    'param': {
+                        'optional': True,
+                        'minLength': 1
+                    }
+                }
+            }
+        )
+
+        self.save_invitation(invitation)        
 
         invitation = Invitation(
             id=self.journal.get_reviewer_custom_max_papers_id(),

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -178,8 +178,13 @@ class Journal(object):
     def get_ae_assignment_configuration_id(self):
         return self.__get_invitation_id(name='Assignment_Configuration', prefix=self.get_action_editors_id())
 
-    def get_ae_assignment_id(self, proposed=False):
-        return self.__get_invitation_id(name='Proposed_Assignment' if proposed else 'Assignment', prefix=self.get_action_editors_id())
+    def get_ae_assignment_id(self, proposed=False, archived=False):
+        name = 'Assignment'
+        if archived:
+            name = 'Archived_Assignment'
+        if proposed:
+            name = 'Proposed_Assignment'
+        return self.__get_invitation_id(name=name, prefix=self.get_action_editors_id())    
 
     def get_ae_recommendation_id(self, number=None):
         return self.__get_invitation_id(name='Recommendation', prefix=self.get_action_editors_id(number=number))
@@ -228,8 +233,11 @@ class Journal(object):
     def get_reviewer_affinity_score_id(self):
         return self.__get_invitation_id(name='Affinity_Score', prefix=self.get_reviewers_id())
 
-    def get_reviewer_assignment_id(self, number=None):
-        return self.__get_invitation_id(name='Assignment', prefix=self.get_reviewers_id(number))
+    def get_reviewer_assignment_id(self, number=None, archived=False):
+        name = 'Assignment'
+        if archived:
+            name = 'Archived_Assignment'
+        return self.__get_invitation_id(name=name, prefix=self.get_reviewers_id(number))
 
     def get_reviewer_assignment_acknowledgement_id(self, number=None, reviewer_id=None):
         if reviewer_id:
@@ -895,3 +903,46 @@ Your {lower_formatted_invitation} on a submission has been {action}
         invitation.domain = None
         invitation.invitations = None
         self.invitation_builder.post_invitation_edit(invitation, replacement=True)
+
+
+    def archive_assignments(self):
+
+        submissions = self.client.get_all_notes(invitation=self.get_author_submission_id())
+
+        ae_assignments = { e['id']['head']: e['values'] for e in self.client.get_grouped_edges(invitation=self.get_ae_assignment_id(), groupby='head')}
+        reviewer_assignments = { e['id']['head']: e['values'] for e in self.client.get_grouped_edges(invitation=self.get_reviewer_assignment_id(), groupby='head')}
+
+        ## Archive papers done
+        for submission in tqdm(submissions):
+            venueid = submission.content['venueid']['value']
+            if venueid in [self.accepted_venue_id, self.rejected_venue_id, self.desk_rejected_venue_id, self.withdrawn_venue_id, self.retracted_venue_id]:
+                submission_ae_assignments = ae_assignments.get(submission.id, [])
+                for ae_assignment in submission_ae_assignments:
+                    ae_assignment_edge = openreview.api.Edge.from_json(ae_assignment)
+                    archived_edge = openreview.api.Edge(
+                        invitation=self.get_ae_assignment_id(archived=True),
+                        head=ae_assignment_edge.head,
+                        tail=ae_assignment_edge.tail,
+                        weight=ae_assignment_edge.weight,
+                        label=ae_assignment_edge.label
+                    )
+                    self.client.post_edge(archived_edge)
+                    ## avoid process function execution
+                    self.client.delete_edges(invitation=ae_assignment_edge.invitation, head=ae_assignment_edge.head, tail=ae_assignment_edge.tail, soft_delete=True, wait_to_finish=True)
+
+                    
+                submission_reviewer_assignments = reviewer_assignments.get(submission.id, [])
+                for reviewer_assignment in submission_reviewer_assignments:
+                    reviewer_assignment_edge = openreview.api.Edge.from_json(reviewer_assignment)
+                    archived_edge = openreview.api.Edge(
+                        invitation=self.get_reviewer_assignment_id(archived=True),
+                        head=reviewer_assignment_edge.head,
+                        tail=reviewer_assignment_edge.tail,
+                        weight=reviewer_assignment_edge.weight,
+                        label=reviewer_assignment_edge.label,
+                        signatures=[self.venue_id]
+                    )
+                    self.client.post_edge(archived_edge)
+                    ## avoid process function execution
+                    self.client.delete_edges(invitation=reviewer_assignment_edge.invitation, head=reviewer_assignment_edge.head, tail=reviewer_assignment_edge.tail, soft_delete=True, wait_to_finish=True)
+                    

--- a/openreview/journal/webfield/editorsInChiefWebfield.js
+++ b/openreview/journal/webfield/editorsInChiefWebfield.js
@@ -24,12 +24,14 @@ var ASSIGNMENT_ACKNOWLEDGEMENT_NAME = 'Assignment/Acknowledgement';
 var AVAILABILITY_NAME = 'Assignment_Availability';
 
 var REVIEWERS_ASSIGNMENT_ID = REVIEWERS_ID + '/-/Assignment';
+var REVIEWERS_ARCHIVED_ASSIGNMENT_ID = REVIEWERS_ID + '/-/Archived_Assignment';
 var REVIEWERS_CONFLICT_ID = REVIEWERS_ID + '/-/Conflict';
 var REVIEWERS_AFFINITY_SCORE_ID = REVIEWERS_ID + '/-/Affinity_Score';
 var REVIEWERS_CUSTOM_MAX_PAPERS_ID = REVIEWERS_ID + '/-/Custom_Max_Papers';
 var REVIEWERS_PENDING_REVIEWS_ID = REVIEWERS_ID + '/-/Pending_Reviews';
 var REVIEWERS_AVAILABILITY_ID = REVIEWERS_ID + '/-/' + AVAILABILITY_NAME;
 var ACTION_EDITORS_ASSIGNMENT_ID = ACTION_EDITOR_ID + '/-/Assignment';
+var ACTION_EDITORS_ARCHIVED_ASSIGNMENT_ID = ACTION_EDITOR_ID + '/-/Archived_Assignment';
 var ACTION_EDITORS_CONFLICT_ID = ACTION_EDITOR_ID + '/-/Conflict';
 var ACTION_EDITORS_AFFINITY_SCORE_ID = ACTION_EDITOR_ID + '/-/Affinity_Score';
 var ACTION_EDITORS_CUSTOM_MAX_PAPERS_ID = ACTION_EDITOR_ID + '/-/Custom_Max_Papers';
@@ -70,11 +72,11 @@ var DESK_REJECTED_STATUS = VENUE_ID + '/Desk_Rejected'
 var referrerUrl = encodeURIComponent('[Editors-in-Chief Console](/group?id=' + EDITORS_IN_CHIEF_ID + ')');
 var ae_url = '/edges/browse?traverse=' + ACTION_EDITORS_ASSIGNMENT_ID +
   '&edit=' + ACTION_EDITORS_ASSIGNMENT_ID + ';' + ACTION_EDITORS_CUSTOM_MAX_PAPERS_ID + ',head:ignore' +
-  '&browse=' + ACTION_EDITORS_AFFINITY_SCORE_ID +';' + ACTION_EDITORS_RECOMMENDATION_ID + ';' + ACTION_EDITORS_CONFLICT_ID + ';' + ACTION_EDITORS_AVAILABILITY_ID + ',head:ignore' +
+  '&browse=' + ACTION_EDITORS_ARCHIVED_ASSIGNMENT_ID + ';' + ACTION_EDITORS_AFFINITY_SCORE_ID +';' + ACTION_EDITORS_RECOMMENDATION_ID + ';' + ACTION_EDITORS_CONFLICT_ID + ';' + ACTION_EDITORS_AVAILABILITY_ID + ',head:ignore' +
   '&version=2&referrer=' + referrerUrl;
 var reviewers_url = '/edges/browse?traverse=' + REVIEWERS_ASSIGNMENT_ID +
   '&edit=' + REVIEWERS_ASSIGNMENT_ID + ';' + REVIEWERS_CUSTOM_MAX_PAPERS_ID + ',head:ignore;' +
-  '&browse=' + REVIEWERS_AFFINITY_SCORE_ID+ ';' + REVIEWERS_CONFLICT_ID + ';' + REVIEWERS_PENDING_REVIEWS_ID + ',head:ignore;' + REVIEWERS_AVAILABILITY_ID + ',head:ignore' +
+  '&browse=' + REVIEWERS_ARCHIVED_ASSIGNMENT_ID + ';' + REVIEWERS_AFFINITY_SCORE_ID+ ';' + REVIEWERS_CONFLICT_ID + ';' + REVIEWERS_PENDING_REVIEWS_ID + ',head:ignore;' + REVIEWERS_AVAILABILITY_ID + ',head:ignore' +
   '&version=2&referrer=' + referrerUrl;
 HEADER.instructions = '<ul class="list-inline mb-0"><li><strong>Assignments Browser:</strong></li>' +
   '<li><a href="' + ae_url + '">Modify Action Editor Assignments</a></li>' +
@@ -676,7 +678,7 @@ var formatData = function(
         url: '/edges/browse?start=staticList,type:head,ids:' + submission.id +
         '&traverse=' + ACTION_EDITORS_ASSIGNMENT_ID +
         '&edit=' + ACTION_EDITORS_ASSIGNMENT_ID + ';' + ACTION_EDITORS_CUSTOM_MAX_PAPERS_ID + ',head:ignore' +
-        '&browse=' + ACTION_EDITORS_AFFINITY_SCORE_ID + ';' + ACTION_EDITORS_RECOMMENDATION_ID + ';' + ACTION_EDITORS_CONFLICT_ID + ';' + ACTION_EDITORS_AVAILABILITY_ID + ',head:ignore' +
+        '&browse=' + ACTION_EDITORS_ARCHIVED_ASSIGNMENT_ID + ';' + ACTION_EDITORS_AFFINITY_SCORE_ID + ';' + ACTION_EDITORS_RECOMMENDATION_ID + ';' + ACTION_EDITORS_CONFLICT_ID + ';' + ACTION_EDITORS_AVAILABILITY_ID + ',head:ignore' +
         '&version=2'
       }
     ] : [];
@@ -707,7 +709,7 @@ var formatData = function(
             url: '/edges/browse?start=staticList,type:head,ids:' + submission.id +
             '&traverse='+ REVIEWERS_ASSIGNMENT_ID +
             '&edit='+ REVIEWERS_ASSIGNMENT_ID + ';' + REVIEWERS_CUSTOM_MAX_PAPERS_ID + ',head:ignore;' +
-            '&browse=' + REVIEWERS_AFFINITY_SCORE_ID + ';' + REVIEWERS_CONFLICT_ID + ';' + REVIEWERS_PENDING_REVIEWS_ID + ',head:ignore;' + REVIEWERS_AVAILABILITY_ID + ',head:ignore' +
+            '&browse=' + REVIEWERS_ARCHIVED_ASSIGNMENT_ID + ';' + REVIEWERS_AFFINITY_SCORE_ID + ';' + REVIEWERS_CONFLICT_ID + ';' + REVIEWERS_PENDING_REVIEWS_ID + ',head:ignore;' + REVIEWERS_AVAILABILITY_ID + ',head:ignore' +
             '&version=2'
           }
         ] : [],


### PR DESCRIPTION
Reset the anual assignment counters for Action Editors and reviewers of the journal. 

- Soft delete assignments of submissions that are not under review anymore
- Create archived assignment edges to keep history of all the assignments in the edge browser.
- Update the EIC console to show the archived edges in the browse parameter.