### PR TITLE
Let support users remove emails from profiles

### DIFF
--- a/openreview/profile/management.py
+++ b/openreview/profile/management.py
@@ -13,6 +13,7 @@ class ProfileManagement():
 
     def setup(self):
         self.set_remove_name_invitations()
+        self.set_remove_email_invitations()
         self.set_archive_invitations()
         self.set_merge_profiles_invitations()
         self.set_dblp_invitations()
@@ -212,6 +213,57 @@ class ProfileManagement():
                 }
             }
         ))            
+
+    def set_remove_email_invitations(self):
+
+        content = {
+            'email': {
+                'order': 1,
+                'description': 'email that want to be removed.',
+                'value-regex': '.*',
+                'required': True                
+            },
+            'profile_id': {
+                'order': 2,
+                'description': 'profile id where the email associated with.',
+                'value-regex': '~.*',
+                'required': True
+            },
+            'comment': {
+                'order': 3,
+                'value-regex': '[\\S\\s]{1,5000}',
+                'description': 'Reason why you want to delete your name.',
+                'required': False
+            }
+        }
+
+        with open(os.path.join(os.path.dirname(__file__), 'process/request_remove_email_process.py'), 'r') as f:
+            file_content = f.read()
+            file_content = file_content.replace("SUPPORT_USER_ID = ''", "SUPPORT_USER_ID = '" + self.support_group_id + "'")
+            file_content = file_content.replace("AUTHOR_RENAME_INVITATION_ID = ''", "AUTHOR_RENAME_INVITATION_ID = '" + self.author_rename_invitation_id + "'")
+            with open(os.path.join(os.path.dirname(__file__), 'process/request_remove_email_pre_process.py'), 'r') as pre:
+                pre_file_content = pre.read()
+                self.client.post_invitation(openreview.Invitation(
+                    id=f'{self.support_group_id}/-/Profile_Email_Removal',
+                    readers=['everyone'],
+                    writers=[self.support_group_id],
+                    signatures=[self.super_user],
+                    invitees=['~'],
+                    process_string=file_content,
+                    preprocess=pre_file_content,
+                    reply={
+                        'readers': {
+                            'values-copied': [self.support_group_id]
+                        },
+                        'writers': {
+                            'values':[self.support_group_id],
+                        },
+                        'signatures': {
+                            'values': [self.support_group_id]
+                        },
+                        'content': content
+                    }
+                ))
 
     def set_archive_invitations(self):
 

--- a/openreview/profile/process/request_remove_email_pre_process.py
+++ b/openreview/profile/process/request_remove_email_pre_process.py
@@ -1,0 +1,16 @@
+def process(client, note, invitation):
+
+    email = note.content.get('email')
+    profile_id = note.content.get('profile_id')
+
+    profiles = openreview.tools.get_profiles(client, [profile_id])
+
+    if not profiles:
+        raise openreview.OpenReviewException(f'Profile not found for {profile_id}')
+    
+    if email not in profiles[0].content.get('emails'):
+        raise openreview.OpenReviewException(f'Email {email} not found in profile {profile_id}')
+    
+    if email == profiles[0].get_preferred_email():
+        raise openreview.OpenReviewException(f'Email {email} is already the preferred email in profile {profile_id}')
+

--- a/openreview/profile/process/request_remove_email_process.py
+++ b/openreview/profile/process/request_remove_email_process.py
@@ -114,7 +114,7 @@ def process(client, note, invitation):
     if head_edges or tail_edges:
         client.rename_edges(email, profile.id)
         
-    print('Replace all the group members that contain the name to remove')
+    print('Replace all the group members that contain the email to remove')
     memberships = [ g for g in client.get_all_groups(member=email) if email in g.members ]
 
     anon_groups = [g for g in memberships if g.anonids == True ]
@@ -133,7 +133,7 @@ def process(client, note, invitation):
         if group.id not in processed_group_ids:
             replace_group_members(group, email, profile.id)
 
-    print('Post a profile reference to remove the name')
+    print('Post a profile reference to remove the email')
     
     group = client.get_group(email)
     group.members = []

