### PR TITLE
Fix/ builder: restore assignment edges when submission is restored

### DIFF
--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -52,6 +52,21 @@ def process_update(client, note, invitation, existing_note):
             forum_note.readers = SUBMISSION_READERS
             forum_note = client.post_note(forum_note)
 
+            #restore assignment edges
+            conference_roles = '|'.join(CONFERENCE_ROLES)
+            paper_groups = client.get_groups(regex=f'{CONFERENCE_ID}/Paper{forum_note.number}/({conference_roles})$')
+            members = []
+            for group in paper_groups:
+                members.extend(group.members)
+
+            for role in CONFERENCE_ROLES:
+                edges = client.get_edges(invitation=f'{CONFERENCE_ID}/{role}/-/Assignment', head=forum_note.id, trash=True)
+                for edge in edges:
+                    if edge.tail in members:
+                        print('Restoring edge:', edge.id)
+                        edge.ddate = None
+                        client.post_edge(edge)
+
             # Restore review, meta-review and decision invitations
             invitation_ids = ','.join([
                 f'{CONFERENCE_ID}/Paper{str(forum_note.number)}/-/Official_Review',


### PR DESCRIPTION
- Restores assignment edges or desk-reject/withdrawal reversion
- Not sure how we can revert the `/Proposed_Assignment` edges. For `/Assignment` edges, I am checking the paper groups to make sure I am not restoring old assignment edges. 