### PR TITLE
Track Paper Matching: configure edge browser urls based on committee role

### DIFF
--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -216,13 +216,12 @@ class Venue(object):
             return name[:-1] if name.endswith('s') else name
         return self.reviewers_name
     
+    def get_anon_committee_name(self, name):
+        rev_name = name[:-1] if name.endswith('s') else name
+        return rev_name + '_'         
+    
     def get_anon_reviewers_name(self, pretty=True):
-        rev_name = self.reviewers_name[:-1] if self.reviewers_name.endswith('s') else self.reviewers_name
-        return rev_name + '_'    
-
-    def get_anon_reviewers_name(self, pretty=True):
-        rev_name = self.reviewers_name[:-1] if self.reviewers_name.endswith('s') else self.reviewers_name
-        return rev_name + '_'
+        return self.get_anon_committee_name(self.reviewers_name)
 
     def get_ethics_reviewers_name(self, pretty=True):
         if pretty:
@@ -231,8 +230,7 @@ class Venue(object):
         return self.ethics_reviewers_name
 
     def anon_ethics_reviewers_name(self, pretty=True):
-        rev_name = self.ethics_reviewers_name[:-1] if self.ethics_reviewers_name.endswith('s') else self.ethics_reviewers_name
-        return rev_name + '_'
+        return self.get_anon_committee_name(self.ethics_reviewers_name)
 
     def get_area_chairs_name(self, pretty=True):
         if pretty:
@@ -241,8 +239,7 @@ class Venue(object):
         return self.area_chairs_name
 
     def get_anon_area_chairs_name(self, pretty=True):
-        rev_name = self.area_chairs_name[:-1] if self.area_chairs_name.endswith('s') else self.area_chairs_name
-        return rev_name + '_' 
+        return self.get_anon_committee_name(self.area_chairs_name)
 
     def get_reviewers_id(self, number = None, anon=False, submitted=False):
         rev_name = self.get_anon_reviewers_name()

--- a/openreview/venue/webfield/areachairsWebfield.js
+++ b/openreview/venue/webfield/areachairsWebfield.js
@@ -1,17 +1,21 @@
 // Webfield component
-const committee_name = entity.id.split('/').slice(-1)[0].replaceAll('_', ' ')
+const committee_name = entity.id.split('/').slice(-1)[0]
+const committee_reviewer_name = committee_name.replace(domain.content.area_chairs_name?.value, domain.content.reviewers_name?.value)
+const committee_sac_name = committee_name.replace(domain.content.area_chairs_name?.value, domain.content.senior_area_chairs_name?.value)
+const replaceAreaChairName = (invitationId) => invitationId.replace(domain.content.area_chairs_name?.value, committee_name)
+const replaceReviewerName = (invitationId) => invitationId.replace(domain.content.reviewers_name?.value, committee_reviewer_name)
+
 const reviewerAssignmentTitle = domain.content.reviewers_proposed_assignment_title?.value
