### PR TITLE
Feat/ Venue: SAC releaxed conflict computation

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1454,6 +1454,33 @@ def get_neurips_profile_info(profile, n_years=None):
         'publications': publications
     }
 
+def get_sac_profile_info(profile, submission_venue_id):
+    """
+    Gets only submissions submitted to the current venue
+
+    :param profile: Profile from which all publications will be obtained
+    :type profile: Profile
+    :param submission_venue_id: venue_id of submissions we want to obtain
+    :type submission_venue_id: str
+
+    :return: Dictionary with the current publications associated with the passed Profile
+    :rtype: dict
+    """
+    publications = set()
+
+    ## Get publications
+    for publication in profile.content.get('publications', []):
+        print(publication.content)
+        if isinstance(publication.content.get('venueid'), dict) and publication.content['venueid']['value'] == submission_venue_id:
+            publications.add(publication.id)
+
+    return {
+        'id': profile.id,
+        'domains': set(),
+        'emails': set(),
+        'relations': set(),
+        'publications': publications
+    }
 
 def post_bulk_edges (client, edges, batch_size = 50000):
     num_edges = len(edges)

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
+import inspect
 
 import json
 import os
@@ -1244,10 +1245,14 @@ def get_all_venues(client):
     return client.get_group("host").members
 
 def info_function_builder(policy_function):
-    def inner(profile, n_years=None):
+    def inner(profile, n_years=None, submission_venueid=None):
         common_domains = ['gmail.com', 'qq.com', '126.com', '163.com',
                     'outlook.com', 'hotmail.com', 'yahoo.com', 'foxmail.com', 'aol.com', 'msn.com', 'ymail.com', 'googlemail.com', 'live.com']
-        result = policy_function(profile, n_years)
+        argspec = inspect.getfullargspec(policy_function)
+        if 'submission_venueid' in argspec.args:
+            result = policy_function(profile, n_years, submission_venueid)
+        else:
+            result = policy_function(profile, n_years)
         domains = set()
         subdomains_dict = {}
         for domain in result['domains']:
@@ -1454,7 +1459,7 @@ def get_neurips_profile_info(profile, n_years=None):
         'publications': publications
     }
 
-def get_sac_profile_info(profile, submission_venue_id):
+def get_current_submissions_profile_info(profile, n_years=None, submission_venueid=None):
     """
     Gets only submissions submitted to the current venue
 
@@ -1466,19 +1471,47 @@ def get_sac_profile_info(profile, submission_venue_id):
     :return: Dictionary with the current publications associated with the passed Profile
     :rtype: dict
     """
+    domains = set()
+    relations = set()
     publications = set()
+
+    if n_years is not None:
+        cut_off_date = datetime.datetime.now()
+        cut_off_date = cut_off_date.replace(year=cut_off_date.year - n_years)
+        cut_off_year = cut_off_date.year
+    else:
+        cut_off_year = -1
+
+    ## Institution section, get history within the last n years, excluding internships
+    for h in profile.content.get('history', []):
+        position = h.get('position')
+        if not position or (isinstance(position, str) and 'intern' not in position.lower()):
+            try:
+                end = int(h.get('end', 0) or 0)
+            except:
+                end = 0
+            if not end or (int(end) > cut_off_year):
+                domain = h.get('institution', {}).get('domain', '')
+                domains.add(domain)
+
+    ## Relations section, get coauthor/coworker relations within the last n years + all the other relations
+    for r in profile.content.get('relations', []):
+        if (r.get('relation', '') or '') in ['Coauthor','Coworker']:
+            if r.get('end') is None or int(r.get('end')) > cut_off_year:
+                relations.add(r['email'])
+        else:
+            relations.add(r['email'])
 
     ## Get publications
     for publication in profile.content.get('publications', []):
-        print(publication.content)
-        if isinstance(publication.content.get('venueid'), dict) and publication.content['venueid']['value'] == submission_venue_id:
+        if isinstance(publication.content.get('venueid'), dict) and publication.content['venueid']['value'] == submission_venueid:
             publications.add(publication.id)
 
     return {
         'id': profile.id,
-        'domains': set(),
+        'domains': domains,
         'emails': set(),
-        'relations': set(),
+        'relations': relations,
         'publications': publications
     }
 

