### PR TITLE
Journal: new feature requests

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -120,7 +120,7 @@ class GroupBuilder(object):
             content = content.replace("var DESK_REJECTED_ID = '';", "var DESK_REJECTED_ID = '" + venue_id + "/Desk_Rejection';")
             content = content.replace("var WITHDRAWN_ID = '';", "var WITHDRAWN_ID = '" + venue_id + "/Withdrawn_Submission';")
             content = content.replace("var REJECTED_ID = '';", "var REJECTED_ID = '" + venue_id + "/Rejection';")
-            content = content.replace("var CERTIFICATIONS = [];", "var CERTIFICATIONS = " + json.dumps(self.journal.get_certifications()) + ";")
+            content = content.replace("var CERTIFICATIONS = [];", "var CERTIFICATIONS = " + json.dumps(self.journal.get_certifications() + ['Expert Reviewer Certification'] if self.journal.has_expert_reviewers() else []) + ";")
             venue_group.web = content
             self.post_group(venue_group)
 
@@ -269,12 +269,15 @@ class GroupBuilder(object):
             expert_reviewers_id = self.journal.get_expert_reviewers_id()
             expert_reviewers_group = openreview.tools.get_group(self.client, expert_reviewers_id)
             if not expert_reviewers_group:
-                self.post_group(Group(id=expert_reviewers_id,
-                                readers=['everyone'],
-                                writers=[venue_id],
-                                signatures=[venue_id],
-                                signatories=[],
-                                members=[]))        
+                with open(os.path.join(os.path.dirname(__file__), 'webfield/expertReviewerWebfield.js')) as f:
+                    content = f.read()                
+                    self.post_group(Group(id=expert_reviewers_id,
+                                    readers=['everyone'],
+                                    writers=[venue_id],
+                                    signatures=[venue_id],
+                                    signatories=[],
+                                    members=[],
+                                    web=content))        
 
         ## authors group
         authors_id = self.journal.get_authors_id()

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -263,6 +263,18 @@ class GroupBuilder(object):
                             signatures=[venue_id],
                             signatories=[],
                             members=[]))
+            
+        ## expert reviewer group
+        if self.journal.has_expert_reviewers():
+            expert_reviewers_id = self.journal.get_expert_reviewers_id()
+            expert_reviewers_group = openreview.tools.get_group(self.client, expert_reviewers_id)
+            if not expert_reviewers_group:
+                self.post_group(Group(id=expert_reviewers_id,
+                                readers=['everyone'],
+                                writers=[venue_id],
+                                signatures=[venue_id],
+                                signatories=[],
+                                members=[]))        
 
         ## authors group
         authors_id = self.journal.get_authors_id()

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -129,7 +129,7 @@ class GroupBuilder(object):
             content = content.replace("var DESK_REJECTED_ID = '';", "var DESK_REJECTED_ID = '" + venue_id + "/Desk_Rejection';")
             content = content.replace("var WITHDRAWN_ID = '';", "var WITHDRAWN_ID = '" + venue_id + "/Withdrawn_Submission';")
             content = content.replace("var REJECTED_ID = '';", "var REJECTED_ID = '" + venue_id + "/Rejection';")
-            content = content.replace("var CERTIFICATIONS = [];", "var CERTIFICATIONS = " + json.dumps(self.journal.get_certifications() + ['Expert Reviewer Certification'] if self.journal.has_expert_reviewers() else []) + ";")
+            content = content.replace("var CERTIFICATIONS = [];", "var CERTIFICATIONS = " + json.dumps(self.journal.get_certifications() + [self.journal.get_expert_reviewer_certification()] if self.journal.has_expert_reviewers() else []) + ";")
             if not venue_group.web:
                 venue_group.web = content
                 self.post_group(venue_group)

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -186,6 +186,28 @@ class GroupBuilder(object):
                             signatures=[venue_id],
                             signatories=[],
                             members=[]))
+            
+        ## archived action editors group
+        action_editors_archived_id = f'{action_editors_id}/Archived'
+        action_editor_archived_group = openreview.tools.get_group(self.client, action_editors_archived_id)
+        if not action_editor_archived_group:
+            action_editor_archived_group=self.post_group(Group(id=action_editors_archived_id,
+                            readers=['everyone'],
+                            writers=[venue_id],
+                            signatures=[venue_id],
+                            signatories=[venue_id],
+                            members=[]))
+        with open(os.path.join(os.path.dirname(__file__), 'webfield/actionEditorWebfield.js')) as f:
+            content = f.read()
+            content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
+            content = content.replace("var SHORT_PHRASE = '';", f'var SHORT_PHRASE = "{self.journal.short_name}";')
+            content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + self.journal.get_author_submission_id() + "';")
+            content = content.replace("var ACTION_EDITOR_NAME = '';", "var ACTION_EDITOR_NAME = '" + self.journal.action_editors_name + "';")
+            content = content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + self.journal.reviewers_name + "';")
+            content = content.replace("var SUBMISSION_GROUP_NAME = '';", "var SUBMISSION_GROUP_NAME = '" + self.journal.submission_group_name + "';")
+
+            action_editor_archived_group.web = content
+            self.post_group(action_editor_archived_group)            
 
         ## reviewers group
         reviewers_id = self.journal.get_reviewers_id()

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -32,6 +32,7 @@ class GroupBuilder(object):
         venue_id = self.journal.venue_id
         editor_in_chief_id = self.journal.get_editors_in_chief_id()
         reviewer_report_form = self.journal.get_reviewer_report_form()
+        additional_committee = [self.journal.get_action_editors_archived_id()] if self.journal.has_archived_action_editors() else []
 
         ## venue group
         venue_group=self.post_group(Group(id=venue_id,
@@ -214,7 +215,7 @@ class GroupBuilder(object):
         reviewer_group = openreview.tools.get_group(self.client, reviewers_id)
         if not reviewer_group:
             reviewer_group = Group(id=reviewers_id,
-                            readers=[venue_id, action_editors_id, reviewers_id],
+                            readers=[venue_id, action_editors_id, reviewers_id] + additional_committee,
                             writers=[venue_id],
                             signatures=[venue_id],
                             signatories=[venue_id],

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3060,7 +3060,19 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'input': 'select'
                     }
                 }
-            }            
+            }
+
+        if self.journal.has_expert_reviewers():
+            invitation.edit['note']['content']['expert_reviewers'] = {
+                'order': 5,
+                'description': 'List of expert reviewers',
+                'value': {
+                    'param': {
+                        'type': 'string[]',
+                        'optional': True
+                    }
+                }
+            }                        
 
 
         self.save_invitation(invitation)

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -1489,7 +1489,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_ae_custom_max_papers_id(),
             invitees=[venue_id, action_editors_id],
-            readers=[venue_id, action_editors_id],
+            readers=[venue_id, action_editors_id, authors_id],
             writers=[venue_id],
             signatures=[venue_id],
             minReplies=1,
@@ -1516,7 +1516,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'deletable': True
                     }
                 },
-                'readers': [venue_id, '${2/tail}'],
+                'readers': [venue_id, authors_id, '${2/tail}'],
                 'nonreaders': [],
                 'writers': [venue_id, '${2/tail}'],
                 'signatures': {
@@ -1605,7 +1605,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_ae_availability_id(),
             invitees=[venue_id, action_editors_id],
-            readers=[venue_id, action_editors_id],
+            readers=[venue_id, action_editors_id, authors_id],
             writers=[venue_id],
             signatures=['~Super_User1'], ## user super user so it can update the edges
             minReplies=1,
@@ -1632,7 +1632,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'deletable': True
                     }
                 },
-                'readers': [venue_id, '${2/tail}'],
+                'readers': [venue_id, authors_id, '${2/tail}'],
                 'nonreaders': [],
                 'writers': [venue_id, '${2/tail}'],
                 'signatures': {
@@ -3181,10 +3181,10 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         }
 
         conflict_id = f'{action_editors_id}/-/Conflict'
-        score_ids = [f'{action_editors_id}/-/Affinity_Score']
+        score_ids = [f'{action_editors_id}/-/Affinity_Score', f'{action_editors_id}/-/Custom_Max_Papers,head:ignore', f'{action_editors_id}/-/Assignment_Availability,head:ignore']
         edit_param = f'{action_editors_id}/-/Recommendation'
         browse_param = ';'.join(score_ids)
-        params = f'start=staticList,type:head,ids:{note.id}&traverse={edit_param}&edit={edit_param}&browse={browse_param}&hide={conflict_id}&version=2&referrer=[Instructions](/invitation?id={invitation.id})&maxColumns=2&showCounter=false&version=2'
+        params = f'start=staticList,type:head,ids:{note.id}&traverse={edit_param}&edit={edit_param}&browse={browse_param}&hide={conflict_id}&version=2&maxColumns=2&showCounter=false&version=2&filter={action_editors_id}/-/Assignment_Availability == Available&referrer=[Instructions](/invitation?id={invitation.id})'
         with open(os.path.join(os.path.dirname(__file__), 'webfield/suggestAEWebfield.js')) as f:
             content = f.read()
             content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + venue_id + "';")

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -91,6 +91,7 @@ class InvitationBuilder(object):
         self.set_eic_revision_invitation()
         self.set_expertise_selection_invitations()
         self.set_review_rating_enabling_invitation()
+        self.set_expertise_reviewer_invitation()
 
     
     def get_super_process_content(self, field_name):
@@ -5839,3 +5840,31 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         build_expertise_selection(self.journal.get_reviewers_id(), self.journal.get_reviewer_expertise_selection_id())
         build_expertise_selection(self.journal.get_action_editors_id(), self.journal.get_ae_expertise_selection_id())
 