--- a/openreview/profile/process/request_remove_email_process.py
+++ b/openreview/profile/process/request_remove_email_process.py
@@ -1,0 +1,162 @@
+def process(client, note, invitation):
+
+    AUTHOR_RENAME_INVITATION_ID = ''
+    SUPPORT_USER_ID = ''
+    request_note = client.get_note(note.id)
+    email = request_note.content['email']
+    profile_id = request_note.content['profile_id']
+
+    profile = client.get_profile(profile_id)
+    preferred_id = profile.get_preferred_name()
+    preferred_name = profile.get_preferred_name(pretty=True)
+    
+    def replace_group_members(group, current_member, new_member):
+        existing_group = openreview.tools.get_group(client, group.id)
+        if not existing_group:
+            print('group not fond', group.id)
+            return
+
+        if group.domain is not None:
+            client_v2.remove_members_from_group(group.id, current_member)
+            if not group.id.startswith('~'):
+                client_v2.add_members_to_group(group.id, new_member)
+        else:
+            client.remove_members_from_group(group.id, current_member)
+            if not group.id.startswith('~'):
+                client.add_members_to_group(group.id, new_member)
+
+
+    
+    print('Replace all the publications that contain the email to remove')
+    publications = client.get_all_notes(content={ 'authorids': email})
+    for publication in publications:
+        authors = []
+        authorids = []
+        needs_change = False
+        for index, author in enumerate(publication.content.get('authorids')):
+            if email == author:
+                authors.append(preferred_name)
+                authorids.append(preferred_id)
+                needs_change = True
+            else:
+                if publication.content.get('authors') and len(publication.content['authors']) > index:
+                    authors.append(publication.content['authors'][index])
+                authorids.append(publication.content['authorids'][index])
+        if needs_change:
+            content = {
+                'authors': authors,
+                'authorids': authorids
+            }
+            if '_bibtex' in publication.content:
+                content['_bibtex'] = publication.content['_bibtex'].replace(openreview.tools.pretty_id(username), preferred_name)                
+            client.post_note(openreview.Note(
+                invitation=AUTHOR_RENAME_INVITATION_ID,
+                referent=publication.id, 
+                readers=publication.readers,
+                writers=[SUPPORT_USER_ID],
+                signatures=[SUPPORT_USER_ID],
+                content=content
+            ))
+
+    baseurl_v2 = 'http://localhost:3001'
+
+    if 'https://devapi' in client.baseurl:
+        baseurl_v2 = 'https://devapi2.openreview.net'
+    if 'https://api' in client.baseurl:
+        baseurl_v2 = 'https://api2.openreview.net'                
+
+    client_v2 = openreview.api.OpenReviewClient(baseurl=baseurl_v2, token=client.token)
+    publications = client_v2.get_all_notes(content={ 'authorids': email})
+    for publication in publications:
+        authors = []
+        authorids = []
+        signatures = None
+        readers = None
+        writers = None
+        needs_change = False
+        for index, author in enumerate(publication.content.get('authorids', {}).get('value')):
+            if username == author:
+                authors.append(preferred_name)
+                authorids.append(preferred_id)
+                needs_change = True
+            else:
+                if publication.content.get('authors') and len(publication.content['authors']['value']) > index:
+                    authors.append(publication.content['authors']['value'][index])
+                authorids.append(publication.content['authorids']['value'][index])
+
+        if email in publication.signatures:
+            signatures = [profile.id if g == email else g for g in publication.signatures]
+        if email in publication.readers:
+            readers = [profile.id if g == email else g for g in publication.readers]
+        if email in publication.writers:
+            writers = [profile.id if g == email else g for g in publication.writers]
+
+        if needs_change:
+            content = {
+                'authors': { 'value': authors },
+                'authorids': { 'value': authorids }
+            }
+            if '_bibtex' in publication.content:
+                content['_bibtex'] = { 'value': publication.content['_bibtex']['value'].replace(openreview.tools.pretty_id(username), preferred_name) }
+            client_v2.post_note_edit(
+                invitation = publication.domain + '/-/Edit',
+                readers = [publication.domain],
+                signatures = [SUPPORT_USER_ID],
+                note = openreview.api.Note(
+                    id=publication.id, 
+                    content=content,
+                    readers=readers,
+                    writers=writers,
+                    signatures=signatures
+            ))
+        
+              
+
+    print('Rename all the edges')
+    head_edges = client.get_edges(head=email, limit=1)
+    tail_edges = client.get_edges(tail=email, limit=1)
+    if head_edges or tail_edges:
+        client.rename_edges(email, profile.id)
+        
+    print('Replace all the group members that contain the name to remove')
+    memberships = [ g for g in client.get_all_groups(member=email) if email in g.members ]
+
+    anon_groups = [g for g in memberships if g.anonids == True ]
+    processed_group_ids = []
+
+    for anon_group in anon_groups:
+        regex = anon_group.id[:-1] if anon_group.id.endswith('s') else anon_group.id
+        for group in memberships:
+            if group.id.startswith(regex + '_'):
+                replace_group_members(group, email, profile.id)
+                processed_group_ids.append(group.id)
+        replace_group_members(anon_group, email, profile.id)
+        processed_group_ids.append(anon_group.id)
+
+    for group in memberships:
+        if group.id not in processed_group_ids:
+            replace_group_members(group, email, profile.id)
+
+    print('Post a profile reference to remove the name')
+    
+    group = client.get_group(email)
+    group.members = []
+    group.signatures = ['~Super_User1']
+    client.post_group(group)
+    
+    client.post_profile(openreview.Profile(
+        referent = profile.id, 
+        invitation = '~/-/invitation',
+        signatures = ['~Super_User1'],
+        content = {},
+        metaContent = {
+            'emails': { 
+                'values': [email],
+                'weights': [-1] 
+            }
+        })
+    )
+    
+
+    print('Remove email group')
+    client.delete_group(email)