--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -23,6 +23,7 @@ class Matching(object):
         self.is_ethics_reviewer = venue.get_ethics_reviewers_id() == match_group.id
         self.should_read_by_area_chair = venue.get_reviewers_id() == match_group.id and venue.use_area_chairs
         self.sac_profile_info = None #expects a policy, for example: openreview.tools.get_sac_profile_info
+        self.sac_n_years = None
 
     def _get_edge_invitation_id(self, edge_name):
         return self.venue.get_invitation_id(edge_name, prefix=self.match_group.id)
@@ -256,7 +257,8 @@ class Matching(object):
             if sacs_by_ac:
                 sac_user_profiles = openreview.tools.get_profiles(self.client, self.client.get_group(self.venue.get_senior_area_chairs_id()).members, with_publications=True)
                 if self.sac_profile_info:
-                    sac_user_info_by_id = { p.id: self.sac_profile_info(p, self.venue.get_submission_venue_id()) for p in sac_user_profiles }
+                    info_funcion = tools.info_function_builder(self.sac_profile_info)
+                    sac_user_info_by_id = { p.id: info_funcion(p, self.sac_n_years, self.venue.get_submission_venue_id()) for p in sac_user_profiles }
                 else:
                     sac_user_info_by_id = { p.id: info_function(p, compute_conflicts_n_years) for p in sac_user_profiles }
         edges = []

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -1120,33 +1120,34 @@ If you would like to change your decision, please follow the link in the previou
 #         withdraw_super_invitation = client.get_invitation(conference.get_invitation_id('Withdraw'))
 #         assert 'REVEAL_AUTHORS_ON_WITHDRAW = False' in withdraw_super_invitation.process
 
-    def test_setup_matching(self, client, openreview_client, helpers):
+    # def test_setup_matching(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+    #     now = datetime.datetime.utcnow()
 
-        pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
-        request_form = pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
-        venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
-        submissions=venue.get_submissions(sort='number:asc')
+    #     pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
+    #     request_form = pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+    #     venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
+    #     submissions=venue.get_submissions(sort='number:asc')
 
-        with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w') as file_handle:
-            writer = csv.writer(file_handle)
-            for submission in submissions:
-                writer.writerow([submission.id, '~Area_IBMChair1', round(random.random(), 2)])
-                writer.writerow([submission.id, '~Area_GoogleChair1', round(random.random(), 2)])
-                writer.writerow([submission.id, '~Area_UMassChair1', round(random.random(), 2)])
+    #     with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w') as file_handle:
+    #         writer = csv.writer(file_handle)
+    #         for submission in submissions:
+    #             writer.writerow([submission.id, '~Area_IBMChair1', round(random.random(), 2)])
+    #             writer.writerow([submission.id, '~Area_GoogleChair1', round(random.random(), 2)])
+    #             writer.writerow([submission.id, '~Area_UMassChair1', round(random.random(), 2)])
 
-        venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(venue.get_area_chairs_id()))
-        venue_matching.setup(compute_affinity_scores=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), compute_conflicts='NeurIPS')
-        conflicts = client.get_edges(invitation='NeurIPS.cc/2023/Conference/Area_Chairs/-/Conflict', head=submissions[1].id, tail='~Area_GoogleChair1') ## assigned SAC and author are from facebook
-        assert len(conflicts) == 1
+    #     venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(venue.get_area_chairs_id()))
+    #     venue_matching.setup(compute_affinity_scores=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), compute_conflicts='NeurIPS')
+    #     conflicts = client.get_edges(invitation='NeurIPS.cc/2023/Conference/Area_Chairs/-/Conflict', head=submissions[1].id, tail='~Area_GoogleChair1') ## assigned SAC and author are from facebook
+    #     assert len(conflicts) == 1
 
-        venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(venue.get_area_chairs_id()))
-        venue_matching.sac_profile_info = openreview.tools.get_sac_profile_info
-        venue_matching.setup(compute_affinity_scores=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), compute_conflicts='NeurIPS')
+    #     venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(venue.get_area_chairs_id()))
+    #     venue_matching.sac_profile_info = openreview.tools.get_current_submissions_profile_info
+    #     venue_matching.sac_n_years = 0
+    #     venue_matching.setup(compute_affinity_scores=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), compute_conflicts='NeurIPS')
 