+    def set_expertise_reviewer_invitation(self):
+
+        venue_id = self.journal.venue_id
+
+        invitation = Invitation(id=self.journal.get_expert_reviewers_member_id(),
+            invitees=[venue_id],
+            readers=[venue_id],
+            writers=[venue_id],
+            signatures=[venue_id],
+            process=self.get_process_content('process/expert_reviewers_member_process.py'),
+            edit={
+                'signatures': [venue_id],
+                'readers': [venue_id],
+                'writers': [venue_id],
+                'group': {
+                    'id': self.journal.get_expert_reviewers_id(),
+                    'members': {
+                        'param': {
+                            'regex': '~.*',
+                            'change': 'append'
+                        }
+                    }
+                }
+
+            }
+        )
+
+        self.save_invitation(invitation)

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3048,7 +3048,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         if self.journal.get_certifications():
             certificaaion_options = self.journal.get_certifications()
             if self.journal.has_expert_reviewers():
-                certificaaion_options.append('Expert Reviewer Certification')
+                certificaaion_options.append(self.journal.get_expert_reviewer_certification())
             invitation.edit['note']['content']['certifications'] = {
                 'order': 3,
                 'description': 'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE, however you are asked to submit your recommendation.',

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3045,13 +3045,16 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             }            
 
         if self.journal.get_certifications():
+            certificaaion_options = self.journal.get_certifications()
+            if self.journal.has_expert_reviewers():
+                certificaaion_options.append('Expert Reviewer Certification')
             invitation.edit['note']['content']['certifications'] = {
                 'order': 3,
                 'description': 'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE, however you are asked to submit your recommendation.',
                 'value': {
                     'param': {
                         'type': 'string[]',
-                        'enum': self.journal.get_certifications(),
+                        'enum': certificaaion_options,
                         'optional': True,
                         'input': 'select'
                     }

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3182,10 +3182,10 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         }
 
         conflict_id = f'{action_editors_id}/-/Conflict'
-        score_ids = [f'{action_editors_id}/-/Affinity_Score', f'{action_editors_id}/-/Custom_Max_Papers,head:ignore', f'{action_editors_id}/-/Assignment_Availability,head:ignore']
+        score_ids = [f'{action_editors_id}/-/Affinity_Score', f'{action_editors_id}/-/Custom_Max_Papers,head:ignore', f'{action_editors_id}/-/Assignment_Availability,head:ignore', f'{action_editors_id}/-/Assignment,head:count']
         edit_param = f'{action_editors_id}/-/Recommendation'
         browse_param = ';'.join(score_ids)
-        params = f'start=staticList,type:head,ids:{note.id}&traverse={edit_param}&edit={edit_param}&browse={browse_param}&hide={conflict_id}&version=2&maxColumns=2&showCounter=false&version=2&filter={action_editors_id}/-/Assignment_Availability == Available&referrer=[Instructions](/invitation?id={invitation.id})'
+        params = f'start=staticList,type:head,ids:{note.id}&traverse={edit_param}&edit={edit_param}&browse={browse_param}&hide={conflict_id}&version=2&maxColumns=2&showCounter=false&version=2&filter={action_editors_id}/-/Assignment_Availability == Available AND {action_editors_id}/-/Custom_Max_Papers > {action_editors_id}/-/Assignment&referrer=[Instructions](/invitation?id={invitation.id})'
         with open(os.path.join(os.path.dirname(__file__), 'webfield/suggestAEWebfield.js')) as f:
             content = f.read()
             content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + venue_id + "';")

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3048,7 +3048,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         if self.journal.get_certifications():
             certification_options = self.journal.get_certifications()
             if self.journal.has_expert_reviewers():
-                certificaaion_options.append(self.journal.get_expert_reviewer_certification())
+                certification_options.append(self.journal.get_expert_reviewer_certification())
             invitation.edit['note']['content']['certifications'] = {
                 'order': 3,
                 'description': 'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE, however you are asked to submit your recommendation.',

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -1674,13 +1674,14 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         author_submission_id = self.journal.get_author_submission_id()
         editor_in_chief_id = self.journal.get_editors_in_chief_id()
         action_editors_id = self.journal.get_action_editors_id()
+        action_editors_archived_id = self.journal.get_action_editors_archived_id()
         reviewers_id = self.journal.get_reviewers_id()
         authors_id = self.journal.get_authors_id()
 
         invitation = Invitation(
             id=self.journal.get_reviewer_conflict_id(),
             invitees=[venue_id],
-            readers=[venue_id, action_editors_id],
+            readers=[venue_id, action_editors_id, action_editors_archived_id],
             writers=[venue_id],
             signatures=[editor_in_chief_id], ## to compute conflicts
             minReplies=1,
@@ -1741,7 +1742,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_affinity_score_id(),
             invitees=[venue_id],
-            readers=[venue_id, action_editors_id],
+            readers=[venue_id, action_editors_id, action_editors_archived_id],
             writers=[venue_id],
             signatures=[venue_id],
             minReplies=1,
@@ -1802,8 +1803,8 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
 
         invitation = Invitation(
             id=self.journal.get_reviewer_assignment_id(),
-            invitees=[venue_id, action_editors_id],
-            readers=[venue_id, action_editors_id],
+            invitees=[venue_id, action_editors_id, action_editors_archived_id],
+            readers=[venue_id, action_editors_id, action_editors_archived_id],
             writers=[venue_id],
             signatures=[self.journal.get_editors_in_chief_id()],
             minReplies=1,
@@ -1875,7 +1876,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_assignment_id(archived=True),
             invitees=[venue_id],
-            readers=[venue_id, action_editors_id],
+            readers=[venue_id, action_editors_id, action_editors_archived_id],
             writers=[venue_id],
             signatures=[self.journal.get_editors_in_chief_id()],
             minReplies=1,
@@ -1942,7 +1943,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_custom_max_papers_id(),
             invitees=[venue_id, reviewers_id],
-            readers=[venue_id, action_editors_id, reviewers_id],
+            readers=[venue_id, action_editors_id, reviewers_id, action_editors_archived_id],
             writers=[venue_id],
             signatures=[venue_id],
             minReplies=1,
@@ -2002,7 +2003,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_pending_review_id(),
             invitees=[venue_id],
-            readers=[venue_id, action_editors_id],
+            readers=[venue_id, action_editors_id, action_editors_archived_id],
             writers=[venue_id],
             signatures=[venue_id],
             minReplies=1,
@@ -2057,7 +2058,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_availability_id(),
             invitees=[venue_id, reviewers_id],
-            readers=[venue_id, action_editors_id, reviewers_id],
+            readers=[venue_id, action_editors_id, reviewers_id, action_editors_archived_id],
             writers=[venue_id],
             signatures=['~Super_User1'], ## user super user so it can update the edges
             minReplies=1,

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3046,7 +3046,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             }            
 
         if self.journal.get_certifications():
-            certificaaion_options = self.journal.get_certifications()
+            certification_options = self.journal.get_certifications()
             if self.journal.has_expert_reviewers():
                 certificaaion_options.append(self.journal.get_expert_reviewer_certification())
             invitation.edit['note']['content']['certifications'] = {

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3055,7 +3055,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                 'value': {
                     'param': {
                         'type': 'string[]',
-                        'enum': certificaaion_options,
+                        'enum': certification_options,
                         'optional': True,
                         'input': 'select'
                     }

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -1482,7 +1482,8 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'minimum': -1
                     }
                 }
-            }
+            },
+            preprocess = self.get_process_content('process/ae_recommendation_pre_process.py')
         )
         self.save_invitation(invitation)
 

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -1244,7 +1244,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_ae_assignment_id(),
             invitees=[venue_id, editor_in_chief_id],
-            readers=[venue_id, action_editors_id],
+            readers=[venue_id, action_editors_id, authors_id],
             writers=[venue_id],
             signatures=[editor_in_chief_id], ## EIC have permission to check conflicts
             minReplies=1,
@@ -3182,7 +3182,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         }
 
         conflict_id = f'{action_editors_id}/-/Conflict'
-        score_ids = [f'{action_editors_id}/-/Affinity_Score', f'{action_editors_id}/-/Custom_Max_Papers,head:ignore', f'{action_editors_id}/-/Assignment_Availability,head:ignore', f'{action_editors_id}/-/Assignment,head:count']
+        score_ids = [f'{action_editors_id}/-/Affinity_Score', f'{action_editors_id}/-/Custom_Max_Papers,head:ignore', f'{action_editors_id}/-/Assignment_Availability,head:ignore', f'{action_editors_id}/-/Assignment,count:tail']
         edit_param = f'{action_editors_id}/-/Recommendation'
         browse_param = ';'.join(score_ids)
         params = f'start=staticList,type:head,ids:{note.id}&traverse={edit_param}&edit={edit_param}&browse={browse_param}&hide={conflict_id}&version=2&maxColumns=2&showCounter=false&version=2&filter={action_editors_id}/-/Assignment_Availability == Available AND {action_editors_id}/-/Custom_Max_Papers > {action_editors_id}/-/Assignment&referrer=[Instructions](/invitation?id={invitation.id})'

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -1675,14 +1675,14 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         author_submission_id = self.journal.get_author_submission_id()
         editor_in_chief_id = self.journal.get_editors_in_chief_id()
         action_editors_id = self.journal.get_action_editors_id()
-        action_editors_archived_id = self.journal.get_action_editors_archived_id()
         reviewers_id = self.journal.get_reviewers_id()
         authors_id = self.journal.get_authors_id()
