### PR TITLE
let SAC edit meta reviews

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1012,6 +1012,17 @@ class MetaReviewStage(object):
         readers.append(conference.get_program_chairs_id())
 
         return readers
+    
+    def get_writers(self, conference, number):
+
+        writers = [conference.id]
+
+        if conference.use_senior_area_chairs:
+            writers.append(conference.get_senior_area_chairs_id(number = number))
+
+        writers.append('${3/signatures}')
+
+        return writers
 
     def get_nonreaders(self, conference, number):
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -603,7 +603,7 @@ class InvitationBuilder(object):
                             'signatures': ['${3/signatures}'],
                             'readers': meta_review_stage.get_readers(self.venue, '${5/content/noteNumber/value}'),
                             'nonreaders': meta_review_stage.get_nonreaders(self.venue, '${5/content/noteNumber/value}'),
-                            'writers': [venue_id, '${3/signatures}'],
+                            'writers': meta_review_stage.get_writers(self.venue, '${5/content/noteNumber/value}'),
                             'content': content
                         }
                     }
@@ -618,6 +618,76 @@ class InvitationBuilder(object):
             invitation.edit['invitation']['expdate'] = meta_review_expdate         
 
         self.save_invitation(invitation, replacement=False)
+
+        if self.venue.use_senior_area_chairs:
+
+            meta_review_sac_edit_invitation_id = self.venue.get_invitation_id(meta_review_stage.name + '_SAC_Revision')
+            invitation = Invitation(id=meta_review_sac_edit_invitation_id,
+                invitees=[venue_id],
+                readers=[venue_id],
+                writers=[venue_id],
+                signatures=[venue_id],
+                cdate=meta_review_cdate,
+                date_processes=[{ 
+                    'dates': ["#{4/edit/invitation/cdate}", self.update_date_string],
+                    'script': self.invitation_edit_process              
+                }],
+                content = {
+                },
+                edit={
+                    'signatures': [venue_id],
+                    'readers': [venue_id],
+                    'writers': [venue_id],
+                    'content': {
+                        'noteNumber': { 
+                            'value': {
+                                'param': {
+                                    'regex': '.*', 'type': 'integer' 
+                                }
+                            }
+                        },
+                        'noteId': {
+                            'value': {
+                                'param': {
+                                    'regex': '.*', 'type': 'string' 
+                                }
+                            }
+                        }
+                    },
+                    'replacement': True,
+                    'invitation': {
+                        'id': self.venue.get_invitation_id(meta_review_stage.name + '_SAC_Revision', '${2/content/noteNumber/value}'),
+                        'signatures': [ venue_id ],
+                        'readers': ['everyone'],
+                        'writers': [venue_id],
+                        'invitees': [venue_id, self.venue.get_senior_area_chairs_id(number='${3/content/noteNumber/value}')],
+                        'maxReplies': 1,
+                        'cdate': meta_review_cdate,
+                        'edit': {
+                            'signatures': { 'param': { 'regex': self.venue.get_senior_area_chairs_id(number='${5/content/noteNumber/value}') }},
+                            'readers': meta_review_stage.get_readers(self.venue, '${4/content/noteNumber/value}'),
+                            'nonreaders': meta_review_stage.get_nonreaders(self.venue, '${4/content/noteNumber/value}'),
+                            'writers': [venue_id],
+                            'note': {
+                                'id': {
+                                    'param': {
+                                        'withInvitation': self.venue.get_invitation_id(meta_review_stage.name, '${6/content/noteNumber/value}')
+                                    }
+                                },
+                                'forum': '${4/content/noteId/value}',
+                                'replyto': '${4/content/noteId/value}',
+                                'content': content
+                            }
+                        }
+                    }
+                }
+            )
+
+            if meta_review_expdate:
+                invitation.edit['invitation']['expdate'] = meta_review_expdate
+
+            self.save_invitation(invitation, replacement=False)
+
         return invitation
 
     def set_recruitment_invitation(self, committee_name, options):

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -3651,6 +3651,20 @@ ICML 2023 Conference Program Chairs'''
             'ICML.cc/2023/Conference/Submission2/Senior_Area_Chairs'
         ]
 
+        ## SAC can edit the meta review
+        meta_review_edit = sac_client.post_note_edit(
+            invitation='ICML.cc/2023/Conference/Submission2/-/Meta_Review_SAC_Revision',
+            signatures=['ICML.cc/2023/Conference/Submission2/Senior_Area_Chairs'],
+            note=openreview.api.Note(
+                id=metareviews[0].id,
+                content={
+                    'metareview': { 'value': 'I reverted the AC decision' },
+                    'recommendation': { 'value': 'Accept'}
+                }
+            )
+        )
+
+
     def test_decision_stage(self, openreview_client, helpers):
 
         pc_client=openreview.Client(username='pc@icml.cc', password='1234')


### PR DESCRIPTION
This PR creates an invitation that let the SAC to edit the content of existing meta reviews. This already working on the live site: https://openreview.net/invitation/edit?id=ICML.cc/2023/Conference/-/Meta_Review_SAC_Revision

Celete, please make sure to extend this expdate when you change the meta review expdate. 

I still need to work on an way to update the expdate automatically.