### PR TITLE
Feat/ Venue homepage: add decision tabs after post decision stage

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -20,6 +20,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.reviewer_identity_readers = get_identity_readers(note, 'reviewer_identity')
         venue.area_chair_identity_readers = get_identity_readers(note, 'area_chair_identity')
         venue.senior_area_chair_identity_readers = get_identity_readers(note, 'senior_area_chair_identity')
+        venue.decision_heading_map = get_decision_heading_map(venue.short_name, note)
         
         if domain_group:
             venue.enable_reviewers_reassignment = domain_group.content.get('enable_reviewers_reassignment', {}).get('value', False)
@@ -289,6 +290,14 @@ def get_identity_readers(request_forum, field_name):
     }
 
     return [readers_map[r] for r in request_forum.content.get(field_name, [])]
+
+def get_decision_heading_map(short_name, request_forum):
+    map = request_forum.content.get('home_page_tab_names', {})
+    decision_heading_map = {}
+    for decision, tabName in map.items():
+        decision_heading_map[openreview.tools.decision_to_venue(short_name, decision)] = tabName
+
+    return decision_heading_map
 
 def get_submission_stage(request_forum):
 

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -177,7 +177,8 @@ class GroupBuilder(object):
             'desk_rejection_reversion_id': { 'value': self.venue.get_invitation_id('Desk_Rejection_Reversion') },
             'desk_reject_committee': { 'value': self.venue.get_participants(number="{number}", with_authors=True, with_program_chairs=True)},
             'desk_rejection_name': { 'value': 'Desk_Rejection'},
-            'conflict_policy': { 'value': self.venue.conflict_policy }
+            'conflict_policy': { 'value': self.venue.conflict_policy },
+            'decision_heading_map': { 'value': self.venue.decision_heading_map }
         }
 
         if self.venue.submission_stage.subject_areas:

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -65,6 +65,7 @@ class Venue(object):
         self.enable_reviewers_reassignment = False
         self.reviewers_proposed_assignment_title = None
         self.conflict_policy = 'default'
+        self.decision_heading_map = {}
 
     def get_id(self):
         return self.venue_id

--- a/openreview/venue/webfield/homepageWebfield.js
+++ b/openreview/venue/webfield/homepageWebfield.js
@@ -4,6 +4,22 @@ const tabs = [{
   type: 'consoles'
 }]
 
+const decisionHeadingMap = domain.content.decision_heading_map?.value
+
+if (decisionHeadingMap) {
+  for (const [venue, tabName] of Object.entries(decisionHeadingMap)) {
+    tabs.push({
+      name:tabName,
+      query: {
+        'content.venue': venue
+      },
+      options: {
+        hideWhenEmpty: true
+      }
+    })
+  }
+}
+
 if (domain.content.public_submissions.value) {
   tabs.push({
     name: 'Active Submissions',

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -2192,7 +2192,7 @@ Please refer to the FAQ for pointers on how to run the matcher: https://openrevi
                 'home_page_tab_names': {
                     'Accept': 'Accept',
                     'Revision Needed': 'Revision Needed',
-                    'Reject': 'Reject'
+                    'Reject': 'Submitted'
                 },
                 'send_decision_notifications': 'Yes, send an email notification to the authors',
                 'accept_email_content': f'''Dear {{{{fullname}}}},
@@ -2278,6 +2278,16 @@ Best,
         last_message = client.get_messages(to='venue_author_v2@mail.com', subject='[TestVenue@OR\'2030V2] Decision notification for your submission 1: test submission')[0]
         assert "Dear VenueTwo Author,\n\nThank you for submitting your paper, test submission, to TestVenue@OR'2030V2." in last_message['content']['text']
         assert f"https://openreview.net/forum?id={submissions[0].id}" in last_message['content']['text']
+
+        request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token, wait_for_element='header')
+        notes_panel = selenium.find_element_by_id('notes')
+        assert notes_panel
+        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element(By.LINK_TEXT, "Your Consoles")
+        assert tabs.find_element(By.LINK_TEXT, "Accept")
+        assert tabs.find_element(By.LINK_TEXT, "Submitted")
+        assert tabs.find_element(By.LINK_TEXT, "Recent Activity")
 
         # Post another revision stage note
         now = datetime.datetime.utcnow()


### PR DESCRIPTION
- Fixes #1602
- Should we hide the 'Your Consoles' and 'Recent Acitivity' tabs after the post decision is run?
<img width="1209" alt="Screen Shot 2023-03-16 at 4 17 31 PM" src="https://user-images.githubusercontent.com/32438984/225742829-2c109cfe-6be9-4ed5-afd8-ba7857035e49.png">



Works well with https://github.com/openreview/openreview-web/pull/1383