### PR TITLE
Journal: support EIC certifications

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -129,7 +129,7 @@ class GroupBuilder(object):
             content = content.replace("var DESK_REJECTED_ID = '';", "var DESK_REJECTED_ID = '" + venue_id + "/Desk_Rejection';")
             content = content.replace("var WITHDRAWN_ID = '';", "var WITHDRAWN_ID = '" + venue_id + "/Withdrawn_Submission';")
             content = content.replace("var REJECTED_ID = '';", "var REJECTED_ID = '" + venue_id + "/Rejection';")
-            content = content.replace("var CERTIFICATIONS = [];", "var CERTIFICATIONS = " + json.dumps(self.journal.get_certifications() + [self.journal.get_expert_reviewer_certification()] if self.journal.has_expert_reviewers() else []) + ";")
+            content = content.replace("var CERTIFICATIONS = [];", "var CERTIFICATIONS = " + json.dumps(self.journal.get_certifications() + self.journal.get_eic_certifications() + [self.journal.get_expert_reviewer_certification()] if self.journal.has_expert_reviewers() else []) + ";")
             if not venue_group.web:
                 venue_group.web = content
                 self.post_group(venue_group)

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -5437,7 +5437,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                 "value": {
                     "param": {
                         "type": "string[]",
-                        "enum": self.journal.get_certifications(),
+                        "enum": self.journal.get_certifications() + self.journal.get_eic_certifications(),
                         "optional": True,
                         "input": "select"
                     }

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -422,7 +422,10 @@ class Journal(object):
         return self.settings.get('skip_ac_recommendation', False)
 
     def get_certifications(self):
-        return self.settings.get('certifications', [])        
+        return self.settings.get('certifications', []) 
+
+    def get_eic_certifications(self):
+        return self.settings.get('eic_certifications', [])            
 
     def get_submission_length(self):
         return self.settings.get('submission_length', [])

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -90,6 +90,9 @@ class TestJournal():
                                 'Reproducibility Certification',
                                 'Survey Certification'
                             ],
+                            'eic_certifications': [
+                                'Outstanding Certification'
+                            ],                            
                             'submission_length': [
                                 'Regular submission (no more than 12 pages of main content)', 
                                 'Long submission (more than 12 pages of main content)'
@@ -2226,7 +2229,8 @@ note={Featured Certification, Reproducibility Certification, Expert Certificatio
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
                     'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'video': { 'value': 'https://youtube.com/dfenxkw'}
+                    'video': { 'value': 'https://youtube.com/dfenxkw'},
+                    'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification', 'Expert Certification', 'Outstanding Certification'] },
                 }
             )
         )
@@ -2259,9 +2263,8 @@ journal={Transactions on Machine Learning Research},
 issn={2835-8856},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},
-note={Featured Certification, Reproducibility Certification, Expert Certification}
+note={Featured Certification, Reproducibility Certification, Expert Certification, Outstanding Certification}
 }'''
-
 
         ## Retract the paper
         retraction_note = test_client.post_note_edit(invitation='TMLR/Paper1/-/Retraction',


### PR DESCRIPTION
Let EICs set certifications different than the ones recommended by the AE/Reviewers. For example: "Outstanding Certification"