--- a/openreview/profile/process/request_remove_email_process.py
+++ b/openreview/profile/process/request_remove_email_process.py
@@ -47,8 +47,6 @@ def process(client, note, invitation):
                 'authors': authors,
                 'authorids': authorids
             }
-            if '_bibtex' in publication.content:
-                content['_bibtex'] = publication.content['_bibtex'].replace(openreview.tools.pretty_id(username), preferred_name)                
             client.post_note(openreview.Note(
                 invitation=AUTHOR_RENAME_INVITATION_ID,
                 referent=publication.id, 
@@ -75,7 +73,7 @@ def process(client, note, invitation):
         writers = None
         needs_change = False
         for index, author in enumerate(publication.content.get('authorids', {}).get('value')):
-            if username == author:
+            if email == author:
                 authors.append(preferred_name)
                 authorids.append(preferred_id)
                 needs_change = True
@@ -96,8 +94,6 @@ def process(client, note, invitation):
                 'authors': { 'value': authors },
                 'authorids': { 'value': authorids }
             }
-            if '_bibtex' in publication.content:
-                content['_bibtex'] = { 'value': publication.content['_bibtex']['value'].replace(openreview.tools.pretty_id(username), preferred_name) }
             client_v2.post_note_edit(
                 invitation = publication.domain + '/-/Edit',
                 readers = [publication.domain],

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -1416,25 +1416,25 @@ The OpenReview Team.
 
         ## Create committee groups
         client.post_group(openreview.Group(
-            id='ICLRR.cc',
+            id='ICMLR.cc',
             readers=['everyone'],
-            writers=['ICLRR.cc'],
+            writers=['ICMLR.cc'],
             signatures=['~Super_User1'],
             signatories=[],
             members=[]
         ))
 
         client.post_group(openreview.Group(
-            id='ICLRR.cc/Reviewers',
+            id='ICMLR.cc/Reviewers',
             readers=['everyone'],
-            writers=['ICLRR.cc'],
+            writers=['ICMLR.cc'],
             signatures=['~Super_User1'],
             signatories=[],
             members=['alternate_harold@profile.org'],
             anonids=True
         ))
 
-        anon_groups = client.get_groups(regex='ICLRR.cc/Reviewer_')
+        anon_groups = client.get_groups(regex='ICMLR.cc/Reviewer_')
         assert len(anon_groups) == 1
         assert 'alternate_harold@profile.org' in anon_groups[0].members
         first_anon_group_id = anon_groups[0].id                
@@ -1465,11 +1465,11 @@ The OpenReview Team.
         assert '~Harold_Last1' in publications[1].writers
         assert '~Harold_Last1' in publications[1].signatures
 
-        group = client.get_group('ICLRR.cc/Reviewers')
+        group = client.get_group('ICMLR.cc/Reviewers')
         assert 'alternate_harold@profile.org' not in group.members
         assert '~Harold_Last1' in group.members
 
-        anon_groups = client.get_groups(regex='ICLRR.cc/Reviewer_')
+        anon_groups = client.get_groups(regex='ICMLR.cc/Reviewer_')
         assert len(anon_groups) == 1
         assert 'alternate_harold@profile.org' not in anon_groups[0].members
         assert '~Harold_Last1' in anon_groups[0].members


### PR DESCRIPTION
- Create a note invitation to request the removal of an email in a profile.
- The process function of this invitation performs all the actions needed to remove the email from a profile.

@xkopenreview there are two options to implement this:

1. add a new tab in the moderation page where we can post a new note to delete the email
2. add the button next to each email in the profile that is only visible by openreview.net/Support users

I think option 2 is easier but I would like to see somewhere the list of all the requests. 