### PR TITLE
add pdate and odate to accepted papers

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -25,6 +25,26 @@ Client
 .. autoclass:: Profile
    :members:
 
+API 2 Client
+-------
+
+.. automodule:: openreview.api
+
+.. autoclass:: OpenReviewClient
+   :members:
+
+.. autoclass:: Group
+   :members:
+
+.. autoclass:: Invitation
+   :members:
+
+.. autoclass:: Note
+   :members:
+
+.. autoclass:: Edit
+   :members:
+
 
 Tools
 -------

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1986,6 +1986,7 @@ class Note(object):
         number=None,
         cdate=None,
         pdate=None,
+        odate=None,
         mdate=None,
         tcdate=None,
         tmdate=None,
@@ -2000,6 +2001,7 @@ class Note(object):
         self.number = number
         self.cdate = cdate
         self.pdate = pdate
+        self.odate = odate
         self.mdate = mdate
         self.tcdate = tcdate
         self.tmdate = tmdate
@@ -2047,6 +2049,8 @@ class Note(object):
             body['cdate'] = self.cdate
         if self.pdate:
             body['pdate'] = self.pdate
+        if self.odate:
+            body['odate'] = self.odate
         if self.mdate:
             body['mdate'] = self.mdate
         if self.ddate:
@@ -2077,6 +2081,8 @@ class Note(object):
         number = n.get('number'),
         cdate = n.get('cdate'),
         mdate = n.get('mdate'),
+        pdate = n.get('pdate'),
+        odate = n.get('odate'), 
         tcdate = n.get('tcdate'),
         tmdate =n.get('tmdate'),
         ddate=n.get('ddate'),

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1580,6 +1580,8 @@ Program Chairs
             result = future.result()
 
     def post_decision_stage(self, reveal_all_authors=False, reveal_authors_accepted=False, decision_heading_map=None, submission_readers=None):
+        
+        publication_date = openreview.tools.datetime_millis(datetime.datetime.utcnow())
         submissions = self.get_submissions(details='original,directReplies')
 
         def is_release_authors(is_note_accepted):
@@ -1639,7 +1641,8 @@ Program Chairs
                     'venue': venue,
                     'venueid': self.id,
                     '_bibtex': bibtex
-                }
+                },
+                pdate = publication_date if (note_accepted and submission.pdate is None) else None
             ))
 
         venue_heading_map = {}

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1642,7 +1642,8 @@ Program Chairs
                     'venueid': self.id,
                     '_bibtex': bibtex
                 },
