### PR TITLE
Feature/AC console - show multiple SACs

### DIFF
--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -215,7 +215,7 @@ var loadData = function(paperNums) {
   var noteNumbers = _.uniq(_.concat(acPapers, secondaryAcPapers));
   var blindedNotesP;
   var allReviewersP;
-  var assignedSACsP = $.Deferred().resolve();
+  var assignedSACsP = $.Deferred().resolve([]);
 
   if (noteNumbers.length) {
     var noteNumbersStr = noteNumbers.join(',');


### PR DESCRIPTION
there's a section at top of AC console to show the assigned SAC
currently only the first SAC will be shown.

this pr should show multiple SACs if they are assigned to the same AC