+        additional_committee = [self.journal.get_action_editors_archived_id()] if self.journal.has_archived_action_editors() else []
 
         invitation = Invitation(
             id=self.journal.get_reviewer_conflict_id(),
             invitees=[venue_id],
-            readers=[venue_id, action_editors_id, action_editors_archived_id],
+            readers=[venue_id, action_editors_id] + additional_committee,
             writers=[venue_id],
             signatures=[editor_in_chief_id], ## to compute conflicts
             minReplies=1,
@@ -1743,7 +1743,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_affinity_score_id(),
             invitees=[venue_id],
-            readers=[venue_id, action_editors_id, action_editors_archived_id],
+            readers=[venue_id, action_editors_id] + additional_committee,
             writers=[venue_id],
             signatures=[venue_id],
             minReplies=1,
@@ -1804,8 +1804,8 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
 
         invitation = Invitation(
             id=self.journal.get_reviewer_assignment_id(),
-            invitees=[venue_id, action_editors_id, action_editors_archived_id],
-            readers=[venue_id, action_editors_id, action_editors_archived_id],
+            invitees=[venue_id, action_editors_id] + additional_committee,
+            readers=[venue_id, action_editors_id] + additional_committee,
             writers=[venue_id],
             signatures=[self.journal.get_editors_in_chief_id()],
             minReplies=1,
@@ -1877,7 +1877,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_assignment_id(archived=True),
             invitees=[venue_id],
-            readers=[venue_id, action_editors_id, action_editors_archived_id],
+            readers=[venue_id, action_editors_id] + additional_committee,
             writers=[venue_id],
             signatures=[self.journal.get_editors_in_chief_id()],
             minReplies=1,
@@ -1944,7 +1944,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_custom_max_papers_id(),
             invitees=[venue_id, reviewers_id],
-            readers=[venue_id, action_editors_id, reviewers_id, action_editors_archived_id],
+            readers=[venue_id, action_editors_id, reviewers_id] + additional_committee,
             writers=[venue_id],
             signatures=[venue_id],
             minReplies=1,
@@ -1971,7 +1971,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'deletable': True
                     }
                 },
-                'readers': [venue_id, self.journal.get_action_editors_id(), '${2/tail}'],
+                'readers': [venue_id, self.journal.get_action_editors_id(), '${2/tail}'] + additional_committee,
                 'nonreaders': [],
                 'writers': [venue_id, '${2/tail}'],
                 'signatures': {
@@ -2004,7 +2004,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_pending_review_id(),
             invitees=[venue_id],
-            readers=[venue_id, action_editors_id, action_editors_archived_id],
+            readers=[venue_id, action_editors_id] + additional_committee,
             writers=[venue_id],
             signatures=[venue_id],
             minReplies=1,
@@ -2031,7 +2031,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'deletable': True
                     }
                 },
-                'readers': [venue_id, self.journal.get_action_editors_id(), '${2/tail}'],
+                'readers': [venue_id, self.journal.get_action_editors_id(), '${2/tail}'] + additional_committee,
                 'nonreaders': [],
                 'writers': [venue_id],
                 'signatures': [venue_id],
@@ -2059,7 +2059,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         invitation = Invitation(
             id=self.journal.get_reviewer_availability_id(),
             invitees=[venue_id, reviewers_id],
-            readers=[venue_id, action_editors_id, reviewers_id, action_editors_archived_id],
+            readers=[venue_id, action_editors_id, reviewers_id] + additional_committee,
             writers=[venue_id],
             signatures=['~Super_User1'], ## user super user so it can update the edges
             minReplies=1,
@@ -2086,7 +2086,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'deletable': True
                     }
                 },
