### PR TITLE
Feat/ Venue: allow SACs and ACs to desk-reject papers

### DIFF
--- a/openreview/venue/process/desk_rejected_submission_process.py
+++ b/openreview/venue/process/desk_rejected_submission_process.py
@@ -41,6 +41,9 @@ def process(client, edit, invitation):
             }
         )
 
+    signature = desk_rejection_notes[0].signatures[0].split('/')[-1]
+    pretty_signature = openreview.tools.pretty_id(signature)
+
     print(f'Remove {paper_group_id}/{authors_name} from {venue_id}/{authors_name}')
     client.remove_members_from_group(f'{venue_id}/{authors_name}', f'{paper_group_id}/{authors_name}')
 
@@ -49,8 +52,8 @@ def process(client, edit, invitation):
     for group in formatted_committee:
         if openreview.tools.get_group(client, group):
             final_committee.append(group)
-    email_subject = f'''[{short_name}]: Paper #{submission.number} desk-rejected by program chairs'''
-    email_body = f'''The {short_name} paper "{submission.content.get('title', {}).get('value', '#'+str(submission.number))}" has been desk-rejected by the program chairs.
+    email_subject = f'''[{short_name}]: Paper #{submission.number} desk-rejected by {pretty_signature}'''
+    email_body = f'''The {short_name} paper "{submission.content.get('title', {}).get('value', '#'+str(submission.number))}" has been desk-rejected by {pretty_signature}.
 
 For more information, click here https://openreview.net/forum?id={submission.id}
 '''

--- a/tests/test_emnlp_conference.py
+++ b/tests/test_emnlp_conference.py
@@ -805,7 +805,7 @@ url={https://openreview.net/forum?id='''
 
         helpers.await_queue()
 
-        submissions = openreview_client.get_notes(invitation='EMNLP/2023/Conference/-/Submission', sort='number:asc')
+        submissions = openreview_client.get_notes(content={'venueid':'EMNLP/2023/Conference/Submission'}, sort='number:asc')
         assert len(submissions) == 3
 
         for submission in submissions:

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -673,13 +673,13 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Public_Comment')
         assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
 
-        messages = openreview_client.get_messages(to='celeste@maileleven.com', subject='[TV 22]: Paper #2 desk-rejected by program chairs')
+        messages = openreview_client.get_messages(to='celeste@maileleven.com', subject='[TV 22]: Paper #2 desk-rejected by Program Chairs')
         assert len(messages) == 1
-        assert messages[0]['content']['text'] == f'The TV 22 paper \"Paper 2 Title\" has been desk-rejected by the program chairs.\n\nFor more information, click here https://openreview.net/forum?id={note.id}\n'
+        assert messages[0]['content']['text'] == f'The TV 22 paper \"Paper 2 Title\" has been desk-rejected by Program Chairs.\n\nFor more information, click here https://openreview.net/forum?id={note.id}\n'
 
-        messages = openreview_client.get_messages(to='venue_pc@mail.com', subject='[TV 22]: Paper #2 desk-rejected by program chairs')
+        messages = openreview_client.get_messages(to='venue_pc@mail.com', subject='[TV 22]: Paper #2 desk-rejected by Program Chairs')
         assert len(messages) == 1
-        assert messages[0]['content']['text'] == f'The TV 22 paper \"Paper 2 Title\" has been desk-rejected by the program chairs.\n\nFor more information, click here https://openreview.net/forum?id={note.id}\n'
+        assert messages[0]['content']['text'] == f'The TV 22 paper \"Paper 2 Title\" has been desk-rejected by Program Chairs.\n\nFor more information, click here https://openreview.net/forum?id={note.id}\n'
 
         assert openreview_client.get_invitation('TestVenue.cc/Submission2/-/Desk_Rejection_Reversion')
 


### PR DESCRIPTION
SACs and ACs can be allowed to desk-reject papers. However, only PCs can revert a desk-rejection.