### PR TITLE
Update venue_request.py to clarify Force Profiles

### DIFF
--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1279,7 +1279,7 @@ class VenueRequest():
                 'hidden': True
             },
             'force_profiles_only': {
-                'description': 'Should all authors of papers have OpenReview profiles before submitting a paper?',
+                'description': 'Submitting authors must have an OpenReview profile, however, should all co-authors be required to have profiles?',
                 'value-radio': [
                     'Yes, require all authors to have an OpenReview profile',
                     'No, allow submissions with email addresses'


### PR DESCRIPTION
The description for Force profiles in the request form has caused some confusion. I changed the description to mitigate confusion about whether or not submitting authors need a profile.