-                'readers': [venue_id, self.journal.get_action_editors_id(), '${2/tail}'],
+                'readers': [venue_id, self.journal.get_action_editors_id(), '${2/tail}'] + additional_committee,
                 'nonreaders': [],
                 'writers': [venue_id, '${2/tail}'],
                 'signatures': {
@@ -5842,6 +5842,9 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
 
     def set_expertise_reviewer_invitation(self):
 
+        if not self.journal.has_expert_reviewers():
+            return
+        
         venue_id = self.journal.venue_id
 
         invitation = Invitation(id=self.journal.get_expert_reviewers_member_id(),

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -346,6 +346,9 @@ class Journal(object):
             if 'Long submission' in note.content['submission_length']['value']:
                 return 2 * review_period ## weeks
         return review_period ## weeks
+    
+    def get_expert_reviewer_certification(self):
+        return "Expert Certification"
 
     def is_active_submission(self, submission):
         venue_id = submission.content.get('venueid', {}).get('value')

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -203,6 +203,9 @@ class Journal(object):
 
     def get_review_rating_id(self, signature=None):
         return self.__get_invitation_id(name='Rating', prefix=signature)
+    
+    def get_review_rating_enabling_id(self, number=None):
+        return self.__get_invitation_id(name='Review_Rating_Enabling', number=number)
 
     def get_accepted_id(self):
         return self.__get_invitation_id(name='Accepted')

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -75,6 +75,9 @@ class Journal(object):
 
     def get_publication_chairs_id(self):
         return f'{self.venue_id}/Publication_Chairs'
+    
+    def get_action_editors_archived_id(self):
+        return f'{self.get_action_editors_id()}/Archived'    
 
     def get_action_editors_id(self, number=None):
         return self.__get_group_id(self.action_editors_name, number)
@@ -426,6 +429,9 @@ class Journal(object):
 
     def has_publication_chairs(self):
         return self.settings.get('has_publication_chairs', False)
+    
+    def has_archived_action_editors(self):
+        return self.settings.get('archived_action_editors', False)    
 
     def get_number_of_reviewers(self):
         return self.settings.get('number_of_reviewers', 3)

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -87,6 +87,9 @@ class Journal(object):
 
     def get_reviewers_reported_id(self):
         return self.get_reviewers_id() + '/Reported'
+    
+    def get_expert_reviewers_id(self):
+        return self.__get_group_id('Expert_Reviewers')
 
     def get_solicit_reviewers_id(self, number=None, declined=False):
         group_id = self.__get_group_id(self.solicit_reviewers_name, number)
@@ -431,7 +434,10 @@ class Journal(object):
         return self.settings.get('has_publication_chairs', False)
     
     def has_archived_action_editors(self):
-        return self.settings.get('archived_action_editors', False)    
+        return self.settings.get('archived_action_editors', False)
+
+    def has_expert_reviewers(self):
+        return self.settings.get('expert_reviewers', False)        
 
     def get_number_of_reviewers(self):
         return self.settings.get('number_of_reviewers', 3)

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -90,6 +90,9 @@ class Journal(object):
     
     def get_expert_reviewers_id(self):
         return self.__get_group_id('Expert_Reviewers')
+    
+    def get_expert_reviewers_member_id(self):
+        return self.__get_invitation_id(name='Member', prefix=self.get_expert_reviewers_id())    
 
     def get_solicit_reviewers_id(self, number=None, declined=False):
         group_id = self.__get_group_id(self.solicit_reviewers_name, number)

--- a/openreview/journal/process/ae_recommendation_pre_process.py
+++ b/openreview/journal/process/ae_recommendation_pre_process.py
@@ -1,0 +1,20 @@
+def process(client, edge, invitation):
+
+    if edge.ddate:
+        return
+
+    journal = openreview.journal.Journal()
+
+    edges = client.get_edges(invitation=journal.get_ae_availability_id(), tail=edge.tail)
+    if edges and edges[0].label == 'Unavailable':
+        raise openreview.OpenReviewException(f'Action Editor {edge.tail} is currently unavailable.') 
+
+    quota = journal.get_ae_max_papers() 
+    edges = client.get_edges(invitation=journal.get_ae_custom_max_papers_id(), tail=edge.tail)
+    if edges:
+        quota = edges[0].weight
+    
+    assignments = client.get_edges(invitation=journal.get_ae_assignment_id(), tail=edge.tail)
+    if len(assignments) >= quota:
+        raise openreview.OpenReviewException(f'Action Editor {edge.tail} has reached the maximum number of papers.')
+

--- a/openreview/journal/process/camera_ready_verification_process.py
+++ b/openreview/journal/process/camera_ready_verification_process.py
@@ -25,7 +25,7 @@ def process(client, edit, invitation):
                 print('checking', authorid)
                 if client.get_groups(member=authorid, id=journal.get_expert_reviewers_id()) and not expert_reviewer_ceritification:
                     print('append expert reviewer certification')
-                    certifications.append('Expert Reviewer Certification')
+                    certifications.append(journal.get_expert_reviewer_certification())
                     expert_reviewer_ceritification = True
 
     content= {

--- a/openreview/journal/process/camera_ready_verification_process.py
+++ b/openreview/journal/process/camera_ready_verification_process.py
@@ -16,13 +16,25 @@ def process(client, edit, invitation):
     decision = decisions[0]
     certifications = decision.content.get('certifications', {}).get('value', [])
 
+    if journal.get_certifications():
+        if journal.has_expert_reviewers():
+            expert_reviewer_ceritification = False
+            authorids = submission.content['authorids']['value']
+            print('check if an author is an expert reviewer')
+            for authorid in authorids:
+                print('checking', authorid)
+                if client.get_groups(member=authorid, id=journal.get_expert_reviewers_id()) and not expert_reviewer_ceritification:
+                    print('append expert reviewer certification')
+                    certifications.append('Expert Reviewer Certification')
+                    expert_reviewer_ceritification = True
+
     content= {
         '_bibtex': {
             'value': journal.get_bibtex(submission, journal.accepted_venue_id, certifications=certifications)
         }
     }
 
-    if journal.get_certifications():
+    if certifications:
         content['certifications'] = { 'value': certifications }
 
     acceptance_note = client.post_note_edit(invitation=journal.get_accepted_id(),

--- a/openreview/journal/process/camera_ready_verification_process.py
+++ b/openreview/journal/process/camera_ready_verification_process.py
@@ -15,6 +15,7 @@ def process(client, edit, invitation):
 
     decision = decisions[0]
     certifications = decision.content.get('certifications', {}).get('value', [])
+    expert_reviewers = []
 
     if journal.get_certifications():
         if journal.has_expert_reviewers():
@@ -26,6 +27,7 @@ def process(client, edit, invitation):
                 if client.get_groups(member=authorid, id=journal.get_expert_reviewers_id()) and not expert_reviewer_ceritification:
                     print('append expert reviewer certification')
                     certifications.append(journal.get_expert_reviewer_certification())
+                    expert_reviewers.append(authorid)
                     expert_reviewer_ceritification = True
 
     content= {
@@ -36,6 +38,9 @@ def process(client, edit, invitation):
 
     if certifications:
         content['certifications'] = { 'value': certifications }
+
+    if expert_reviewers:
+        content['expert_reviewers'] = { 'value': expert_reviewers }
 
     acceptance_note = client.post_note_edit(invitation=journal.get_accepted_id(),
                         signatures=[venue_id],

--- a/openreview/journal/process/expert_reviewers_member_process.py
+++ b/openreview/journal/process/expert_reviewers_member_process.py
@@ -1,0 +1,29 @@
+def process(client, edit, invitation):
+
+    journal = openreview.journal.Journal()
+
+    members = edit.group.members.get('append', [])
+
+    print('Add expert reviewers', members)
+
+    for member in members:
+        ## find TMLR publications for member
+        tmlr_notes = client.get_notes(content= { 'venueid': journal.venue_id, 'authorids': member })
+        for note in tmlr_notes:
+            client.post_note_edit(
+                invitation=journal.get_meta_invitation_id(),
+                signatures=[journal.venue_id],
+                note=openreview.api.Note(
+                    id=note.id,
+                    content={
+                        'certifications': {
+                            'value': {
+                                'append': ['Expert Reviewer Certification']
+                            }
+                        },
+                        '_bibtex': {
+                            'value': journal.get_bibtex(note, journal.accepted_venue_id, certifications=note.content.get('certifications', {}).get('value', []) + ['Expert Reviewer Certification'])
+                        }
+                    }
+                )
+            )

--- a/openreview/journal/process/expert_reviewers_member_process.py
+++ b/openreview/journal/process/expert_reviewers_member_process.py
@@ -18,11 +18,11 @@ def process(client, edit, invitation):
                     content={
                         'certifications': {
                             'value': {
-                                'append': ['Expert Reviewer Certification']
+                                'append': [journal.get_expert_reviewer_certification()]
                             }
                         },
                         '_bibtex': {
-                            'value': journal.get_bibtex(note, journal.accepted_venue_id, certifications=note.content.get('certifications', {}).get('value', []) + ['Expert Reviewer Certification'])
+                            'value': journal.get_bibtex(note, journal.accepted_venue_id, certifications=note.content.get('certifications', {}).get('value', []) + [journal.get_expert_reviewer_certification()])
                         }
                     }
                 )

--- a/openreview/journal/process/expert_reviewers_member_process.py
+++ b/openreview/journal/process/expert_reviewers_member_process.py
@@ -21,6 +21,11 @@ def process(client, edit, invitation):
                                 'append': [journal.get_expert_reviewer_certification()]
                             }
                         },
+                        'expert_reviewers': {
+                            'value': {
+                                'append': [member]
+                            }
+                        },                        
                         '_bibtex': {
                             'value': journal.get_bibtex(note, journal.accepted_venue_id, certifications=note.content.get('certifications', {}).get('value', []) + [journal.get_expert_reviewer_certification()])
                         }

--- a/openreview/journal/process/official_recommendation_cdate_process.py
+++ b/openreview/journal/process/official_recommendation_cdate_process.py
@@ -46,3 +46,6 @@ The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=journal.contact_info
     )
+
+    print('Let EICs enable the review rating')
+    journal.invitation_builder.set_note_review_rating_enabling_invitation(submission)

--- a/openreview/journal/process/remind_ae_unavailable_process.py
+++ b/openreview/journal/process/remind_ae_unavailable_process.py
@@ -42,6 +42,9 @@ The {journal.short_name} Editors-in-Chief
 
     print('reminder_period', reminder_period)
     for edge in edges:
+        is_ae = client.get_groups(member=edge.tail, id=journal.get_action_editors_id())
+        if not is_ae:
+            continue
         recipients=[edge.tail]
         if edge.tmdate < back_to_available_period:
             print(f"back to available: {edge.tail}")

--- a/openreview/journal/process/reviewer_assignment_process.py
+++ b/openreview/journal/process/reviewer_assignment_process.py
@@ -23,9 +23,6 @@ def process_update(client, edge, invitation, existing_edge):
         if not submission_edges:
             print('Mark task a complete')
             client.post_edge(openreview.api.Edge(invitation=journal.get_reviewer_assignment_id(number=note.number),
-                readers = [venue_id, journal.get_action_editors_id(number=note.number)],
-                nonreaders = [journal.get_authors_id(number=note.number)],
-                writers = [venue_id],
                 signatures = [journal.get_action_editors_id(number=note.number)],
                 head = note.id,
                 tail = journal.get_reviewers_id(),
@@ -92,8 +89,6 @@ note: replies to this email will go to the AE, {assigned_action_editor.get_prefe
             client.post_edge(pending_review_edge)
         else:
             client.post_edge(openreview.api.Edge(invitation = journal.get_reviewer_pending_review_id(),
-                readers = [venue_id, journal.get_action_editors_id(), edge.tail],
-                writers = [venue_id],
                 signatures = [venue_id],
                 head = journal.get_reviewers_id(),
                 tail = edge.tail,

--- a/openreview/journal/process/submission_decision_approval_process.py
+++ b/openreview/journal/process/submission_decision_approval_process.py
@@ -38,6 +38,11 @@ def process(client, edit, invitation):
     print('Enable Camera Ready Revision')
     journal.invitation_builder.set_note_camera_ready_revision_invitation(submission, journal.get_due_date(weeks = journal.get_camera_ready_period_length()))
 
+    ## Expire reviewer tasks
+    print('Expire reviewer tasks')
+    journal.invitation_builder.expire_invitation(journal.get_review_id(submission.number))
+    journal.invitation_builder.expire_invitation(journal.get_reviewer_recommendation_id(submission.number))
+
     ## Send email to authors
     print('Send email to authors')
     if decision.content['recommendation']['value'] == 'Accept as is':

--- a/openreview/journal/webfield/expertReviewerWebfield.js
+++ b/openreview/journal/webfield/expertReviewerWebfield.js
@@ -4,7 +4,7 @@ return {
     properties: {
       title: `${domain.id} Expert Reviewers`,
       description: `*${domain.id} is proud to highlight the following Expert Reviewers, i.e. reviewers for ${domain.id} who have done exemplary work in evaluating ${domain.id} submissions. They have stood out in various ways, including by writing detailed reviews, engaging deeply with authors and performing their work in a timely fashion.
-  To highlight their contribution and expertise, the accepted ${domain.id} papers they author are also given an Expert Reviewer Certification.*`,
+  To highlight their contribution and expertise, the accepted ${domain.id} papers they author are also given an Expert Certification.*`,
       links: entity.members
     }
   }

--- a/openreview/journal/webfield/expertReviewerWebfield.js
+++ b/openreview/journal/webfield/expertReviewerWebfield.js
@@ -1,0 +1,10 @@
+// Webfield component
+return {
+    component: 'GroupDirectory',
+    properties: {
+      title: `${domain.id} Expert Reviewers`,
+      description: `*${domain.id} is proud to highlight the following Expert Reviewers, i.e. reviewers for ${domain.id} who have done exemplary work in evaluating ${domain.id} submissions. They have stood out in various ways, including by writing detailed reviews, engaging deeply with authors and performing their work in a timely fashion.
+  To highlight their contribution and expertise, the accepted ${domain.id} papers they author are also given an Expert Reviewer Certification.*`,
+      links: entity.members
+    }
+  }

--- a/openreview/journal/webfield/homepage.js
+++ b/openreview/journal/webfield/homepage.js
@@ -188,7 +188,7 @@ function renderContent(acceptedResponse, acceptedNotesWithVideo, certificationsR
 
   CERTIFICATIONS.forEach(function(certification, index) {
     var response = certificationsResponse[index];
-    var key = certification.toLowerCase().replace(' ', '-');
+    var key = certification.toLowerCase().replaceAll(' ', '-');
     Webfield2.ui.renderSubmissionList('#' + key, SUBMISSION_ID, response.notes, response.count,
     Object.assign({}, options, { query: { 'content.venueid': VENUE_ID, 'content.certifications': certification, sort: 'pdate:desc' }}));
   })

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -915,7 +915,7 @@ reviewer6@gmail.com, Reviewer ICMLSix
         ## try to edit a submission as a PC
         submissions = pc_client_v2.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
         submission = submissions[0]
-        pc_client_v2.post_note_edit(invitation='ICML.cc/2023/Conference/-/PC_Revision',
+        edit_note = pc_client_v2.post_note_edit(invitation='ICML.cc/2023/Conference/-/PC_Revision',
             signatures=['ICML.cc/2023/Conference/Program_Chairs'],
             note=openreview.api.Note(
                 id = submission.id,
@@ -932,7 +932,7 @@ reviewer6@gmail.com, Reviewer ICMLSix
                 }
             ))
 
-        helpers.await_queue(openreview_client)
+        helpers.await_queue_edit(openreview_client, edit_id=edit_note['id'])
 
         submission = ac_client.get_note(submission.id)
         assert ['ICML.cc/2023/Conference',
@@ -1424,7 +1424,7 @@ To view your submission, click here: https://openreview.net/forum?id={submission
                     weight=1
             ))
 
-        ac_client.post_edge(
+        edge = ac_client.post_edge(
             openreview.api.Edge(invitation='ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment',
                 signatures=[anon_group_id],
                 head=submissions[0].id,
@@ -1432,11 +1432,11 @@ To view your submission, click here: https://openreview.net/forum?id={submission
                 label='Invitation Sent',
                 weight=1
         ))
-        helpers.await_queue(openreview_client)
+        helpers.await_queue_edit(openreview_client, edge.id)
 
         helpers.create_user('javier@icml.cc', 'Javier', 'ICML')
 
-        ac_client.post_edge(
+        edge = ac_client.post_edge(
             openreview.api.Edge(invitation='ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment',
                 signatures=[anon_group_id],
                 head=submissions[0].id,
@@ -1444,7 +1444,7 @@ To view your submission, click here: https://openreview.net/forum?id={submission
                 label='Invitation Sent',
                 weight=1
         ))
-        helpers.await_queue(openreview_client)
+        helpers.await_queue_edit(openreview_client, edge.id)
 
         with pytest.raises(openreview.OpenReviewException, match=r'the user is already invited'):
             ac_client.post_edge(

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -1898,8 +1898,6 @@ ICML 2023 Conference Program Chairs'''
         client.rename_edges(new_id='~Rachel_ICML2', current_id='~Rachel_ICML1')
         client.merge_profiles(profileTo='~Rachel_ICML2', profileFrom='~Rachel_ICML1')
 
-        assert False
-
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False, comment='I am too busy.')
 
         helpers.await_queue(openreview_client)

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -510,7 +510,7 @@ reviewer6@gmail.com, Reviewer ICMLSix
             invitation_url = re.search('https://.*\n', text).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
             helpers.respond_invitation(selenium, request_page, invitation_url, accept=True, quota=3)
 
-        helpers.await_queue_edit(openreview_client, invitation='ICML.cc/2023/Conference/Reviewers/-/Recruitment', count=6)
+        helpers.await_queue_edit(openreview_client, invitation='ICML.cc/2023/Conference/Reviewers/-/Recruitment', count=12)
 
         messages = client.get_messages(subject='[ICML 2023] Reviewer Invitation accepted with reduced load')
         assert len(messages) == 6
@@ -1884,6 +1884,8 @@ ICML 2023 Conference Program Chairs'''
 
         client.rename_edges(new_id='~Rachel_ICML2', current_id='~Rachel_ICML1')
         client.merge_profiles(profileTo='~Rachel_ICML2', profileFrom='~Rachel_ICML1')
+
+        assert False
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False, comment='I am too busy.')
 

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1565,6 +1565,7 @@ To view the acknowledgement, click here: https://openreview.net/forum?id={note_i
         assert f"{venue_id}/Paper1/-/Official_Comment" in [i.id for i in invitations]
         assert f"{venue_id}/Paper1/-/Moderation" in [i.id for i in invitations]
         assert f"{venue_id}/Paper1/-/Official_Recommendation" in [i.id for i in invitations]
+        assert f"{venue_id}/Paper1/-/Review_Rating_Enabling" not in [i.id for i in invitations]
 
         ## All the reviewes should be public now
         reviews=openreview_client.get_notes(forum=note_id_1, invitation=f'{venue_id}/Paper1/-/Review', sort= 'number:asc')
@@ -1785,6 +1786,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
         assert f"{venue_id}/Paper1/-/Official_Comment" in [i.id for i in invitations]
         assert f"{venue_id}/Paper1/-/Moderation" in [i.id for i in invitations]
         assert f"{venue_id}/Paper1/-/Official_Recommendation" in [i.id for i in invitations]
+        assert f"{venue_id}/Paper1/-/Review_Rating_Enabling" in [i.id for i in invitations]
 
         official_recommendation_note = david_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Official_Recommendation',
             signatures=[david_anon_groups[0].id],
@@ -1810,6 +1812,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
         assert f"{venue_id}/Paper1/-/Official_Comment" in [i.id for i in invitations]
         assert f"{venue_id}/Paper1/-/Moderation" in [i.id for i in invitations]
         assert f"{venue_id}/Paper1/-/Official_Recommendation" in [i.id for i in invitations]
+        assert f"{venue_id}/Paper1/-/Review_Rating_Enabling" in [i.id for i in invitations]
 
         official_recommendation_note = javier_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Official_Recommendation',
             signatures=[javier_anon_groups[0].id],
@@ -1853,6 +1856,8 @@ note: replies to this email will go to the AE, Joelle Pineau.
         assert f"{javier_anon_groups[0].id}/-/Rating" in [i.id for i in invitations]
         assert f"{carlos_anon_groups[0].id}/-/Rating" in [i.id for i in invitations]
         assert f"{hugo_anon_groups[0].id}/-/Rating" in [i.id for i in invitations]
+        assert f"{venue_id}/Paper1/-/Review_Rating_Enabling" not in [i.id for i in invitations]
+
 
         messages = journal.client.get_messages(to = 'joelle@mailseven.com', subject = '[TMLR] Evaluate reviewers and submit decision for TMLR submission 1: Paper title UPDATED')
         assert len(messages) == 1
@@ -2748,19 +2753,17 @@ note: replies to this email will go to the AE, Joelle Pineau.
 
         helpers.await_queue_edit(openreview_client, edit_id=official_recommendation_note['id'])
 
-        ## Post a review recommendation
-        official_recommendation_note = david_client.post_note_edit(invitation=f'{venue_id}/Paper4/-/Official_Recommendation',
-            signatures=[david_anon_groups[0].id],
+        ## Enable review rating before all the recommendations are in
+        review_rating_enabling_note = raia_client.post_note_edit(invitation=f'{venue_id}/Paper4/-/Review_Rating_Enabling',
+            signatures=['TMLR/Editors_In_Chief'],
             note=Note(
                 content={
-                    'decision_recommendation': { 'value': 'Reject' },
-                    'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'approval': { 'value': 'I approve enabling review rating even if there are official recommendations missing.' },
                 }
             )
         )
 
-        helpers.await_queue_edit(openreview_client, edit_id=official_recommendation_note['id'])
+        helpers.await_queue_edit(openreview_client, edit_id=review_rating_enabling_note['id'])       
 
         reviews=openreview_client.get_notes(forum=note_id_4, invitation=f'{venue_id}/Paper4/-/Review', sort= 'number:asc')
 

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -269,6 +269,19 @@ class TestJournal():
 
         Journal.update_affinity_scores(openreview.api.OpenReviewClient(username='openreview.net', password=helpers.strong_password), support_group_id='openreview.net/Support')
 
+        edges = []
+        for ae in openreview_client.get_group('TMLR/Action_Editors').members:
+            edges.append(openreview.api.Edge(invitation='TMLR/Action_Editors/-/Affinity_Score',
+                readers=['TMLR', 'TMLR/Paper1/Authors', ae],
+                writers=['TMLR'],
+                signatures=['TMLR'],
+                head=note_id_1,
+                tail=ae,
+                weight=0.5
+            ))
+
+        openreview_client.post_edges(edges)
+
         openreview_client.get_invitation('TMLR/Paper1/Action_Editors/-/Recommendation')
 
         messages = openreview_client.get_messages(to = 'test@mail.com', subject = '[TMLR] Suggest candidate Action Editor for your new TMLR submission')

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -2190,6 +2190,7 @@ The TMLR Editors-in-Chief
         assert note.content['title']['value'] == 'Paper title VERSION 2'
         assert note.content['abstract']['value'] == 'Paper abstract'
         assert note.content['certifications']['value'] == ['Featured Certification', 'Reproducibility Certification', 'Expert Certification']
+        assert note.content['expert_reviewers']['value'] == ['~Andrew_McCallum1']
         assert note.content['_bibtex']['value'] == '''@article{
 eight''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
 title={Paper title {VERSION} 2},
@@ -4578,4 +4579,5 @@ issn={2835-8856},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_13 + '''},
 note={Expert Certification}
-}'''                                                               
+}'''
+        assert note.content['expert_reviewers']['value'] == ['~Hugo_Larochelle1']                                                              

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -116,12 +116,15 @@ class TestJournal():
                             'camera_ready_period': 4,
                             'camera_ready_verification_period': 1,
                             'archived_action_editors': True,
+                            'expert_reviewers': True,
                         }
                     }
                 }
             ))
 
         helpers.await_queue_edit(openreview_client, request_form['id'])
+
+        openreview_client.add_members_to_group('TMLR/Expert_Reviewers', ['~Andrew_McCallum1'])
 
         assert openreview_client.get_group('TMLR')
 
@@ -254,8 +257,8 @@ class TestJournal():
                 content={
                     'title': { 'value': 'Paper title' },
                     'abstract': { 'value': 'Paper abstract' },
-                    'authors': { 'value': ['SomeFirstName User', 'Melissa Eight']},
-                    'authorids': { 'value': ['~SomeFirstName_User1', '~Melissa_Eight1']},
+                    'authors': { 'value': ['SomeFirstName User', 'Melissa Eight', 'Andrew McCallum']},
+                    'authorids': { 'value': ['~SomeFirstName_User1', '~Melissa_Eight1', '~Andrew_McCallum1']},
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     #'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
@@ -301,7 +304,7 @@ The TMLR Editors-in-Chief
 
         author_group=openreview_client.get_group(f"{venue_id}/Paper1/Authors")
         assert author_group
-        assert author_group.members == ['~SomeFirstName_User1', '~Melissa_Eight1']
+        assert author_group.members == ['~SomeFirstName_User1', '~Melissa_Eight1', '~Andrew_McCallum1']
         assert openreview_client.get_group(f"{venue_id}/Paper1/Reviewers")
         assert openreview_client.get_group(f"{venue_id}/Paper1/Action_Editors")
 
@@ -311,7 +314,7 @@ The TMLR Editors-in-Chief
         assert note.readers == ['TMLR', 'TMLR/Paper1/Action_Editors', 'TMLR/Paper1/Authors']
         assert note.writers == ['TMLR', 'TMLR/Paper1/Authors']
         assert note.signatures == ['TMLR/Paper1/Authors']
-        assert note.content['authorids']['value'] == ['~SomeFirstName_User1', '~Melissa_Eight1']
+        assert note.content['authorids']['value'] == ['~SomeFirstName_User1', '~Melissa_Eight1', '~Andrew_McCallum1']
         assert note.content['venue']['value'] == 'Submitted to TMLR'
         assert note.content['venueid']['value'] == 'TMLR/Submitted'
 
@@ -348,7 +351,7 @@ The TMLR Editors-in-Chief
         helpers.await_queue_edit(openreview_client, 'TMLR/Paper1/Action_Editors/-/Recommendation-0-0')
 
         messages = journal.client.get_messages(subject = '[TMLR] You are late in performing a task for your paper 1: Paper title')
-        assert len(messages) == 2
+        assert len(messages) == 3
         messages = journal.client.get_messages(to = 'test@mail.com', subject = '[TMLR] You are late in performing a task for your paper 1: Paper title')
         assert messages[0]['content']['text'] == f'''Hi SomeFirstName User,
 
@@ -393,12 +396,12 @@ The TMLR Editors-in-Chief
         assert note.content['venueid']['value'] == 'TMLR/Submitted'
         assert note.content['supplementary_material']['value'] == '/attachment/zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.zip'
         assert note.content['supplementary_material']['readers'] == ["TMLR", "TMLR/Paper1/Action_Editors", "TMLR/Paper1/Reviewers", "TMLR/Paper1/Authors"]
-        assert note.content['authorids']['value'] == ['~SomeFirstName_User1', '~Melissa_Eight1']
+        assert note.content['authorids']['value'] == ['~SomeFirstName_User1', '~Melissa_Eight1', '~Andrew_McCallum1']
         assert note.content['authorids']['readers'] == ['TMLR', 'TMLR/Paper1/Action_Editors', 'TMLR/Paper1/Authors']
 
         author_group=openreview_client.get_group(f"{venue_id}/Paper1/Authors")
         assert author_group
-        assert author_group.members == ['~SomeFirstName_User1', '~Melissa_Eight1']
+        assert author_group.members == ['~SomeFirstName_User1', '~Melissa_Eight1', '~Andrew_McCallum1']
 
         ## Post the submission 2
         submission_note_2 = test_client.post_note_edit(invitation='TMLR/-/Submission',
@@ -558,7 +561,7 @@ The TMLR Editors-in-Chief
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper1/Authors']
         assert note.signatures == ['TMLR/Paper1/Authors']
-        assert note.content['authorids']['value'] == ['~SomeFirstName_User1', '~Melissa_Eight1']
+        assert note.content['authorids']['value'] == ['~SomeFirstName_User1', '~Melissa_Eight1', '~Andrew_McCallum1']
         assert note.content['venue']['value'] == 'Under review for TMLR'
         assert note.content['venueid']['value'] == 'TMLR/Under_Review'
         assert note.content['assigned_action_editor']['value'] == '~Joelle_Pineau1'
@@ -1037,7 +1040,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
         helpers.await_queue_edit(openreview_client, edit_id=comment_note['id'])
 
         messages = journal.client.get_messages(subject = '[TMLR] Official Comment posted on submission 1: Paper title UPDATED')
-        assert len(messages) == 7
+        assert len(messages) == 8
 
         ## Post an official comment from the reviewer
         comment_note = david_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Official_Comment',
@@ -1149,7 +1152,7 @@ To view the official comment, click here: https://openreview.net/forum?id={note_
         helpers.await_queue_edit(openreview_client, edit_id=comment_note['id'])
 
         messages = journal.client.get_messages(subject = '[TMLR] Public Comment posted on submission 1: Paper title UPDATED')
-        assert len(messages) == 8
+        assert len(messages) == 9
         messages = journal.client.get_messages(to = 'joelle@mailseven.com', subject = '[TMLR] Public Comment posted on submission 1: Paper title UPDATED')
         assert len(messages) == 1
         assert messages[0]['content']['to'] == 'joelle@mailseven.com'
@@ -2042,8 +2045,8 @@ The TMLR Editors-in-Chief
             note=Note(
                 content={
                     'title': { 'value': 'Paper title VERSION 2' },
-                    'authors': { 'value': ['Melissa Eight', 'SomeFirstName User'] },
-                    'authorids': { 'value': ['~Melissa_Eight1', '~SomeFirstName_User1'] },
+                    'authors': { 'value': ['Melissa Eight', 'SomeFirstName User', 'Andrew McCallum'] },
+                    'authorids': { 'value': ['~Melissa_Eight1', '~SomeFirstName_User1', '~Andrew_McCallum1'] },
                     'abstract': { 'value': 'Paper abstract' },
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
@@ -2064,8 +2067,8 @@ The TMLR Editors-in-Chief
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper1/Authors']
         assert note.signatures == ['TMLR/Paper1/Authors']
-        assert note.content['authorids']['value'] == ['~Melissa_Eight1', '~SomeFirstName_User1']
-        assert note.content['authors']['value'] == ['Melissa Eight', 'SomeFirstName User']
+        assert note.content['authorids']['value'] == ['~Melissa_Eight1', '~SomeFirstName_User1', '~Andrew_McCallum1']
+        assert note.content['authors']['value'] == ['Melissa Eight', 'SomeFirstName User', 'Andrew McCallum']
         assert note.content['venue']['value'] == 'Decision pending for TMLR'
         assert note.content['venueid']['value'] == 'TMLR/Decision_Pending'
         assert note.content['title']['value'] == 'Paper title VERSION 2'
@@ -2176,8 +2179,8 @@ The TMLR Editors-in-Chief
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR']
         assert note.signatures == ['TMLR/Paper1/Authors']
-        assert note.content['authorids']['value'] == ['~Melissa_Eight1', '~SomeFirstName_User1']
-        assert note.content['authors']['value'] == ['Melissa Eight', 'SomeFirstName User']
+        assert note.content['authorids']['value'] == ['~Melissa_Eight1', '~SomeFirstName_User1', '~Andrew_McCallum1']
+        assert note.content['authors']['value'] == ['Melissa Eight', 'SomeFirstName User', 'Andrew McCallum']
         # Check with cArlos
         assert note.content['authorids'].get('readers') is None
         assert note.content['authors'].get('readers') is None
@@ -2186,15 +2189,16 @@ The TMLR Editors-in-Chief
         assert note.content['venueid']['value'] == 'TMLR'
         assert note.content['title']['value'] == 'Paper title VERSION 2'
         assert note.content['abstract']['value'] == 'Paper abstract'
+        assert note.content['certifications']['value'] == ['Featured Certification', 'Reproducibility Certification', 'Expert Reviewer Certification']
         assert note.content['_bibtex']['value'] == '''@article{
 eight''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
 title={Paper title {VERSION} 2},
-author={Melissa Eight and SomeFirstName User},
+author={Melissa Eight and SomeFirstName User and Andrew McCallum},
 journal={Transactions on Machine Learning Research},
 issn={2835-8856},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},
-note={Featured Certification, Reproducibility Certification}
+note={Featured Certification, Reproducibility Certification, Expert Reviewer Certification}
 }'''
 
         helpers.await_queue_edit(openreview_client, invitation='TMLR/-/Accepted')
@@ -2214,8 +2218,8 @@ note={Featured Certification, Reproducibility Certification}
             note=Note(
                 content={
                     'title': { 'value': 'Paper title VERSION 2' },
-                    'authors': { 'value': ['Melissa Eight', 'SomeFirstName User', 'Celeste Ana Martinez'] },
-                    'authorids': { 'value': ['~Melissa_Eight1', '~SomeFirstName_User1', '~Celeste_Ana_Martinez1'] },
+                    'authors': { 'value': ['Melissa Eight', 'SomeFirstName User', 'Celeste Ana Martinez', 'Andrew McCallum'] },
+                    'authorids': { 'value': ['~Melissa_Eight1', '~SomeFirstName_User1', '~Celeste_Ana_Martinez1', '~Andrew_McCallum1'] },
                     'abstract': { 'value': 'Paper abstract' },
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
@@ -2236,8 +2240,8 @@ note={Featured Certification, Reproducibility Certification}
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR']
         assert note.signatures == ['TMLR/Paper1/Authors']
-        assert note.content['authorids']['value'] == ['~Melissa_Eight1', '~SomeFirstName_User1', '~Celeste_Ana_Martinez1']
-        assert note.content['authors']['value'] == ['Melissa Eight', 'SomeFirstName User', 'Celeste Ana Martinez']
+        assert note.content['authorids']['value'] == ['~Melissa_Eight1', '~SomeFirstName_User1', '~Celeste_Ana_Martinez1', '~Andrew_McCallum1']
+        assert note.content['authors']['value'] == ['Melissa Eight', 'SomeFirstName User', 'Celeste Ana Martinez', 'Andrew McCallum']
         # Check with cArlos
         assert note.content['authorids'].get('readers') is None
         assert note.content['authors'].get('readers') is None
@@ -2249,12 +2253,12 @@ note={Featured Certification, Reproducibility Certification}
         assert note.content['_bibtex']['value'] == '''@article{
 eight''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
 title={Paper title {VERSION} 2},
-author={Melissa Eight and SomeFirstName User and Celeste Ana Martinez},
+author={Melissa Eight and SomeFirstName User and Celeste Ana Martinez and Andrew McCallum},
 journal={Transactions on Machine Learning Research},
 issn={2835-8856},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},
-note={Featured Certification, Reproducibility Certification}
+note={Featured Certification, Reproducibility Certification, Expert Reviewer Certification}
 }'''
 
 
@@ -2293,7 +2297,7 @@ OpenReview Team
         helpers.await_queue_edit(openreview_client, edit_id=approval_note['id'])
 
         messages = journal.client.get_messages(subject = '[TMLR] Decision available for retraction request of TMLR submission 1: Paper title VERSION 2')
-        assert len(messages) == 3
+        assert len(messages) == 4
         messages = journal.client.get_messages(to='test@mail.com', subject = '[TMLR] Decision available for retraction request of TMLR submission 1: Paper title VERSION 2')
         assert messages[0]['content']['text'] == f'''Hi SomeFirstName User,
 
@@ -2317,7 +2321,7 @@ The TMLR Editors-in-Chief
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR']
         assert note.signatures == ['TMLR/Paper1/Authors']
-        assert note.content['authorids']['value'] == ['~Melissa_Eight1', '~SomeFirstName_User1', '~Celeste_Ana_Martinez1']
+        assert note.content['authorids']['value'] == ['~Melissa_Eight1', '~SomeFirstName_User1', '~Celeste_Ana_Martinez1', '~Andrew_McCallum1']
         # Check with cArlos
         assert note.content['authorids'].get('readers') is None
         assert note.content['authors'].get('readers') is None
@@ -2329,7 +2333,7 @@ The TMLR Editors-in-Chief
         assert note.content['_bibtex']['value'] == '''@article{
 eight''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
 title={Paper title {VERSION} 2},
-author={Melissa Eight and SomeFirstName User and Celeste Ana Martinez},
+author={Melissa Eight and SomeFirstName User and Celeste Ana Martinez and Andrew McCallum},
 journal={Submitted to Transactions on Machine Learning Research},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -2003,6 +2003,8 @@ The TMLR Editors-in-Chief
 
         helpers.await_queue_edit(openreview_client, edit_id=approval_note['id'])
 
+        assert openreview_client.get_invitation(f"{venue_id}/Paper1/-/Review").expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert openreview_client.get_invitation(f"{venue_id}/Paper1/-/Official_Recommendation").expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
 
         decision_note = raia_client.get_note(decision_note.id)
         assert decision_note.readers == ['everyone']

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -4245,8 +4245,8 @@ note={Under review}
                 content={
                     'title': { 'value': 'Paper title 13' },
                     'abstract': { 'value': 'Paper abstract' },
-                    'authors': { 'value': ['SomeFirstName User', 'Melissa Eight']},
-                    'authorids': { 'value': ['~SomeFirstName_User1', '~Melissa_Eight1']},
+                    'authors': { 'value': ['SomeFirstName User', 'Melissa Eight', 'Hugo Larochelle']},
+                    'authorids': { 'value': ['~SomeFirstName_User1', '~Melissa_Eight1', '~Hugo_Larochelle1']},
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     #'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
@@ -4352,3 +4352,227 @@ note={Under review}
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        david_anon_groups=david_client.get_groups(prefix=f'{venue_id}/Paper13/Reviewer_.*', signatory='~David_Belanger1')
+        assert len(david_anon_groups) == 1
+
+        ## Post a review edit
+        david_review_note = david_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Review',
+            signatures=[david_anon_groups[0].id],
+            note=Note(
+                content={
+                    'summary_of_contributions': { 'value': 'summary_of_contributions' },
+                    'strengths_and_weaknesses': { 'value': 'strengths_and_weaknesses' },
+                    'requested_changes': { 'value': 'requested_changes' },
+                    'broader_impact_concerns': { 'value': 'broader_impact_concerns' },
+                    'claims_and_evidence': { 'value': 'Yes' },
+                    'audience': { 'value': 'Yes' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=david_review_note['id'])
+
+        carlos_anon_groups=carlos_client.get_groups(prefix=f'{venue_id}/Paper13/Reviewer_.*', signatory='~Carlos_Mondragon1')
+        assert len(carlos_anon_groups) == 1
+
+        ## Post a review edit
+        review_note = carlos_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Review',
+            signatures=[carlos_anon_groups[0].id],
+            note=Note(
+                content={
+                    'summary_of_contributions': { 'value': 'summary_of_contributions' },
+                    'strengths_and_weaknesses': { 'value': 'strengths_and_weaknesses' },
+                    'requested_changes': { 'value': 'requested_changes' },
+                    'broader_impact_concerns': { 'value': 'broader_impact_concerns' },
+                    'claims_and_evidence': { 'value': 'Yes' },
+                    'audience': { 'value': 'Yes' }               }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=review_note['id'])
+
+        javier_anon_groups=javier_client.get_groups(prefix=f'{venue_id}/Paper13/Reviewer_.*', signatory='~Javier_Burroni1')
+        assert len(javier_anon_groups) == 1
+
+        ## Post a review edit
+        review_note = javier_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Review',
+            signatures=[javier_anon_groups[0].id],
+            note=Note(
+                content={
+                    'summary_of_contributions': { 'value': 'summary_of_contributions' },
+                    'strengths_and_weaknesses': { 'value': 'strengths_and_weaknesses' },
+                    'requested_changes': { 'value': 'requested_changes' },
+                    'broader_impact_concerns': { 'value': 'broader_impact_concerns' },
+                    'claims_and_evidence': { 'value': 'Yes' },
+                    'audience': { 'value': 'Yes' }                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=review_note['id'])                
+
+        raia_client.post_invitation_edit(
+            invitations='TMLR/-/Edit',
+            readers=[venue_id],
+            writers=[venue_id],
+            signatures=[venue_id],
+            invitation=openreview.api.Invitation(id=f'{venue_id}/Paper13/-/Official_Recommendation',
+                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 1000,
+                signatures=['TMLR/Editors_In_Chief']
+            )
+        )
+
+        time.sleep(5) ## wait until the process function runs        
+
+        ## Post a review recommendation
+        official_recommendation_note = carlos_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Official_Recommendation',
+            signatures=[carlos_anon_groups[0].id],
+            note=Note(
+                content={
+                    'decision_recommendation': { 'value': 'Accept' },
+                    'certification_recommendations': { 'value': ['Featured Certification'] },
+                    'claims_and_evidence': { 'value': 'Yes' },
+                    'audience': { 'value': 'Yes' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=official_recommendation_note['id'])        
+        
+        official_recommendation_note = david_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Official_Recommendation',
+            signatures=[david_anon_groups[0].id],
+            note=Note(
+                content={
+                    'decision_recommendation': { 'value': 'Accept' },
+                    'certification_recommendations': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
+                    'claims_and_evidence': { 'value': 'Yes' },
+                    'audience': { 'value': 'Yes' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=official_recommendation_note['id'])
+
+        official_recommendation_note = javier_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Official_Recommendation',
+            signatures=[javier_anon_groups[0].id],
+            note=Note(
+                content={
+                    'decision_recommendation': { 'value': 'Accept' },
+                    'certification_recommendations': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
+                    'claims_and_evidence': { 'value': 'Yes' },
+                    'audience': { 'value': 'Yes' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=official_recommendation_note['id'])
+
+        reviews = joelle_client.get_notes(forum=note_id_13, invitation=f'{venue_id}/Paper13/-/Review', sort= 'number:asc')
+
+        for review in reviews:
+            signature=review.signatures[0]
+            rating_note=joelle_client.post_note_edit(invitation=f'{signature}/-/Rating',
+                signatures=[f"{venue_id}/Paper13/Action_Editors"],
+                note=Note(
+                    content={
+                        'rating': { 'value': 'Exceeds expectations' }
+                    }
+                )
+            )
+            helpers.await_queue_edit(openreview_client, edit_id=rating_note['id'])
+            process_logs = openreview_client.get_process_logs(id = rating_note['id'])
+            assert len(process_logs) == 1
+            assert process_logs[0]['status'] == 'ok'
+
+        decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Decision',
+            signatures=[f"{venue_id}/Paper13/Action_Editors"],
+            note=Note(
+                content={
+                    'claims_and_evidence': { 'value': 'Accept as is' },
+                    'audience': { 'value': 'Accept as is' },
+                    'recommendation': { 'value': 'Accept with minor revision' },
+                    'comment': { 'value': 'This is a good paper' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=decision_note['id'])
+
+        approval_note = raia_client.post_note_edit(invitation='TMLR/Paper13/-/Decision_Approval',
+            signatures=['TMLR/Editors_In_Chief'],
+            note=Note(
+            content= {
+                'approval': { 'value': 'I approve the AE\'s decision.' },
+                'comment_to_the_AE': { 'value': 'I agree with the AE' }
+            }))
+
+        helpers.await_queue_edit(openreview_client, edit_id=approval_note['id'])
+
+        revision_note = test_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Camera_Ready_Revision',
+            signatures=[f"{venue_id}/Paper13/Authors"],
+            note=Note(
+                content={
+                    'title': { 'value': 'Paper title 13 VERSION 2' },
+                    'authors': { 'value': ['SomeFirstName User', 'Melissa Eight', 'Hugo Larochelle']},
+                    'authorids': { 'value': ['~SomeFirstName_User1', '~Melissa_Eight1', '~Hugo_Larochelle1']},
+                    'abstract': { 'value': 'Paper abstract' },
+                    'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
+                    'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
+                    'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
+                    'human_subjects_reporting': { 'value': 'Not applicable'},
+                    'video': { 'value': 'https://youtube.com/dfenxkw'}
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=revision_note['id'])
+
+        verification_note = joelle_client.post_note_edit(invitation='TMLR/Paper13/-/Camera_Ready_Verification',
+                            signatures=[f"{venue_id}/Paper13/Action_Editors"],
+                            note=Note(
+                                signatures=[f"{venue_id}/Paper13/Action_Editors"],
+                                content= {
+                                    'verification': { 'value': 'I confirm that camera ready manuscript complies with the TMLR stylefile and, if appropriate, includes the minor revisions that were requested.' }
+                                 }
+                            ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=verification_note['id'])
+
+        note = openreview_client.get_note(note_id_13)
+        assert 'certifications' not in note.content
+        assert note.content['_bibtex']['value'] == '''@article{
+user''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
+title={Paper title 13 {VERSION} 2},
+author={SomeFirstName User and Melissa Eight and Hugo Larochelle},
+journal={Transactions on Machine Learning Research},
+issn={2835-8856},
+year={''' + str(datetime.datetime.today().year) + '''},
+url={https://openreview.net/forum?id=''' + note_id_13 + '''},
+note={}
+}'''        
+
+        edit_group = raia_client.post_group_edit(
+            invitation='TMLR/Expert_Reviewers/-/Member',
+            signatures=['TMLR'],
+            group=openreview.api.Group(
+                members={
+                    'append': ['~Hugo_Larochelle1']
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=edit_group['id'])
+
+        assert openreview_client.get_group('TMLR/Expert_Reviewers').members == ['~Andrew_McCallum1', '~Hugo_Larochelle1']
+
+        note = openreview_client.get_note(note_id_13)
+        assert note.content['certifications']['value'] == ['Expert Reviewer Certification']
+        assert note.content['_bibtex']['value'] == '''@article{
+user''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
+title={Paper title 13 {VERSION} 2},
+author={SomeFirstName User and Melissa Eight and Hugo Larochelle},
+journal={Transactions on Machine Learning Research},
+issn={2835-8856},
+year={''' + str(datetime.datetime.today().year) + '''},
+url={https://openreview.net/forum?id=''' + note_id_13 + '''},
+note={Expert Reviewer Certification}
+}'''                                                               

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -233,7 +233,7 @@ class TestJournal():
 
         ## Set a max quota
         david_client.post_edge(openreview.Edge(invitation='TMLR/Reviewers/-/Custom_Max_Papers',
-            readers=[venue_id, 'TMLR/Action_Editors', '~David_Belanger1'],
+            readers=[venue_id, 'TMLR/Action_Editors', '~David_Belanger1', 'TMLR/Action_Editors/Archived'],
             writers=[venue_id, '~David_Belanger1'],
             signatures=['~David_Belanger1'],
             head='TMLR/Reviewers',

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -3855,6 +3855,8 @@ The TMLR Editors-in-Chief
         submission = raia_client.get_note(note_id_8)
         assert '~Samy_Bengio1' == submission.content['assigned_action_editor']['value']
 
+        journal.invitation_builder.expire_paper_invitations(submission)        
+
 
     def test_desk_rejected_submission_by_eic(self, journal, openreview_client, helpers):
 
@@ -4085,10 +4087,7 @@ The TMLR Editors-in-Chief
 
         helpers.await_queue_edit(openreview_client, edit_id=under_review_note['id'])
               
-        note = openreview_client.get_note(note_id_11)
         journal.invitation_builder.expire_paper_invitations(note)
-        journal.invitation_builder.expire_reviewer_responsibility_invitations()
-        journal.invitation_builder.expire_assignment_availability_invitations()
 
     def test_decline_desk_rejection(self, journal, openreview_client, helpers):
 
@@ -4195,3 +4194,8 @@ note={Under review}
         messages = openreview_client.get_messages(to = 'melissa@maileight.com', subject = '[TMLR] Review Approval edited on submission 12: Paper title 12')
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'Hi Melissa Eight,\n\nA review approval has been edited on your submission.\n\nSubmission: Paper title 12\nUnder review: Appropriate for Review\nComment: \n\nTo view the review approval, click here: https://openreview.net/forum?id={note_id_12}&noteId={notes[0].id}\n\n'
+
+        note = openreview_client.get_note(note_id_12)
+        journal.invitation_builder.expire_paper_invitations(note)
+        journal.invitation_builder.expire_reviewer_responsibility_invitations()
+        journal.invitation_builder.expire_assignment_availability_invitations()

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -2189,7 +2189,7 @@ The TMLR Editors-in-Chief
         assert note.content['venueid']['value'] == 'TMLR'
         assert note.content['title']['value'] == 'Paper title VERSION 2'
         assert note.content['abstract']['value'] == 'Paper abstract'
-        assert note.content['certifications']['value'] == ['Featured Certification', 'Reproducibility Certification', 'Expert Reviewer Certification']
+        assert note.content['certifications']['value'] == ['Featured Certification', 'Reproducibility Certification', 'Expert Certification']
         assert note.content['_bibtex']['value'] == '''@article{
 eight''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
 title={Paper title {VERSION} 2},
@@ -2198,7 +2198,7 @@ journal={Transactions on Machine Learning Research},
 issn={2835-8856},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},
-note={Featured Certification, Reproducibility Certification, Expert Reviewer Certification}
+note={Featured Certification, Reproducibility Certification, Expert Certification}
 }'''
 
         helpers.await_queue_edit(openreview_client, invitation='TMLR/-/Accepted')
@@ -2258,7 +2258,7 @@ journal={Transactions on Machine Learning Research},
 issn={2835-8856},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},
-note={Featured Certification, Reproducibility Certification, Expert Reviewer Certification}
+note={Featured Certification, Reproducibility Certification, Expert Certification}
 }'''
 
 
@@ -2724,10 +2724,13 @@ note: replies to this email will go to the AE, Joelle Pineau.
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper4/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 1000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
+
+        time.sleep(5) ## wait until the process function runs
+        assert raia_client.get_invitation(f'{venue_id}/Paper4/-/Review_Rating_Enabling')
 
         ## Post a review recommendation
         official_recommendation_note = carlos_client.post_note_edit(invitation=f'{venue_id}/Paper4/-/Official_Recommendation',
@@ -4565,7 +4568,7 @@ note={}
         assert openreview_client.get_group('TMLR/Expert_Reviewers').members == ['~Andrew_McCallum1', '~Hugo_Larochelle1']
 
         note = openreview_client.get_note(note_id_13)
-        assert note.content['certifications']['value'] == ['Expert Reviewer Certification']
+        assert note.content['certifications']['value'] == ['Expert Certification']
         assert note.content['_bibtex']['value'] == '''@article{
 user''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
 title={Paper title 13 {VERSION} 2},
@@ -4574,5 +4577,5 @@ journal={Transactions on Machine Learning Research},
 issn={2835-8856},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_13 + '''},
-note={Expert Reviewer Certification}
+note={Expert Certification}
 }'''                                                               

--- a/tests/test_journal_matching.py
+++ b/tests/test_journal_matching.py
@@ -75,9 +75,7 @@ class TestJournalMatching():
         ken_client = OpenReviewClient(username='ken@beck.com', password=helpers.strong_password)
 
         ## Set a max quota
-        ana_client.post_edge(openreview.Edge(invitation='CARP/Action_Editors/-/Custom_Max_Papers',
-            readers=[venue_id, '~Ana_Prada1'],
-            writers=[venue_id, '~Ana_Prada1'],
+        ana_client.post_edge(openreview.api.Edge(invitation='CARP/Action_Editors/-/Custom_Max_Papers',
             signatures=['~Ana_Prada1'],
             head='CARP/Action_Editors',
             tail='~Ana_Prada1',
@@ -85,9 +83,7 @@ class TestJournalMatching():
         ))
 
         ## Set unavailable
-        ken_client.post_edge(openreview.Edge(invitation='CARP/Action_Editors/-/Assignment_Availability',
-            readers=[venue_id, '~Ken_Beck1'],
-            writers=[venue_id, '~Ken_Beck1'],
+        ken_client.post_edge(openreview.api.Edge(invitation='CARP/Action_Editors/-/Assignment_Availability',
             signatures=['~Ken_Beck1'],
             head='CARP/Action_Editors',
             tail='~Ken_Beck1',


### PR DESCRIPTION
- Add a filter to author can filter the AEs that are not available or maxed out the quota.
- Add a pre process function to avoid the AE recommendation of AEs that are not available or don't have quota
- Add a button for the EIC to enable the review rating if there is a recommendation missing.
- Create an archived AE group to move the users that are not AEs anymore but they still have assigned papers under review
- Create expert reviewers group and a group invitation that add the "expert reviewer certification" when one of the authors is an expert reviewer.
- fix issue when AE is not in the group and the edge that says unavailable send the reminder