-                pdate = publication_date if (note_accepted and submission.pdate is None) else None
+                pdate = publication_date if (note_accepted and submission.pdate is None) else None,
+                odate = publication_date if ('everyone' in submission.readers and submission.odate is None) else None
             ))
 
         venue_heading_map = {}

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -953,6 +953,7 @@ class Conference(object):
 
                 revision_note = self.client.post_note(openreview.Note(
                     invitation = f'{self.support_user}/-/{self.venue_revision_name}',
+                    odate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if note.odate is None else None,
                     forum = note.id,
                     referent = note.id,
                     readers = ['everyone'],
@@ -981,6 +982,7 @@ class Conference(object):
                 final_readers =  self.submission_stage.get_readers(conference=self, number=s.number)
                 if s.readers != final_readers:
                     s.readers = final_readers
+                    s.odate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if ('everyone' in s.readers and s.odate is None) else None
                     self.client.post_note(s)
 
         self.create_paper_groups(authors=True, reviewers=True, area_chairs=True, senior_area_chairs=True)

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -954,7 +954,7 @@ class Conference(object):
 
                 revision_note = self.client.post_note(openreview.Note(
                     invitation = f'{self.support_user}/-/{self.venue_revision_name}',
-                    odate = online_date if note.odate is None else None,
+                    odate = online_date if note.odate is None else note.odate,
                     forum = note.id,
                     referent = note.id,
                     readers = ['everyone'],
@@ -984,7 +984,7 @@ class Conference(object):
                 final_readers =  self.submission_stage.get_readers(conference=self, number=s.number)
                 if s.readers != final_readers:
                     s.readers = final_readers
-                    s.odate = online_date if ('everyone' in s.readers and s.odate is None) else None
+                    s.odate = online_date if ('everyone' in s.readers and s.odate is None) else s.odate
                     self.client.post_note(s)
 
         self.create_paper_groups(authors=True, reviewers=True, area_chairs=True, senior_area_chairs=True)
@@ -1028,7 +1028,7 @@ class Conference(object):
                 final_readers =  self.submission_stage.get_readers(conference=self, number=note.number)
                 if note.readers != final_readers:
                     note.readers = final_readers
-                    note.odate =  online_date if ('everyone' in note.readers and note.odate is None) else None
+                    note.odate =  online_date if ('everyone' in note.readers and note.odate is None) else note.odate
                     self.client.post_note(note)
 
         self.create_paper_groups(authors=True, reviewers=True, area_chairs=True, senior_area_chairs=True)
@@ -1648,8 +1648,8 @@ Program Chairs
                     'venueid': self.id,
                     '_bibtex': bibtex
                 },
-                pdate = publication_date if (note_accepted and submission.pdate is None) else None,
-                odate = publication_date if ('everyone' in submission.readers and submission.odate is None) else None
+                pdate = publication_date if (note_accepted and submission.pdate is None) else submission.pdate,
+                odate = publication_date if ('everyone' in submission.readers and submission.odate is None) else submission.odate
             ))
 
         venue_heading_map = {}

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -2599,6 +2599,13 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                             'withInvitation': self.journal.get_author_submission_id() 
                         },
                     },
+                    'odate': {
+                        'param': {
+                            'range': [ 0, 9999999999999 ],
+                            'optional': True,
+                            'deletable': True
+                        }
+                    },                    
                     'readers': self.journal.get_under_review_submission_readers('${2/number}'),
                     'content': {
                         'assigned_action_editor': {
@@ -2841,6 +2848,11 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                             'withInvitation': self.journal.get_under_review_id() 
                         }
                     },
