### PR TITLE
use authorids as readers before the submission deadline

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -129,10 +129,6 @@ class InvitationBuilder(object):
 
         content = default_content.submission_v2.copy()
         
-        if submission_stage.double_blind:
-            content['authors']['readers'] = [venue_id, self.venue.get_authors_id('${4/number}')]
-            content['authorids']['readers'] = [venue_id, self.venue.get_authors_id('${4/number}')]
-
         for field in submission_stage.remove_fields:
             del content[field]
 
@@ -161,8 +157,8 @@ class InvitationBuilder(object):
             }
         }
 
-        edit_readers = ['everyone'] if submission_stage.create_groups else [venue_id, self.venue.get_authors_id('${2/note/number}')]
-        note_readers = ['everyone'] if submission_stage.create_groups else [venue_id, self.venue.get_authors_id('${2/number}')]
+        edit_readers = ['everyone'] if submission_stage.create_groups else [venue_id, '${2/note/content/authorids/value}']
+        note_readers = ['everyone'] if submission_stage.create_groups else [venue_id, '${2/content/authorids/value}']
 
         submission_id = submission_stage.get_submission_id(self.venue)
         submission_cdate = tools.datetime_millis(submission_stage.start_date if submission_stage.start_date else datetime.datetime.utcnow())
@@ -179,7 +175,7 @@ class InvitationBuilder(object):
             edit = {
                 'signatures': { 'param': { 'regex': '~.*' } },
                 'readers': edit_readers,
-                'writers': [venue_id, self.venue.get_authors_id('${2/note/number}')],
+                'writers': [venue_id, '${2/note/content/authorids/value}'],
                 'note': {
                     'id': {
                         'param': {
@@ -194,9 +190,9 @@ class InvitationBuilder(object):
                             'deletable': True
                         }
                     },                    
-                    'signatures': [ self.venue.get_authors_id('${2/number}') ],
+                    'signatures': [ '${3/signatures}' ],
                     'readers': note_readers,
-                    'writers': [venue_id, self.venue.get_authors_id('${2/number}')],
+                    'writers': [venue_id, '${2/content/authorids/value}'],
                     'content': content
                 }
             },

--- a/openreview/venue/process/submission_process.py
+++ b/openreview/venue/process/submission_process.py
@@ -32,6 +32,35 @@ Title: {note.content['title']['value']} {note_abstract}
 
 To view your submission, click here: https://openreview.net/forum?id={note.forum}'''
     
+    #send tauthor email
+    client.post_message(
+        subject=author_subject,
+        message=author_message,
+        recipients=[edit.tauthor]
+    )
+
+    # send co-author emails
+    if ('authorids' in note.content and len(note.content['authorids']['value'])):
+        author_message += f'''\n\nIf you are not an author of this submission and would like to be removed, please contact the author who added you at {edit.tauthor}'''
+        client.post_message(
+            subject=author_subject,
+            message=author_message,
+            recipients=note.signatures,
+            ignoreRecipients=[edit.tauthor]
+        )
+
+    if email_pcs:
+        client.post_message(
+            subject=f'''{short_phrase} has received a new submission titled {note.content['title']['value']}''',
+            message=f'''A submission to {short_phrase} has been posted.
+
+Submission Number: {note.number}
+Title: {note.content['title']['value']} {note_abstract}
+
+To view the submission, click here: https://openreview.net/forum?id={note.forum}''',
+            recipients=[program_chairs_id]
+        )
+
     paper_group_id=f'{venue_id}/{submission_name}{note.number}'
     paper_group=openreview.tools.get_group(client, paper_group_id)
     if not paper_group:
@@ -65,32 +94,3 @@ To view your submission, click here: https://openreview.net/forum?id={note.forum
         )
     )    
     client.add_members_to_group(authors_id, authors_group_id)
-
-    #send tauthor email
-    client.post_message(
-        subject=author_subject,
-        message=author_message,
-        recipients=[edit.tauthor]
-    )
-
-    # send co-author emails
-    if ('authorids' in note.content and len(note.content['authorids']['value'])):
-        author_message += f'''\n\nIf you are not an author of this submission and would like to be removed, please contact the author who added you at {edit.tauthor}'''
-        client.post_message(
-            subject=author_subject,
-            message=author_message,
-            recipients=note.signatures,
-            ignoreRecipients=[edit.tauthor]
-        )
-
-    if email_pcs:
-        client.post_message(
-            subject=f'''{short_phrase} has received a new submission titled {note.content['title']['value']}''',
-            message=f'''A submission to {short_phrase} has been posted.
-
-Submission Number: {note.number}
-Title: {note.content['title']['value']} {note_abstract}
-
-To view the submission, click here: https://openreview.net/forum?id={note.forum}''',
-            recipients=[program_chairs_id]
-        )

