### PR TITLE
Fix/ Ethics Stage Comment Stage

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -619,7 +619,8 @@ def get_ethics_review_stage(request_forum):
         release_to_reviewers = release_to_reviewers,
         additional_fields = review_form_additional_options,
         remove_fields = review_form_remove_options,
-        submission_numbers = flagged_submissions
+        submission_numbers = flagged_submissions,
+        enable_comments = (request_forum.content.get('enable_comments_for_ethics_reviewers', '').startswith('Yes'))
     )
 
 def get_meta_review_stage(request_forum):

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -650,7 +650,8 @@ class EthicsReviewStage(object):
         release_to_reviewers = Readers.ETHICS_REVIEWER_SIGNATURE,
         additional_fields = {},
         remove_fields = [],
-        submission_numbers = []
+        submission_numbers = [],
+        enable_comments = False
     ):
 
         self.start_date = start_date
@@ -662,6 +663,7 @@ class EthicsReviewStage(object):
         self.additional_fields = additional_fields
         self.remove_fields = remove_fields
         self.submission_numbers = submission_numbers
+        self.enable_comments = enable_comments
 
     def get_readers(self, conference, number, ethics_review_signature=None):
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -1037,7 +1037,7 @@ class InvitationBuilder(object):
         if comment_expdate:
             invitation.edit['invitation']['expdate'] = comment_expdate
 
-        if self.venue.ethics_review_stage:
+        if self.venue.ethics_review_stage and self.venue.ethics_review_stage.enable_comments:
             invitation.edit['content']['noteReaders'] = {
                 'value': {
                     'param': {
@@ -1048,7 +1048,7 @@ class InvitationBuilder(object):
             invitation.content['comment_readers'] = {
                 'value': comment_stage.get_readers(self.venue, '{number}')
             }
-            invitation.content['readers_delection'] = {
+            invitation.content['readers_selection'] = {
                 'value': comment_stage.reader_selection
             }
             comment_readers = ['${5/content/noteReaders/value}']
@@ -2890,12 +2890,6 @@ class InvitationBuilder(object):
             content = {
                 'review_readers': {
                     'value': self.venue.review_stage.get_readers(self.venue, '{number}')
-                },
-                'comment_readers': {
-                    'value': self.venue.comment_stage.get_readers(self.venue, '{number}')
-                },
-                'readers_selection': {
-                    'value': self.venue.comment_stage.reader_selection
                 }
             },
             edit = {
@@ -2946,6 +2940,14 @@ class InvitationBuilder(object):
                         'append': [self.venue.get_ethics_reviewers_id('${{3/id}/number}')]
                     }
                 }
+            }
+
+        if ethics_review_stage.enable_comments:
+            ethics_stage_invitation.content['comment_readers'] = {
+                'value': self.venue.comment_stage.get_readers(self.venue, '{number}')
+            }
+            ethics_stage_invitation.content['readers_selection'] = {
+                'value': self.venue.comment_stage.reader_selection
             }
 
         self.save_invitation(ethics_stage_invitation, replacement=False)

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -92,8 +92,8 @@ def process(client, edit, invitation):
         )
 
         # edit comment invitation
-        invitation = openreview.tools.get_invitation(client, f'{venue_id}/{submission_name}{submission.number}/-/Official_Comment')
-        if invitation:
+        comment_invitation = openreview.tools.get_invitation(client, f'{venue_id}/{submission_name}{submission.number}/-/Official_Comment')
+        if comment_invitation and 'comment_readers' in invitation.content:
             comment_readers = invitation.content['comment_readers']['value']
             final_readers = []
             final_readers.extend(comment_readers)

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -508,6 +508,8 @@ class Venue(object):
         self.invitation_builder.set_ethics_paper_groups_invitation()
         self.invitation_builder.set_review_invitation()
         self.invitation_builder.set_ethics_review_invitation()
+        if self.ethics_review_stage.enable_comments:
+            self.invitation_builder.set_official_comment_invitation()
 
         # setup paper matching
         group = tools.get_group(self.client, id=self.get_ethics_reviewers_id())

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -393,6 +393,16 @@ class VenueStages():
                 "order": 9,
                 "value-checkbox": "We confirm we want to release the submissions and reviews to the ethics reviewers",
                 "required": True
+            },
+            'enable_comments_for_ethics_reviewers': {
+                'description': 'Should ethics reviewers be able to post comments? Note you can control the comment stage deadline as well who else can post comments by using the Comment Stage button.',
+                'value-radio': [
+                    'Yes, enable commenting for ethics reviewers.',
+                    'No, do not enable commenting for ethics reviewers.'
+                ],
+                'required': False,
+                'default': 'No, do not enable commenting for ethics reviewers.',
+                'order': 10
             }
         }
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -3311,7 +3311,8 @@ ICML 2023 Conference Program Chairs'''
                         }
                     }
                 },
-                'release_submissions_to_ethics_reviewers': 'We confirm we want to release the submissions and reviews to the ethics reviewers'
+                'release_submissions_to_ethics_reviewers': 'We confirm we want to release the submissions and reviews to the ethics reviewers',
+                'enable_comments_for_ethics_reviewers': 'Yes, enable commenting for ethics reviewers.'
             },
             forum=request_form.forum,
             referent=request_form.forum,
@@ -3417,6 +3418,12 @@ ICML 2023 Conference Program Chairs'''
         invitation = openreview_client.get_invitations(id='ICML.cc/2023/Conference/Submission52/-/Ethics_Review')[0]
         assert invitation
         assert 'ICML.cc/2023/Conference/Submission52/Ethics_Reviewers' in invitation.invitees
+
+        # comment invitations are created for all papers, with only PCs and ethics reviewers as invitees
+        invitations = openreview_client.get_all_invitations(invitation='ICML.cc/2023/Conference/-/Official_Comment')
+        assert len(invitations) == 100
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Official_Comment')
+        assert invitation.invitees == ['ICML.cc/2023/Conference', 'openreview.net/Support', 'ICML.cc/2023/Conference/Submission1/Ethics_Reviewers']
 
     def test_comment_stage(self, openreview_client, helpers):
 


### PR DESCRIPTION
I am adding a field to the request form to enable comments when running the Ethics Review Stage. If comments are enabled for ethics reviewers but the comment stage hasn't been run, the stage will be created with only PCs and ethics reviewers as invitees.