### PR TITLE
Fix/PC console - bidding progress is not updated

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -565,11 +565,11 @@ var getBidCounts = function(bidInvitationGroup) {
     invitation: bidInvitationGroup + '/-/' + BID_NAME,
     groupBy: 'tail',
     select: 'count'
-  }, 'groupedEdges').then(function(results) {
-    if (!results || !results.length) {
+  }).then(function(results) {
+    if (!results.groupedEdges || !results.groupedEdges.length) {
       return {};
     }
-    return results.reduce(function(profileMap, groupedEdge) {
+    return results.groupedEdges.reduce(function(profileMap, groupedEdge) {
       profileMap[groupedEdge.id.tail] = groupedEdge.count;
       return profileMap;
     }, {});


### PR DESCRIPTION
the fn call in ln564 was changed from getAll() to get() in https://github.com/openreview/openreview-py/pull/1435

get() does not accept result key so results.length will always be undefined because results is in the form of
```bash
{
    'groupedEdges':{...}
}
```

this pr should fix this issue by reading results.groupedEdges instead