### PR TITLE
Name deletion: fix index error when renaming publications

### DIFF
--- a/openreview/profile/process/request_remove_name_decision_process.py
+++ b/openreview/profile/process/request_remove_name_decision_process.py
@@ -92,7 +92,7 @@ The OpenReview Team.
                     authorids.append(preferred_id)
                     needs_change = True
                 else:
-                    if publication.content.get('authors') and len(publication.content['authors']) > index:
+                    if publication.content.get('authors') and len(publication.content['authors']['value']) > index:
                         authors.append(publication.content['authors']['value'][index])
                     authorids.append(publication.content['authorids']['value'][index])
 

--- a/openreview/profile/process/request_remove_name_decision_process.py
+++ b/openreview/profile/process/request_remove_name_decision_process.py
@@ -51,7 +51,7 @@ The OpenReview Team.
                     authorids.append(preferred_id)
                     needs_change = True
                 else:
-                    if publication.content.get('authors'):
+                    if publication.content.get('authors') and len(publication.content['authors']) > index:
                         authors.append(publication.content['authors'][index])
                     authorids.append(publication.content['authorids'][index])
             if needs_change:
@@ -92,7 +92,7 @@ The OpenReview Team.
                     authorids.append(preferred_id)
                     needs_change = True
                 else:
-                    if publication.content.get('authors'):
+                    if publication.content.get('authors') and len(publication.content['authors']) > index:
                         authors.append(publication.content['authors']['value'][index])
                     authorids.append(publication.content['authorids']['value'][index])
 

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -911,8 +911,8 @@ note={}
                 content={
                     'title': { 'value': 'Paper title' },
                     'abstract': { 'value': 'Paper abstract' },
-                    'authors': { 'value': ['SomeFirstName User', 'Paul Alternate Last']},
-                    'authorids': { 'value': ['~SomeFirstName_User1', '~Paul_Alternate_Last1']},
+                    'authors': { 'value': ['SomeFirstName User', 'Paul Alternate Last', 'Ana Alternate Last']},
+                    'authorids': { 'value': ['~SomeFirstName_User1', '~Paul_Alternate_Last1', '~Ana_Alternate_Last1']},
                     'keywords': { 'value': ['data', 'mining']},
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' }
                 }
@@ -998,8 +998,10 @@ The OpenReview Team.
 
         publications = openreview_client.get_notes(content={ 'authorids': '~Paul_Last1'})
         assert len(publications) == 3
-        assert ['ACMM.org/2023/Conference', '~SomeFirstName_User1', '~Paul_Last1'] == publications[0].writers
-        assert ['ACMM.org/2023/Conference', '~SomeFirstName_User1', '~Paul_Last1'] == publications[0].readers
+        assert ['ACMM.org/2023/Conference', '~SomeFirstName_User1', '~Paul_Last1', '~Ana_Alternate_Last1'] == publications[0].writers
+        assert ['ACMM.org/2023/Conference', '~SomeFirstName_User1', '~Paul_Last1', '~Ana_Alternate_Last1'] == publications[0].readers
+        assert ['~SomeFirstName_User1', '~Paul_Last1', '~Ana_Alternate_Last1'] == publications[0].content['authorids']['value']
+        assert ['SomeFirstName User', 'Paul Last', 'Ana Alternate Last'] == publications[0].content['authors']['value']
         assert ['~SomeFirstName_User1'] == publications[0].signatures
 
         note = openreview_client.get_note(note_id_2)

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -108,7 +108,7 @@ class TestProfileManagement():
                 'title': 'Paper title 2',
                 'abstract': 'Paper abstract 2',
                 'authors': ['John Last', 'Test Client'],
-                'authorids': ['~John_Last1', 'test@mail.com']
+                'authorids': ['~John_Last1', 'test@mail.com', 'another@mail.com']
             }
         ))
 
@@ -191,6 +191,8 @@ The OpenReview Team.
         assert len(publications) == 2
         assert '~John_Last1' in publications[0].writers
         assert '~John_Last1' in publications[0].signatures
+        assert ['John Last', 'Test Client'] == publications[0].content['authors']
+        assert ['~John_Last1', 'test@mail.com', 'another@mail.com'] == publications[0].content['authorids']
         assert '~John_Last1' in publications[1].writers
         assert '~John_Last1' in publications[1].signatures
 


### PR DESCRIPTION
Sometimes the authorids and the authords don't have the same length. 