### PR TITLE
Fix/ Venue request: remove recommendation_options

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -639,22 +639,29 @@ def get_meta_review_stage(request_forum):
 
     meta_review_form_additional_options = request_forum.content.get('additional_meta_review_form_options', {})
     options = request_forum.content.get('recommendation_options', '').strip()
-    if options:
+    if options: #to keep backward compatibility
         if request_forum.content.get('api_version') == '2':
-            meta_review_form_additional_options['recommendation'] = {
-                'value': {
-                    'param': {
-                        'type': 'string',
-                        'enum': [s.translate(str.maketrans('', '', '"\'')).strip() for s in options.split(',')]
+            if 'recommendation' in meta_review_form_additional_options and 'enum' in meta_review_form_additional_options['recommendation']['value']['param']:
+                meta_review_form_additional_options['recommendation']['value']['param']['enum'] = [s.translate(str.maketrans('', '', '"\'')).strip() for s in options.split(',')]
+            else:
+                meta_review_form_additional_options['recommendation'] = {
+                    'value': {
+                        'param': {
+                            'type': 'string',
+                            'enum': [s.translate(str.maketrans('', '', '"\'')).strip() for s in options.split(',')]
+                        }
                     }
                 }
-            }
         else:
-            meta_review_form_additional_options['recommendation'] = {
-                'value-dropdown':[s.translate(str.maketrans('', '', '"\'')).strip() for s in options.split(',')],
-                'required': True}
+            if 'recommendation' in meta_review_form_additional_options and 'value-dropdown' in meta_review_form_additional_options['recommendation']:
+                meta_review_form_additional_options['recommendation']['value-dropdown'] = [s.translate(str.maketrans('', '', '"\'')).strip() for s in options.split(',')]
+            else:
+                meta_review_form_additional_options['recommendation'] = {
+                    'value-dropdown':[s.translate(str.maketrans('', '', '"\'')).strip() for s in options.split(',')],
+                    'required': True
+                }
 
-    meta_review_form_remove_options = request_forum.content.get('remove_meta_review_form_options', '').replace(',', ' ').split()
+    meta_review_form_remove_options = request_forum.content.get('remove_meta_review_form_options', [])
 
     readers_map = {
         'Meta reviews should be immediately revealed to all reviewers': openreview.stages.MetaReviewStage.Readers.REVIEWERS,

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -554,19 +554,20 @@ class VenueStages():
             'recommendation_options': {
                 'description': 'What are the meta review recommendation options (provide comma separated values, e.g. Accept (Best Paper), Accept, Reject)? Leave empty for default options - Accept (Oral), Accept (Poster), Reject',
                 'value-regex': '.*',
+                'hidden': True,
                 'order': 29
             },
             'additional_meta_review_form_options': {
                 'order' : 30,
                 'value-dict': {},
                 'required': False,
-                'description': 'Configure additional options in the meta review form. Use lowercase for the field names and underscores to represent spaces. The UI will auto-format the names, for example: supplementary_material -> Supplementary Material. Valid JSON expected.'
+                'description': 'Configure additional options in the meta review form. Use lowercase for the field names and underscores to represent spaces. The UI will auto-format the names, for example: supplementary_material -> Supplementary Material. Valid JSON expected. For more information on the default meta review form, please refer to our FAQ: https://openreview.net/faq#question-default-forms'
             },
             'remove_meta_review_form_options': {
                 'order': 31,
-                'value-regex': r'^[^,]+(,\s*[^,]*)*$',
+                'values-dropdown': ['recommendation', 'confidence'],
                 'required': False,
-                'description': 'Comma separated list of fields (metareview, recommendation, confidence) that you want removed from the meta review form. For more information on the default meta review form, please refer to our FAQ: https://openreview.net/faq#question-default-forms'
+                'description': 'Select which fields should be removed from the meta review form. For more information on the default meta review form, please refer to our FAQ: https://openreview.net/faq#question-default-forms'
             }
         }
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -3569,6 +3569,17 @@ ICML 2023 Conference Program Chairs'''
                 'release_meta_reviews_to_authors': 'No, meta reviews should NOT be revealed when they are posted to the paper\'s authors',
                 'release_meta_reviews_to_reviewers': 'Meta reviews should be immediately revealed to the paper\'s reviewers who have already submitted their review',
                 'additional_meta_review_form_options': {
+                    'recommendation': {
+                        'description': 'Please select a recommendation for the paper',
+                        'value': {
+                            'param': {
+                                'type': 'string',
+                                'enum': ['Accept', 'Reject'],
+                                'input': 'select'
+                            }
+                        },
+                        'order': 2
+                    },
                     'suggestions': {
                         'description': 'Please provide suggestions on how to improve the paper',
                         'value': {
@@ -3581,7 +3592,7 @@ ICML 2023 Conference Program Chairs'''
                         }
                     }
                 },