-const areaChairsId = domain.content.area_chairs_id?.value
-const reviewerGroup = domain.content.reviewers_id?.value
-const startParam = `${domain.content.area_chairs_assignment_id?.value},tail:${user.profile.id}`
-const traverseProposedParam = `${domain.content.reviewers_proposed_assignment_id?.value},label:${reviewerAssignmentTitle}`
-const traverseParam = `${domain.content.reviewers_assignment_id?.value}`
+const reviewerGroup = replaceReviewerName(domain.content.reviewers_id?.value)
+const startParam = `${replaceAreaChairName(domain.content.area_chairs_assignment_id?.value)},tail:${user.profile.id}`
+const traverseProposedParam = `${replaceReviewerName(domain.content.reviewers_proposed_assignment_id?.value)},label:${reviewerAssignmentTitle}`
+const traverseParam = `${replaceReviewerName(domain.content.reviewers_assignment_id?.value)}`
 const browseInvitations = []
 const browseProposedInvitations = [`${reviewerGroup}/-/Aggregate_Score,label:${reviewerAssignmentTitle}`]
 
 if (domain.content.reviewers_affinity_score_id?.value) {
-  browseInvitations.push(domain.content.reviewers_affinity_score_id?.value)
-  browseProposedInvitations.push(domain.content.reviewers_affinity_score_id?.value)
+  browseInvitations.push(replaceReviewerName(domain.content.reviewers_affinity_score_id?.value))
+  browseProposedInvitations.push(replaceReviewerName(domain.content.reviewers_affinity_score_id?.value))
 }
 
 if (domain.content.bid_name?.value) {
@@ -20,18 +24,18 @@ if (domain.content.bid_name?.value) {
 }
 
 if (domain.content.reviewers_custom_max_papers_id?.value) {
-  browseInvitations.push(`${domain.content.reviewers_custom_max_papers_id?.value},head:ignore`)
-  browseProposedInvitations.push(`${domain.content.reviewers_custom_max_papers_id?.value},head:ignore`)
+  browseInvitations.push(`${replaceReviewerName(domain.content.reviewers_custom_max_papers_id?.value)},head:ignore`)
+  browseProposedInvitations.push(`${replaceReviewerName(domain.content.reviewers_custom_max_papers_id?.value)},head:ignore`)
 }
 
-const otherParams = `&hide=${domain.content.reviewers_conflict_id?.value}&maxColumns=2&version=2&referrer=[AC%20Console](/group?id=${areaChairsId})`
+const otherParams = `&hide=${replaceReviewerName(domain.content.reviewers_conflict_id?.value)}&maxColumns=2&version=2&referrer=[AC%20Console](/group?id=${entity.id})`
 
 return {
   component: 'AreaChairConsole',
   version: 1,
   properties: {
     header: {
-      title: `${committee_name} Console`,
+      title: `${committee_name.replaceAll('_', ' ')} Console`,
       instructions: `<p class="dark">This page provides information and status updates for the ${domain.content.subtitle?.value}. It will be regularly updated as the conference progresses, so please check back frequently.</p>`,
     },
     apiVersion: 2,
@@ -39,8 +43,8 @@ return {
     reviewerAssignment: {
       showEdgeBrowserUrl: domain.content.enable_reviewers_reassignment?.value,
       proposedAssignmentTitle: reviewerAssignmentTitle,
-      edgeBrowserProposedUrl: `/edges/browse?start=${startParam}&traverse=${traverseProposedParam}&edit=${domain.content.reviewers_proposed_assignment_id?.value},label:${reviewerAssignmentTitle};${domain.content.reviewers_invite_assignment_id?.value}&browse=${browseProposedInvitations.join(';')}${otherParams}`,
-      edgeBrowserDeployedUrl: `/edges/browse?start=${startParam}&traverse=${traverseParam}&edit=${domain.content.reviewers_invite_assignment_id?.value}&browse=${browseInvitations.join(';')}${otherParams}`,
+      edgeBrowserProposedUrl: `/edges/browse?start=${startParam}&traverse=${traverseProposedParam}&edit=${replaceReviewerName(domain.content.reviewers_proposed_assignment_id?.value)},label:${reviewerAssignmentTitle};${replaceReviewerName(domain.content.reviewers_invite_assignment_id?.value)}&browse=${browseProposedInvitations.join(';')}${otherParams}`,
+      edgeBrowserDeployedUrl: `/edges/browse?start=${startParam}&traverse=${traverseParam}&edit=${replaceReviewerName(domain.content.reviewers_invite_assignment_id?.value)}&browse=${browseInvitations.join(';')}${otherParams}`,
     },
     submissionInvitationId: domain.content.submission_id?.value,
     seniorAreaChairsId: domain.content.senior_area_chairs_id?.value,

--- a/openreview/venue/webfield/seniorAreaChairsWebfield.js
+++ b/openreview/venue/webfield/seniorAreaChairsWebfield.js
@@ -1,27 +1,32 @@
 // Webfield component
-const committee_name = entity.id.split('/').slice(-1)[0].replaceAll('_', ' ')
-const startParam = `${domain.content.area_chairs_assignment_id?.value},tail:{ac.profile.id}`
-const traverseParam = `${domain.content.reviewers_assignment_id?.value}`
+const committee_name = entity.id.split('/').slice(-1)[0]
+const committee_ac_name = committee_name.replace(domain.content.senior_area_chairs_name?.value, domain.content.area_chairs_name?.value)
+const committee_reviewer_name = committee_ac_name.replace(domain.content.area_chairs_name?.value, domain.content.reviewers_name?.value)
+const replaceAreaChairName = (invitationId) => invitationId.replace(domain.content.area_chairs_name?.value, committee_ac_name)
+const replaceReviewerName = (invitationId) => invitationId.replace(domain.content.reviewers_name?.value, committee_reviewer_name)
+const startParam = `${replaceAreaChairName(domain.content.area_chairs_assignment_id?.value)},tail:{ac.profile.id}`
+const traverseParam = `${replaceReviewerName(domain.content.reviewers_assignment_id?.value)}`
+const editParam = `${replaceReviewerName(domain.content.reviewers_invite_assignment_id?.value)}`
 const browseInvitations = []
 
 if (domain.content.reviewers_affinity_score_id?.value) {
-  browseInvitations.push(domain.content.reviewers_affinity_score_id?.value)
+  browseInvitations.push(replaceReviewerName(domain.content.reviewers_affinity_score_id?.value))
 }
 if (domain.content.bid_name?.value) {
-  browseInvitations.push(`${domain.content.reviewers_id?.value}/-/${domain.content.bid_name?.value}`)
+  browseInvitations.push(replaceReviewerName(`${domain.content.reviewers_id?.value}/-/${domain.content.bid_name?.value}`))
 }
 if (domain.content.reviewers_custom_max_papers_id?.value) {
-  browseInvitations.push(`${domain.content.reviewers_custom_max_papers_id?.value},head:ignore`)
+  browseInvitations.push(replaceReviewerName(`${domain.content.reviewers_custom_max_papers_id?.value},head:ignore`))
 }
 
-const otherParams = `&hide=${domain.content.reviewers_conflict_id?.value}&maxColumns=2&version=2&referrer=[Senior Area Chair Console](/group?id=${domain.content.senior_area_chairs_id?.value})`
+const otherParams = `&hide=${replaceReviewerName(domain.content.reviewers_conflict_id?.value)}&maxColumns=2&version=2&referrer=[Senior Area Chair Console](/group?id=${entity.id})`
 
 return {
   component: 'SeniorAreaChairConsole',
   version: 1,
   properties: {
     header: {
-      title: `${committee_name} Console`,
+      title: `${committee_name.replaceAll('_', ' ')} Console`,
       instructions: `<p class="dark">This page provides information and status updates for the ${domain.content.subtitle?.value}. It will be regularly updated as the conference progresses, so please check back frequently.</p>`
     },
     apiVersion: 2,
@@ -43,6 +48,6 @@ return {
     recommendationName: domain.content.meta_review_recommendation?.value || 'recommendation',
     shortPhrase: domain.content.subtitle?.value,
     enableQuerySearch: true,
-    edgeBrowserDeployedUrl: `/edges/browse?start=${startParam}&traverse=${traverseParam}&edit=${domain.content.reviewers_invite_assignment_id?.value}&browse=${browseInvitations.join(';')}${otherParams}`
+    edgeBrowserDeployedUrl: `/edges/browse?start=${startParam}&traverse=${traverseParam}&edit=${editParam}&browse=${browseInvitations.join(';')}${otherParams}`
   }
 }

--- a/tests/test_venue_with_tracks.py
+++ b/tests/test_venue_with_tracks.py
@@ -60,8 +60,8 @@ class TestVenueWithTracks():
         helpers.create_user('ac18@webconf.com', 'AC', 'WebChairEightTeen')        
         helpers.create_user('ac19@webconf.com', 'AC', 'WebChairNineTeen')        
         helpers.create_user('ac20@webconf.com', 'AC', 'WebChairTwenty')        
-        helpers.create_user('ac21@webconf.com', 'AC', 'WebChairTwentyOne')        
-        helpers.create_user('ac22@webconf.com', 'AC', 'WebChairTwentyTwo')
+        helpers.create_user('ac21@gmail.com', 'AC', 'WebChairTwentyOne')        
+        helpers.create_user('ac22@gmail.com', 'AC', 'WebChairTwentyTwo')
 
         helpers.create_user('reviewer1@webconf.com', 'Reviewer', 'WebChairOne')
         helpers.create_user('reviewer2@webconf.com', 'Reviewer', 'WebChairTwo')
@@ -83,8 +83,8 @@ class TestVenueWithTracks():
         helpers.create_user('reviewer18@webconf.com', 'Reviewer', 'WebChairEightTeen')        
         helpers.create_user('reviewer19@webconf.com', 'Reviewer', 'WebChairNineTeen')        
         helpers.create_user('reviewer20@webconf.com', 'Reviewer', 'WebChairTwenty')        
-        helpers.create_user('reviewer21@webconf.com', 'Reviewer', 'WebChairTwentyOne')        
-        helpers.create_user('reviewer22@webconf.com', 'Reviewer', 'WebChairTwentyTwo')                
+        helpers.create_user('reviewer21@gmail.com', 'Reviewer', 'WebChairTwentyOne')        
+        helpers.create_user('reviewer22@gmail.com', 'Reviewer', 'WebChairTwentyTwo')                
 
         request_form_note = pc_client.post_note(openreview.Note(
             invitation='openreview.net/Support/-/Request_Form',
@@ -264,21 +264,6 @@ class TestVenueWithTracks():
         submission_invitation = openreview_client.get_invitation('ACM.org/TheWebConf/2024/Conference/-/Submission')
         assert submission_invitation
         assert 'track' in submission_invitation.edit['note']['content']
-
-        # openreview_client.add_members_to_group('ACM.org/TheWebConf/2024/Conference/Senior_Area_Chairs', [
-        #     'sac1@webconf.com',
-        #     'sac2@webconf.com',
-        #     'sac3@webconf.com',
-        #     'sac4@webconf.com',
-        #     'sac5@webconf.com',
-        #     'sac6@webconf.com',
-        #     'sac7@webconf.com',
-        #     'sac8@webconf.com',
-        #     'sac9@webconf.com',
-        #     'sac10@webconf.com',
-        #     'sac11@gmail.com',
-        #     'sac12@webconf.com'
-        # ])
 
         invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form_note.number}/Paper_Matching_Setup')
         assert 'ACM.org/TheWebConf/2024/Conference/COI_Senior_Area_Chairs' in invitation.reply['content']['matching_group']['value-dropdown']
@@ -513,8 +498,8 @@ class TestVenueWithTracks():
 
         for ac_role in ac_roles:
 
-            reviewer_details = f'''ac{ac_counter}@webconf.com, Area ChairOne
-ac{ac_counter + 1}@webconf.com, Area ChairTwo
+            reviewer_details = f'''ac{ac_counter}@{'gmail' if ac_counter == 21 else 'webconf'}.com, Area ChairOne
+ac{ac_counter + 1}@{'gmail' if ac_counter == 21 else 'webconf'}.com, Area ChairTwo
 '''
             ac_counter += 2
             pc_client.post_note(openreview.Note(
@@ -665,6 +650,13 @@ ac{ac_counter + 1}@webconf.com, Area ChairTwo
             assert assignment_configuration_invitation.edit['note']['content']['paper_invitation']['value']['param']['default'] == 'ACM.org/TheWebConf/2024/Conference/-/Submission&content.venueid=ACM.org/TheWebConf/2024/Conference/Submission&content.track=' + tracks[index]                  
             proposed_assignment_invitation = openreview_client.get_invitation(f'{ac_id}/-/Proposed_Assignment')
             assert proposed_assignment_invitation.edit['head']['param']['withContent'] == { 'track': track }
+            assert proposed_assignment_invitation.readers == ['ACM.org/TheWebConf/2024/Conference', f'ACM.org/TheWebConf/2024/Conference/{ac_role.replace("Area_Chairs", "Senior_Area_Chairs")}', f'ACM.org/TheWebConf/2024/Conference/{ac_role}']
+            assert proposed_assignment_invitation.edit['readers'] == ["ACM.org/TheWebConf/2024/Conference", 'ACM.org/TheWebConf/2024/Conference/Submission${{2/head}/number}/Senior_Area_Chairs', "${2/tail}"]
+            affinity_score_invitation = openreview_client.get_invitation(f'{ac_id}/-/Affinity_Score')
+            assert affinity_score_invitation.edit['head']['param']['withContent'] == { 'track': track }
+            assert affinity_score_invitation.readers == ['ACM.org/TheWebConf/2024/Conference', f'ACM.org/TheWebConf/2024/Conference/{ac_role.replace("Area_Chairs", "Senior_Area_Chairs")}']
+            assert affinity_score_invitation.edit['readers'] == ["ACM.org/TheWebConf/2024/Conference", f'ACM.org/TheWebConf/2024/Conference/{ac_role.replace("Area_Chairs", "Senior_Area_Chairs")}', "${2/tail}"]
+
 
         ## Build proposed assignments
         for submission in submissions:
@@ -673,7 +665,7 @@ ac{ac_counter + 1}@webconf.com, Area ChairTwo
                 index = 10
             ac_role = ac_roles[index]
             ac_id = f'ACM.org/TheWebConf/2024/Conference/{ac_role}'
-            ac_profile = pc_client_v2.get_profile(f'ac{((index * 2) + 1)}@webconf.com')
+            ac_profile = pc_client_v2.get_profile(f'ac{((index * 2) + 1)}@{"gmail" if ((index * 2) + 1) == 21 else "webconf"}.com')
             pc_client_v2.post_edge(
                 openreview.api.Edge(
                     invitation=f'{ac_id}/-/Proposed_Assignment',
@@ -706,6 +698,33 @@ ac{ac_counter + 1}@webconf.com, Area ChairTwo
         assert pc_client_v2.get_group('ACM.org/TheWebConf/2024/Conference/Submission10/Area_Chairs').members == ['~AC_WebChairOne1']
 
 
+        ## Add second AC
+        posted_edge = pc_client_v2.post_edge(
+            openreview.api.Edge(
+                invitation=f'{ac_id}/-/Assignment',
+                signatures=['ACM.org/TheWebConf/2024/Conference'],
+                head=submissions[0].id,
+                tail='~AC_WebChairFive1',
+                weight=1.0
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, posted_edge.id)      
+
+        assert pc_client_v2.get_group('ACM.org/TheWebConf/2024/Conference/Submission1/Area_Chairs').members == ['~AC_WebChairTwentyOne1', '~AC_WebChairFive1']                        
+        assert pc_client_v2.get_group('ACM.org/TheWebConf/2024/Conference/Submission1/Senior_Area_Chairs').members == ['~SAC_WebChairEleven1']
+
+        ## Remove second AC
+        edges = pc_client_v2.get_edges(invitation=f'{ac_id}/-/Assignment', head=submissions[0].id, tail='~AC_WebChairTwentyOne1')
+        edge = edges[0]
+        edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        posted_edge = pc_client_v2.post_edge(edge)
+
+        helpers.await_queue_edit(openreview_client, posted_edge.id)                      
+
+        assert pc_client_v2.get_group('ACM.org/TheWebConf/2024/Conference/Submission1/Area_Chairs').members == ['~AC_WebChairFive1']                        
+        assert pc_client_v2.get_group('ACM.org/TheWebConf/2024/Conference/Submission1/Senior_Area_Chairs').members == ['~SAC_WebChairEleven1']
+
     def test_recruit_reviewers(self, client, openreview_client, helpers, selenium, request_page):
 
         pc_client=openreview.Client(username='pc@webconf.org', password=helpers.strong_password)
@@ -729,8 +748,8 @@ ac{ac_counter + 1}@webconf.com, Area ChairTwo
 
         for reviewer_role in reviewer_roles:
 
-            reviewer_details = f'''reviewer{reviewer_counter}@webconf.com, Reviewer ChairOne
-reviewer{reviewer_counter + 1}@webconf.com, Reviewer ChairTwo
+            reviewer_details = f'''reviewer{reviewer_counter}@{'gmail' if reviewer_counter == 21 else 'webconf'}.com, Reviewer ChairOne
+reviewer{reviewer_counter + 1}@{'gmail' if reviewer_counter == 21 else 'webconf'}.com, Reviewer ChairTwo
 '''
             reviewer_counter += 2
             pc_client.post_note(openreview.Note(
@@ -847,7 +866,7 @@ reviewer{reviewer_counter + 1}@webconf.com, Reviewer ChairTwo
                 index = 10
             reviewer_role = reviewer_roles[index]
             reviewer_id = f'ACM.org/TheWebConf/2024/Conference/{reviewer_role}'
-            reviewer_profile = pc_client_v2.get_profile(f'reviewer{((index * 2) + 1)}@webconf.com')
+            reviewer_profile = pc_client_v2.get_profile(f'reviewer{((index * 2) + 1)}@{"gmail" if ((index * 2) + 1) == 21 else "webconf"}.com')
             pc_client_v2.post_edge(
                 openreview.api.Edge(
                     invitation=f'{reviewer_id}/-/Proposed_Assignment',
@@ -858,7 +877,7 @@ reviewer{reviewer_counter + 1}@webconf.com, Reviewer ChairTwo
                     weight=1.0
                 )
             )
-            reviewer_profile = pc_client_v2.get_profile(f'reviewer{((index * 2) + 2)}@webconf.com')
+            reviewer_profile = pc_client_v2.get_profile(f'reviewer{((index * 2) + 2)}@{"gmail" if ((index * 2) + 2) == 22 else "webconf"}.com')
             pc_client_v2.post_edge(
                 openreview.api.Edge(
                     invitation=f'{reviewer_id}/-/Proposed_Assignment',
@@ -872,8 +891,10 @@ reviewer{reviewer_counter + 1}@webconf.com, Reviewer ChairTwo
 
         venue = openreview.helpers.get_conference(pc_client, request_form.id, setup=False)
 
-        for reviewer_role in reviewer_roles:
-            venue.set_assignments(assignment_title='reviewer-assignment', committee_id=f'ACM.org/TheWebConf/2024/Conference/{reviewer_role}')
+        for index, reviewer_role in enumerate(reviewer_roles):
+            venue.set_assignments(assignment_title='reviewer-assignment', committee_id=f'ACM.org/TheWebConf/2024/Conference/{reviewer_role}', enable_reviewer_reassignment=True)
+            invite_assignment_invitation = openreview_client.get_invitation(f'ACM.org/TheWebConf/2024/Conference/{reviewer_role}/-/Invite_Assignment')
+            assert invite_assignment_invitation.edit['head']['param']['withContent'] == { 'track': tracks[index] }
 
         group = pc_client_v2.get_group('ACM.org/TheWebConf/2024/Conference/Submission1/Reviewers')
         assert len(group.members) == 2


### PR DESCRIPTION
- Parametrize the edge invitations using the track groups instead of the general committee groups.
- Parametrize the edge browser urls in the SAC and AC consoles to use the track groups.