### PR TITLE
Fix/ Venue recruitment: catch multiple errors

### DIFF
--- a/openreview/venue/recruitment.py
+++ b/openreview/venue/recruitment.py
@@ -156,7 +156,13 @@ class Recruitment(object):
                     if 'NotFoundError' in error_string:
                         error_string = 'InvalidGroup'
                     else:
-                        self.client.remove_members_from_group(committee_invited_id, email)
+                        try:
+                            self.client.remove_members_from_group(committee_invited_id, email)
+                        except Exception as e:
+                            new_error_string = repr(e)
+                            if new_error_string not in recruitment_status['errors']:
+                                recruitment_status['errors'][new_error_string] = []
+                            recruitment_status['errors'][new_error_string].append(email)
                     if error_string not in recruitment_status['errors']:
                         recruitment_status['errors'][error_string] = []
                     recruitment_status['errors'][error_string].append(email)

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -483,6 +483,36 @@ class TestVenueRequest():
         assert error_string in last_comment.content['error']
         assert '0 users' in last_comment.content['invited']
 
+        # make sure we catch both KeyError and Group Not Found error
+        reviewer_details = '''celeste@uni-a,de, Celeste'''
+        recruitment_note = test_client.post_note(openreview.Note(
+            content={
+                'title': 'Recruitment',
+                'invitee_role': 'Reviewers',
+                'invitee_details': reviewer_details,
+                'invitation_email_subject': '[' + venue['request_form_note'].content['Abbreviated Venue Name'] + '] Invitation to serve as {{invitee_role}}',
+                'invitation_email_content': 'Dear {name},\n\nYou have been nominated by the program chair committee of Theoretical Foundations of RL Workshop @ ICML 2020 to serve as {{invitee_role}}.\n\nACCEPT LINK:\n\n{{accept_url}}\n\nDECLINE LINK:\n\n{{decline_url}}\n\nCheers!\n\nProgram Chairs'
+            },
+            forum=venue['request_form_note'].forum,
+            replyto=venue['request_form_note'].forum,
+            invitation='{}/-/Request{}/Recruitment'.format(venue['support_group_id'], venue['request_form_note'].number),
+            readers=['{}/Program_Chairs'.format(venue['venue_id']), venue['support_group_id']],
+            signatures=['~SomeFirstName_User1'],
+            writers=[]
+        ))
+        assert recruitment_note
+
+        helpers.await_queue()
+        process_logs = client.get_process_logs(id=recruitment_note.id)
+        assert len(process_logs) == 1
+        assert process_logs[0]['status'] == 'ok'
+
+        last_comment = client.get_notes(invitation=recruitment_status_invitation, sort='tmdate')[0]
+
+        assert '"OpenReviewException({\'name\': \'NotFoundError\', \'message\': \'Group Not Found: celeste@uni-a\'' in last_comment.content['error']
+        assert '"KeyError(\'name\')"' in last_comment.content['error']
+        assert '0 users' in last_comment.content['invited']
+
     def test_venue_recruitment(self, client, test_client, selenium, request_page, venue, helpers, openreview_client):
 
         # Test Reviewer Recruitment


### PR DESCRIPTION
Fixes this error: https://api.openreview.net/logs/process?id=yLOTtIRi7L

I did it like this so we can catch and show both errors instead of only one.