-                'remove_meta_review_form_options': 'confidence'
+                'remove_meta_review_form_options': ['confidence']
             },
             forum=request_form.forum,
             invitation=f'openreview.net/Support/-/Request{request_form.number}/Meta_Review_Stage',

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -1451,7 +1451,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                         'required': False,
                     }
                 },
-                'remove_meta_review_form_options': 'confidence'
+                'remove_meta_review_form_options': ['confidence']
             },
             forum=venue['request_form_note'].forum,
             invitation='{}/-/Request{}/Meta_Review_Stage'.format(venue['support_group_id'], venue['request_form_note'].number),

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -1586,6 +1586,17 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                 'release_meta_reviews_to_authors': 'No, meta reviews should NOT be revealed when they are posted to the paper\'s authors',
                 'release_meta_reviews_to_reviewers': 'Meta reviews should be immediately revealed to the paper\'s reviewers who have already submitted their review',
                 'additional_meta_review_form_options': {
+                    'recommendation': {
+                        'description': 'Please select a recommendation for the paper',
+                        'value': {
+                            'param': {
+                                'type': 'string',
+                                'enum': ['Accept', 'Reject'],
+                                'input': 'radio'
+                            }
+                        },
+                        'order': 2
+                    },
                     'suggestions': {
                         'description': 'Please provide suggestions on how to improve the paper',
                         'value': {
@@ -1598,7 +1609,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                         }
                     }
                 },
-                'remove_meta_review_form_options': 'confidence'
+                'remove_meta_review_form_options': ['confidence']
             },
             forum=venue['request_form_note'].forum,
             invitation='{}/-/Request{}/Meta_Review_Stage'.format(venue['support_group_id'], venue['request_form_note'].number),
@@ -1646,6 +1657,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert 'confidence' not in meta_review_invitation.edit['note']['content']
         assert 'suggestions' in meta_review_invitation.edit['note']['content']
         assert 'Accept' in meta_review_invitation.edit['note']['content']['recommendation']['value']['param']['enum']
+        assert meta_review_invitation.edit['note']['content']['recommendation']['value']['param']['input'] == 'radio'
         assert len(meta_review_invitation.edit['note']['readers']) == 4
 
         #post a meta review
@@ -1681,10 +1693,20 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                 'make_meta_reviews_public': 'No, meta reviews should NOT be revealed publicly when they are posted',
                 'meta_review_start_date': start_date.strftime('%Y/%m/%d'),
                 'meta_review_deadline': due_date.strftime('%Y/%m/%d'),
-                'recommendation_options': 'Accept, Reject',
                 'release_meta_reviews_to_authors': 'Yes, meta reviews should be revealed when they are posted to the paper\'s authors',
                 'release_meta_reviews_to_reviewers': 'Meta reviews should be immediately revealed to the paper\'s reviewers',
                 'additional_meta_review_form_options': {
+                    'recommendation': {
+                        'description': 'Please select a recommendation for the paper',
+                        'value': {
+                            'param': {
+                                'type': 'string',
+                                'enum': ['Accept', 'Reject'],
+                                'input': 'radio'
+                            }
+                        },
+                        'order': 2
+                    },
                     'suggestions': {
                         'description': 'Please provide suggestions on how to improve the paper',
                         'value': {
@@ -1697,7 +1719,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                         }
                     }
                 },
-                'remove_meta_review_form_options': 'confidence'
+                'remove_meta_review_form_options': ['confidence']
             },
             forum=venue['request_form_note'].forum,
             invitation='{}/-/Request{}/Meta_Review_Stage'.format(venue['support_group_id'], venue['request_form_note'].number),


### PR DESCRIPTION
- Fixes #1675
- `recommendation_options` is only used for the metareview form, but PCs are still allowed to remove the field `recommendation` from the form (ARR does this every cycle). So I would like to remove this field (while keeping backward compatibility for those requests that have it still) and allow PCs to edit the recommendation field directly using `additional_meta_review_form_options`