### PR TITLE
support empty rows and emails between ()

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1340,7 +1340,7 @@ class Conference(object):
         reviewers_invited_id = reviewers_id + '/Invited'
         reviewers_accepted_id = reviewers_id
         hash_seed = '1234'
-        invitees = [e.lower() if '@' in e else e for e in invitees]
+        invitees = [e.lower() if '@' in e else e for e in invitees if len(e) > 0]
         self.set_default_load(default_load, reviewers_name)
 
         reviewers_accepted_group = self.__create_group(reviewers_accepted_id, pcs_id)

--- a/openreview/venue_request/process/recruitmentProcess.py
+++ b/openreview/venue_request/process/recruitmentProcess.py
@@ -27,7 +27,7 @@ def process(client, note, invitation):
     note.content['invitation_email_subject'] = note.content['invitation_email_subject'].replace('{{invitee_role}}', pretty_role)
     note.content['invitation_email_content'] = note.content['invitation_email_content'].replace('{{invitee_role}}', pretty_role)
 
-    invitee_details_str = note.content.get('invitee_details', None)
+    invitee_details_str = note.content.get('invitee_details', None).strip()
     invitee_emails = []
     invitee_names = []
     if invitee_details_str:
@@ -36,11 +36,11 @@ def process(client, note, invitation):
             if invitee:
                 details = [i.strip() for i in invitee.split(',') if i]
                 if len(details) == 1:
-                    email = details[0]
+                    email = details[0][1:] if details[0].startswith('(') else details[0]
                     name = None
                 else:
-                    email = details[0]
-                    name = details[1]
+                    email = details[0][1:] if details[0].startswith('(') else details[0]
+                    name = details[1][:-1] if details[1].endswith(')') else details[1]
                 invitee_emails.append(email)
                 invitee_names.append(name)
 

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -481,7 +481,7 @@ class TestVenueRequest():
         assert reply_row
         buttons = reply_row.find_elements_by_class_name('btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
-        reviewer_details = '''reviewer_candidate1@email.com, Reviewer One\nreviewer_candidate2@email.com, Reviewer Two'''
+        reviewer_details = '''(reviewer_candidate1@email.com, Reviewer One)\nreviewer_candidate2@email.com, Reviewer Two\n '''
         recruitment_note = test_client.post_note(openreview.Note(
             content={
                 'title': 'Recruitment',


### PR DESCRIPTION
- Remove empty lines in invitee_details
- Remove empty emails in the invitees params
- Support invitees surrounded by (), like '(melisa@openreview.net, Melisa Bok)'