--- a/openreview/venue/process/submission_process.py
+++ b/openreview/venue/process/submission_process.py
@@ -16,15 +16,19 @@ def process(client, edit, invitation):
     author_subject = f'''{short_phrase} has received your submission titled {note.content['title']['value']}'''
     note_abstract = f'''\n\nAbstract: {note.content['abstract']['value']}''' if 'abstract' in note.content else ''
 
+    action = 'posted' if note.tcdate == note.tmdate else 'updated'
+    if note.ddate:
+        action = 'deleted'
+
     if submission_email:
         author_message=submission_email.replace('{{Abbreviated_Venue_Name}}', short_phrase)
-        author_message=author_message.replace('{{action}}', 'posted')
+        author_message=author_message.replace('{{action}}', action)
         author_message=author_message.replace('{{note_title}}', note.content['title']['value'])
         author_message=author_message.replace('{{note_abstract}}', note_abstract)
         author_message=author_message.replace('{{note_number}}', str(note.number))
         author_message=author_message.replace('{{note_forum}}', note.forum)
     else:
-        author_message = f'''Your submission to {short_phrase} has been posted.
+        author_message = f'''Your submission to {short_phrase} has been {action}.
 
 Submission Number: {note.number}
 
@@ -52,7 +56,7 @@ To view your submission, click here: https://openreview.net/forum?id={note.forum
     if email_pcs:
         client.post_message(
             subject=f'''{short_phrase} has received a new submission titled {note.content['title']['value']}''',
-            message=f'''A submission to {short_phrase} has been posted.
+            message=f'''A submission to {short_phrase} has been {action}.
 
 Submission Number: {note.number}
 Title: {note.content['title']['value']} {note_abstract}

--- a/openreview/venue/process/submission_process.py
+++ b/openreview/venue/process/submission_process.py
@@ -45,7 +45,7 @@ To view your submission, click here: https://openreview.net/forum?id={note.forum
         client.post_message(
             subject=author_subject,
             message=author_message,
-            recipients=note.signatures,
+            recipients=note.content['authorids']['value'],
             ignoreRecipients=[edit.tauthor]
         )
 

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -384,17 +384,36 @@ class Venue(object):
     def setup_post_submission_stage(self, force=False, hide_fields=[]):
         venue_id = self.venue_id
         submissions = self.get_submissions()
+        final_hide_fields = ['authors', 'authorids'] + hide_fields
         
         self.group_builder.create_paper_committee_groups(submissions)
         
         def update_submission_readers(submission):
+            note_content = {}
+            note_readers = None
+            note_writers = None
+            note_signatures = None
+
+            for field in final_hide_fields:
+                note_content[field] = {
+                    'readers': [venue_id, self.get_authors_id(submission.number)]
+                }
+
             if submission.content['venueid']['value'] == self.get_submission_venue_id():
+                note_readers = self.submission_stage.get_readers(self, submission.number)
+                note_writers = self.submission_stage.get_readers(self, submission.number)
+                note_signatures = [self.get_authors_id(submission.number)]
+
+            if note_content or note_readers:
                 return self.client.post_note_edit(invitation=self.get_meta_invitation_id(),
                     readers=[venue_id],
                     writers=[venue_id],
                     signatures=[venue_id],
                     note=openreview.api.Note(id=submission.id,
-                            readers = self.submission_stage.get_readers(self, submission.number)
+                            readers = note_readers,
+                            writers = note_writers,
+                            signatures = note_signatures,
+                            content = note_content 
                         )
                     )
         ## Release the submissions to specified readers if venueid is still submission

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -389,22 +389,19 @@ class Venue(object):
         self.group_builder.create_paper_committee_groups(submissions)
         
         def update_submission_readers(submission):
-            note_content = {}
-            note_readers = None
-            note_writers = None
-            note_signatures = None
-
-            for field in final_hide_fields:
-                note_content[field] = {
-                    'readers': [venue_id, self.get_authors_id(submission.number)]
-                }
 
             if submission.content['venueid']['value'] == self.get_submission_venue_id():
+
+                note_content = {}
+                for field in final_hide_fields:
+                    note_content[field] = {
+                        'readers': [venue_id, self.get_authors_id(submission.number)]
+                    }
+
                 note_readers = self.submission_stage.get_readers(self, submission.number)
-                note_writers = self.submission_stage.get_readers(self, submission.number)
+                note_writers = [venue_id,self.get_authors_id(submission.number)]
                 note_signatures = [self.get_authors_id(submission.number)]
 
-            if note_content or note_readers:
                 return self.client.post_note_edit(invitation=self.get_meta_invitation_id(),
                     readers=[venue_id],
                     writers=[venue_id],

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -384,7 +384,8 @@ class Venue(object):
     def setup_post_submission_stage(self, force=False, hide_fields=[]):
         venue_id = self.venue_id
         submissions = self.get_submissions()
-        final_hide_fields = ['authors', 'authorids'] + hide_fields
+        hide_author_fields = ['authors', 'authorids'] if self.submission_stage.double_blind else []
+        final_hide_fields = hide_author_fields + hide_fields
         
         self.group_builder.create_paper_committee_groups(submissions)
         

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -150,41 +150,34 @@ class TestICMLConference():
                 'use_recruitment_template': 'Yes',
                 'Additional Submission Options': {
                     "supplementary_material": {
-                        'value': {
-                            'param': {
-                                'type': 'file',
-                                'extensions': ['zip', 'pdf'],
-                                'maxSize': 100,
+                        "value": {
+                            "param": {
+                                "type": "file",
+                                "extensions": [
+                                    "zip",
+                                    "pdf",
+                                    "tgz",
+                                    "gz"
+                                ],
+                                "maxSize": 500,
                                 "optional": True
                             }
                         },
-                        "description": "All supplementary material must be self-contained and zipped into a single file. Note that supplementary material will be visible to reviewers and the public throughout and after the review period, and ensure all material is anonymized. The maximum file size is 100MB.",
-                        "order": 7,
-                        'readers': [ 
-                            'ICML.cc/2023/Conference', 
-                            'ICML.cc/2023/Conference/Submission${4/number}/Senior_Area_Chairs', 
-                            'ICML.cc/2023/Conference/Submission${4/number}/Area_Chairs', 
-                            'ICML.cc/2023/Conference/Submission${4/number}/Authors'
-                        ]
+                        "description": "All supplementary material must be self-contained and zipped into a single file. Note that supplementary material will be visible to reviewers and the public throughout and after the review period, and ensure all material is anonymized. The maximum file size is 500MB.",
+                        "order": 8
                     },
-                    "student_paper": {
-                        'value': {
-                            'param': {
-                                'type': 'string',
-                                'enum': ['Yes', 'No'],
-                                'input': 'radio'
+                    "financial_aid": {
+                        "order": 9,
+                        "description": "Each paper may designate up to one (1) icml.cc account email address of a corresponding student author who confirms that they would need the support to attend the conference, and agrees to volunteer if they get selected.",
+                        "value": {
+                            "param": {
+                                "type": "string",
+                                "maxLength": 100,
+                                "optional": True
                             }
-                        },
-                        "description": "Indicate if the submission is from a student.",
-                        "order": 7,
-                        'readers': [ 
-                            'ICML.cc/2023/Conference', 
-                            'ICML.cc/2023/Conference/Submission${4/number}/Authors'
-                        ]
+                        }
                     }
-
                 }
-  
             }
         ))
         helpers.await_queue()
@@ -192,7 +185,7 @@ class TestICMLConference():
         submission_invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/-/Submission')
         assert submission_invitation
         assert 'supplementary_material' in submission_invitation.edit['note']['content']
-        assert 'student_paper' in submission_invitation.edit['note']['content']
+        assert 'financial_aid' in submission_invitation.edit['note']['content']
 
 
 
@@ -447,7 +440,7 @@ reviewer6@icml.cc, Reviewer ICMLSix
                     'keywords': { 'value': ['machine learning', 'nlp'] },
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
-                    'student_paper': { 'value': 'Yes' }
+                    'financial_aid': { 'value': 'Yes' }
                 }
             )
             if i == 1:
@@ -458,12 +451,12 @@ reviewer6@icml.cc, Reviewer ICMLSix
                 signatures=['~SomeFirstName_User1'],
                 note=note)
 
