### PR TITLE
Fix/icml fixes

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -175,7 +175,14 @@ class InvitationBuilder(object):
             edit = {
                 'signatures': { 'param': { 'regex': '~.*' } },
                 'readers': edit_readers,
-                'writers': [venue_id, '${2/note/content/authorids/value}'],
+                'writers': [venue_id],
+                'ddate': {
+                    'param': {
+                        'range': [ 0, 9999999999999 ],
+                        'optional': True,
+                        'deletable': True
+                    }
+                },                
                 'note': {
                     'id': {
                         'param': {

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -173,7 +173,7 @@ class InvitationBuilder(object):
             duedate=tools.datetime_millis(submission_stage.due_date) if submission_stage.due_date else None,
             expdate = tools.datetime_millis(submission_stage.due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)) if submission_stage.due_date else None,
             edit = {
-                'signatures': { 'param': { 'regex': '~.*' } },
+                'signatures': { 'param': { 'regex': f'~.*|{self.venue.get_program_chairs_id()}' } },
                 'readers': edit_readers,
                 'writers': [venue_id],
                 'ddate': {
@@ -1049,6 +1049,7 @@ class InvitationBuilder(object):
         withdrawn_invitation = Invitation (
             id=self.venue.get_withdrawn_id(),
             invitees = [venue_id],
+            noninvitees = [self.venue.get_program_chairs_id()],
             signatures = [venue_id],
             readers = ['everyone'],
             writers = [venue_id],
@@ -1303,6 +1304,7 @@ class InvitationBuilder(object):
         desk_rejected_invitation = Invitation (
             id=self.venue.get_desk_rejected_id(),
             invitees = [venue_id],
+            noninvitees = [self.venue.get_program_chairs_id()],
             signatures = [venue_id],
             readers = ['everyone'],
             writers = [venue_id],

--- a/openreview/venue/process/submission_process.py
+++ b/openreview/venue/process/submission_process.py
@@ -97,4 +97,7 @@ To view the submission, click here: https://openreview.net/forum?id={note.forum}
             members=note.content['authorids']['value'] ## always update authors
         )
     )    
-    client.add_members_to_group(authors_id, authors_group_id)
+    if action == 'posted' or action == 'updated':
+        client.add_members_to_group(authors_id, authors_group_id)
+    if action == 'deleted':
+        client.remove_members_from_group(authors_id, authors_group_id)

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1149,7 +1149,7 @@ class VenueRequest():
             },
             'api_version': {
                 'description': 'Which API version would you like to use? API 2 is still in the experimental phase, contact us if you would like more information.',
-                'value-checkbox': ['1', '2'],
+                'value-radio': ['1', '2'],
                 'default': '1',
                 'order': 39
             },

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -458,6 +458,65 @@ reviewer6@icml.cc, Reviewer ICMLSix
         assert ['ICML.cc/2023/Conference', '~SomeFirstName_User1', 'peter@mail.com', 'andrew@amazon.com', '~SAC_ICMLOne1'] == submissions[0].readers    
         assert ['~SomeFirstName_User1', 'peter@mail.com', 'andrew@amazon.com', '~SAC_ICMLOne1'] == submissions[0].content['authorids']['value']
 
+        authors_group = openreview_client.get_group(id='ICML.cc/2023/Conference/Authors')
+
+        for i in range(1,101):
+            assert f'ICML.cc/2023/Conference/Submission{i}/Authors' in authors_group.members
+
+        ## delete a submission and update authors group
+        submission = submissions[0]
+        test_client.post_note_edit(invitation='ICML.cc/2023/Conference/-/Submission',
+            signatures=['~SomeFirstName_User1'],
+            note=openreview.api.Note(
+                id = submission.id,
+                ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                content = {
+                    'title': submission.content['title'],
+                    'abstract': submission.content['abstract'],
+                    'authorids': submission.content['authorids'],
+                    'authors': submission.content['authors'],
+                    'keywords': submission.content['keywords'],
+                    'pdf': submission.content['pdf'],
+                    'supplementary_material': submission.content['supplementary_material'],
+                    'financial_aid': submission.content['financial_aid'],                    
+                }
+            ))
+
+        helpers.await_queue(openreview_client)
+
+        authors_group = openreview_client.get_group(id='ICML.cc/2023/Conference/Authors')
+
+        assert f'ICML.cc/2023/Conference/Submission1/Authors' not in authors_group.members
+        for i in range(2,101):
+            assert f'ICML.cc/2023/Conference/Submission{i}/Authors' in authors_group.members
+
+        ## restore the submission and update the authors group
+        submission = submissions[0]
+        test_client.post_note_edit(invitation='ICML.cc/2023/Conference/-/Submission',
+            signatures=['~SomeFirstName_User1'],
+            note=openreview.api.Note(
+                id = submission.id,
+                ddate = { 'delete': True },
+                content = {
+                    'title': submission.content['title'],
+                    'abstract': submission.content['abstract'],
+                    'authorids': submission.content['authorids'],
+                    'authors': submission.content['authors'],
+                    'keywords': submission.content['keywords'],
+                    'pdf': submission.content['pdf'],
+                    'supplementary_material': submission.content['supplementary_material'],
+                    'financial_aid': submission.content['financial_aid'],                    
+                }
+            ))
+
+        helpers.await_queue(openreview_client)
+
+        authors_group = openreview_client.get_group(id='ICML.cc/2023/Conference/Authors')
+
+        for i in range(1,101):
+            assert f'ICML.cc/2023/Conference/Submission{i}/Authors' in authors_group.members        
+
+
     def test_ac_bidding(self, client, openreview_client, helpers, test_client):
 
         pc_client=openreview.Client(username='pc@icml.cc', password='1234')


### PR DESCRIPTION
- Let the PCs sign submission edits.
- Only PCs can edit/trash submission edits.
- Add PCs as non invitees of internal invitation so they don't appear in the UI.
- Update authors group when submission is deleted or restored