+                    'pdate': {
+                        'param': {
+                            'range': [ 0, 9999999999999 ]
+                        }
+                    },                    
                     'writers': [ venue_id ],
                     'content': {
                         '_bibtex': {

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -577,7 +577,7 @@ class Journal(object):
                     invitee_members.append(profile.id)
                 elif '@' in invitee:
                     profile = openreview.tools.get_profile(self.client, invitee)
-                    invitee_members.append(profile.id)
+                    invitee_members.append(profile.id if profile else invitee)
                 else:
                     invitee_members = invitee_members + self.client.get_group(invitee).members
 

--- a/openreview/journal/process/camera_ready_verification_process.py
+++ b/openreview/journal/process/camera_ready_verification_process.py
@@ -28,6 +28,7 @@ def process(client, edit, invitation):
     acceptance_note = client.post_note_edit(invitation=journal.get_accepted_id(),
                         signatures=[venue_id],
                         note=openreview.api.Note(id=submission.id,
+                            pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()),
                             content= content
                         )
                     )

--- a/openreview/journal/process/review_approval_process.py
+++ b/openreview/journal/process/review_approval_process.py
@@ -25,6 +25,7 @@ def process(client, edit, invitation):
         return client.post_note_edit(invitation= journal.get_under_review_id(),
                                 signatures=[venue_id],
                                 note=openreview.api.Note(id=edit.note.forum,
+                                odate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if journal.is_submission_public() else None,
                                 content={
                                     '_bibtex': {
                                         'value': journal.get_bibtex(submission, journal.under_review_venue_id)

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -2329,6 +2329,7 @@ class Note(object):
         number=None,
         cdate=None,
         pdate=None,
+        odate=None,
         mdate=None,
         tcdate=None,
         tmdate=None,
@@ -2345,6 +2346,7 @@ class Note(object):
         self.number = number
         self.cdate = cdate
         self.pdate = pdate
+        self.odate = odate
         self.mdate = mdate
         self.tcdate = tcdate
         self.tmdate = tmdate
@@ -2382,6 +2384,7 @@ class Note(object):
             'original': self.original,
             'cdate': self.cdate,
             'pdate': self.pdate,
+            'odate': self.odate,
             'mdate': self.mdate,
             'tcdate': self.tcdate,
             'tmdate': self.tmdate,
@@ -2415,6 +2418,8 @@ class Note(object):
         id = n.get('id'),
         original = n.get('original'),
         number = n.get('number'),
+        pdate = n.get('pdate'),
+        odate = n.get('odate'),
         cdate = n.get('cdate'),
         mdate = n.get('mdate'),
         tcdate = n.get('tcdate'),

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -407,17 +407,21 @@ class Venue(object):
                 note_writers = [venue_id,self.get_authors_id(submission.number)]
                 note_signatures = [self.get_authors_id(submission.number)]
 
-                return self.client.post_note_edit(invitation=self.get_meta_invitation_id(),
-                    readers=[venue_id],
-                    writers=[venue_id],
-                    signatures=[venue_id],
-                    note=openreview.api.Note(id=submission.id,
-                            readers = note_readers,
-                            writers = note_writers,
-                            signatures = note_signatures,
-                            content = note_content 
+                if submission.readers != note_readers:
+                    return self.client.post_note_edit(invitation=self.get_meta_invitation_id(),
+                        readers=[venue_id],
+                        writers=[venue_id],
+                        signatures=[venue_id],
+                        note=openreview.api.Note(id=submission.id,
+                                odate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if (submission.odate is None and 'everyone' in note_readers) else None,
+                                readers = note_readers,
+                                writers = note_writers,
+                                signatures = note_signatures,
+                                content = note_content 
+                            )
                         )
-                    )
+                else:
+                    return submission
         ## Release the submissions to specified readers if venueid is still submission
         openreview.tools.concurrent_requests(update_submission_readers, submissions, desc='update_submission_readers')
 
@@ -625,6 +629,7 @@ Total Errors: {len(errors)}
                 note=openreview.api.Note(id=submission.id,
                         readers = submission_readers,
                         content = content,
+                        odate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if (submission.odate is None and 'everyone' in submission_readers) else None,
                         pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if (submission.pdate is None and note_accepted) else None
                     )
                 )

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -1,8 +1,7 @@
 import csv
 import json
 from json import tool
-import os
-import time
+import datetime
 from io import StringIO
 from multiprocessing import cpu_count
 from concurrent.futures import ThreadPoolExecutor
@@ -625,7 +624,8 @@ Total Errors: {len(errors)}
                 signatures=[venue_id],
                 note=openreview.api.Note(id=submission.id,
                         readers = submission_readers,
-                        content = content
+                        content = content,
+                        pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if (submission.pdate is None and note_accepted) else None
                     )
                 )
 

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -2116,6 +2116,13 @@ url={'''
         conference = builder.get_result()
         conference.create_decision_stage()
 
+        notes = conference.get_submissions(sort='tmdate')
+        assert notes
+        assert len(notes) == 1
+        note = notes[0]
+        original_pdate = note.pdate
+        orignal_odate = note.odate
+
         conference.post_decision_stage(reveal_authors_accepted=True, decision_heading_map={'Accept (Poster)': 'Accepted poster papers', 'Accept (Oral)': 'Accepted oral papers', 'Reject': 'Reject'})
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", wait_for_element='reject')
@@ -2153,7 +2160,8 @@ url={'''
         assert note.content['_bibtex'] == valid_bibtex
         assert note.content['venue'] == 'AKBC 2019 Oral'
         assert note.content['venueid'] == 'AKBC.ws/2019/Conference'
-        assert note.pdate
+        assert note.pdate == original_pdate
+        assert note.odate == orignal_odate
 
         accepted_authors = client.get_group('AKBC.ws/2019/Conference/Authors/Accepted')
         assert accepted_authors

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -2034,6 +2034,7 @@ url={'''
         assert note.content['_bibtex'] == valid_bibtex
         assert 'venue' in note.content and not note.content['venue']
         assert 'venueid' in note.content and not note.content['venueid']
+        assert note.pdate is None
 
     def test_release_accepted_notes_without_revealing_authors(self, client, request_page, selenium):
         builder = openreview.conference.ConferenceBuilder(client, support_user='openreview.net/Support')
@@ -2090,6 +2091,7 @@ url={'''
         assert note.content['venueid'] == 'AKBC.ws/2019/Conference'
         assert note.content['authors'] == ['Anonymous']
         assert note.content['authorids'] == ['AKBC.ws/2019/Conference/Paper1/Authors']
+        assert note.pdate is None
 
         accepted_authors = client.get_group('AKBC.ws/2019/Conference/Authors/Accepted')
         assert accepted_authors
@@ -2148,6 +2150,7 @@ url={'''
         assert note.content['_bibtex'] == valid_bibtex
         assert note.content['venue'] == 'AKBC 2019 Oral'
         assert note.content['venueid'] == 'AKBC.ws/2019/Conference'
+        assert note.pdate
 
         accepted_authors = client.get_group('AKBC.ws/2019/Conference/Authors/Accepted')
         assert accepted_authors
@@ -2248,6 +2251,7 @@ url={'''
         assert note.content['_bibtex'] == valid_bibtex
         assert note.content['venue'] == 'AKBC 2019 Oral'
         assert note.content['venueid'] == 'AKBC.ws/2019/Conference'
+        assert note.pdate
 
         accepted_authors = client.get_group('AKBC.ws/2019/Conference/Authors/Accepted')
         assert accepted_authors

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -885,6 +885,7 @@ class TestDoubleBlindConference():
         assert len(blind_submissions_3) == 3
         assert blind_submissions[0].id == blind_submissions_3[2].id
         assert blind_submissions_3[2].readers == ['everyone']
+        assert blind_submissions_3[2].odate
 
         assert client.get_group('AKBC.ws/2019/Conference/Paper1/Authors')
         assert client.get_group('AKBC.ws/2019/Conference/Paper2/Authors')
@@ -2035,6 +2036,7 @@ url={'''
         assert 'venue' in note.content and not note.content['venue']
         assert 'venueid' in note.content and not note.content['venueid']
         assert note.pdate is None
+        assert note.odate
 
     def test_release_accepted_notes_without_revealing_authors(self, client, request_page, selenium):
         builder = openreview.conference.ConferenceBuilder(client, support_user='openreview.net/Support')
@@ -2091,7 +2093,8 @@ url={'''
         assert note.content['venueid'] == 'AKBC.ws/2019/Conference'
         assert note.content['authors'] == ['Anonymous']
         assert note.content['authorids'] == ['AKBC.ws/2019/Conference/Paper1/Authors']
-        assert note.pdate is None
+        assert note.pdate
+        assert note.odate
 
         accepted_authors = client.get_group('AKBC.ws/2019/Conference/Authors/Accepted')
         assert accepted_authors

--- a/tests/test_eswc_conference.py
+++ b/tests/test_eswc_conference.py
@@ -339,9 +339,13 @@ url={https://openreview.net/forum?id=''' + withdrawn_notes[0].id + '''}
         submissions = conference.get_submissions(sort='number:desc')
         assert len(submissions) == 4
         assert submissions[0].readers == ['everyone']
+        assert submissions[0].odate
         assert submissions[1].readers == ['everyone']
+        assert submissions[1].odate
         assert submissions[2].readers == ['everyone']
+        assert submissions[2].odate
         assert submissions[3].readers == ['everyone']
+        assert submissions[3].odate
 
         ## Withdraw paper
         test_client.post_note(openreview.Note(invitation='eswc-conferences.org/ESWC/2021/Conference/Paper5/-/Withdraw',

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -637,9 +637,13 @@ Naila, Katja, Alice, and Ivan
         submissions = conference.get_submissions(sort='tmdate')
         assert len(submissions) == 4
         assert submissions[0].readers == ['everyone']
+        assert submissions[0].odate
         assert submissions[1].readers == ['everyone']
+        assert submissions[1].odate
         assert submissions[2].readers == ['everyone']
+        assert submissions[2].odate
         assert submissions[3].readers == ['everyone']
+        assert submissions[3].odate
 
         ## Withdraw paper
         test_client.post_note(openreview.Note(invitation='ICLR.cc/2021/Conference/Paper2/-/Withdraw',

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -480,6 +480,7 @@ The TMLR Editors-in-Chief
 
         note = joelle_client.get_note(note_id_1)
         assert note
+        assert note.odate
         assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Under_Review']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper1/Authors']
@@ -1975,6 +1976,7 @@ The TMLR Editors-in-Chief
         assert note
         assert note.forum == note_id_1
         assert note.replyto is None
+        assert note.pdate
         assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Under_Review', 'TMLR/Paper1/-/Camera_Ready_Revision', 'TMLR/-/Accepted']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR']

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -864,6 +864,7 @@ The OpenReview Team.
         acceptance_note = openreview_client.post_note_edit(invitation=journal.get_accepted_id(),
             signatures=['CABJ'],
             note=openreview.api.Note(id=submission.id,
+                pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()),
                 content= {
                     '_bibtex': {
                         'value': journal.get_bibtex(submission, journal.accepted_venue_id, certifications=[])

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -782,6 +782,8 @@ url={https://openreview.net/forum?id='''
 }'''
 
         assert submissions[0].content['_bibtex'] == valid_bibtex
+        assert submissions[0].pdate
+        assert submissions[0].odate
 
     def test_enable_camera_ready_revisions(self, client, test_client, helpers):
 

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -2241,18 +2241,21 @@ Best,
         # Assert accepted submission is public and rejected submission and submission with no decision are private
         assert submissions[0].readers == ['everyone']
         assert submissions[0].pdate
+        assert submissions[0].odate
         assert submissions[1].readers == ['V2.cc/2030/Conference',
             'V2.cc/2030/Conference/Submission2/Senior_Area_Chairs',
             'V2.cc/2030/Conference/Submission2/Area_Chairs',
             'V2.cc/2030/Conference/Submission2/Reviewers',
             'V2.cc/2030/Conference/Submission2/Authors']
         assert not submissions[1].pdate
+        assert not submissions[1].odate
         assert submissions[2].readers == ['V2.cc/2030/Conference',
             'V2.cc/2030/Conference/Submission3/Senior_Area_Chairs',
             'V2.cc/2030/Conference/Submission3/Area_Chairs',
             'V2.cc/2030/Conference/Submission3/Reviewers',
             'V2.cc/2030/Conference/Submission3/Authors']
         assert not submissions[2].pdate
+        assert not submissions[2].odate
 
         # assert authors of accepted paper were released
         assert submissions[0].content['venue']['value'] == 'TestVenue@OR\'2030V2'

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -2240,16 +2240,19 @@ Best,
 
         # Assert accepted submission is public and rejected submission and submission with no decision are private
         assert submissions[0].readers == ['everyone']
+        assert submissions[0].pdate
         assert submissions[1].readers == ['V2.cc/2030/Conference',
             'V2.cc/2030/Conference/Submission2/Senior_Area_Chairs',
             'V2.cc/2030/Conference/Submission2/Area_Chairs',
             'V2.cc/2030/Conference/Submission2/Reviewers',
             'V2.cc/2030/Conference/Submission2/Authors']
+        assert not submissions[1].pdate
         assert submissions[2].readers == ['V2.cc/2030/Conference',
             'V2.cc/2030/Conference/Submission3/Senior_Area_Chairs',
             'V2.cc/2030/Conference/Submission3/Area_Chairs',
             'V2.cc/2030/Conference/Submission3/Reviewers',
             'V2.cc/2030/Conference/Submission3/Authors']
+        assert not submissions[2].pdate
 
         # assert authors of accepted paper were released
         assert submissions[0].content['venue']['value'] == 'TestVenue@OR\'2030V2'


### PR DESCRIPTION
Set odate and pdate for submissions hosted in API 1 and API2. 

UPDATE: add small fix to the journal get late invitees.

Fixes: https://github.com/openreview/openreview-py/issues/1368