### PR TITLE
don't override if the webfield is not a landing page

### DIFF
--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -44,7 +44,7 @@ class WebfieldBuilder(object):
 
     def set_landing_page(self, group, parentGroup, options = {}):
         ## Remove existing webfield to the UI renders the groups directory
-        if group.web:
+        if group.web and 'VENUE_LINKS' in group.web:
             group.web = None
             self.client.post_group(group)
 


### PR DESCRIPTION
To fix KDD where the parent group has a special webfield