-        conflicts = client.get_edges(invitation='NeurIPS.cc/2023/Conference/Area_Chairs/-/Conflict', head=submissions[1].id, tail='~Area_GoogleChair1') ## no conflict because we are not using SACs emails or history
-        assert len(conflicts)==0
+    #     conflicts = client.get_edges(invitation='NeurIPS.cc/2023/Conference/Area_Chairs/-/Conflict', head=submissions[1].id, tail='~Area_GoogleChair1') ## no conflict because we are not using SACs emails or history
+    #     assert len(conflicts)==0
 
 #         conflicts = client.get_edges_count(invitation='NeurIPS.cc/2023/Conference/Area_Chairs/-/Conflict')
 #         assert conflicts == 3

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -1120,23 +1120,34 @@ If you would like to change your decision, please follow the link in the previou
 #         withdraw_super_invitation = client.get_invitation(conference.get_invitation_id('Withdraw'))
 #         assert 'REVEAL_AUTHORS_ON_WITHDRAW = False' in withdraw_super_invitation.process
 
-#     def test_setup_matching(self, conference, client, helpers):
+    def test_setup_matching(self, client, openreview_client, helpers):
 
-#         now = datetime.datetime.utcnow()
+        now = datetime.datetime.utcnow()
 
-#         pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
-#         request_form = pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
-#         submissions=conference.get_submissions(sort='tmdate')
+        pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
+        request_form = pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
+        submissions=venue.get_submissions(sort='number:asc')
 
-#         with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w') as file_handle:
-#             writer = csv.writer(file_handle)
-#             for submission in submissions:
-#                 writer.writerow([submission.id, '~Area_IBMChair1', round(random.random(), 2)])
-#                 writer.writerow([submission.id, '~Area_GoogleChair1', round(random.random(), 2)])
-#                 writer.writerow([submission.id, '~Area_UMassChair1', round(random.random(), 2)])
+        with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w') as file_handle:
+            writer = csv.writer(file_handle)
+            for submission in submissions:
+                writer.writerow([submission.id, '~Area_IBMChair1', round(random.random(), 2)])
+                writer.writerow([submission.id, '~Area_GoogleChair1', round(random.random(), 2)])
+                writer.writerow([submission.id, '~Area_UMassChair1', round(random.random(), 2)])
 
-#         conference.setup_matching(committee_id=conference.get_area_chairs_id(), build_conflicts='NeurIPS', affinity_score_file=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'))
-        
+        venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(venue.get_area_chairs_id()))
+        venue_matching.setup(compute_affinity_scores=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), compute_conflicts='NeurIPS')
+        conflicts = client.get_edges(invitation='NeurIPS.cc/2023/Conference/Area_Chairs/-/Conflict', head=submissions[1].id, tail='~Area_GoogleChair1') ## assigned SAC and author are from facebook
+        assert len(conflicts) == 1
+
+        venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(venue.get_area_chairs_id()))
+        venue_matching.sac_profile_info = openreview.tools.get_sac_profile_info
+        venue_matching.setup(compute_affinity_scores=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), compute_conflicts='NeurIPS')
+
+        conflicts = client.get_edges(invitation='NeurIPS.cc/2023/Conference/Area_Chairs/-/Conflict', head=submissions[1].id, tail='~Area_GoogleChair1') ## no conflict because we are not using SACs emails or history
+        assert len(conflicts)==0
+
 #         conflicts = client.get_edges_count(invitation='NeurIPS.cc/2023/Conference/Area_Chairs/-/Conflict')
 #         assert conflicts == 3
 


### PR DESCRIPTION
- NeurIPS asked to use only current SAC submissions when transfering conflicts to ACs
- Run as follows:
```
venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(venue.get_area_chairs_id()))
venue_matching.sac_profile_info = openreview.tools.get_sac_profile_info
venue_matching.setup(compute_affinity_scores=True, compute_conflicts='NeurIPS')
```