-        helpers.await_queue()
+        helpers.await_queue(openreview_client)
 
         submissions = openreview_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
         assert len(submissions) == 100
-        assert ['ICML.cc/2023/Conference', 'ICML.cc/2023/Conference/Submission1/Authors'] == submissions[0].readers    
-
+        assert ['ICML.cc/2023/Conference', '~SomeFirstName_User1', 'peter@mail.com', 'andrew@amazon.com', '~SAC_ICMLOne1'] == submissions[0].readers    
+        assert ['~SomeFirstName_User1', 'peter@mail.com', 'andrew@amazon.com', '~SAC_ICMLOne1'] == submissions[0].content['authorids']['value']
 
     def test_ac_bidding(self, client, openreview_client, helpers, test_client):
 
@@ -474,7 +467,8 @@ reviewer6@icml.cc, Reviewer ICMLSix
         pc_client.post_note(openreview.Note(
             content= {
                 'force': 'Yes',
-                'submission_readers': 'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)'
+                'submission_readers': 'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)',
+                'hide_fields': ['financial_aid']
             },
             forum= request_form.id,
             invitation= f'openreview.net/Support/-/Request{request_form.number}/Post_Submission',
@@ -487,13 +481,23 @@ reviewer6@icml.cc, Reviewer ICMLSix
 
         helpers.await_queue()
 
-        submissions = openreview_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
+        ac_client = openreview.api.OpenReviewClient(username = 'ac1@icml.cc', password='1234')
+        submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
         assert len(submissions) == 100
         assert ['ICML.cc/2023/Conference', 
         'ICML.cc/2023/Conference/Senior_Area_Chairs',
         'ICML.cc/2023/Conference/Area_Chairs',
         'ICML.cc/2023/Conference/Reviewers',
         'ICML.cc/2023/Conference/Submission1/Authors'] == submissions[0].readers
+        assert ['ICML.cc/2023/Conference', 
+        'ICML.cc/2023/Conference/Senior_Area_Chairs',
+        'ICML.cc/2023/Conference/Area_Chairs',
+        'ICML.cc/2023/Conference/Reviewers',
+        'ICML.cc/2023/Conference/Submission1/Authors'] == submissions[0].writers
+        assert ['ICML.cc/2023/Conference/Submission1/Authors'] == submissions[0].signatures        
+        assert 'authorids' not in submissions[0].content
+        assert 'authors' not in submissions[0].content
+        assert 'financial_aid'not in submissions[0].content
 
         with open(os.path.join(os.path.dirname(__file__), 'data/rev_scores_venue.csv'), 'w') as file_handle:
             writer = csv.writer(file_handle)

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -490,9 +490,6 @@ reviewer6@icml.cc, Reviewer ICMLSix
         'ICML.cc/2023/Conference/Reviewers',
         'ICML.cc/2023/Conference/Submission1/Authors'] == submissions[0].readers
         assert ['ICML.cc/2023/Conference', 
-        'ICML.cc/2023/Conference/Senior_Area_Chairs',
-        'ICML.cc/2023/Conference/Area_Chairs',
-        'ICML.cc/2023/Conference/Reviewers',
         'ICML.cc/2023/Conference/Submission1/Authors'] == submissions[0].writers
         assert ['ICML.cc/2023/Conference/Submission1/Authors'] == submissions[0].signatures        
         assert 'authorids' not in submissions[0].content

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -114,7 +114,7 @@ class TestVenueSubmission():
         submission = openreview_client.get_note(submission_note_1['note']['id'])
         assert len(submission.readers) == 2
         assert 'TestVenue.cc' in submission.readers
-        assert 'TestVenue.cc/Submission1/Authors' in submission.readers
+        assert ['TestVenue.cc', '~Celeste_MartinezEleven1'] == submission.readers
 
         #TODO: check emails, check author console
 

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -116,7 +116,31 @@ class TestVenueSubmission():
         assert 'TestVenue.cc' in submission.readers
         assert ['TestVenue.cc', '~Celeste_MartinezEleven1'] == submission.readers
 
-        #TODO: check emails, check author console
+        messages = openreview_client.get_messages(subject = 'TV 22 has received your submission titled Paper 1 Title')
+        assert len(messages) == 1
+        assert 'Your submission to TV 22 has been posted.' in messages[0]['content']['text']
+
+        #update submission 1
+        updated_submission_note_1 = author_client.post_note_edit(invitation='TestVenue.cc/-/Submission',
+            signatures=['~Celeste_MartinezEleven1'],
+            note=Note(id=submission.id,
+                content={
+                    'title': { 'value': 'Paper 1 Title UPDATED' },
+                    'abstract': { 'value': 'Paper abstract' },
+                    'authors': { 'value': ['Celeste MartinezEleven']},
+                    'authorids': { 'value': ['~Celeste_MartinezEleven1']},
+                    'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
+                    'keywords': {'value': ['aa'] }
+                }
+            ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=updated_submission_note_1['id'])
+
+        messages = openreview_client.get_messages(subject = 'TV 22 has received your submission titled Paper 1 Title UPDATED')
+        assert len(messages) == 1
+        assert 'Your submission to TV 22 has been updated.' in messages[0]['content']['text']
+
+        #TODO: check author console
 
         submission_note_2 = author_client.post_note_edit(
             invitation='TestVenue.cc/-/Submission',


### PR DESCRIPTION
Authors can see and edit their submission without depending on the process function to be executed with no errors. 