### PR TITLE
Fix/ venue recruitment: convert emails to lowercase

### DIFF
--- a/openreview/venue/recruitment.py
+++ b/openreview/venue/recruitment.py
@@ -55,6 +55,8 @@ class Recruitment(object):
         invitation_id = invitation.id
         hash_seed = invitation.content['hash_seed']['value']
 
+        invitees = [invitee.lower() if not invitee.startswith('~') else invitee for invitee in invitees]
+
         if remind:
             committee_invited_group = self.client.get_group(committee_invited_id)
             invited_committee = committee_invited_group.members

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -485,7 +485,7 @@ class TestVenueRequest():
         # assert reply_row
         # buttons = reply_row.find_elements_by_class_name('btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Recruitment']
-        reviewer_details = '''reviewer_candidate1_v2@mail.com, Reviewer One\nreviewer_candidate2_v2@mail.com, Reviewer Two'''
+        reviewer_details = '''reviewer_candidate1_v2@mail.com, Reviewer One\nReviewer_Candidate2_v2@mail.com, Reviewer Two'''
         recruitment_note = test_client.post_note(openreview.Note(
             content={
                 'title': 'Recruitment',


### PR DESCRIPTION
- Fixes #1567
- The lowercase email was being correctly added to the invited group, but I was getting an error with sending the email. Now, I am making all emails lowercase before starting the recruitment.