### PR TITLE
more journal configurations

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -62,6 +62,7 @@ class GroupBuilder(object):
             content = content.replace("var SHORT_PHRASE = '';", f'var SHORT_PHRASE = "{self.journal.short_name}";')
             content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + self.journal.get_author_submission_id() + "';")
             content = content.replace("var EDITORS_IN_CHIEF_NAME = '';", "var EDITORS_IN_CHIEF_NAME = '" + self.journal.editors_in_chief_name + "';")
+            content = content.replace("var EDITORS_IN_CHIEF_EMAIL = '';", "var EDITORS_IN_CHIEF_EMAIL = '" + self.journal.get_editors_in_chief_email() + "';")
             content = content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + self.journal.reviewers_name + "';")
             content = content.replace("var ACTION_EDITOR_NAME = '';", "var ACTION_EDITOR_NAME = '" + self.journal.action_editors_name + "';")
             if self.journal.request_form_id:

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3882,7 +3882,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
 
         submission_length = self.journal.get_submission_length()
         if submission_length:
-            invitation.edit['note']['content']['submission_length'] = {
+            invitation['edit']['note']['content']['submission_length'] = {
                 'value': {
                     'param': {
                         'type': 'string',

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -441,7 +441,8 @@ class InvitationBuilder(object):
                                 'param': {
                                     'type': "string",
                                     'maxLength': 50000,
-                                    'markdown': True
+                                    'markdown': True,
+                                    'input': 'textarea'
                                 }
                             }
                         }
@@ -459,13 +460,13 @@ class InvitationBuilder(object):
                     signatures = [editors_in_chief_id],
                     content = {
                         'title': { 'value': 'Acknowledgement of reviewer responsibility'},
-                        'description': { 'value': '''TMLR operates somewhat differently to other journals and conferences. Please read and acknowledge the following critical points before undertaking your first review. Note that the items below are stated very briefly; please see the full guidelines and instructions for reviewers on the journal website (links below).
+                        'description': { 'value': f'''{venue_id} operates somewhat differently to other journals and conferences. Please read and acknowledge the following critical points before undertaking your first review. Note that the items below are stated very briefly; please see the full guidelines and instructions for reviewers on the journal website (links below).
 
-- [Reviewer guidelines](https://jmlr.org/tmlr/reviewer-guide.html)
-- [Editorial policies](https://jmlr.org/tmlr/editorial-policies.html)
-- [FAQ](https://jmlr.org/tmlr/contact.html)
+- [Reviewer guidelines]({self.journal.get_website_url("reviewer_guide")})
+- [Editorial policies]({self.journal.get_website_url("editorial_policies")})
+- [FAQ]({self.journal.get_website_url("faq")})
 
-If you have questions after reviewing the points below that are not answered on the website, please contact the Editors-In-Chief: tmlr-editors@jmlr.org
+If you have questions after reviewing the points below that are not answered on the website, please contact the Editors-In-Chief: {self.journal.get_editors_in_chief_email()}
 '''}
                     }
                 )
@@ -533,7 +534,7 @@ If you have questions after reviewing the points below that are not answered on 
                                     'value': {
                                         'param': {
                                             'type': "string",
-                                            'enum': ['I understand that TMLR has a strict 6 week review process (for submissions of at most 12 pages of main content), and that I will need to submit an initial review (within 2 weeks), engage in discussion, and enter a recommendation within that period.'],
+                                            'enum': [f'I understand that {venue_id} has a strict 6 week review process (for submissions of at most 12 pages of main content), and that I will need to submit an initial review (within 2 weeks), engage in discussion, and enter a recommendation within that period.'],
                                             'input': 'checkbox'
                                         }
                                     }
@@ -544,7 +545,7 @@ If you have questions after reviewing the points below that are not answered on 
                                     'value': {
                                         'param': {
                                             'type': "string",
-                                            'enum': ['I understand that TMLR does not accept submissions which are expanded or modified versions of previously published papers.'],
+                                            'enum': [f'I understand that {venue_id} does not accept submissions which are expanded or modified versions of previously published papers.'],
                                             'input': 'checkbox'
                                         }
                                     }
@@ -554,14 +555,14 @@ If you have questions after reviewing the points below that are not answered on 
                                     'value': {
                                         'param': {
                                             'type': "string",
-                                            'enum': ['I understand that the acceptance criteria for TMLR is technical correctness and clarity of presentation rather than significance or impact.'],
+                                            'enum': [f'I understand that the acceptance criteria for {venue_id} is technical correctness and clarity of presentation rather than significance or impact.'],
                                             'input': 'checkbox'
                                         }
                                     }
                                 },
                                 'action_editor_visibility': {
                                     'order': 5,
-                                    'description': 'TMLR is double blind for reviewers and authors, but the Action Editor assigned to a submission is visible to both reviewers and authors.',
+                                    'description': f'{venue_id} is double blind for reviewers and authors, but the Action Editor assigned to a submission is visible to both reviewers and authors.',
                                     'value': {
                                         'param': {
                                             'type': "string",
@@ -704,11 +705,11 @@ If you have questions after reviewing the points below that are not answered on 
                     signatures = [editors_in_chief_id],
                     content = {
                         'title': { 'value': 'Reviewer Report'},
-                        'description': { 'value': '''Use this report page to give feedback about a reviewer. 
+                        'description': { 'value': f'''Use this report page to give feedback about a reviewer. 
                         
 Tick one or more of the given reasons, and optionally add additional details in the comments.
 
-If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
+If you have questions please contact the Editors-In-Chief: {self.journal.get_editors_in_chief_id()}
 '''}
                     }
                 )
@@ -759,7 +760,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                                         'Reviewer never responded to my messages to them',
                                         'Reviewer used inappropriate language, was aggressive, or showed significant bias.',
                                         'Reviewer plagiarized all or part of their review',
-                                        'Reviewer violated the TMLR Code of Conduct',                            
+                                        f'Reviewer violated the {venue_id} Code of Conduct',                            
                                         'Other'
                                     ],
                                     'input': 'checkbox'
@@ -867,18 +868,18 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                             'description': 'Upload a PDF file that ends with .pdf.',
                             'order': 5,
                         },
-                        'submission_length': {
-                            'value': {
-                                'param': {
-                                    'type': 'string',
-                                    'enum': ['Regular submission (no more than 12 pages of main content)', 'Long submission (more than 12 pages of main content)'],
-                                    'input': 'radio'
+                        # 'submission_length': {
+                        #     'value': {
+                        #         'param': {
+                        #             'type': 'string',
+                        #             'enum': ['Regular submission (no more than 12 pages of main content)', 'Long submission (more than 12 pages of main content)'],
+                        #             'input': 'radio'
 
-                                }
-                            },
-                            'description': "Check if this is a regular length submission, i.e. the main content (all pages before references and appendices) is 12 pages or less. Note that the review process may take significantly longer for papers longer than 12 pages.",
-                            'order': 6
-                        },                        
+                        #         }
+                        #     },
+                        #     'description': "Check if this is a regular length submission, i.e. the main content (all pages before references and appendices) is 12 pages or less. Note that the review process may take significantly longer for papers longer than 12 pages.",
+                        #     'order': 6
+                        # },                        
                         "supplementary_material": {
                             'value': {
                                 'param': {
@@ -968,6 +969,21 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
         if author_submission_readers:
             invitation.edit['note']['content']['authorids']['readers'] = author_submission_readers
             invitation.edit['note']['content']['authors']['readers'] = author_submission_readers
+
+        submission_length = self.journal.get_submission_length()
+        if submission_length:
+            invitation.edit['note']['content']['submission_length'] = {
+                'value': {
+                    'param': {
+                        'type': 'string',
+                        'enum': submission_length,
+                        'input': 'radio'
+
+                    }
+                },
+                'description': "Check if this is a regular length submission, i.e. the main content (all pages before references and appendices) is 12 pages or less. Note that the review process may take significantly longer for papers longer than 12 pages.",
+                'order': 6                
+            }
 
         self.save_invitation(invitation)
 
@@ -2050,7 +2066,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                         },
                         'comment': {
                             'order': 2,
-                            'description': 'Give an explanation for the desk reject decision. Be specific so that authors understand the decision, and explain why the submission does not meet TMLR\'s acceptance criteria if the rejection is based on the content rather than the format: https://jmlr.org/tmlr/reviewer-guide.html',
+                            'description': f'Give an explanation for the desk reject decision. Be specific so that authors understand the decision, and explain why the submission does not meet {venue_id}\'s acceptance criteria if the rejection is based on the content rather than the format: {self.journal.get_website_url("reviewer_guide")}',
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -3016,12 +3032,12 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
 
         header = {
             'title': f'{self.journal.short_name} Action Editor Suggestion',
-            'instructions': '<p class="dark"><strong>Instructions:</strong></p>\
+            'instructions': f'<p class="dark"><strong>Instructions:</strong></p>\
                 <ul>\
                     <li>For your submission, please select at least 3 AEs to recommend.</li>\
                     <li>AEs who have conflicts with your submission are not shown.</li>\
                     <li>The list of AEs for a given paper can be sorted by affinity score. In addition, the search box can be used to search for a specific AE by name or institution.</li>\
-                    <li>See <a href="https://jmlr.org/tmlr/editorial-board.html" target="_blank" rel="nofollow">this page</a> for the list of Action Editors and their expertise.</li>\
+                    <li>See <a href="{self.journal.get_website_url("editorial_board")}" target="_blank" rel="nofollow">this page</a> for the list of Action Editors and their expertise.</li>\
                     <li>To get started click the button below.</li>\
                 </ul>\
                 <br>'
@@ -3240,7 +3256,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                         },
                         'claims_and_evidence': {
                             'order': 5,
-                            'description': 'Are the claims made in the submission supported by accurate, convincing and clear evidence? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                            'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -3251,7 +3267,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                         },
                         'audience': {
                             'order': 6,
-                            'description': f'Would at least some individuals in {self.journal.short_name}\'s audience be interested in knowing the findings of this paper? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                            'description': f'Would at least some individuals in {self.journal.short_name}\'s audience be interested in knowing the findings of this paper? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -3415,7 +3431,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                     'content': {
                         'claims_and_evidence': {
                             'order': 1,
-                            'description': 'Are the claims made in the submission supported by accurate, convincing and clear evidence? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                            'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -3426,7 +3442,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                         },
                         'audience': {
                             'order': 2,
-                            'description': f'Would at least some individuals in {self.journal.short_name}\'s audience be interested in knowing the findings of this paper? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                            'description': f'Would at least some individuals in {self.journal.short_name}\'s audience be interested in knowing the findings of this paper? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -3453,7 +3469,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                         },
                         'comment': {
                             'order': 5,
-                            'description': 'Briefly explain your recommendation, including justification for certification recommendation (if applicable). Refer to TMLR acceptance criteria here: https://jmlr.org/tmlr/reviewer-guide.html',
+                            'description': f'Briefly explain your recommendation, including justification for certification recommendation (if applicable). Refer to {self.journal.short_name} acceptance criteria here: {self.journal.get_website_url("reviewer_guide")}',
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -3472,7 +3488,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
         if self.journal.get_certifications():
             invitation['edit']['note']['content']['certification_recommendations'] = {
                 'order': 4,
-                'description': 'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE, however you are asked to submit your recommendation. See certification details here: https://jmlr.org/tmlr/editorial-policies.html',
+                'description': f'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE, however you are asked to submit your recommendation. See certification details here: {self.journal.get_website_url("editorial_policies")}',
                 'value': {
                     'param': {
                         'type': 'string[]',
@@ -4001,7 +4017,8 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                                 'param': {
                                     'type': 'string',
                                     'maxLength': 500,
-                                    'input': 'text'
+                                    'input': 'text',
+                                    'optional': True
                                 }
                             }
                         },
@@ -4080,7 +4097,8 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                                 'param': {
                                     'type': 'string',
                                     'maxLength': 500,
-                                    'input': 'text'
+                                    'input': 'text',
+                                    'optional': True
                                 }
                             }
                         },
@@ -4137,7 +4155,8 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                                 'param': {
                                     'type': 'string',
                                     'maxLength': 500,
-                                    'input': 'text'
+                                    'input': 'text',
+                                    'optional': True
                                 }
                             },
                             'readers': [ venue_id, self.journal.get_action_editors_id(number='${7/content/noteNumber/value}'), '${5/signatures}']
@@ -4186,7 +4205,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
         if self.journal.is_submission_public():
             self.save_super_invitation(self.journal.get_release_comment_id(), {}, edit_content, invitation)        
 
-    def set_note_comment_invitation(self, note):
+    def set_note_comment_invitation(self, note, public=True):
         
         self.client.post_invitation_edit(invitations=self.journal.get_official_comment_id(),
             content={ 
@@ -4198,7 +4217,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
             signatures=[self.journal.venue_id]
         )        
 
-        if self.journal.is_submission_public():
+        if public and self.journal.is_submission_public():
             self.client.post_invitation_edit(invitations=self.journal.get_public_comment_id(),
                 content={ 
                     'noteId': { 'value': note.id }, 
@@ -4319,7 +4338,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                     'content': {
                         'claims_and_evidence': {
                             'order': 2,
-                            'description': 'Are the claims made in the submission supported by accurate, convincing and clear evidence? If not why? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                            'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? If not why? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -4331,7 +4350,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                         },
                         'audience': {
                             'order': 3,
-                            'description': f'Would at least some individuals in {self.journal.short_name}\'s audience be interested in knowing the findings of this paper? If not, why? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                            'description': f'Would at least some individuals in {self.journal.short_name}\'s audience be interested in knowing the findings of this paper? If not, why? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -4378,7 +4397,7 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
         if self.journal.get_certifications():
             invitation['edit']['note']['content']['certifications'] = {
                 'order': 6,
-                'description': 'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE and will be reviewed by the Editors-in-Chief. See certification details here: https://jmlr.org/tmlr/editorial-policies.html',
+                'description': f'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE and will be reviewed by the Editors-in-Chief. See certification details here: {self.journal.get_website_url("editorial_policies")}.',
                 'value': {
                     'param': {
                         'type': 'string[]',
@@ -4625,6 +4644,12 @@ If you have questions please contact the Editors-In-Chief: tmlr-editors@jmlr.org
                     'nonreaders': [ self.journal.get_authors_id(number='${4/content/noteNumber/value}') ],
                     'writers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                     'note': {
+                        'id': {
+                            'param': {
+                                'withInvitation': self.journal.get_review_rating_id(signature='${6/content/signature/value}'),
+                                'optional': True
+                            }
+                        },            
                         'forum': '${4/content/noteId/value}',
                         'replyto': '${4/content/replytoId/value}',
                         'signatures': [self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')],

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -868,18 +868,6 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                             'description': 'Upload a PDF file that ends with .pdf.',
                             'order': 5,
                         },
-                        # 'submission_length': {
-                        #     'value': {
-                        #         'param': {
-                        #             'type': 'string',
-                        #             'enum': ['Regular submission (no more than 12 pages of main content)', 'Long submission (more than 12 pages of main content)'],
-                        #             'input': 'radio'
-
-                        #         }
-                        #     },
-                        #     'description': "Check if this is a regular length submission, i.e. the main content (all pages before references and appendices) is 12 pages or less. Note that the review process may take significantly longer for papers longer than 12 pages.",
-                        #     'order': 6
-                        # },                        
                         "supplementary_material": {
                             'value': {
                                 'param': {
@@ -3825,18 +3813,6 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                             'description': 'Upload a PDF file that ends with .pdf.',
                             'order': 5,
                         },
-                        'submission_length': {
-                            'value': {
-                                'param': {
-                                    'type': 'string',
-                                    'enum': ['Regular submission (no more than 12 pages of main content)', 'Long submission (more than 12 pages of main content)'],
-                                    'input': 'radio'
-
-                                }
-                            },
-                            'description': "Check if this is a regular length submission, i.e. the main content (all pages before references and appendices) is 12 pages or less. Note that the review process may take significantly longer for papers longer than 12 pages.",
-                            'order': 6
-                        },                        
                         "supplementary_material": {
                             'value': {
                                 'param': {
@@ -3903,6 +3879,21 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             },
             'process': self.process_script                    
         }
+
+        submission_length = self.journal.get_submission_length()
+        if submission_length:
+            invitation.edit['note']['content']['submission_length'] = {
+                'value': {
+                    'param': {
+                        'type': 'string',
+                        'enum': submission_length,
+                        'input': 'radio'
+
+                    }
+                },
+                'description': "Check if this is a regular length submission, i.e. the main content (all pages before references and appendices) is 12 pages or less. Note that the review process may take significantly longer for papers longer than 12 pages.",
+                'order': 6                
+            }        
 
         self.save_super_invitation(self.journal.get_revision_id(), invitation_content, edit_content, invitation)
 

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -354,6 +354,7 @@ class Journal(object):
         self.invitation_builder.set_note_revision_invitation(note)
         self.invitation_builder.set_note_withdrawal_invitation(note)
         self.invitation_builder.set_note_desk_rejection_invitation(note)
+        self.invitation_builder.set_note_comment_invitation(note, public=False) 
         self.setup_ae_assignment(note)
         self.invitation_builder.set_ae_recommendation_invitation(note, self.get_due_date(weeks = 1))
         self.setup_reviewer_assignment(note)
@@ -381,6 +382,15 @@ class Journal(object):
 
     def get_certifications(self):
         return self.settings.get('certifications', [])        
+
+    def get_submission_length(self):
+        return self.settings.get('submission_length', [])
+    
+    def get_website_url(self, key):
+        return self.settings.get('website_urls', {}).get(key, 'url not available')
+    
+    def get_editors_in_chief_email(self):
+        return self.settings.get('editors_email', self.contact_info)
 
     def should_show_conflict_details(self):
         return self.settings.get('show_conflict_details', False)

--- a/openreview/journal/webfield/editorsInChiefWebfield.js
+++ b/openreview/journal/webfield/editorsInChiefWebfield.js
@@ -11,6 +11,7 @@ var VENUE_ID = '';
 var SHORT_PHRASE = '';
 var SUBMISSION_ID = '';
 var EDITORS_IN_CHIEF_NAME = '';
+var EDITORS_IN_CHIEF_EMAIL = '';
 var REVIEWERS_NAME = '';
 var ACTION_EDITOR_NAME = '';
 var JOURNAL_REQUEST_ID = '';
@@ -915,7 +916,7 @@ var renderTable = function(container, rows) {
       defaultBody: 'Hi {{fullname}},\n\nThis is a reminder to please submit your review for ' + SHORT_PHRASE + '.\n\n' +
         'Click on the link below to go to the submission page:\n\n{{forumUrl}}\n\n' +
         'Thank you,\n' + SHORT_PHRASE + ' Editor-in-Chief',
-      replyTo: 'tmlr-editors@jmlr.org',
+      replyTo: EDITORS_IN_CHIEF_EMAIL,
       menu: [{
         id: 'all-reviewers',
         name: 'All reviewers of selected papers',

--- a/openreview/journal/webfield/homepage.js
+++ b/openreview/journal/webfield/homepage.js
@@ -108,13 +108,15 @@ function load() {
     'content.venueid': [UNDER_REVIEW_ID, DECISION_PENDING_ID].join(','),
     pageSize: PAGE_SIZE,
     details: 'replyCount',
-    includeCount: true
+    includeCount: true,
+    sort: 'mdate:desc'
   });
 
   var allNotesP = Webfield2.api.getSubmissions(SUBMISSION_ID, {
     pageSize: PAGE_SIZE,
     details: 'replyCount',
-    includeCount: true
+    includeCount: true,
+    sort: 'mdate:desc'
   });
 
   var userGroupsP = $.Deferred().resolve([]);
@@ -173,21 +175,22 @@ function renderContent(acceptedResponse, acceptedNotesWithVideo, certificationsR
   }
 
   Webfield2.ui.renderSubmissionList('#accepted-papers', SUBMISSION_ID, acceptedResponse.notes, acceptedResponse.count,
-  Object.assign({}, options, { query: { 'content.venueid': VENUE_ID }}));
+  Object.assign({}, options, { query: { 'content.venueid': VENUE_ID, sort: 'pdate:desc' }}));
 
   Webfield2.ui.renderSubmissionList('#accepted-papers-with-video', SUBMISSION_ID, acceptedNotesWithVideo, acceptedNotesWithVideo.length,
   Object.assign({}, options, { localSearch: true }));
 
   Webfield2.ui.renderSubmissionList('#under-review-submissions', SUBMISSION_ID, underReviewResponse.notes, underReviewResponse.count,
-  Object.assign({}, options, { query: {'content.venueid': UNDER_REVIEW_ID } } ));
+  Object.assign({}, options, { query: {'content.venueid': UNDER_REVIEW_ID, sort: 'mdate:desc' } } ));
 
-  Webfield2.ui.renderSubmissionList('#all-submissions', SUBMISSION_ID, allResponse.notes, allResponse.count, options);
+  Webfield2.ui.renderSubmissionList('#all-submissions', SUBMISSION_ID, allResponse.notes, allResponse.count, 
+  Object.assign({}, options, { sort: 'mdate:desc' }));
 
   CERTIFICATIONS.forEach(function(certification, index) {
     var response = certificationsResponse[index];
     var key = certification.toLowerCase().replace(' ', '-');
     Webfield2.ui.renderSubmissionList('#' + key, SUBMISSION_ID, response.notes, response.count,
-    Object.assign({}, options, { query: { 'content.venueid': VENUE_ID, 'content.certifications': certification }}));
+    Object.assign({}, options, { query: { 'content.venueid': VENUE_ID, 'content.certifications': certification, sort: 'pdate:desc' }}));
   })
 
   $('#notes .spinner-container').remove();

--- a/tests/test_jmlr_journal.py
+++ b/tests/test_jmlr_journal.py
@@ -76,8 +76,7 @@ class TestJMLRJournal():
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
-                    'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                    'human_subjects_reporting': { 'value': 'Not applicable'}
                 }
             ))
 

--- a/tests/test_journal_matching.py
+++ b/tests/test_journal_matching.py
@@ -105,8 +105,7 @@ class TestJournalMatching():
                         'authorids': { 'value': ['~SomeFirstName_User1', '~Sigur_Ros1', '~John_Travolta1']},
                         'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                         'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
-                        'human_subjects_reporting': { 'value': 'Not applicable'},
-                        'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                        'human_subjects_reporting': { 'value': 'Not applicable'}
                     }
                 ))
 

--- a/tests/test_melba_journal.py
+++ b/tests/test_melba_journal.py
@@ -154,8 +154,7 @@ class TestJournal():
                     'authorids': { 'value': ['~SomeFirstName_User1', '~Celeste_Martinez1']},
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
-                    'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                    'human_subjects_reporting': { 'value': 'Not applicable'}
                 }
             ))
 

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -811,8 +811,7 @@ The OpenReview Team.
                     'authorids': { 'value': ['~SomeFirstName_User1', '~Paul_Alternate_Last1']},
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
-                    'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                    'human_subjects_reporting': { 'value': 'Not applicable'}
                 }
             ))
 
@@ -828,8 +827,7 @@ The OpenReview Team.
                     'authorids': { 'value': ['~SomeFirstName_User1', '~Paul_Alternate_Last1']},
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
-                    'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                    'human_subjects_reporting': { 'value': 'Not applicable'}
                 }
             ))
 

--- a/tests/test_tacl_journal.py
+++ b/tests/test_tacl_journal.py
@@ -91,8 +91,7 @@ class TestTACLJournal():
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
-                    'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                    'human_subjects_reporting': { 'value': 'Not applicable'}
                 }
             ))
 
@@ -140,8 +139,7 @@ The TACL Editors-in-Chief
                     'supplementary_material': { 'value': '/attachment/' + 'z' * 40 +'.zip'},
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
                     'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'pdf': { 'value': '/pdf/22234qweoiuweroi22234qweoiuweroi12345678.pdf' },
-                    'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                    'pdf': { 'value': '/pdf/22234qweoiuweroi22234qweoiuweroi12345678.pdf' }
                 }
             ))
         helpers.await_queue_edit(openreview_client, edit_id=updated_submission_note_1['id'])
@@ -665,8 +663,7 @@ note={Featured Certification, Reproducibility Certification}
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
-                    'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                    'human_subjects_reporting': { 'value': 'Not applicable'}
                 }
             ))
 


### PR DESCRIPTION
- Make review ratings editable.
- Enable official comment when the submission is submitted, before to be marked as under review.
- Fix sorting in the EIC console using pagination.
- Remove "TMLR" and replace it with the journal short name.
- Use text areas for the description field used in forum as "registration" tasks.
- Make the title optional in comment invitation.
- Parametrize submission_length fields, some venues don't want it.
- Parametrize editors in chief email address.
- Parametrize all the website urls shown in the descriptions.