### PR TITLE
Selenium: translate deprecated methods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
             cd ~/openreview-py-repo
             pip install -U pytest
             pip install selenium==4.9.1
-            pip install pytest-selenium==3
+            pip install pytest-selenium
             pip install -e .
             TEST_FILES=$(circleci tests glob "tests/test_*.py" | circleci tests split --split-by=timings)
             mkdir test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
             cd ~/openreview-py-repo
             pip install -U pytest
             pip install py
-            pip install selenium
+            pip install selenium==4.9.1
             pip install pytest-selenium
             pip install -e .
             TEST_FILES=$(circleci tests glob "tests/test_*.py" | circleci tests split --split-by=timings)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
           command: |
             cd ~/openreview-py-repo
             pip install -U pytest
+            pip install py
             pip install selenium
             pip install pytest-selenium
             pip install -e .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           command: |
             cd ~/openreview-py-repo
             pip install -U pytest
-            pip install selenium==4.2.0
+            pip install selenium==4.9.1
             pip install pytest-selenium==3
             pip install -e .
             TEST_FILES=$(circleci tests glob "tests/test_*.py" | circleci tests split --split-by=timings)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
           command: |
             cd ~/openreview-py-repo
             pip install -U pytest
+            pip install py
             pip install selenium==4.9.1
             pip install pytest-selenium
             pip install -e .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,6 @@ jobs:
           command: |
             cd ~/openreview-py-repo
             pip install -U pytest
-            pip install py
             pip install selenium
             pip install pytest-selenium
             pip install -e .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
             cd ~/openreview-py-repo
             pip install -U pytest
             pip install py
-            pip install selenium==4.9.1
+            pip install selenium
             pip install pytest-selenium
             pip install -e .
             TEST_FILES=$(circleci tests glob "tests/test_*.py" | circleci tests split --split-by=timings)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,32 +106,32 @@ class Helpers:
 
         request_page(selenium, url, by=By.CLASS_NAME, wait_for_element='note_editor')
 
-        container = selenium.find_element_by_class_name('note_editor')
+        container = selenium.find_element(By.CLASS_NAME, 'note_editor')
 
-        buttons = container.find_elements_by_tag_name("button")
+        buttons = container.find_elements(By.TAG_NAME, "button")
         assert len(buttons) == 2
 
         if quota:
             buttons[1].click() ## Decline
             time.sleep(1)
-            reduce_quota_link = selenium.find_element_by_class_name('reduced-load-link')
+            reduce_quota_link = selenium.find_element(By.CLASS_NAME, 'reduced-load-link')
             reduce_quota_link.click()
             time.sleep(1)
-            dropdown = selenium.find_element_by_class_name('dropdown-select__input-container')
+            dropdown = selenium.find_element(By.CLASS_NAME, 'dropdown-select__input-container')
             dropdown.click()
             time.sleep(1)
-            values = selenium.find_elements_by_class_name('dropdown-select__option')
+            values = selenium.find_elements(By.CLASS_NAME, 'dropdown-select__option')
             assert len(values) > 0
             values[0].click()
             time.sleep(1)
-            button = selenium.find_element_by_xpath('//button[text()="Submit"]')
+            button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
             button.click()
         elif comment:
             buttons[1].click()
             time.sleep(1)
-            text_area = selenium.find_element_by_css_selector(".note_content_value, [class*='TextareaWidget_textarea']")
+            text_area = selenium.find_element(By. CSS_SELECTOR, ".note_content_value, [class*='TextareaWidget_textarea']")
             text_area.send_keys("I am too busy.")
-            button = selenium.find_element_by_xpath('//button[text()="Submit"]')
+            button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
             button.click()
         elif accept:
             buttons[0].click()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,7 +218,7 @@ def request_page():
     return request
 
 @pytest.fixture
-def selenium(request):
+def selenium():
     # Specify the path to the Firefox WebDriver executable
     geckodriver_path = 'drivers/geckodriver'  # Replace with the actual path
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,7 @@ class Helpers:
         elif comment:
             buttons[1].click()
             time.sleep(1)
-            text_area = selenium.find_element(By. CSS_SELECTOR, ".note_content_value, [class*='TextareaWidget_textarea']")
+            text_area = selenium.find_element(By.CSS_SELECTOR, ".note_content_value, [class*='TextareaWidget_textarea']")
             text_area.send_keys("I am too busy.")
             button = selenium.find_element(By.XPATH, '//button[text()="Submit"]')
             button.click()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,21 +216,3 @@ def request_page():
             print("Timed out waiting for page to load")
 
     return request
-
-@pytest.fixture
-def selenium():
-    # Specify the path to the Firefox WebDriver executable
-    geckodriver_path = 'drivers/geckodriver'  # Replace with the actual path
-    
-    # Set up Firefox options and specify the executable path
-    options = Options()
-    options.headless = True
-    options.executable_path = geckodriver_path
-
-    # Initialize the Firefox WebDriver with the options
-    driver = webdriver.Firefox(options=options)
-    
-    yield driver
-
-    # Teardown: Close the WebDriver session
-    driver.quit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,14 +126,14 @@ class Helpers:
             assert len(values) > 0
             values[0].click()
             time.sleep(1)
-            button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
+            button = selenium.find_element(By.XPATH, '//button[text()="Submit"]')
             button.click()
         elif comment:
             buttons[1].click()
             time.sleep(1)
             text_area = selenium.find_element(By. CSS_SELECTOR, ".note_content_value, [class*='TextareaWidget_textarea']")
             text_area.send_keys("I am too busy.")
-            button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
+            button = selenium.find_element(By.XPATH, '//button[text()="Submit"]')
             button.click()
         elif accept:
             buttons[0].click()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import openreview
 import pytest
 import requests
 import time
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -214,3 +216,21 @@ def request_page():
             print("Timed out waiting for page to load")
 
     return request
+
+@pytest.fixture
+def selenium(request):
+    # Specify the path to the Firefox WebDriver executable
+    geckodriver_path = 'drivers/geckodriver'  # Replace with the actual path
+    
+    # Set up Firefox options and specify the executable path
+    options = Options()
+    options.headless = True
+    options.executable_path = geckodriver_path
+
+    # Initialize the Firefox WebDriver with the options
+    driver = webdriver.Firefox(options=options)
+    
+    yield driver
+
+    # Teardown: Close the WebDriver session
+    driver.quit()

--- a/tests/test_agora.py
+++ b/tests/test_agora.py
@@ -2,6 +2,7 @@ import openreview
 import pytest
 import time
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 
 
 class TestAgora():
@@ -23,16 +24,16 @@ class TestAgora():
         agora = openreview.agora.Agora(client, support_group.id, 'openreview.net', 'editor@agora.net')
 
         request_page(selenium, "http://localhost:3030/group?id=-Agora/COVID-19", by='class name', wait_for_element='tabs-container')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         with pytest.raises(NoSuchElementException):
-            notes_panel.find_element_by_class_name('spinner-container')
+            notes_panel.find_element(By.CLASS_NAME, 'spinner-container')
 
     def test_post_submission(self, client, helpers):
 

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -8,6 +8,7 @@ import os
 import re
 import csv
 import random
+from selenium.webdriver.common.by import By
 
 class TestARRVenue():
 
@@ -659,9 +660,9 @@ class TestARRVenue():
 
         invitation_url = re.search('https://.*\n', invitation_message).group(0).replace('https://openreview.net', 'http://localhost:3030')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        notes = selenium.find_element_by_class_name('note_editor')
+        notes = selenium.find_element(By.CLASS_NAME, 'note_editor')
         assert notes
-        messages = notes.find_elements_by_tag_name('h4')
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'Thank you for accepting this invitation from ACL Rolling Review - September 2021.' == messages[0].text
 
@@ -715,9 +716,9 @@ ACL ARR 2021 September Program Chairs'''
 
         invitation_url = re.search('https://.*\n', invitation_message).group(0).replace('https://openreview.net', 'http://localhost:3030')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        notes = selenium.find_element_by_class_name('note_editor')
+        notes = selenium.find_element(By.CLASS_NAME, 'note_editor')
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'You have declined the invitation from ACL Rolling Review - September 2021.' == messages[0].text
 
@@ -744,9 +745,9 @@ OpenReview Team'''
         ## Check the AC console edge browser url
         ac_client = openreview.Client(username='ac1@gmail.com', password=helpers.strong_password)
         request_page(selenium, "http://localhost:3030/group?id=aclweb.org/ACL/ARR/2021/September/Area_Chairs", ac_client.token, wait_for_element='edge_browser_url')
-        header = selenium.find_element_by_id("header")
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        url = header.find_element_by_id("edge_browser_url")
+        url = header.find_element(By.ID, 'edge_browser_url')
         assert url
         assert 'Reviewers/-/Proposed_Assignment,label:reviewer-matching' in url.get_attribute('href')
 
@@ -768,9 +769,9 @@ OpenReview Team'''
 
         invitation_url = re.search('https://.*\n', invitation_message).group(0).replace('https://openreview.net', 'http://localhost:3030')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        notes = selenium.find_element_by_class_name('note_editor')
+        notes = selenium.find_element(By.CLASS_NAME, 'note_editor')
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'Thank you for accepting this invitation from ACL Rolling Review - September 2021.' == messages[0].text
 
@@ -827,9 +828,9 @@ ACL ARR 2021 September Program Chairs'''
 
         invitation_url = re.search('https://.*\n', invitation_message).group(0).replace('https://openreview.net', 'http://localhost:3030')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        notes = selenium.find_element_by_class_name('note_editor')
+        notes = selenium.find_element(By.CLASS_NAME, 'note_editor')
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'You have declined the invitation from ACL Rolling Review - September 2021.' == messages[0].text
 
@@ -865,9 +866,9 @@ OpenReview Team'''
         ## Check the AC console edge browser url
         ac_client = openreview.Client(username='ac1@gmail.com', password=helpers.strong_password)
         request_page(selenium, "http://localhost:3030/group?id=aclweb.org/ACL/ARR/2021/September/Area_Chairs", ac_client.token, wait_for_element='edge_browser_url')
-        header = selenium.find_element_by_id("header")
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        url = header.find_element_by_id("edge_browser_url")
+        url = header.find_element(By.ID, 'edge_browser_url')
         assert url
         assert 'Reviewers/-/Assignment' in url.get_attribute('href')
 
@@ -908,7 +909,7 @@ OpenReview Team'''
 
         invitation_url = re.search('https://.*\n', invitation_message).group(0).replace('https://openreview.net', 'http://localhost:3030')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'This submission is no longer under review. No action is required from your end.' == error_message.text
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -29,13 +29,13 @@ class TestBuilder():
         assert home_group.id == 'test.org/2019/Conference'
 
         request_page(selenium, 'http://localhost:3030/group?id=test.org/2019/Conference')
-        assert selenium.find_element_by_tag_name('h3').text == 'test.org/2019/Conference'
+        assert selenium.find_element(By.TAG_NAME, 'h3').text == 'test.org/2019/Conference'
 
         builder.set_homepage_header({ 'subtitle': 'TEST 2019' })
         conference = builder.get_result()
 
         request_page(selenium, 'http://localhost:3030/group?id=test.org/2019/Conference')
-        assert selenium.find_element_by_tag_name('h3').text == 'TEST 2019'
+        assert selenium.find_element(By.TAG_NAME, 'h3').text == 'TEST 2019'
 
 
     def test_modify_review_form(self, client, test_client, selenium, request_page, helpers):
@@ -94,9 +94,9 @@ class TestBuilder():
         conference.set_assignment('reviewer_test1@mail.com', blind_submissions[0].number)
 
         request_page(selenium=selenium, url="http://localhost:3030/forum?id=" + blind_submissions[0].id, token=reviewer_client.token, wait_for_element='note_{}'.format(blind_submissions[0].id))
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Official Review' == reply_row.find_elements_by_class_name('btn')[0].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
+        assert 'Official Review' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         official_review_invitations = reviewer_client.get_invitations(regex = conference.get_invitation_id('Official_Review', blind_submissions[0].number))
         assert len(official_review_invitations) == 1
@@ -192,8 +192,8 @@ class TestBuilder():
         pc_client = helpers.create_user('pc_testconsole1@mail.com', 'SomeFirstName', 'PCConsole')
         request_page(selenium, 'http://localhost:3030/group?id=' + conference.get_program_chairs_id() + '#paper-status', pc_client.token, wait_for_element='venue-configuration')
 
-        assert selenium.find_element_by_xpath('//a[@href="#paper-status"]')
-        assert selenium.find_element_by_xpath('//div[@id="venue-configuration"]//h3')
+        assert selenium.find_element(By. XPATH, '//a[@href="#paper-status"]')
+        assert selenium.find_element(By. XPATH, '//div[@id="venue-configuration"]//h3')
 
         WebDriverWait(selenium, 10).until(
             EC.presence_of_element_located((By.CLASS_NAME, 'message-papers-btn'))
@@ -202,11 +202,11 @@ class TestBuilder():
         expected_options = ['Paper Number', 'Paper Title', 'Average Rating', 'Max Rating', 'Min Rating', 'Average Confidence', 'Max Confidence', 'Min Confidence', 'Reviewers Assigned', 'Reviews Submitted', 'Reviews Missing', 'Decision']
         unexpected_options = ['Meta Review Missing']
         for option in expected_options:
-            assert selenium.find_element_by_class_name('-'.join(option.split(' ')) + '-paper-status')
+            assert selenium.find_element(By.CLASS_NAME, '-'.join(option.split(' ')) + '-paper-status')
 
         with pytest.raises(NoSuchElementException):
             for option in unexpected_options:
-                assert selenium.find_element_by_class_name('-'.join(option.split(' ')) + '-paper-status')
+                assert selenium.find_element(By.CLASS_NAME, '-'.join(option.split(' ')) + '-paper-status')
 
         builder.has_area_chairs(True)
         conference = builder.get_result()
@@ -215,4 +215,4 @@ class TestBuilder():
 
         expected_options.append('Meta Review Missing')
         for option in expected_options:
-            assert selenium.find_element_by_class_name('-'.join(option.split(' ')) + '-paper-status')
+            assert selenium.find_element(By.CLASS_NAME, '-'.join(option.split(' ')) + '-paper-status')

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -192,8 +192,8 @@ class TestBuilder():
         pc_client = helpers.create_user('pc_testconsole1@mail.com', 'SomeFirstName', 'PCConsole')
         request_page(selenium, 'http://localhost:3030/group?id=' + conference.get_program_chairs_id() + '#paper-status', pc_client.token, wait_for_element='venue-configuration')
 
-        assert selenium.find_element(By. XPATH, '//a[@href="#paper-status"]')
-        assert selenium.find_element(By. XPATH, '//div[@id="venue-configuration"]//h3')
+        assert selenium.find_element(By.XPATH, '//a[@href="#paper-status"]')
+        assert selenium.find_element(By.XPATH, '//div[@id="venue-configuration"]//h3')
 
         WebDriverWait(selenium, 10).until(
             EC.presence_of_element_located((By.CLASS_NAME, 'message-papers-btn'))

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -784,8 +784,8 @@ class TestDoubleBlindConference():
 
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='edit_button')
 
-        assert len(selenium.find_element(By.CLASS_NAME, 'edit_button')) == 1
-        assert len(selenium.find_element(By.CLASS_NAME, 'trash_button')) == 1
+        assert len(selenium.find_elements(By.CLASS_NAME, 'edit_button')) == 1
+        assert len(selenium.find_elements(By.CLASS_NAME, 'trash_button')) == 1
 
     def test_create_blind_submissions(self, client, test_client):
 
@@ -950,9 +950,9 @@ class TestDoubleBlindConference():
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 2
-        assert 'Official Comment' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
-        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[1].text
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 2
+        assert 'Official Comment' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
+        assert 'Withdraw' == reply_row.find_elements(By.CLASS_NAME, 'btn')[1].text
 
     def test_close_comments(self, client, test_client, selenium, request_page):
 
@@ -972,8 +972,8 @@ class TestDoubleBlindConference():
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
-        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text        
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text        
 
     def test_open_bids(self, client, test_client, selenium, request_page, helpers):
 
@@ -998,13 +998,13 @@ class TestDoubleBlindConference():
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tabs-containe')
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_element(By.CLASS_NAME, 'note')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token, by=By.CLASS_NAME, wait_for_element='tabs-containe')
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_element(By.CLASS_NAME, 'note')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         conference.bid_stages['AKBC.ws/2019/Conference/Reviewers'] = openreview.stages.BidStage('AKBC.ws/2019/Conference/Reviewers', due_date =  now + datetime.timedelta(minutes = 10), request_count = 50, score_ids=['AKBC.ws/2019/Conference/Reviewers/-/Affinity_Score'])
@@ -1014,19 +1014,19 @@ class TestDoubleBlindConference():
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token, by=By.CLASS_NAME, wait_for_element='note')
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_element(By.CLASS_NAME, 'note')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer2_client.token, by=By.CLASS_NAME, wait_for_element='note')
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_element(By.CLASS_NAME, 'note')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token, by=By.CLASS_NAME, wait_for_element='note')
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_element(By.CLASS_NAME, 'note')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         notes = client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
@@ -1042,19 +1042,19 @@ class TestDoubleBlindConference():
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token, by=By.CLASS_NAME, wait_for_element='note')
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_element(By.CLASS_NAME, 'note')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note')
         assert not notes
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer2_client.token, by=By.CLASS_NAME, wait_for_element='note')
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_element(By.CLASS_NAME, 'note')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note')
         assert len(notes) == 1
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token, by=By.CLASS_NAME, wait_for_element='note')
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_element(By.CLASS_NAME, 'note')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
     def test_open_reviews(self, client, test_client, selenium, request_page, helpers):
@@ -1085,15 +1085,15 @@ class TestDoubleBlindConference():
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
-        assert 'Official Review' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
+        assert 'Official Review' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         # Author
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
-        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         anon_reviewers_group_id = reviewer_client.get_groups(regex=f'{conference.id}/Paper1/Reviewer_', signatory='reviewer2@mail.com')[0].id
 

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1554,7 +1554,7 @@ class TestDoubleBlindConference():
         dropdown_Options_Present=EC.presence_of_element_located((By.XPATH,'//*[@id="1-add-reviewer"]/div/div'))
         WebDriverWait(selenium,5).until(dropdown_Options_Present)
         dropdown_Options=selenium.find_element(By.XPATH, '//*[@id="1-add-reviewer"]/div/div')
-        assert len(dropdown_Options.find_elements(By. XPATH, '//*[@id="1-add-reviewer"]/div/div/div'))==1
+        assert len(dropdown_Options.find_elements(By.XPATH, '//*[@id="1-add-reviewer"]/div/div/div'))==1
 
     def test_open_revise_submissions(self, client, test_client, helpers):
 

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -13,6 +13,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 
 class TestDoubleBlindConference():
 
@@ -182,22 +183,22 @@ class TestDoubleBlindConference():
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", wait_for_element='notes')
         assert "AKBC 2019 Conference | OpenReview" in selenium.title
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert "AKBC 2019" == header.find_element_by_tag_name("h1").text
-        assert "Automated Knowledge Base Construction" == header.find_element_by_tag_name("h3").text
-        assert "Amherst, Massachusetts, United States" == header.find_element_by_xpath(".//span[@class='venue-location']").text
-        assert "May 20 - May 21, 2019" == header.find_element_by_xpath(".//span[@class='venue-date']").text
-        assert "http://www.akbc.ws/2019/" == header.find_element_by_xpath(".//span[@class='venue-website']/a").text
-        invitation_panel = selenium.find_element_by_id('invitation')
+        assert "AKBC 2019" == header.find_element(By.TAG_NAME, "h1").text
+        assert "Automated Knowledge Base Construction" == header.find_element(By.TAG_NAME, "h3").text
+        assert "Amherst, Massachusetts, United States" == header.find_element(By.XPATH, ".//span[@class='venue-location']").text
+        assert "May 20 - May 21, 2019" == header.find_element(By.XPATH, ".//span[@class='venue-date']").text
+        assert "http://www.akbc.ws/2019/" == header.find_element(By.XPATH, ".//span[@class='venue-website']/a").text
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 0
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         with pytest.raises(NoSuchElementException):
-            notes_panel.find_element_by_class_name('spinner-container')
+            notes_panel.find_element(By.CLASS_NAME, 'spinner-container')
 
     def test_enable_submissions(self, client, selenium, request_page):
 
@@ -245,25 +246,25 @@ class TestDoubleBlindConference():
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", wait_for_element='notes')
 
         assert "AKBC 2019 Conference | OpenReview" in selenium.title
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert "AKBC 2019" == header.find_element_by_tag_name("h1").text
-        assert "Automated Knowledge Base Construction" == header.find_element_by_tag_name("h3").text
-        assert "Amherst, Massachusetts, United States" == header.find_element_by_xpath(".//span[@class='venue-location']").text
-        assert "May 20 - May 21, 2019" == header.find_element_by_xpath(".//span[@class='venue-date']").text
-        assert "http://www.akbc.ws/2019/" == header.find_element_by_xpath(".//span[@class='venue-website']/a").text
-        invitation_panel = selenium.find_element_by_id('invitation')
+        assert "AKBC 2019" == header.find_element(By.TAG_NAME, "h1").text
+        assert "Automated Knowledge Base Construction" == header.find_element(By.TAG_NAME, "h3").text
+        assert "Amherst, Massachusetts, United States" == header.find_element(By.XPATH, ".//span[@class='venue-location']").text
+        assert "May 20 - May 21, 2019" == header.find_element(By.XPATH, ".//span[@class='venue-date']").text
+        assert "http://www.akbc.ws/2019/" == header.find_element(By.XPATH, ".//span[@class='venue-website']/a").text
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'AKBC 2019 Conference Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'AKBC 2019 Conference Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 0
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_tag_name('ul')) == 0
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 0
+        assert tabs.find_elements(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.TAG_NAME, 'ul')) == 0
 
     def test_post_submissions(self, client, test_client, peter_client, selenium, request_page):
 
@@ -340,68 +341,68 @@ class TestDoubleBlindConference():
 
         # Author user
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", test_client.token, wait_for_element='your-consoles')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'AKBC 2019 Conference Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'AKBC 2019 Conference Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Author Console' == console.find_element_by_tag_name('a').text
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 1
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
+        assert tabs.find_elements(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 1
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference/Authors", test_client.token, wait_for_element='your-submissions')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 2
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 2
 
         # Guest user
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", wait_for_element='your-consoles')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'AKBC 2019 Conference Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'AKBC 2019 Conference Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 0
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 0
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 0
+        assert tabs.find_elements(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 0
 
         # Co-author user
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", peter_client.token, wait_for_element='your-consoles')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'AKBC 2019 Conference Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'AKBC 2019 Conference Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Author Console' == console.find_element_by_tag_name('a').text
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 1
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
+        assert tabs.find_elements(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 1
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference/Authors", peter_client.token, wait_for_element='your-submissions')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 2
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 2
 
     def test_recruit_reviewers(self, client, selenium, request_page, helpers):
 
@@ -674,7 +675,7 @@ class TestDoubleBlindConference():
 
         request_page(selenium, accept_url, alert=True)
 
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'Wrong key, please refer back to the recruitment email' == error_message.text
 
         group = client.get_group('AKBC.ws/2019/Conference/Area_Chairs')
@@ -737,9 +738,9 @@ class TestDoubleBlindConference():
         assert len(group.members) == 0
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference/Program_Chairs", client.token, by='link text', wait_for_element='Paper Status')
-        assert selenium.find_element_by_link_text('Paper Status')
-        assert selenium.find_element_by_link_text('Area Chair Status')
-        assert selenium.find_element_by_link_text('Reviewer Status')
+        assert selenium.find_element(By.LINK_TEXT, 'Paper Status')
+        assert selenium.find_element(By.LINK_TEXT, 'Area Chair Status')
+        assert selenium.find_element(By.LINK_TEXT, 'Reviewer Status')
 
     def test_close_submission(self, client, test_client, selenium, request_page):
 
@@ -783,8 +784,8 @@ class TestDoubleBlindConference():
 
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='edit_button')
 
-        assert len(selenium.find_elements_by_class_name('edit_button')) == 1
-        assert len(selenium.find_elements_by_class_name('trash_button')) == 1
+        assert len(selenium.find_element(By.CLASS_NAME, 'edit_button')) == 1
+        assert len(selenium.find_element(By.CLASS_NAME, 'trash_button')) == 1
 
     def test_create_blind_submissions(self, client, test_client):
 
@@ -948,10 +949,10 @@ class TestDoubleBlindConference():
         submission = notes[0]
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 2
-        assert 'Official Comment' == reply_row.find_elements_by_class_name('btn')[0].text
-        assert 'Withdraw' == reply_row.find_elements_by_class_name('btn')[1].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 2
+        assert 'Official Comment' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
+        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[1].text
 
     def test_close_comments(self, client, test_client, selenium, request_page):
 
@@ -970,9 +971,9 @@ class TestDoubleBlindConference():
         submission = notes[0]
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Withdraw' == reply_row.find_elements_by_class_name('btn')[0].text        
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text        
 
     def test_open_bids(self, client, test_client, selenium, request_page, helpers):
 
@@ -995,15 +996,15 @@ class TestDoubleBlindConference():
         conference.create_bid_stages()
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tabs-containe')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_elements_by_class_name('note')
+        notes = selenium.find_element(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token, by=By.CLASS_NAME, wait_for_element='tabs-containe')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_elements_by_class_name('note')
+        notes = selenium.find_element(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         conference.bid_stages['AKBC.ws/2019/Conference/Reviewers'] = openreview.stages.BidStage('AKBC.ws/2019/Conference/Reviewers', due_date =  now + datetime.timedelta(minutes = 10), request_count = 50, score_ids=['AKBC.ws/2019/Conference/Reviewers/-/Affinity_Score'])
@@ -1011,21 +1012,21 @@ class TestDoubleBlindConference():
         conference.create_bid_stages()
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token, by=By.CLASS_NAME, wait_for_element='note')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_elements_by_class_name('note')
+        notes = selenium.find_element(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer2_client.token, by=By.CLASS_NAME, wait_for_element='note')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_elements_by_class_name('note')
+        notes = selenium.find_element(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token, by=By.CLASS_NAME, wait_for_element='note')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_elements_by_class_name('note')
+        notes = selenium.find_element(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
         notes = client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
@@ -1039,21 +1040,21 @@ class TestDoubleBlindConference():
         conference.setup_matching(affinity_score_file=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), build_conflicts=True)
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token, by=By.CLASS_NAME, wait_for_element='note')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_elements_by_class_name('note')
+        notes = selenium.find_element(By.CLASS_NAME, 'note')
         assert not notes
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer2_client.token, by=By.CLASS_NAME, wait_for_element='note')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_elements_by_class_name('note')
+        notes = selenium.find_element(By.CLASS_NAME, 'note')
         assert len(notes) == 1
 
         request_page(selenium, "http://localhost:3030/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token, by=By.CLASS_NAME, wait_for_element='note')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        notes = selenium.find_elements_by_class_name('note')
+        notes = selenium.find_element(By.CLASS_NAME, 'note')
         assert len(notes) == 3
 
     def test_open_reviews(self, client, test_client, selenium, request_page, helpers):
@@ -1083,16 +1084,16 @@ class TestDoubleBlindConference():
         # Reviewer
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Official Review' == reply_row.find_elements_by_class_name('btn')[0].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert 'Official Review' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
 
         # Author
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Withdraw' == reply_row.find_elements_by_class_name('btn')[0].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
 
         anon_reviewers_group_id = reviewer_client.get_groups(regex=f'{conference.id}/Paper1/Reviewer_', signatory='reviewer2@mail.com')[0].id
 
@@ -1500,31 +1501,31 @@ class TestDoubleBlindConference():
         pc_client = openreview.Client(baseurl = 'http://localhost:3000', username='pc@mail.com', password=helpers.strong_password)
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", pc_client.token, wait_for_element='your-consoles')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Program Chair Console' == console.find_element_by_tag_name('a').text
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Program Chair Console' == console.find_element(By.TAG_NAME, 'a').text
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference/Program_Chairs#paper-status", pc_client.token, wait_for_element='paper-status')
         assert "AKBC 2019 Conference Program Chairs | OpenReview" in selenium.title
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('venue-configuration')
-        assert tabs.find_element_by_id('paper-status')
-        assert tabs.find_element_by_id('reviewer-status')
-        assert tabs.find_element_by_id('areachair-status')
+        assert tabs.find_element(By.ID, 'venue-configuration')
+        assert tabs.find_element(By.ID, 'paper-status')
+        assert tabs.find_element(By.ID, 'reviewer-status')
+        assert tabs.find_element(By.ID, 'areachair-status')
 
-        assert '#' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-1').text
-        assert 'Paper Summary' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-2').text
-        assert 'Review Progress' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-3').text
-        assert 'Status' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-4').text
-        assert 'Decision' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-5').text
+        assert '#' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-1').text
+        assert 'Paper Summary' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-2').text
+        assert 'Review Progress' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-3').text
+        assert 'Status' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-4').text
+        assert 'Decision' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-5').text
 
     def test_reassign_reviewers_with_conflict_of_interest(self, client, test_client, selenium, request_page, helpers):
         builder=openreview.conference.ConferenceBuilder(client)
@@ -1539,21 +1540,21 @@ class TestDoubleBlindConference():
         ac_client=openreview.Client(baseurl = 'http://localhost:3000', username='ac@mail.com', password=helpers.strong_password)
         request_page(selenium,"http://localhost:3030/group?id=AKBC.ws/2019/Conference/Area_Chairs",ac_client.token, by=By.XPATH, wait_for_element='//*[@id="1-reviewer-progress"]/a')
 
-        show_Reviewers_AnchorTag=selenium.find_element_by_xpath('//*[@id="1-reviewer-progress"]/a')
+        show_Reviewers_AnchorTag=selenium.find_element(By. XPATH, '//*[@id="1-reviewer-progress"]/a')
         selenium.execute_script("arguments[0].click()",show_Reviewers_AnchorTag) #click on "show reviewers anchor tag"
         time.sleep(5) #leave some time for the API and js to complete
 
         #get the reviewers textbox and click on it to show dropdown
         assign_Reviewer_Textbox_Present=EC.presence_of_element_located((By.XPATH,'//*[@id="1-add-reviewer"]/div/input'))
         WebDriverWait(selenium,5).until(assign_Reviewer_Textbox_Present)
-        assign_Reviewer_Textbox=selenium.find_element_by_xpath('//*[@id="1-add-reviewer"]/div/input')
+        assign_Reviewer_Textbox=selenium.find_element(By. XPATH, '//*[@id="1-add-reviewer"]/div/input')
         selenium.execute_script("arguments[0].click()",assign_Reviewer_Textbox)
 
         #get the dropdown div and check how many dropdown options in it
         dropdown_Options_Present=EC.presence_of_element_located((By.XPATH,'//*[@id="1-add-reviewer"]/div/div'))
         WebDriverWait(selenium,5).until(dropdown_Options_Present)
-        dropdown_Options=selenium.find_element_by_xpath('//*[@id="1-add-reviewer"]/div/div')
-        assert len(dropdown_Options.find_elements_by_xpath('//*[@id="1-add-reviewer"]/div/div/div'))==1
+        dropdown_Options=selenium.find_element(By. XPATH, '//*[@id="1-add-reviewer"]/div/div')
+        assert len(dropdown_Options.find_elements(By. XPATH, '//*[@id="1-add-reviewer"]/div/div/div'))==1
 
     def test_open_revise_submissions(self, client, test_client, helpers):
 
@@ -2060,21 +2061,21 @@ url={'''
                                                              'Reject': 'Reject'})
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", by=By.ID, wait_for_element='header')
         assert "AKBC 2019 Conference | OpenReview" in selenium.title
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert "AKBC.ws/2019/Conference" == header.find_element_by_tag_name("h1").text
-        invitation_panel = selenium.find_element_by_id('invitation')
+        assert "AKBC.ws/2019/Conference" == header.find_element(By.TAG_NAME, "h1").text
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 0
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         with pytest.raises(NoSuchElementException):
-            notes_panel.find_element_by_class_name('spinner-container')
-        assert tabs.find_element_by_id('accepted-poster-papers')
-        assert tabs.find_element_by_id('accepted-oral-papers')
-        assert tabs.find_element_by_id('reject')
+            notes_panel.find_element(By.CLASS_NAME, 'spinner-container')
+        assert tabs.find_element(By.ID, 'accepted-poster-papers')
+        assert tabs.find_element(By.ID, 'accepted-oral-papers')
+        assert tabs.find_element(By.ID, 'reject')
 
         notes = conference.get_submissions(sort='tmdate')
         assert notes
@@ -2129,21 +2130,21 @@ url={'''
 
         request_page(selenium, "http://localhost:3030/group?id=AKBC.ws/2019/Conference", wait_for_element='reject')
         assert "AKBC 2019 Conference | OpenReview" in selenium.title
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert "AKBC.ws/2019/Conference" == header.find_element_by_tag_name("h1").text
-        invitation_panel = selenium.find_element_by_id('invitation')
+        assert "AKBC.ws/2019/Conference" == header.find_element(By.TAG_NAME, "h1").text
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 0
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         with pytest.raises(NoSuchElementException):
-            notes_panel.find_element_by_class_name('spinner-container')
-        assert tabs.find_element_by_id('accepted-poster-papers')
-        assert tabs.find_element_by_id('accepted-oral-papers')
-        assert tabs.find_element_by_id('reject')
+            notes_panel.find_element(By.CLASS_NAME, 'spinner-container')
+        assert tabs.find_element(By.ID, 'accepted-poster-papers')
+        assert tabs.find_element(By.ID, 'accepted-oral-papers')
+        assert tabs.find_element(By.ID, 'reject')
 
         notes = conference.get_submissions(sort='tmdate')
         assert notes

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1540,20 +1540,20 @@ class TestDoubleBlindConference():
         ac_client=openreview.Client(baseurl = 'http://localhost:3000', username='ac@mail.com', password=helpers.strong_password)
         request_page(selenium,"http://localhost:3030/group?id=AKBC.ws/2019/Conference/Area_Chairs",ac_client.token, by=By.XPATH, wait_for_element='//*[@id="1-reviewer-progress"]/a')
 
-        show_Reviewers_AnchorTag=selenium.find_element(By. XPATH, '//*[@id="1-reviewer-progress"]/a')
+        show_Reviewers_AnchorTag=selenium.find_element(By.XPATH, '//*[@id="1-reviewer-progress"]/a')
         selenium.execute_script("arguments[0].click()",show_Reviewers_AnchorTag) #click on "show reviewers anchor tag"
         time.sleep(5) #leave some time for the API and js to complete
 
         #get the reviewers textbox and click on it to show dropdown
         assign_Reviewer_Textbox_Present=EC.presence_of_element_located((By.XPATH,'//*[@id="1-add-reviewer"]/div/input'))
         WebDriverWait(selenium,5).until(assign_Reviewer_Textbox_Present)
-        assign_Reviewer_Textbox=selenium.find_element(By. XPATH, '//*[@id="1-add-reviewer"]/div/input')
+        assign_Reviewer_Textbox=selenium.find_element(By.XPATH, '//*[@id="1-add-reviewer"]/div/input')
         selenium.execute_script("arguments[0].click()",assign_Reviewer_Textbox)
 
         #get the dropdown div and check how many dropdown options in it
         dropdown_Options_Present=EC.presence_of_element_located((By.XPATH,'//*[@id="1-add-reviewer"]/div/div'))
         WebDriverWait(selenium,5).until(dropdown_Options_Present)
-        dropdown_Options=selenium.find_element(By. XPATH, '//*[@id="1-add-reviewer"]/div/div')
+        dropdown_Options=selenium.find_element(By.XPATH, '//*[@id="1-add-reviewer"]/div/div')
         assert len(dropdown_Options.find_elements(By. XPATH, '//*[@id="1-add-reviewer"]/div/div/div'))==1
 
     def test_open_revise_submissions(self, client, test_client, helpers):

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -724,7 +724,7 @@ Please contact info@openreview.net with any questions or concerns about this int
             tpms_score_file=os.path.join(os.path.dirname(__file__), 'data/temp.csv'))
 
         request_page(selenium, url='http://localhost:3030/assignments?group=thecvf.com/ECCV/2020/Conference/Reviewers', token=conference.client.token, wait_for_element='note-editor-modal')
-        new_assignment_btn = selenium.find_element(By. XPATH, '//button[text()="New Assignment Configuration"]')
+        new_assignment_btn = selenium.find_element(By.XPATH, '//button[text()="New Assignment Configuration"]')
         assert new_assignment_btn
         new_assignment_btn.click()
 

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -346,9 +346,9 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         assert len(invited_group.members) == 2
 
         request_page(selenium, reject_url, alert=True, wait_for_element='notes')
-        notes = selenium.find_element_by_id("notes")
+        notes = selenium.find_element(By.ID, 'notes')
         assert notes
-        messages = notes.find_elements_by_tag_name("h3")
+        messages = notes.find_elements(By.TAG_NAME, 'h3')
         assert messages
         assert 'You have declined the invitation from 2020 European Conference on Computer Vision.' == messages[0].text
         assert 'In case you only declined because you think you cannot handle the maximum load of papers, you can reduce your load slightly. Be aware that this will decrease your overall score for an outstanding reviewer award, since all good reviews will accumulate a positive score. You can request a reduced reviewer load by clicking here: Request reduced load' == messages[1].text
@@ -407,12 +407,12 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         reviewer_tasks_url = 'http://localhost:3030/group?id=' + conference.get_reviewers_id() + '#reviewer-tasks'
         request_page(selenium, reviewer_tasks_url, reviewer_client.token)
 
-        assert selenium.find_element_by_link_text('Expertise Selection')
+        assert selenium.find_element(By.LINK_TEXT, 'Expertise Selection')
 
         request_page(selenium, 'http://localhost:3030/invitation?id=thecvf.com/ECCV/2020/Conference/-/Expertise_Selection', reviewer_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_elements_by_class_name("description")
+        notes = header.find_element(By.CLASS_NAME, "description")
         assert notes
         assert len(notes) == 1
         assert notes[0].text == '''Listed below are all the papers you have authored that exist in the OpenReview database.
@@ -431,7 +431,7 @@ Please contact info@openreview.net with any questions or concerns about this int
         reviewer_tasks_url = 'http://localhost:3030/group?id=' + conference.get_reviewers_id() + '#reviewer-tasks'
         request_page(selenium, reviewer_tasks_url, reviewer_client.token, by=By.LINK_TEXT, wait_for_element='Reviewer Profile Confirmation')
 
-        assert selenium.find_element_by_link_text('Reviewer Profile Confirmation')
+        assert selenium.find_element(By.LINK_TEXT, 'Reviewer Profile Confirmation')
 
         registration_notes = reviewer_client.get_notes(invitation = 'thecvf.com/ECCV/2020/Conference/Reviewers/-/Profile_Confirmation_Form')
         assert registration_notes
@@ -467,18 +467,18 @@ Please contact info@openreview.net with any questions or concerns about this int
 
 
         request_page(selenium, 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Reviewers', reviewer_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_elements_by_class_name("description")
+        notes = header.find_element(By.CLASS_NAME, "description")
         assert notes
         assert len(notes) == 1
         assert notes[0].text == 'This page provides information and status updates for the ECCV 2020. It will be regularly updated as the conference progresses, so please check back frequently.\nYou have agreed to review up to 7 papers.'
 
         reviewer2_client = helpers.create_user('mohit+1@mail.com', 'Mohit', 'EccvReviewer')
         request_page(selenium, 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Reviewers', reviewer2_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_elements_by_class_name("description")
+        notes = header.find_element(By.CLASS_NAME, "description")
         assert notes
         assert len(notes) == 1
         assert notes[0].text == 'This page provides information and status updates for the ECCV 2020. It will be regularly updated as the conference progresses, so please check back frequently.\nYou have agreed to review up to 4 papers.'
@@ -489,7 +489,7 @@ Please contact info@openreview.net with any questions or concerns about this int
         reviewer_tasks_url = 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Area_Chairs#areachair-tasks'
         request_page(selenium, reviewer_tasks_url, ac_client.token, by=By.LINK_TEXT, wait_for_element='Area Chair Profile Confirmation')
 
-        assert selenium.find_element_by_link_text('Area Chair Profile Confirmation')
+        assert selenium.find_element(By.LINK_TEXT, 'Area Chair Profile Confirmation')
 
     def test_submission_additional_files(self, conference, test_client):
 
@@ -639,12 +639,12 @@ Please contact info@openreview.net with any questions or concerns about this int
         reviewer_tasks_url = 'http://localhost:3030/group?id=' + conference.get_reviewers_id() + '#reviewer-tasks'
         request_page(selenium, reviewer_tasks_url, reviewer_client.token, by=By.LINK_TEXT, wait_for_element='Reviewer Bid')
 
-        assert selenium.find_element_by_link_text('Reviewer Bid')
+        assert selenium.find_element(By.LINK_TEXT, 'Reviewer Bid')
 
         request_page(selenium, 'http://localhost:3030/invitation?id=thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid', reviewer_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_elements_by_tag_name("li")
+        notes = header.find_elements(By.TAG_NAME, 'li')
         assert notes
         assert len(notes) == 6
         assert notes[4].text == 'Ensure that you have at least 40 bids, which are "Very High" or "High".'
@@ -652,12 +652,12 @@ Please contact info@openreview.net with any questions or concerns about this int
         ac_client = openreview.Client(username='test_ac_eccv@mail.com', password=helpers.strong_password)
         request_page(selenium, 'http://localhost:3030/group?id=' + conference.get_area_chairs_id() + '#areachair-tasks', ac_client.token, by=By.LINK_TEXT, wait_for_element='Area Chair Bid')
 
-        assert selenium.find_element_by_link_text('Area Chair Bid')
+        assert selenium.find_element(By.LINK_TEXT, 'Area Chair Bid')
 
         request_page(selenium, 'http://localhost:3030/invitation?id=thecvf.com/ECCV/2020/Conference/Area_Chairs/-/Bid', ac_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_elements_by_tag_name("li")
+        notes = header.find_elements(By.TAG_NAME, 'li')
         assert notes
         assert len(notes) == 6
         assert notes[4].text == 'Ensure that you have at least 60 bids, which are "Very High" or "High".'
@@ -724,19 +724,19 @@ Please contact info@openreview.net with any questions or concerns about this int
             tpms_score_file=os.path.join(os.path.dirname(__file__), 'data/temp.csv'))
 
         request_page(selenium, url='http://localhost:3030/assignments?group=thecvf.com/ECCV/2020/Conference/Reviewers', token=conference.client.token, wait_for_element='note-editor-modal')
-        new_assignment_btn = selenium.find_element_by_xpath('//button[text()="New Assignment Configuration"]')
+        new_assignment_btn = selenium.find_element(By. XPATH, '//button[text()="New Assignment Configuration"]')
         assert new_assignment_btn
         new_assignment_btn.click()
 
-        pop_up_div = selenium.find_element_by_id('note-editor-modal')
+        pop_up_div = selenium.find_element(By.ID, 'note-editor-modal')
         assert pop_up_div
         assert pop_up_div.get_attribute('class') == 'modal fade in'
 
-        custom_user_demand_invitation = selenium.find_element_by_name('custom_user_demand_invitation')
+        custom_user_demand_invitation = selenium.find_element(By.NAME, 'custom_user_demand_invitation')
         assert custom_user_demand_invitation
         assert custom_user_demand_invitation.get_attribute('value') == 'thecvf.com/ECCV/2020/Conference/Reviewers/-/Custom_User_Demands'
 
-        custom_max_papers_invitation = selenium.find_element_by_name('custom_max_papers_invitation')
+        custom_max_papers_invitation = selenium.find_element(By.NAME, 'custom_max_papers_invitation')
         assert custom_max_papers_invitation
         assert custom_max_papers_invitation.get_attribute('value') == 'thecvf.com/ECCV/2020/Conference/Reviewers/-/Custom_Max_Papers'
 
@@ -926,9 +926,9 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         url = 'http://localhost:3030/edges/browse?start={start}&traverse={edit}&edit={edit}&browse={browse}&hide={hide}&referrer={referrer}&maxColumns=2'.format(start=start, edit=edit, browse=browse, hide=hide, referrer=referrer)
 
         request_page(selenium, 'http://localhost:3030/invitation?id=thecvf.com/ECCV/2020/Conference/Reviewers/-/Recommendation', ac1_client.token, wait_for_element='notes')
-        panel = selenium.find_element_by_id('notes')
+        panel = selenium.find_element(By.ID, 'notes')
         assert panel
-        links = panel.find_elements_by_tag_name('a')
+        links = panel.find_elements(By.TAG_NAME, 'a')
         assert links
         assert len(links) == 1
         assert url == links[0].get_attribute("href")
@@ -1017,12 +1017,12 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         assert 'thecvf.com/ECCV/2020/Conference/Paper5/Authors' not in author_group.members
 
         request_page(selenium, "http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Authors", test_client.token, by=By.CLASS_NAME, wait_for_element='tabs-container')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 5
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 5
 
     def test_withdraw_submission(self, conference, client, test_client, selenium, request_page, helpers):
 
@@ -1079,12 +1079,12 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         assert 'thecvf.com/ECCV/2020/Conference/Paper4/Authors' not in author_group.members
 
         request_page(selenium, "http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Authors", test_client.token, by=By.CLASS_NAME, wait_for_element='tabs-container')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 4
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 4
 
     def test_review_stage(self, conference, client, test_client, selenium, request_page, helpers):
 
@@ -1272,7 +1272,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
         #Assert reviewer is still in reviewer group
         request_page(selenium, reject_url, alert=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'You have already been assigned to a paper. Please contact the paper area chair or program chairs to be unassigned.' == error_message.text
 
         reviewer_group = client.get_group('thecvf.com/ECCV/2020/Conference/Reviewers')
@@ -1391,7 +1391,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
 
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , test_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
-        notes = selenium.find_elements_by_class_name('note_with_children')
+        notes = selenium.find_element(By.CLASS_NAME, 'note_with_children')
         assert len(notes) == 2
 
     def test_paper_ranking_stage(self, conference, client, test_client, selenium, request_page, helpers):
@@ -1400,16 +1400,16 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         ac_url = 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Area_Chairs'
         request_page(selenium, ac_url, ac_client.token, wait_for_element='1-metareview-status')
 
-        status = selenium.find_element_by_id("1-metareview-status")
+        status = selenium.find_element(By.ID, '1-metareview-status')
         assert status
 
-        assert not status.find_elements_by_class_name('tag-widget')
+        assert not status.find_element(By.CLASS_NAME, 'tag-widget')
 
         reviewer_client = openreview.Client(username='reviewer1@fb.com', password=helpers.strong_password)
         reviewer_url = 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-        assert not selenium.find_elements_by_class_name('tag-widget')
+        assert not selenium.find_element(By.CLASS_NAME, 'tag-widget')
 
         now = datetime.datetime.utcnow()
         conference.open_paper_ranking(conference.get_area_chairs_id(), due_date=now + datetime.timedelta(minutes = 40))
@@ -1418,17 +1418,17 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         ac_url = 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Area_Chairs'
         request_page(selenium, ac_url, ac_client.token, wait_for_element='1-metareview-status')
 
-        status = selenium.find_element_by_id("1-metareview-status")
+        status = selenium.find_element(By.ID, '1-metareview-status')
         assert status
 
-        tag = status.find_element_by_class_name('tag-widget')
+        tag = status.find_element(By.CLASS_NAME, 'tag-widget')
         assert tag
 
-        options = tag.find_elements_by_tag_name("li")
+        options = tag.find_elements(By.TAG_NAME, 'li')
         assert options
         assert len(options) == 3
 
-        options = tag.find_elements_by_tag_name("a")
+        options = tag.find_elements(By.TAG_NAME, 'a')
         assert options
         assert len(options) == 3
 
@@ -1446,14 +1446,14 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         reviewer_url = 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-        tags = selenium.find_elements_by_class_name('tag-widget')
+        tags = selenium.find_element(By.CLASS_NAME, 'tag-widget')
         assert tags
 
-        options = tags[0].find_elements_by_tag_name("li")
+        options = tags[0].find_elements(By.TAG_NAME, 'li')
         assert options
         assert len(options) == 3
 
-        options = tags[0].find_elements_by_tag_name("a")
+        options = tags[0].find_elements(By.TAG_NAME, 'a')
         assert options
         assert len(options) == 3
 
@@ -1495,13 +1495,13 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         conference.review_rebuttal_stage = openreview.stages.ReviewRebuttalStage(due_date=now + datetime.timedelta(minutes = 40))
         conference.create_review_rebuttal_stage()
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , test_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
-        notes = selenium.find_elements_by_class_name('note_with_children')
+        notes = selenium.find_element(By.CLASS_NAME, 'note_with_children')
         assert len(notes) == 2
 
-        button = notes[0].find_element_by_class_name('btn')
+        button = notes[0].find_element(By.CLASS_NAME, 'btn')
         assert button
 
-        button = notes[1].find_element_by_class_name('btn')
+        button = notes[1].find_element(By.CLASS_NAME, 'btn')
         assert button
 
         signatory = client.get_groups(regex='thecvf.com/ECCV/2020/Conference/Paper1/Reviewer_.*', signatory='reviewer2@google.com')[0].id
@@ -1575,13 +1575,13 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         reviewer_client = openreview.Client(username='reviewer2@google.com', password=helpers.strong_password)
 
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , reviewer_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
-        notes = selenium.find_elements_by_class_name('note_with_children')
+        notes = selenium.find_element(By.CLASS_NAME, 'note_with_children')
         assert len(notes) == 4
 
-        buttons = notes[0].find_elements_by_class_name('btn')
+        buttons = notes[0].find_element(By.CLASS_NAME, 'btn')
         assert len(buttons) == 4
 
-        buttons = notes[1].find_elements_by_class_name('btn')
+        buttons = notes[1].find_element(By.CLASS_NAME, 'btn')
         assert len(buttons) == 7
 
         signatory = reviewer_client.get_groups(regex='thecvf.com/ECCV/2020/Conference/Paper1/Reviewer_.*', signatory='reviewer2@google.com')[0].id
@@ -1650,13 +1650,13 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         blinded_notes = conference.get_submissions(sort='tmdate')
 
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , ac_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
-        notes = selenium.find_elements_by_class_name('note_with_children')
+        notes = selenium.find_element(By.CLASS_NAME, 'note_with_children')
         assert len(notes) == 4
 
-        buttons = notes[0].find_elements_by_class_name('btn')
+        buttons = notes[0].find_element(By.CLASS_NAME, 'btn')
         assert len(buttons) == 2
 
-        buttons = notes[1].find_elements_by_class_name('btn')
+        buttons = notes[1].find_element(By.CLASS_NAME, 'btn')
         assert len(buttons) == 5
 
         reviews = ac_client.get_notes(forum=blinded_notes[2].id, invitation=f'thecvf.com/ECCV/2020/Conference/Paper{blinded_notes[2].number}/-/Official_Review')
@@ -1691,11 +1691,11 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         request_page(selenium, ac_url, ac_client.token, by=By.LINK_TEXT, wait_for_element='Assigned Papers')
 
         # Check that Secondary AC Assignments tab is not visible
-        notes_div = selenium.find_element_by_id('notes')
-        assert notes_div.find_element_by_link_text('Assigned Papers')
-        assert notes_div.find_element_by_link_text('Area Chair Tasks')
+        notes_div = selenium.find_element(By.ID, 'notes')
+        assert notes_div.find_element(By.LINK_TEXT, 'Assigned Papers')
+        assert notes_div.find_element(By.LINK_TEXT, 'Area Chair Tasks')
         with pytest.raises(NoSuchElementException):
-            notes_div.find_element_by_link_text('Secondary AC Assignments')
+            notes_div.find_element(By.LINK_TEXT, 'Secondary AC Assignments')
 
         # Enable secondary area chairs tab in AC console
         conference.has_secondary_area_chairs(True)
@@ -1719,14 +1719,14 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         ac_client2 = openreview.Client(username='ac2@eccv.org', password=helpers.strong_password)
         request_page(selenium, ac_url, ac_client2.token, by=By.LINK_TEXT, wait_for_element='Assigned Papers')
 
-        notes_div = selenium.find_element_by_id('notes')
-        assert notes_div.find_element_by_link_text('Assigned Papers')
-        assert notes_div.find_element_by_link_text('Area Chair Tasks')
-        assert notes_div.find_element_by_link_text('Secondary AC Assignments')
+        notes_div = selenium.find_element(By.ID, 'notes')
+        assert notes_div.find_element(By.LINK_TEXT, 'Assigned Papers')
+        assert notes_div.find_element(By.LINK_TEXT, 'Area Chair Tasks')
+        assert notes_div.find_element(By.LINK_TEXT, 'Secondary AC Assignments')
 
-        secondary_assignments_div = selenium.find_element_by_id('secondary-papers')
+        secondary_assignments_div = selenium.find_element(By.ID, 'secondary-papers')
         for i in range(1,3):
-            assert secondary_assignments_div.find_elements_by_id('note-summary-{}'.format(i))
+            assert secondary_assignments_div.find_elements(By.ID, 'note-summary-{}'.format(i))
 
     def test_chronological_pc_timeline(self, conference, selenium, request_page, helpers):
         # Assumptions: 1) Items are in list elements
@@ -1753,7 +1753,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         request_page(selenium, ac_url, ac_client.token, by=By.TAG_NAME, wait_for_element='li')
 
         # Get the timeline text - order of elements retrieved is order of elements on page top -> bottom
-        list_elements = selenium.find_elements_by_tag_name('li')
+        list_elements = selenium.find_elements(By.TAG_NAME, 'li')
         retrieved_dates = []
         for element in list_elements:
             element_text = element.text.lower()

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -412,7 +412,7 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         request_page(selenium, 'http://localhost:3030/invitation?id=thecvf.com/ECCV/2020/Conference/-/Expertise_Selection', reviewer_client.token, wait_for_element='header')
         header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_element(By.CLASS_NAME, "description")
+        notes = header.find_elements(By.CLASS_NAME, "description")
         assert notes
         assert len(notes) == 1
         assert notes[0].text == '''Listed below are all the papers you have authored that exist in the OpenReview database.
@@ -469,7 +469,7 @@ Please contact info@openreview.net with any questions or concerns about this int
         request_page(selenium, 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Reviewers', reviewer_client.token, wait_for_element='header')
         header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_element(By.CLASS_NAME, "description")
+        notes = header.find_elements(By.CLASS_NAME, "description")
         assert notes
         assert len(notes) == 1
         assert notes[0].text == 'This page provides information and status updates for the ECCV 2020. It will be regularly updated as the conference progresses, so please check back frequently.\nYou have agreed to review up to 7 papers.'
@@ -478,7 +478,7 @@ Please contact info@openreview.net with any questions or concerns about this int
         request_page(selenium, 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Reviewers', reviewer2_client.token, wait_for_element='header')
         header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_element(By.CLASS_NAME, "description")
+        notes = header.find_elements(By.CLASS_NAME, "description")
         assert notes
         assert len(notes) == 1
         assert notes[0].text == 'This page provides information and status updates for the ECCV 2020. It will be regularly updated as the conference progresses, so please check back frequently.\nYou have agreed to review up to 4 papers.'
@@ -1391,7 +1391,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
 
 
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , test_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
-        notes = selenium.find_element(By.CLASS_NAME, 'note_with_children')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note_with_children')
         assert len(notes) == 2
 
     def test_paper_ranking_stage(self, conference, client, test_client, selenium, request_page, helpers):
@@ -1403,13 +1403,13 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         status = selenium.find_element(By.ID, '1-metareview-status')
         assert status
 
-        assert not status.find_element(By.CLASS_NAME, 'tag-widget')
+        assert not status.find_elements(By.CLASS_NAME, 'tag-widget')
 
         reviewer_client = openreview.Client(username='reviewer1@fb.com', password=helpers.strong_password)
         reviewer_url = 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-        assert not selenium.find_element(By.CLASS_NAME, 'tag-widget')
+        assert not selenium.find_elements(By.CLASS_NAME, 'tag-widget')
 
         now = datetime.datetime.utcnow()
         conference.open_paper_ranking(conference.get_area_chairs_id(), due_date=now + datetime.timedelta(minutes = 40))
@@ -1446,7 +1446,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         reviewer_url = 'http://localhost:3030/group?id=thecvf.com/ECCV/2020/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-        tags = selenium.find_element(By.CLASS_NAME, 'tag-widget')
+        tags = selenium.find_elements(By.CLASS_NAME, 'tag-widget')
         assert tags
 
         options = tags[0].find_elements(By.TAG_NAME, 'li')
@@ -1495,7 +1495,7 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         conference.review_rebuttal_stage = openreview.stages.ReviewRebuttalStage(due_date=now + datetime.timedelta(minutes = 40))
         conference.create_review_rebuttal_stage()
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , test_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
-        notes = selenium.find_element(By.CLASS_NAME, 'note_with_children')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note_with_children')
         assert len(notes) == 2
 
         button = notes[0].find_element(By.CLASS_NAME, 'btn')
@@ -1575,13 +1575,13 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         reviewer_client = openreview.Client(username='reviewer2@google.com', password=helpers.strong_password)
 
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , reviewer_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
-        notes = selenium.find_element(By.CLASS_NAME, 'note_with_children')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note_with_children')
         assert len(notes) == 4
 
-        buttons = notes[0].find_element(By.CLASS_NAME, 'btn')
+        buttons = notes[0].find_elements(By.CLASS_NAME, 'btn')
         assert len(buttons) == 4
 
-        buttons = notes[1].find_element(By.CLASS_NAME, 'btn')
+        buttons = notes[1].find_elements(By.CLASS_NAME, 'btn')
         assert len(buttons) == 7
 
         signatory = reviewer_client.get_groups(regex='thecvf.com/ECCV/2020/Conference/Paper1/Reviewer_.*', signatory='reviewer2@google.com')[0].id
@@ -1650,13 +1650,13 @@ thecvf.com/ECCV/2020/Conference/Reviewers/-/Bid'
         blinded_notes = conference.get_submissions(sort='tmdate')
 
         request_page(selenium, 'http://localhost:3030/forum?id=' + blinded_notes[2].id , ac_client.token, by=By.CLASS_NAME, wait_for_element='note_with_children')
-        notes = selenium.find_element(By.CLASS_NAME, 'note_with_children')
+        notes = selenium.find_elements(By.CLASS_NAME, 'note_with_children')
         assert len(notes) == 4
 
-        buttons = notes[0].find_element(By.CLASS_NAME, 'btn')
+        buttons = notes[0].find_elements(By.CLASS_NAME, 'btn')
         assert len(buttons) == 2
 
-        buttons = notes[1].find_element(By.CLASS_NAME, 'btn')
+        buttons = notes[1].find_elements(By.CLASS_NAME, 'btn')
         assert len(buttons) == 5
 
         reviews = ac_client.get_notes(forum=blinded_notes[2].id, invitation=f'thecvf.com/ECCV/2020/Conference/Paper{blinded_notes[2].number}/-/Official_Review')

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -340,7 +340,7 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         request_page(selenium, 'http://localhost:3030/group?id=ICLR.cc/2021/Conference/Reviewers', reviewer_client.token, wait_for_element='header')
         header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_element(By.CLASS_NAME, "description")
+        notes = header.find_elements(By.CLASS_NAME, "description")
         assert notes
         assert len(notes) == 1
         assert notes[0].text == 'This page provides information and status updates for the ICLR 2021. It will be regularly updated as the conference progresses, so please check back frequently.'
@@ -351,8 +351,8 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         assert selenium.find_element(By.LINK_TEXT, 'Expertise Selection')
         tasks = selenium.find_element(By.ID, 'reviewer-tasks')
         assert tasks
-        assert len(tasks.find_element(By.CLASS_NAME, 'note')) == 2
-        assert len(tasks.find_element(By.CLASS_NAME, 'completed')) == 1
+        assert len(tasks.find_elements(By.CLASS_NAME, 'note')) == 2
+        assert len(tasks.find_elements(By.CLASS_NAME, 'completed')) == 1
 
     def test_remind_registration(self, conference, helpers, client):
 

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -301,8 +301,8 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
         reviewer_tasks_url = 'http://localhost:3030/group?id=ICLR.cc/2021/Conference/Reviewers#reviewer-tasks'
         request_page(selenium, reviewer_tasks_url, reviewer_client.token, by=By.LINK_TEXT, wait_for_element='Reviewer Registration')
 
-        assert selenium.find_element_by_link_text('Reviewer Registration')
-        assert selenium.find_element_by_link_text('Expertise Selection')
+        assert selenium.find_element(By.LINK_TEXT, 'Reviewer Registration')
+        assert selenium.find_element(By.LINK_TEXT, 'Expertise Selection')
 
         registration_notes = reviewer_client.get_notes(invitation = 'ICLR.cc/2021/Conference/Reviewers/-/Registration_Form')
         assert registration_notes
@@ -338,21 +338,21 @@ Ensure that the email you use for your TPMS profile is listed as one of the emai
 
 
         request_page(selenium, 'http://localhost:3030/group?id=ICLR.cc/2021/Conference/Reviewers', reviewer_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        notes = header.find_elements_by_class_name("description")
+        notes = header.find_element(By.CLASS_NAME, "description")
         assert notes
         assert len(notes) == 1
         assert notes[0].text == 'This page provides information and status updates for the ICLR 2021. It will be regularly updated as the conference progresses, so please check back frequently.'
 
         request_page(selenium, reviewer_tasks_url, reviewer_client.token, by=By.LINK_TEXT, wait_for_element='Reviewer Registration')
 
-        assert selenium.find_element_by_link_text('Reviewer Registration')
-        assert selenium.find_element_by_link_text('Expertise Selection')
-        tasks = selenium.find_element_by_id('reviewer-tasks')
+        assert selenium.find_element(By.LINK_TEXT, 'Reviewer Registration')
+        assert selenium.find_element(By.LINK_TEXT, 'Expertise Selection')
+        tasks = selenium.find_element(By.ID, 'reviewer-tasks')
         assert tasks
-        assert len(tasks.find_elements_by_class_name('note')) == 2
-        assert len(tasks.find_elements_by_class_name('completed')) == 1
+        assert len(tasks.find_element(By.CLASS_NAME, 'note')) == 2
+        assert len(tasks.find_element(By.CLASS_NAME, 'completed')) == 1
 
     def test_remind_registration(self, conference, helpers, client):
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -535,7 +535,7 @@ reviewer6@gmail.com, Reviewer ICMLSix
         reviewer_client = openreview.api.OpenReviewClient(username='reviewer1@icml.cc', password=helpers.strong_password)
 
         request_page(selenium, "http://localhost:3030/group?id=ICML.cc/2023/Conference/Reviewers", reviewer_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert 'You have agreed to review up to 1 papers' in header.text
 
     def test_registrations(self, client, openreview_client, helpers, test_client):
@@ -1426,10 +1426,10 @@ To view your submission, click here: https://openreview.net/forum?id={submission
 
         ac_client = openreview.api.OpenReviewClient(username='ac1@icml.cc', password=helpers.strong_password)
         request_page(selenium, "http://localhost:3030/group?id=ICML.cc/2023/Conference/Area_Chairs", ac_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert 'Reviewer Assignment Browser:' in header.text
 
-        url = header.find_element_by_id('edge_browser_url')
+        url = header.find_element(By.ID, 'edge_browser_url')
         assert url
         assert url.get_attribute('href') == 'http://localhost:3030/edges/browse?start=ICML.cc/2023/Conference/Area_Chairs/-/Assignment,tail:~AC_ICMLOne1&traverse=ICML.cc/2023/Conference/Reviewers/-/Proposed_Assignment,label:reviewer-matching&edit=ICML.cc/2023/Conference/Reviewers/-/Proposed_Assignment,label:reviewer-matching;ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment&browse=ICML.cc/2023/Conference/Reviewers/-/Aggregate_Score,label:reviewer-matching;ICML.cc/2023/Conference/Reviewers/-/Affinity_Score;ICML.cc/2023/Conference/Reviewers/-/Bid;ICML.cc/2023/Conference/Reviewers/-/Custom_Max_Papers,head:ignore&hide=ICML.cc/2023/Conference/Reviewers/-/Conflict&maxColumns=2&version=2&referrer=[AC%20Console](/group?id=ICML.cc/2023/Conference/Area_Chairs)'
 
@@ -1690,10 +1690,10 @@ OpenReview Team'''
         )
 
         request_page(selenium, "http://localhost:3030/group?id=ICML.cc/2023/Conference/Area_Chairs", ac_client.token, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert 'Reviewer Assignment Browser:' in header.text
 
-        url = header.find_element_by_id('edge_browser_url')
+        url = header.find_element(By.ID, 'edge_browser_url')
         assert url
         assert url.get_attribute('href') == 'http://localhost:3030/edges/browse?start=ICML.cc/2023/Conference/Area_Chairs/-/Assignment,tail:~AC_ICMLTwo1&traverse=ICML.cc/2023/Conference/Reviewers/-/Assignment&edit=ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment&browse=ICML.cc/2023/Conference/Reviewers/-/Affinity_Score;ICML.cc/2023/Conference/Reviewers/-/Bid;ICML.cc/2023/Conference/Reviewers/-/Custom_Max_Papers,head:ignore&hide=ICML.cc/2023/Conference/Reviewers/-/Conflict&maxColumns=2&version=2&referrer=[AC%20Console](/group?id=ICML.cc/2023/Conference/Area_Chairs)'
 
@@ -1729,7 +1729,7 @@ OpenReview Team'''
         assert invite_edges[0].label == 'Pending Sign Up'
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'You have already accepted this invitation, but the assignment is pending until you create a profile and no conflict are detected.' == error_message.text
 
         assignment_edges=pc_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Assignment', head=submissions[0].id)
@@ -1796,7 +1796,7 @@ OpenReview Team'''
         assert not openreview_client.get_groups('ICML.cc/2023/Conference/Reviewers', member='carlos@icml.cc')
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert "You have already accepted this invitation, but a conflict was detected and the assignment cannot be made." == error_message.text
 
         ac_client.post_edge(
@@ -1866,7 +1866,7 @@ ICML 2023 Conference Program Chairs'''
         assert openreview_client.get_groups('ICML.cc/2023/Conference/Reviewers', member='celeste@icml.cc')
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'You have already accepted this invitation.' == error_message.text
 
         reviewers_group = pc_client.get_group('ICML.cc/2023/Conference/Submission1/Reviewers')
@@ -1900,7 +1900,7 @@ ICML 2023 Conference Program Chairs'''
         helpers.await_queue(openreview_client)
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'You have already declined this invitation.' == error_message.text
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
@@ -1987,7 +1987,7 @@ ICML 2023 Conference Program Chairs'''
 
         #try to accept invitation that has been deleted
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'Invitation no longer exists. No action is required from your end.' == error_message.text
 
         #delete assignments before review stage and not get key error

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -12,6 +12,7 @@ from openreview.api import Note
 from openreview.journal import Journal
 from openreview.journal import JournalRequest
 from openreview import ProfileManagement
+from selenium.webdriver.common.by import By
 
 class TestJournal():
 
@@ -153,9 +154,9 @@ class TestJournal():
             accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
             request_page(selenium, accept_url, alert=True)
 
-            notes = selenium.find_element_by_id("notes")
+            notes = selenium.find_element(By.ID, 'notes')
             assert notes
-            messages = notes.find_elements_by_tag_name("h3")
+            messages = notes.find_elements(By.TAG_NAME, 'h3')
             assert messages
             assert 'Thank you for accepting this invitation from Transactions on Machine Learning Research' == messages[0].text
 
@@ -168,9 +169,9 @@ class TestJournal():
 
         joelle_client = OpenReviewClient(username='joelle@mailseven.com', password=helpers.strong_password)
         request_page(selenium, "http://localhost:3030/group?id=TMLR/Action_Editors", joelle_client.token, wait_for_element='group-container')
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        titles = header.find_elements_by_tag_name('strong')
+        titles = header.find_elements(By.TAG_NAME, 'strong')
         assert 'Reviewer Assignment Browser:' in titles[0].text
         assert 'Journal Recruitment:' in titles[1].text
         assert 'Reviewer Report:' in titles[2].text
@@ -195,9 +196,9 @@ class TestJournal():
             accept_url = re.search('https://.*response=Yes', text).group(0).replace('https://openreview.net', 'http://localhost:3030')
             request_page(selenium, accept_url, alert=True)
 
-            notes = selenium.find_element_by_id("notes")
+            notes = selenium.find_element(By.ID, 'notes')
             assert notes
-            messages = notes.find_elements_by_tag_name("h3")
+            messages = notes.find_elements(By.TAG_NAME, 'h3')
             assert messages
             assert 'Thank you for accepting this invitation from Transactions on Machine Learning Research' == messages[0].text
 

--- a/tests/test_journal_request.py
+++ b/tests/test_journal_request.py
@@ -78,9 +78,9 @@ class TestJournalRequest():
         test_client = OpenReviewClient(username='support_role@mail.com', password=helpers.strong_password)
 
         request_page(selenium, 'http://localhost:3030/forum?id=' + request_form['note']['id'], openreview_client.token, by=By.CLASS_NAME, wait_for_element='invitations-container')
-        invitations_container = selenium.find_element_by_class_name('invitations-container')
-        invitation_buttons = invitations_container.find_element_by_class_name('invitation-buttons')
-        buttons = invitation_buttons.find_elements_by_tag_name('button')
+        invitations_container = selenium.find_element(By.CLASS_NAME, 'invitations-container')
+        invitation_buttons = invitations_container.find_element(By.CLASS_NAME, 'invitation-buttons')
+        buttons = invitation_buttons.find_elements(By.TAG_NAME, 'button')
         assert len(buttons) ==  4
         assert [btn for btn in buttons if btn.text == 'Comment']
 
@@ -108,9 +108,9 @@ TJ22 Editors-in-Chief
         test_client = OpenReviewClient(username='support_role@mail.com', password=helpers.strong_password)
 
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(journal.request_form_id), test_client.token, by=By.CLASS_NAME, wait_for_element='invitations-container')
-        invitations_container = selenium.find_element_by_class_name('invitations-container')
-        invitation_buttons = invitations_container.find_element_by_class_name('invitation-buttons')
-        buttons = invitation_buttons.find_elements_by_tag_name('button')
+        invitations_container = selenium.find_element(By.CLASS_NAME, 'invitations-container')
+        invitation_buttons = invitations_container.find_element(By.CLASS_NAME, 'invitation-buttons')
+        buttons = invitation_buttons.find_elements(By.TAG_NAME, 'button')
         assert len(buttons) ==  3
 
         assert [btn for btn in buttons if btn.text == 'Reviewer Recruitment']
@@ -231,9 +231,9 @@ TJ22 Editors-in-Chief
         ae_client = OpenReviewClient(username='ae_journal1@mail.com', password=helpers.strong_password)
 
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(journal.request_form_id), ae_client.token, by=By.CLASS_NAME, wait_for_element='invitations-container')
-        invitations_container = selenium.find_element_by_class_name('invitations-container')
-        invitation_buttons = invitations_container.find_element_by_class_name('invitation-buttons')
-        buttons = invitation_buttons.find_elements_by_tag_name('button')
+        invitations_container = selenium.find_element(By.CLASS_NAME, 'invitations-container')
+        invitation_buttons = invitations_container.find_element(By.CLASS_NAME, 'invitation-buttons')
+        buttons = invitation_buttons.find_elements(By.TAG_NAME, 'button')
         assert len(buttons) == 1
         assert [btn for btn in buttons if btn.text == 'Reviewer Recruitment by AE']
 

--- a/tests/test_multiple_roles.py
+++ b/tests/test_multiple_roles.py
@@ -103,7 +103,7 @@ class TestMultipleRoles():
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''reviewer1@lifelong-ml.cc, Reviewer UMass\nreviewer2@lifelong-ml.cc, reviewer3@lifelong-ml.cc, Reviewer UMass\nreviewer4@lifelong-ml.cc'''

--- a/tests/test_multiple_roles.py
+++ b/tests/test_multiple_roles.py
@@ -99,11 +99,11 @@ class TestMultipleRoles():
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(request_form.id), pc_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(request_form.id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(request_form.id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''reviewer1@lifelong-ml.cc, Reviewer UMass\nreviewer2@lifelong-ml.cc, reviewer3@lifelong-ml.cc, Reviewer UMass\nreviewer4@lifelong-ml.cc'''

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -249,7 +249,7 @@ If you would like to change your decision, please follow the link in the previou
         assert len(values) > 0
         values[1].click()
         time.sleep(0.5)
-        button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
+        button = selenium.find_element(By.XPATH, '//button[text()="Submit"]')
         button.click()
         time.sleep(0.5)
         helpers.await_queue()
@@ -528,7 +528,7 @@ If you would like to change your decision, please follow the link in the previou
         assert len(values) > 0
         values[2].click()
         time.sleep(0.5)
-        button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
+        button = selenium.find_element(By.XPATH, '//button[text()="Submit"]')
         button.click()
         time.sleep(0.5)
         helpers.await_queue()        

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -122,7 +122,7 @@ class TestNeurIPSConference():
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''sac1@google.com, SAC One\nsac2@gmail.com, SAC Two'''
@@ -245,7 +245,7 @@ If you would like to change your decision, please follow the link in the previou
         dropdown = selenium.find_element(By.CLASS_NAME, 'dropdown-select__input-container')
         dropdown.click()
         time.sleep(0.5)
-        values = selenium.find_element(By.CLASS_NAME, 'dropdown-select__option')
+        values = selenium.find_elements(By.CLASS_NAME, 'dropdown-select__option')
         assert len(values) > 0
         values[1].click()
         time.sleep(0.5)
@@ -335,7 +335,7 @@ If you would like to change your decision, please follow the link in the previou
 
         notes = selenium.find_element(By.ID, 'notes')
         assert notes
-        assert len(notes.find_element(By.CLASS_NAME, 'note')) == 3
+        assert len(notes.find_elements(By.CLASS_NAME, 'note')) == 3
 
         header = selenium.find_element(By.ID, 'header')
         instruction = header.find_element(By.TAG_NAME, 'li')
@@ -453,7 +453,7 @@ If you would like to change your decision, please follow the link in the previou
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''reviewer1@umass.edu, Reviewer UMass\nreviewer2@mit.edu, Reviewer MIT\nsac1@google.com, SAC One\nsac2@gmail.com, SAC Two'''
@@ -524,7 +524,7 @@ If you would like to change your decision, please follow the link in the previou
         dropdown = selenium.find_element(By.CLASS_NAME, 'dropdown-select__input-container')
         dropdown.click()
         time.sleep(0.5)
-        values = selenium.find_element(By.CLASS_NAME, 'dropdown-select__option')
+        values = selenium.find_elements(By.CLASS_NAME, 'dropdown-select__option')
         assert len(values) > 0
         values[2].click()
         time.sleep(0.5)
@@ -933,7 +933,7 @@ If you would like to change your decision, please follow the link in the previou
         ## authors_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Authors'
         ##request_page(selenium, authors_url, test_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-        ##assert selenium.find_element(By.CLASS_NAME, 'tag-widget')
+        ##assert selenium.find_elements(By.CLASS_NAME, 'tag-widget')
 
         client.post_invitation(openreview.Invitation(id=f'{conference.get_authors_id()}/-/Perceived_Likelihood',
             invitees=[conference.get_authors_id()],
@@ -2641,7 +2641,7 @@ NeurIPS 2021 Conference Program Chairs'''
         status = selenium.find_element(By.ID, '5-metareview-status')
         assert status
 
-        assert not status.find_element(By.CLASS_NAME, 'tag-widget')
+        assert not status.find_elements(By.CLASS_NAME, 'tag-widget')
 
         reviewer_client=openreview.Client(username='reviewer1@umass.edu', password=helpers.strong_password)
 
@@ -2652,7 +2652,7 @@ NeurIPS 2021 Conference Program Chairs'''
         reviewer_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token)
 
-        assert not selenium.find_element(By.CLASS_NAME, 'tag-widget')
+        assert not selenium.find_elements(By.CLASS_NAME, 'tag-widget')
 
         now = datetime.datetime.utcnow()
         conference.open_paper_ranking(conference.get_area_chairs_id(), due_date=now + datetime.timedelta(minutes = 40))
@@ -2687,7 +2687,7 @@ NeurIPS 2021 Conference Program Chairs'''
         reviewer_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-        tags = selenium.find_element(By.CLASS_NAME, 'tag-widget')
+        tags = selenium.find_elements(By.CLASS_NAME, 'tag-widget')
         assert tags
 
         options = tags[0].find_elements(By.TAG_NAME, 'li')

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -118,11 +118,11 @@ class TestNeurIPSConference():
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(request_form.id), pc_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(request_form.id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(request_form.id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''sac1@google.com, SAC One\nsac2@gmail.com, SAC Two'''
@@ -179,14 +179,14 @@ If you would like to change your decision, please follow the link in the previou
 
         sac_client = openreview.Client(username='sac1@google.com', password=helpers.strong_password)
         request_page(selenium, "http://localhost:3030/group?id=NeurIPS.cc/2021/Conference", sac_client.token, wait_for_element='notes')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Senior Area Chair Console' == console.find_element_by_tag_name('a').text
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Senior Area Chair Console' == console.find_element(By.TAG_NAME, 'a').text
 
     def test_recruit_area_chairs(self, client, selenium, request_page, helpers):
 
@@ -223,12 +223,12 @@ If you would like to change your decision, please follow the link in the previou
         assert len(rejected_group.members) == 0
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'You have declined the invitation from Conference on Neural Information Processing Systems.' == messages[0].text
-        messages = notes.find_elements_by_tag_name("p")
+        messages = notes.find_elements(By.TAG_NAME, 'p')
         assert 'If you chose to decline the invitation because the paper load is too high, you can request to reduce your load. You can request a reduced reviewer load below:' == messages[0].text
         
         rejected_group = client.get_group(id='NeurIPS.cc/2021/Conference/Area_Chairs/Declined')
@@ -239,17 +239,17 @@ If you would like to change your decision, please follow the link in the previou
         assert len(accepted_group.members) == 0
 
         ## Accept with reduced quota
-        link = selenium.find_element_by_class_name('reduced-load-link')
+        link = selenium.find_element(By.CLASS_NAME, 'reduced-load-link')
         link.click()
         time.sleep(0.5)
-        dropdown = selenium.find_element_by_class_name('dropdown-select__input-container')
+        dropdown = selenium.find_element(By.CLASS_NAME, 'dropdown-select__input-container')
         dropdown.click()
         time.sleep(0.5)
-        values = selenium.find_elements_by_class_name('dropdown-select__option')
+        values = selenium.find_element(By.CLASS_NAME, 'dropdown-select__option')
         assert len(values) > 0
         values[1].click()
         time.sleep(0.5)
-        button = selenium.find_element_by_xpath('//button[text()="Submit"]')
+        button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
         button.click()
         time.sleep(0.5)
         helpers.await_queue()
@@ -327,18 +327,18 @@ If you would like to change your decision, please follow the link in the previou
         tasks_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Senior_Area_Chairs#senior-areachair-tasks'
         request_page(selenium, tasks_url, sac_client.token, by=By.LINK_TEXT, wait_for_element='Senior Area Chair Bid')
 
-        assert selenium.find_element_by_link_text('Senior Area Chair Bid')
+        assert selenium.find_element(By.LINK_TEXT, 'Senior Area Chair Bid')
 
 
         bid_url = 'http://localhost:3030/invitation?id=NeurIPS.cc/2021/Conference/Senior_Area_Chairs/-/Bid'
         request_page(selenium, bid_url, sac_client.token, wait_for_element='notes')
 
-        notes = selenium.find_element_by_id('notes')
+        notes = selenium.find_element(By.ID, 'notes')
         assert notes
-        assert len(notes.find_elements_by_class_name('note')) == 3
+        assert len(notes.find_element(By.CLASS_NAME, 'note')) == 3
 
-        header = selenium.find_element_by_id('header')
-        instruction = header.find_element_by_tag_name('li')
+        header = selenium.find_element(By.ID, 'header')
+        instruction = header.find_element(By.TAG_NAME, 'li')
         assert 'Please indicate your level of interest in the list of Area Chairs below, on a scale from "Very Low" interest to "Very High" interest. Area Chairs were automatically pre-ranked using the expertise information in your profile.' == instruction.text
 
         sac_client.post_edge(openreview.Edge(
@@ -449,11 +449,11 @@ If you would like to change your decision, please follow the link in the previou
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(request_form.id), pc_client.token, by=By.ID, wait_for_element='note_{}'.format(request_form.id))
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(request_form.id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(request_form.id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''reviewer1@umass.edu, Reviewer UMass\nreviewer2@mit.edu, Reviewer MIT\nsac1@google.com, SAC One\nsac2@gmail.com, SAC Two'''
@@ -493,12 +493,12 @@ If you would like to change your decision, please follow the link in the previou
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes        
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'You have declined the invitation from Conference on Neural Information Processing Systems.' == messages[0].text
-        messages = notes.find_elements_by_tag_name("p")
+        messages = notes.find_elements(By.TAG_NAME, 'p')
         assert 'If you chose to decline the invitation because the paper load is too high, you can request to reduce your load. You can request a reduced reviewer load below:' == messages[0].text
 
         assert len(client.get_group('NeurIPS.cc/2021/Conference/Reviewers').members) == 0
@@ -518,17 +518,17 @@ If you would like to change your decision, please follow the link in the previou
         assert len(notes) == 1
 
         ## Accept with reduced load
-        link = selenium.find_element_by_class_name('reduced-load-link')
+        link = selenium.find_element(By.CLASS_NAME, 'reduced-load-link')
         link.click()
         time.sleep(0.5)
-        dropdown = selenium.find_element_by_class_name('dropdown-select__input-container')
+        dropdown = selenium.find_element(By.CLASS_NAME, 'dropdown-select__input-container')
         dropdown.click()
         time.sleep(0.5)
-        values = selenium.find_elements_by_class_name('dropdown-select__option')
+        values = selenium.find_element(By.CLASS_NAME, 'dropdown-select__option')
         assert len(values) > 0
         values[2].click()
         time.sleep(0.5)
-        button = selenium.find_element_by_xpath('//button[text()="Submit"]')
+        button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
         button.click()
         time.sleep(0.5)
         helpers.await_queue()        
@@ -549,8 +549,8 @@ If you would like to change your decision, please follow the link in the previou
         ## Check reviewers console load
         reviewer_client=openreview.Client(username='reviewer1@umass.edu', password=helpers.strong_password)
         request_page(selenium, 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Reviewers', reviewer_client.token, by=By.ID, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
-        strong_elements = header.find_elements_by_tag_name('strong')
+        header = selenium.find_element(By.ID, 'header')
+        strong_elements = header.find_elements(By.TAG_NAME, 'strong')
         assert len(strong_elements) == 1
         assert strong_elements[0].text == '4 papers'
         
@@ -933,7 +933,7 @@ If you would like to change your decision, please follow the link in the previou
         ## authors_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Authors'
         ##request_page(selenium, authors_url, test_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-        ##assert selenium.find_elements_by_class_name('tag-widget')
+        ##assert selenium.find_element(By.CLASS_NAME, 'tag-widget')
 
         client.post_invitation(openreview.Invitation(id=f'{conference.get_authors_id()}/-/Perceived_Likelihood',
             invitees=[conference.get_authors_id()],
@@ -1454,15 +1454,15 @@ Thank you,
 
         invalid_accept_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1].replace('user=~External_Reviewer_Amazon1', 'user=~External_Reviewer_Amazon2').replace('&amp;', '&')
         helpers.respond_invitation(selenium, request_page, invalid_accept_url, accept=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'Wrong key, please refer back to the recruitment email' == error_message.text
 
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'Thank you for accepting this invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -1513,9 +1513,9 @@ OpenReview Team'''
         ## External reviewer declines the invitation, assignment rollback
         invitation_url = re.search('https://.*\n', invitation_message).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'You have declined the invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -1566,9 +1566,9 @@ OpenReview Team'''
         ## External reviewer accepts the invitation again
         invitation_url = re.search('https://.*\n', invitation_message).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'Thank you for accepting this invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -1649,9 +1649,9 @@ OpenReview Team'''
         assert messages and len(messages) == 1
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'You have declined the invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -1720,9 +1720,9 @@ OpenReview Team'''
         assert messages and len(messages) == 1
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'Thank you for accepting this invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -1768,9 +1768,9 @@ OpenReview Team'''
         external_reviewer=helpers.create_user('external_reviewer4@gmail.com', 'Reviewer', 'External')
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'Thank you for accepting this invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -1821,9 +1821,9 @@ OpenReview Team'''
         assert messages and len(messages) == 1
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'You have declined the invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -2256,9 +2256,9 @@ OpenReview Team'''
         assert messages and len(messages) == 1
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'Thank you for accepting this invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -2370,9 +2370,9 @@ NeurIPS 2021 Conference Program Chairs'''
         assert messages and len(messages) == 1
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'Thank you for accepting this invitation from Conference on Neural Information Processing Systems.' == messages[0].text
 
@@ -2638,10 +2638,10 @@ NeurIPS 2021 Conference Program Chairs'''
         ac_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Area_Chairs'
         request_page(selenium, ac_url, ac_client.token, wait_for_element='5-metareview-status')
 
-        status = selenium.find_element_by_id("5-metareview-status")
+        status = selenium.find_element(By.ID, '5-metareview-status')
         assert status
 
-        assert not status.find_elements_by_class_name('tag-widget')
+        assert not status.find_element(By.CLASS_NAME, 'tag-widget')
 
         reviewer_client=openreview.Client(username='reviewer1@umass.edu', password=helpers.strong_password)
 
@@ -2652,7 +2652,7 @@ NeurIPS 2021 Conference Program Chairs'''
         reviewer_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token)
 
-        assert not selenium.find_elements_by_class_name('tag-widget')
+        assert not selenium.find_element(By.CLASS_NAME, 'tag-widget')
 
         now = datetime.datetime.utcnow()
         conference.open_paper_ranking(conference.get_area_chairs_id(), due_date=now + datetime.timedelta(minutes = 40))
@@ -2661,17 +2661,17 @@ NeurIPS 2021 Conference Program Chairs'''
         ac_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Area_Chairs'
         request_page(selenium, ac_url, ac_client.token, by=By.ID, wait_for_element='5-metareview-status')
 
-        status = selenium.find_element_by_id("5-metareview-status")
+        status = selenium.find_element(By.ID, '5-metareview-status')
         assert status
 
-        tag = status.find_element_by_class_name('tag-widget')
+        tag = status.find_element(By.CLASS_NAME, 'tag-widget')
         assert tag
 
-        options = tag.find_elements_by_tag_name("li")
+        options = tag.find_elements(By.TAG_NAME, 'li')
         assert options
         assert len(options) == 3
 
-        options = tag.find_elements_by_tag_name("a")
+        options = tag.find_elements(By.TAG_NAME, 'a')
         assert options
         assert len(options) == 3
 
@@ -2687,14 +2687,14 @@ NeurIPS 2021 Conference Program Chairs'''
         reviewer_url = 'http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Reviewers'
         request_page(selenium, reviewer_url, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-        tags = selenium.find_elements_by_class_name('tag-widget')
+        tags = selenium.find_element(By.CLASS_NAME, 'tag-widget')
         assert tags
 
-        options = tags[0].find_elements_by_tag_name("li")
+        options = tags[0].find_elements(By.TAG_NAME, 'li')
         assert options
         assert len(options) == 5
 
-        options = tags[0].find_elements_by_tag_name("a")
+        options = tags[0].find_elements(By.TAG_NAME, 'a')
         assert options
         assert len(options) == 5
 
@@ -2814,20 +2814,20 @@ NeurIPS 2021 Conference Program Chairs'''
 
         request_page(selenium, "http://localhost:3030/group?id=NeurIPS.cc/2021/Conference/Program_Chairs#paper-status", pc_client.token, wait_for_element='notes')
         assert "NeurIPS 2021 Conference Program Chairs | OpenReview" in selenium.title
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('venue-configuration')
-        assert tabs.find_element_by_id('paper-status')
-        assert tabs.find_element_by_id('reviewer-status')
-        assert tabs.find_element_by_id('areachair-status')
+        assert tabs.find_element(By.ID, 'venue-configuration')
+        assert tabs.find_element(By.ID, 'paper-status')
+        assert tabs.find_element(By.ID, 'reviewer-status')
+        assert tabs.find_element(By.ID, 'areachair-status')
 
-        assert '#' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-1').text
-        assert 'Paper Summary' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-2').text
-        assert 'Review Progress' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-3').text
-        assert 'Status' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-4').text
-        assert 'Decision' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-5').text
+        assert '#' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-1').text
+        assert 'Paper Summary' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-2').text
+        assert 'Review Progress' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-3').text
+        assert 'Status' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-4').text
+        assert 'Decision' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-5').text
 
     def test_desk_reject_after_review(self, conference, helpers, test_client, client, selenium, request_page):
 

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -171,7 +171,7 @@ Please see our [call for papers](https://nips.cc/Conferences/2023/CallForPapers)
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''sac1@google.com, SAC One\nsac2@gmail.com, SAC Two'''
@@ -401,7 +401,7 @@ If you would like to change your decision, please follow the link in the previou
 
         notes = selenium.find_element(By.ID, 'all-area-chairs')
         assert notes
-        assert len(notes.find_element(By.CLASS_NAME, 'bid-container')) == 3
+        assert len(notes.find_elements(By.CLASS_NAME, 'bid-container')) == 3
 
         header = selenium.find_element(By.ID, 'header')
         instruction = header.find_element(By.TAG_NAME, 'li')
@@ -499,7 +499,7 @@ If you would like to change your decision, please follow the link in the previou
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''reviewer1@umass.edu, Reviewer UMass\nreviewer2@mit.edu, Reviewer MIT\nsac1@google.com, SAC One\nsac2@gmail.com, SAC Two'''
@@ -2391,7 +2391,7 @@ If you would like to change your decision, please follow the link in the previou
 #         status = selenium.find_element(By.ID, '5-metareview-status')
 #         assert status
 
-#         assert not status.find_element(By.CLASS_NAME, 'tag-widget')
+#         assert not status.find_elements(By.CLASS_NAME, 'tag-widget')
 
 #         reviewer_client=openreview.Client(username='reviewer1@umass.edu', password=helpers.strong_password)
 
@@ -2402,7 +2402,7 @@ If you would like to change your decision, please follow the link in the previou
 #         reviewer_url = 'http://localhost:3030/group?id=NeurIPS.cc/2023/Conference/Reviewers'
 #         request_page(selenium, reviewer_url, reviewer_client.token)
 
-#         assert not selenium.find_element(By.CLASS_NAME, 'tag-widget')
+#         assert not selenium.find_elements(By.CLASS_NAME, 'tag-widget')
 
 #         now = datetime.datetime.utcnow()
 #         conference.open_paper_ranking(conference.get_area_chairs_id(), due_date=now + datetime.timedelta(minutes = 40))
@@ -2437,7 +2437,7 @@ If you would like to change your decision, please follow the link in the previou
 #         reviewer_url = 'http://localhost:3030/group?id=NeurIPS.cc/2023/Conference/Reviewers'
 #         request_page(selenium, reviewer_url, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-#         tags = selenium.find_element(By.CLASS_NAME, 'tag-widget')
+#         tags = selenium.find_elements(By.CLASS_NAME, 'tag-widget')
 #         assert tags
 
 #         options = tags[0].find_elements(By.TAG_NAME, 'li')

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -576,7 +576,7 @@ If you would like to change your decision, please follow the link in the previou
         assert len(values) > 0
         values[2].click()
         time.sleep(0.5)
-        button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
+        button = selenium.find_element(By.XPATH, '//button[text()="Submit"]')
         button.click()
         time.sleep(0.5)
         helpers.await_queue_edit(openreview_client, invitation='NeurIPS.cc/2023/Conference/Reviewers/-/Recruitment', count=2)

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -572,7 +572,7 @@ If you would like to change your decision, please follow the link in the previou
         dropdown = selenium.find_element(By.CLASS_NAME, 'dropdown-select__input-container')
         dropdown.click()
         time.sleep(0.5)
-        values = selenium.find_element(By.CLASS_NAME, 'dropdown-select__option')
+        values = selenium.find_elements(By.CLASS_NAME, 'dropdown-select__option')
         assert len(values) > 0
         values[2].click()
         time.sleep(0.5)

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -153,11 +153,11 @@ Please see our [call for papers](https://nips.cc/Conferences/2023/CallForPapers)
         helpers.await_queue()
 
         request_page(selenium, 'http://localhost:3030/group?id=NeurIPS.cc/2023/Conference', pc_client.token, wait_for_element='header')
-        header_div = selenium.find_element_by_id('header')
+        header_div = selenium.find_element(By.ID, 'header')
         assert header_div
-        location_tag = header_div.find_element_by_class_name('venue-location')
+        location_tag = header_div.find_element(By.CLASS_NAME, 'venue-location')
         assert location_tag and location_tag.text == request_form.content['Location']
-        description = header_div.find_element_by_class_name('description')
+        description = header_div.find_element(By.CLASS_NAME, 'description')
         assert description and 'Authors' in description.text
 
     def test_recruit_senior_area_chairs(self, client, openreview_client, selenium, request_page, helpers):
@@ -167,11 +167,11 @@ Please see our [call for papers](https://nips.cc/Conferences/2023/CallForPapers)
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(request_form.id), pc_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(request_form.id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(request_form.id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''sac1@google.com, SAC One\nsac2@gmail.com, SAC Two'''
@@ -232,9 +232,9 @@ If you would like to change your decision, please follow the link in the previou
 
         sac_client = openreview.api.OpenReviewClient(username='sac1@google.com', password=helpers.strong_password)
         request_page(selenium, "http://localhost:3030/group?id=NeurIPS.cc/2023/Conference", sac_client.token, wait_for_element='notes')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs.find_element(By.LINK_TEXT, "Senior Area Chair Console")
 
     def test_recruit_area_chairs(self, client, openreview_client, selenium, request_page, helpers):
@@ -399,12 +399,12 @@ If you would like to change your decision, please follow the link in the previou
         bid_url = 'http://localhost:3030/invitation?id=NeurIPS.cc/2023/Conference/Senior_Area_Chairs/-/Bid'
         request_page(selenium, bid_url, sac_client.token, wait_for_element='notes')
 
-        notes = selenium.find_element_by_id('all-area-chairs')
+        notes = selenium.find_element(By.ID, 'all-area-chairs')
         assert notes
-        assert len(notes.find_elements_by_class_name('bid-container')) == 3
+        assert len(notes.find_element(By.CLASS_NAME, 'bid-container')) == 3
 
-        header = selenium.find_element_by_id('header')
-        instruction = header.find_element_by_tag_name('li')
+        header = selenium.find_element(By.ID, 'header')
+        instruction = header.find_element(By.TAG_NAME, 'li')
         assert 'Please indicate your level of interest in the list of Area Chairs below, on a scale from "Very Low" interest to "Very High" interest. Area Chairs were automatically pre-ranked using the expertise information in your profile.' == instruction.text
 
         sac_client.post_edge(openreview.api.Edge(
@@ -495,11 +495,11 @@ If you would like to change your decision, please follow the link in the previou
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(request_form.id), pc_client.token, by=By.ID, wait_for_element='note_{}'.format(request_form.id))
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(request_form.id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(request_form.id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
 
         reviewer_details = '''reviewer1@umass.edu, Reviewer UMass\nreviewer2@mit.edu, Reviewer MIT\nsac1@google.com, SAC One\nsac2@gmail.com, SAC Two'''
@@ -539,12 +539,12 @@ If you would like to change your decision, please follow the link in the previou
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
 
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
-        notes = selenium.find_element_by_class_name("note_editor")
+        notes = selenium.find_element(By.CLASS_NAME, "note_editor")
         assert notes
-        messages = notes.find_elements_by_tag_name("h4")
+        messages = notes.find_elements(By.TAG_NAME, 'h4')
         assert messages
         assert 'You have declined the invitation from NeurIPS 2023.' == messages[0].text
-        messages = notes.find_elements_by_tag_name("p")
+        messages = notes.find_elements(By.TAG_NAME, 'p')
         assert 'If you chose to decline the invitation because the paper load is too high, you can request to reduce your load. You can request a reduced reviewer load below:' == messages[0].text
 
         helpers.await_queue_edit(openreview_client, invitation='NeurIPS.cc/2023/Conference/Reviewers/-/Recruitment', count=1)
@@ -566,17 +566,17 @@ If you would like to change your decision, please follow the link in the previou
         assert len(notes) == 1
 
         ## Accept with reduced load
-        link = selenium.find_element_by_class_name('reduced-load-link')
+        link = selenium.find_element(By.CLASS_NAME, 'reduced-load-link')
         link.click()
         time.sleep(0.5)
-        dropdown = selenium.find_element_by_class_name('dropdown-select__input-container')
+        dropdown = selenium.find_element(By.CLASS_NAME, 'dropdown-select__input-container')
         dropdown.click()
         time.sleep(0.5)
-        values = selenium.find_elements_by_class_name('dropdown-select__option')
+        values = selenium.find_element(By.CLASS_NAME, 'dropdown-select__option')
         assert len(values) > 0
         values[2].click()
         time.sleep(0.5)
-        button = selenium.find_element_by_xpath('//button[text()="Submit"]')
+        button = selenium.find_element(By. XPATH, '//button[text()="Submit"]')
         button.click()
         time.sleep(0.5)
         helpers.await_queue_edit(openreview_client, invitation='NeurIPS.cc/2023/Conference/Reviewers/-/Recruitment', count=2)
@@ -597,8 +597,8 @@ If you would like to change your decision, please follow the link in the previou
         ## Check reviewers console load
         reviewer_client=openreview.api.OpenReviewClient(username='reviewer1@umass.edu', password=helpers.strong_password)
         request_page(selenium, 'http://localhost:3030/group?id=NeurIPS.cc/2023/Conference/Reviewers', reviewer_client.token, by=By.ID, wait_for_element='header')
-        header = selenium.find_element_by_id('header')
-        strong_elements = header.find_elements_by_tag_name('strong')
+        header = selenium.find_element(By.ID, 'header')
+        strong_elements = header.find_elements(By.TAG_NAME, 'strong')
         assert len(strong_elements) == 1
         assert strong_elements[0].text == '4 papers'
 
@@ -2388,10 +2388,10 @@ If you would like to change your decision, please follow the link in the previou
 #         ac_url = 'http://localhost:3030/group?id=NeurIPS.cc/2023/Conference/Area_Chairs'
 #         request_page(selenium, ac_url, ac_client.token, wait_for_element='5-metareview-status')
 
-#         status = selenium.find_element_by_id("5-metareview-status")
+#         status = selenium.find_element(By.ID, '5-metareview-status')
 #         assert status
 
-#         assert not status.find_elements_by_class_name('tag-widget')
+#         assert not status.find_element(By.CLASS_NAME, 'tag-widget')
 
 #         reviewer_client=openreview.Client(username='reviewer1@umass.edu', password=helpers.strong_password)
 
@@ -2402,7 +2402,7 @@ If you would like to change your decision, please follow the link in the previou
 #         reviewer_url = 'http://localhost:3030/group?id=NeurIPS.cc/2023/Conference/Reviewers'
 #         request_page(selenium, reviewer_url, reviewer_client.token)
 
-#         assert not selenium.find_elements_by_class_name('tag-widget')
+#         assert not selenium.find_element(By.CLASS_NAME, 'tag-widget')
 
 #         now = datetime.datetime.utcnow()
 #         conference.open_paper_ranking(conference.get_area_chairs_id(), due_date=now + datetime.timedelta(minutes = 40))
@@ -2411,17 +2411,17 @@ If you would like to change your decision, please follow the link in the previou
 #         ac_url = 'http://localhost:3030/group?id=NeurIPS.cc/2023/Conference/Area_Chairs'
 #         request_page(selenium, ac_url, ac_client.token, by=By.ID, wait_for_element='5-metareview-status')
 
-#         status = selenium.find_element_by_id("5-metareview-status")
+#         status = selenium.find_element(By.ID, '5-metareview-status')
 #         assert status
 
-#         tag = status.find_element_by_class_name('tag-widget')
+#         tag = status.find_element(By.CLASS_NAME, 'tag-widget')
 #         assert tag
 
-#         options = tag.find_elements_by_tag_name("li")
+#         options = tag.find_elements(By.TAG_NAME, 'li')
 #         assert options
 #         assert len(options) == 3
 
-#         options = tag.find_elements_by_tag_name("a")
+#         options = tag.find_elements(By.TAG_NAME, 'a')
 #         assert options
 #         assert len(options) == 3
 
@@ -2437,14 +2437,14 @@ If you would like to change your decision, please follow the link in the previou
 #         reviewer_url = 'http://localhost:3030/group?id=NeurIPS.cc/2023/Conference/Reviewers'
 #         request_page(selenium, reviewer_url, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='tag-widget')
 
-#         tags = selenium.find_elements_by_class_name('tag-widget')
+#         tags = selenium.find_element(By.CLASS_NAME, 'tag-widget')
 #         assert tags
 
-#         options = tags[0].find_elements_by_tag_name("li")
+#         options = tags[0].find_elements(By.TAG_NAME, 'li')
 #         assert options
 #         assert len(options) == 5
 
-#         options = tags[0].find_elements_by_tag_name("a")
+#         options = tags[0].find_elements(By.TAG_NAME, 'a')
 #         assert options
 #         assert len(options) == 5
 
@@ -2564,20 +2564,20 @@ If you would like to change your decision, please follow the link in the previou
 
 #         request_page(selenium, "http://localhost:3030/group?id=NeurIPS.cc/2023/Conference/Program_Chairs#paper-status", pc_client.token, wait_for_element='notes')
 #         assert "NeurIPS 2023 Conference Program Chairs | OpenReview" in selenium.title
-#         notes_panel = selenium.find_element_by_id('notes')
+#         notes_panel = selenium.find_element(By.ID, 'notes')
 #         assert notes_panel
-#         tabs = notes_panel.find_element_by_class_name('tabs-container')
+#         tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
 #         assert tabs
-#         assert tabs.find_element_by_id('venue-configuration')
-#         assert tabs.find_element_by_id('paper-status')
-#         assert tabs.find_element_by_id('reviewer-status')
-#         assert tabs.find_element_by_id('areachair-status')
+#         assert tabs.find_element(By.ID, 'venue-configuration')
+#         assert tabs.find_element(By.ID, 'paper-status')
+#         assert tabs.find_element(By.ID, 'reviewer-status')
+#         assert tabs.find_element(By.ID, 'areachair-status')
 
-#         assert '#' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-1').text
-#         assert 'Paper Summary' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-2').text
-#         assert 'Review Progress' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-3').text
-#         assert 'Status' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-4').text
-#         assert 'Decision' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-5').text
+#         assert '#' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-1').text
+#         assert 'Paper Summary' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-2').text
+#         assert 'Review Progress' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-3').text
+#         assert 'Status' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-4').text
+#         assert 'Decision' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-5').text
 
 #     def test_desk_reject_after_review(self, conference, helpers, test_client, client, selenium, request_page):
 

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -117,7 +117,7 @@ class TestReviewersConference():
         conference.create_review_stage()
 
         request_page(selenium, "http://localhost:3030/group?id=eswc-conferences.org/ESWC/2019/Workshop/KGB/Program_Chairs#paper-status", client.token, by=By.CLASS_NAME, wait_for_element='reviewer-progress')
-        reviews = selenium.find_element(By.CLASS_NAME, 'reviewer-progress')
+        reviews = selenium.find_elements(By.CLASS_NAME, 'reviewer-progress')
         assert reviews
         assert len(reviews) == 1
         headers = reviews[0].find_elements(By.TAG_NAME, 'h4')
@@ -125,7 +125,7 @@ class TestReviewersConference():
         assert headers[0].text == '0 of 2 Reviews Submitted'
 
         request_page(selenium, "http://localhost:3030/group?id=eswc-conferences.org/ESWC/2019/Workshop/KGB/Program_Chairs#reviewer-status", client.token, by=By.CLASS_NAME, wait_for_element='reviewer-progress')
-        reviews = selenium.find_element(By.CLASS_NAME, 'reviewer-progress')
+        reviews = selenium.find_elements(By.CLASS_NAME, 'reviewer-progress')
         assert reviews
         # assert len(reviews) == 5 temporally disable assert
 
@@ -148,7 +148,7 @@ class TestReviewersConference():
         assert review_note
 
         request_page(selenium, "http://localhost:3030/group?id=eswc-conferences.org/ESWC/2019/Workshop/KGB/Program_Chairs#paper-status", client.token, by=By.CLASS_NAME, wait_for_element='reviewer-progress')
-        reviews = selenium.find_element(By.CLASS_NAME, 'reviewer-progress')
+        reviews = selenium.find_elements(By.CLASS_NAME, 'reviewer-progress')
         assert reviews
         assert len(reviews) == 1
         headers = reviews[0].find_elements(By.TAG_NAME, 'h4')

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -37,37 +37,37 @@ class TestReviewersConference():
 
         # Reviewer user
         request_page(selenium, "http://localhost:3030/group?id=learningtheory.org/COLT/2019/Conference", test_client.token, wait_for_element='invitation')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 0
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Program Committee Console' == console.find_element_by_tag_name('a').text
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 0
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Program Committee Console' == console.find_element(By.TAG_NAME, 'a').text
+        assert tabs.find_elements(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 0
 
         # Guest user
         request_page(selenium, "http://localhost:3030/group?id=learningtheory.org/COLT/2019/Conference", wait_for_element='invitation')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 0
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 0
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 0
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 0
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 0
 
         # Reviewer console
         request_page(selenium, "http://localhost:3030/group?id=learningtheory.org/COLT/2019/Conference/Program_Committee", test_client.token, by=By.CLASS_NAME, wait_for_element='tabs-container')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
 
     def test_allow_review_de_anonymization(self, client, test_client, helpers, selenium, request_page):
@@ -117,15 +117,15 @@ class TestReviewersConference():
         conference.create_review_stage()
 
         request_page(selenium, "http://localhost:3030/group?id=eswc-conferences.org/ESWC/2019/Workshop/KGB/Program_Chairs#paper-status", client.token, by=By.CLASS_NAME, wait_for_element='reviewer-progress')
-        reviews = selenium.find_elements_by_class_name('reviewer-progress')
+        reviews = selenium.find_element(By.CLASS_NAME, 'reviewer-progress')
         assert reviews
         assert len(reviews) == 1
-        headers = reviews[0].find_elements_by_tag_name('h4')
+        headers = reviews[0].find_elements(By.TAG_NAME, 'h4')
         assert headers
         assert headers[0].text == '0 of 2 Reviews Submitted'
 
         request_page(selenium, "http://localhost:3030/group?id=eswc-conferences.org/ESWC/2019/Workshop/KGB/Program_Chairs#reviewer-status", client.token, by=By.CLASS_NAME, wait_for_element='reviewer-progress')
-        reviews = selenium.find_elements_by_class_name('reviewer-progress')
+        reviews = selenium.find_element(By.CLASS_NAME, 'reviewer-progress')
         assert reviews
         # assert len(reviews) == 5 temporally disable assert
 
@@ -148,20 +148,20 @@ class TestReviewersConference():
         assert review_note
 
         request_page(selenium, "http://localhost:3030/group?id=eswc-conferences.org/ESWC/2019/Workshop/KGB/Program_Chairs#paper-status", client.token, by=By.CLASS_NAME, wait_for_element='reviewer-progress')
-        reviews = selenium.find_elements_by_class_name('reviewer-progress')
+        reviews = selenium.find_element(By.CLASS_NAME, 'reviewer-progress')
         assert reviews
         assert len(reviews) == 1
-        headers = reviews[0].find_elements_by_tag_name('h4')
+        headers = reviews[0].find_elements(By.TAG_NAME, 'h4')
         assert headers
         assert headers[0].text == '1 of 2 Reviews Submitted'
 
-        assert selenium.find_element_by_link_text('Paper Status')
+        assert selenium.find_element(By.LINK_TEXT, 'Paper Status')
         try:
-            selenium.find_element_by_link_text('Area Chair Status')
+            selenium.find_element(By.LINK_TEXT, 'Area Chair Status')
         except NoSuchElementException as e:
             assert e
 
-        assert selenium.find_element_by_link_text('Reviewer Status')
+        assert selenium.find_element(By.LINK_TEXT, 'Reviewer Status')
 
 
 

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -310,8 +310,8 @@ class TestSingleBlindConference():
 
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='edit_button')
 
-        assert len(selenium.find_element(By.CLASS_NAME, 'edit_button')) == 1
-        assert len(selenium.find_element(By.CLASS_NAME, 'trash_button')) == 1
+        assert len(selenium.find_elements(By.CLASS_NAME, 'edit_button')) == 1
+        assert len(selenium.find_elements(By.CLASS_NAME, 'trash_button')) == 1
 
     def test_open_comments(self, client, test_client, selenium, request_page):
 
@@ -331,9 +331,9 @@ class TestSingleBlindConference():
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 2
-        assert 'Official Comment' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
-        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[1].text
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 2
+        assert 'Official Comment' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
+        assert 'Withdraw' == reply_row.find_elements(By.CLASS_NAME, 'btn')[1].text
 
     def test_close_comments(self, client, test_client, selenium, request_page):
 
@@ -352,8 +352,8 @@ class TestSingleBlindConference():
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
-        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text        
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text        
 
     def test_open_reviews(self, client, test_client, selenium, request_page, helpers):
 
@@ -414,15 +414,15 @@ class TestSingleBlindConference():
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
-        assert 'Official Review' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
+        assert 'Official Review' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         # Author
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
-        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         anon_groups = reviewer_client.get_groups(regex='NIPS.cc/2018/Workshop/MLITS/Paper1/Reviewer_', signatory='~Reviewer_SomeLastName1')
         assert len(anon_groups) == 1
@@ -610,8 +610,8 @@ class TestSingleBlindConference():
         tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         assert tabs.find_element(By.ID, 'your-consoles')
-        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
-        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert len(tabs.find_elements(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_elements(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
         assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Authors", test_client.token, wait_for_element='your-submissions')

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -71,17 +71,17 @@ class TestSingleBlindConference():
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", wait_for_element='header')
 
         assert "NIPS 2018 Workshop MLITS | OpenReview" in selenium.title
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert "2018 NIPS MLITS Workshop" == header.find_element_by_tag_name("h1").text
-        assert "Machine Learning for Intelligent Transportation Systems" == header.find_element_by_tag_name("h3").text
-        assert "Montreal, Canada" == header.find_element_by_xpath(".//span[@class='venue-location']").text
-        assert "December 3-8, 2018" == header.find_element_by_xpath(".//span[@class='venue-date']").text
-        assert "https://sites.google.com/site/nips2018mlits/home" == header.find_element_by_xpath(".//span[@class='venue-website']/a").text
-        invitation_panel = selenium.find_element_by_id('invitation')
+        assert "2018 NIPS MLITS Workshop" == header.find_element(By.TAG_NAME, "h1").text
+        assert "Machine Learning for Intelligent Transportation Systems" == header.find_element(By.TAG_NAME, "h3").text
+        assert "Montreal, Canada" == header.find_element(By.XPATH, ".//span[@class='venue-location']").text
+        assert "December 3-8, 2018" == header.find_element(By.XPATH, ".//span[@class='venue-date']").text
+        assert "https://sites.google.com/site/nips2018mlits/home" == header.find_element(By.XPATH, ".//span[@class='venue-website']/a").text
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 0
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
 
     def test_enable_submissions(self, client, selenium, request_page):
@@ -113,9 +113,9 @@ class TestSingleBlindConference():
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", wait_for_element='invitation')
 
         assert "NIPS 2018 Workshop MLITS | OpenReview" in selenium.title
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 0
 
         builder.set_submission_stage(start_date = now - datetime.timedelta(minutes = 10), due_date = now + datetime.timedelta(minutes = 40), public=True)
         conference = builder.get_result()
@@ -128,18 +128,18 @@ class TestSingleBlindConference():
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", wait_for_element='invitation')
 
         assert "NIPS 2018 Workshop MLITS | OpenReview" in selenium.title
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'NIPS 2018 Workshop MLITS Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'NIPS 2018 Workshop MLITS Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 0
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_tag_name('ul')) == 0
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 0
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.TAG_NAME, 'ul')) == 0
 
     def test_post_submissions(self, client, test_client, peter_client, selenium, request_page, helpers):
 
@@ -216,77 +216,77 @@ class TestSingleBlindConference():
 
         # Author user
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", test_client.token, wait_for_element='notes')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'NIPS 2018 Workshop MLITS Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'NIPS 2018 Workshop MLITS Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Author Console' == console.find_element_by_tag_name('a').text
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 1
-        allsubmissions_tab = tabs.find_element_by_id('all-submissions')
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 1
+        allsubmissions_tab = tabs.find_element(By.ID, 'all-submissions')
         assert allsubmissions_tab
-        assert len(allsubmissions_tab.find_element_by_class_name('submissions-list').find_elements_by_tag_name('li')) == 2
+        assert len(allsubmissions_tab.find_element(By.CLASS_NAME, 'submissions-list').find_elements(By.TAG_NAME, 'li')) == 2
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Authors", test_client.token, wait_for_element='your-submissions')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 2
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 2
 
         # Guest user
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", wait_for_element='all-submissions')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'NIPS 2018 Workshop MLITS Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'NIPS 2018 Workshop MLITS Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 0
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 0
-        allsubmissions_tab = tabs.find_element_by_id('all-submissions')
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 0
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 0
+        allsubmissions_tab = tabs.find_element(By.ID, 'all-submissions')
         assert allsubmissions_tab
-        assert len(allsubmissions_tab.find_element_by_class_name('submissions-list').find_elements_by_tag_name('li')) == 2
+        assert len(allsubmissions_tab.find_element(By.CLASS_NAME, 'submissions-list').find_elements(By.TAG_NAME, 'li')) == 2
 
         # Co-author user
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", peter_client.token, wait_for_element='all-submissions')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'NIPS 2018 Workshop MLITS Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'NIPS 2018 Workshop MLITS Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Author Console' == console.find_element_by_tag_name('a').text
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 1
-        allsubmissions_tab = tabs.find_element_by_id('all-submissions')
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 1
+        allsubmissions_tab = tabs.find_element(By.ID, 'all-submissions')
         assert allsubmissions_tab
-        assert len(allsubmissions_tab.find_element_by_class_name('submissions-list').find_elements_by_tag_name('li')) == 2
+        assert len(allsubmissions_tab.find_element(By.CLASS_NAME, 'submissions-list').find_elements(By.TAG_NAME, 'li')) == 2
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Authors", peter_client.token, wait_for_element='your-submissions')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 2
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 2
 
     def test_close_submission(self, client, test_client, selenium, request_page):
 
@@ -310,8 +310,8 @@ class TestSingleBlindConference():
 
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='edit_button')
 
-        assert len(selenium.find_elements_by_class_name('edit_button')) == 1
-        assert len(selenium.find_elements_by_class_name('trash_button')) == 1
+        assert len(selenium.find_element(By.CLASS_NAME, 'edit_button')) == 1
+        assert len(selenium.find_element(By.CLASS_NAME, 'trash_button')) == 1
 
     def test_open_comments(self, client, test_client, selenium, request_page):
 
@@ -330,10 +330,10 @@ class TestSingleBlindConference():
         submission = notes[0]
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 2
-        assert 'Official Comment' == reply_row.find_elements_by_class_name('btn')[0].text
-        assert 'Withdraw' == reply_row.find_elements_by_class_name('btn')[1].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 2
+        assert 'Official Comment' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
+        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[1].text
 
     def test_close_comments(self, client, test_client, selenium, request_page):
 
@@ -351,9 +351,9 @@ class TestSingleBlindConference():
         submission = notes[0]
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Withdraw' == reply_row.find_elements_by_class_name('btn')[0].text        
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text        
 
     def test_open_reviews(self, client, test_client, selenium, request_page, helpers):
 
@@ -413,16 +413,16 @@ class TestSingleBlindConference():
         # Reviewer
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Official Review' == reply_row.find_elements_by_class_name('btn')[0].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert 'Official Review' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
 
         # Author
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Withdraw' == reply_row.find_elements_by_class_name('btn')[0].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_element(By.CLASS_NAME, 'btn')[0].text
 
         anon_groups = reviewer_client.get_groups(regex='NIPS.cc/2018/Workshop/MLITS/Paper1/Reviewer_', signatory='~Reviewer_SomeLastName1')
         assert len(anon_groups) == 1
@@ -605,22 +605,22 @@ class TestSingleBlindConference():
 
         # Author user
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", test_client.token, wait_for_element='your-consoles')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Author Console' == console.find_element_by_tag_name('a').text
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Authors", test_client.token, wait_for_element='your-submissions')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 2
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 2
 
         conference.set_authorpage_header({
             'title': 'Author Console',
@@ -630,38 +630,38 @@ class TestSingleBlindConference():
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Authors", test_client.token, wait_for_element='your-submissions')
 
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert len(header.find_elements_by_tag_name('h1')) == 1
-        assert 'Author Console' == header.find_elements_by_tag_name('h1')[0].text
-        assert len(header.find_elements_by_class_name('description')) == 1
-        assert 'Set of instructions' == header.find_elements_by_class_name('description')[0].text
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert len(header.find_elements(By.TAG_NAME, 'h1')) == 1
+        assert 'Author Console' == header.find_elements(By.TAG_NAME, 'h1')[0].text
+        assert len(header.find_element(By.CLASS_NAME, 'description')) == 1
+        assert 'Set of instructions' == header.find_element(By.CLASS_NAME, 'description')[0].text
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 2
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 2
 
         # Reviewer user
         reviewer_client = openreview.Client(baseurl = 'http://localhost:3000', username='reviewer@mail.com', password=helpers.strong_password)
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", reviewer_client.token, wait_for_element='your-submissions')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Reviewer Console' == console.find_element_by_tag_name('a').text
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Reviewer Console' == console.find_element(By.TAG_NAME, 'a').text
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Reviewers", reviewer_client.token, wait_for_element='reviewer-tasks')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('assigned-papers')
-        assert len(tabs.find_element_by_id('assigned-papers').find_elements_by_class_name('note')) == 1
-        assert tabs.find_element_by_id('reviewer-tasks')
-        assert len(tabs.find_element_by_id('reviewer-tasks').find_elements_by_class_name('note')) == 1
+        assert tabs.find_element(By.ID, 'assigned-papers')
+        assert len(tabs.find_element(By.ID, 'assigned-papers').find_element(By.CLASS_NAME, 'note')) == 1
+        assert tabs.find_element(By.ID, 'reviewer-tasks')
+        assert len(tabs.find_element(By.ID, 'reviewer-tasks').find_element(By.CLASS_NAME, 'note')) == 1
 
         conference.set_reviewerpage_header({
             'title': 'Reviewer Console',
@@ -671,42 +671,42 @@ class TestSingleBlindConference():
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Reviewers", reviewer_client.token, wait_for_element='reviewer-tasks')
 
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert len(header.find_elements_by_tag_name('h1')) == 1
-        assert 'Reviewer Console' == header.find_elements_by_tag_name('h1')[0].text
-        assert len(header.find_elements_by_class_name('description')) == 1
-        assert 'Set of instructions' == header.find_elements_by_class_name('description')[0].text
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert len(header.find_elements(By.TAG_NAME, 'h1')) == 1
+        assert 'Reviewer Console' == header.find_elements(By.TAG_NAME, 'h1')[0].text
+        assert len(header.find_element(By.CLASS_NAME, 'description')) == 1
+        assert 'Set of instructions' == header.find_element(By.CLASS_NAME, 'description')[0].text
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('assigned-papers')
-        assert len(tabs.find_element_by_id('assigned-papers').find_elements_by_class_name('note')) == 1
-        assert tabs.find_element_by_id('reviewer-tasks')
-        assert len(tabs.find_element_by_id('reviewer-tasks').find_elements_by_class_name('note')) == 1
+        assert tabs.find_element(By.ID, 'assigned-papers')
+        assert len(tabs.find_element(By.ID, 'assigned-papers').find_element(By.CLASS_NAME, 'note')) == 1
+        assert tabs.find_element(By.ID, 'reviewer-tasks')
+        assert len(tabs.find_element(By.ID, 'reviewer-tasks').find_element(By.CLASS_NAME, 'note')) == 1
 
         # Area chair user
         ac_client = helpers.create_user('ac2@mail.com', 'AC', 'MLITS')
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", ac_client.token, wait_for_element='your-consoles')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Area Chair Console' == console.find_element_by_tag_name('a').text
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Area Chair Console' == console.find_element(By.TAG_NAME, 'a').text
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Area_Chairs", ac_client.token, wait_for_element='areachair-tasks')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('assigned-papers')
-        assert len(tabs.find_element_by_id('assigned-papers').find_elements_by_class_name('note')) == 1
-        assert tabs.find_element_by_id('areachair-tasks')
-        assert len(tabs.find_element_by_id('areachair-tasks').find_elements_by_class_name('note')) == 0
-        reviews = tabs.find_elements_by_class_name('reviewer-progress')
+        assert tabs.find_element(By.ID, 'assigned-papers')
+        assert len(tabs.find_element(By.ID, 'assigned-papers').find_element(By.CLASS_NAME, 'note')) == 1
+        assert tabs.find_element(By.ID, 'areachair-tasks')
+        assert len(tabs.find_element(By.ID, 'areachair-tasks').find_element(By.CLASS_NAME, 'note')) == 0
+        reviews = tabs.find_element(By.CLASS_NAME, 'reviewer-progress')
         assert reviews
         assert len(reviews) == 1
-        headers = reviews[0].find_elements_by_tag_name('h4')
+        headers = reviews[0].find_elements(By.TAG_NAME, 'h4')
         assert headers
         assert headers[0].text == '2 of 2 Reviews Submitted'
 
@@ -714,21 +714,21 @@ class TestSingleBlindConference():
         pc_client = helpers.create_user('pc2@mail.com', 'ProgramChair', 'SomeLastName')
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS", pc_client.token, wait_for_element='your-consoles')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Program Chair Console' == console.find_element_by_tag_name('a').text
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Program Chair Console' == console.find_element(By.TAG_NAME, 'a').text
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Program_Chairs", pc_client.token, by=By.CLASS_NAME, wait_for_element='reviewer-status')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('paper-status')
-        assert tabs.find_element_by_id('areachair-status')
-        assert tabs.find_element_by_id('reviewer-status')
+        assert tabs.find_element(By.ID, 'paper-status')
+        assert tabs.find_element(By.ID, 'areachair-status')
+        assert tabs.find_element(By.ID, 'reviewer-status')
 
     def test_post_decisions(self, client, selenium, request_page):
 

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -610,8 +610,8 @@ class TestSingleBlindConference():
         tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         assert tabs.find_element(By.ID, 'your-consoles')
-        assert len(tabs.find_elements(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
-        console = tabs.find_elements(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
         assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
 
         request_page(selenium, "http://localhost:3030/group?id=NIPS.cc/2018/Workshop/MLITS/Authors", test_client.token, wait_for_element='your-submissions')
@@ -634,8 +634,8 @@ class TestSingleBlindConference():
         assert header
         assert len(header.find_elements(By.TAG_NAME, 'h1')) == 1
         assert 'Author Console' == header.find_elements(By.TAG_NAME, 'h1')[0].text
-        assert len(header.find_element(By.CLASS_NAME, 'description')) == 1
-        assert 'Set of instructions' == header.find_element(By.CLASS_NAME, 'description')[0].text
+        assert len(header.find_elements(By.CLASS_NAME, 'description')) == 1
+        assert 'Set of instructions' == header.find_elements(By.CLASS_NAME, 'description')[0].text
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         assert tabs.find_element(By.ID, 'author-tasks')
@@ -659,9 +659,9 @@ class TestSingleBlindConference():
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         assert tabs.find_element(By.ID, 'assigned-papers')
-        assert len(tabs.find_element(By.ID, 'assigned-papers').find_element(By.CLASS_NAME, 'note')) == 1
+        assert len(tabs.find_element(By.ID, 'assigned-papers').find_elements(By.CLASS_NAME, 'note')) == 1
         assert tabs.find_element(By.ID, 'reviewer-tasks')
-        assert len(tabs.find_element(By.ID, 'reviewer-tasks').find_element(By.CLASS_NAME, 'note')) == 1
+        assert len(tabs.find_element(By.ID, 'reviewer-tasks').find_elements(By.CLASS_NAME, 'note')) == 1
 
         conference.set_reviewerpage_header({
             'title': 'Reviewer Console',
@@ -675,14 +675,14 @@ class TestSingleBlindConference():
         assert header
         assert len(header.find_elements(By.TAG_NAME, 'h1')) == 1
         assert 'Reviewer Console' == header.find_elements(By.TAG_NAME, 'h1')[0].text
-        assert len(header.find_element(By.CLASS_NAME, 'description')) == 1
-        assert 'Set of instructions' == header.find_element(By.CLASS_NAME, 'description')[0].text
+        assert len(header.find_elements(By.CLASS_NAME, 'description')) == 1
+        assert 'Set of instructions' == header.find_elements(By.CLASS_NAME, 'description')[0].text
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         assert tabs.find_element(By.ID, 'assigned-papers')
-        assert len(tabs.find_element(By.ID, 'assigned-papers').find_element(By.CLASS_NAME, 'note')) == 1
+        assert len(tabs.find_element(By.ID, 'assigned-papers').find_elements(By.CLASS_NAME, 'note')) == 1
         assert tabs.find_element(By.ID, 'reviewer-tasks')
-        assert len(tabs.find_element(By.ID, 'reviewer-tasks').find_element(By.CLASS_NAME, 'note')) == 1
+        assert len(tabs.find_element(By.ID, 'reviewer-tasks').find_elements(By.CLASS_NAME, 'note')) == 1
 
         # Area chair user
         ac_client = helpers.create_user('ac2@mail.com', 'AC', 'MLITS')
@@ -700,10 +700,10 @@ class TestSingleBlindConference():
         tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         assert tabs.find_element(By.ID, 'assigned-papers')
-        assert len(tabs.find_element(By.ID, 'assigned-papers').find_element(By.CLASS_NAME, 'note')) == 1
+        assert len(tabs.find_element(By.ID, 'assigned-papers').find_elements(By.CLASS_NAME, 'note')) == 1
         assert tabs.find_element(By.ID, 'areachair-tasks')
-        assert len(tabs.find_element(By.ID, 'areachair-tasks').find_element(By.CLASS_NAME, 'note')) == 0
-        reviews = tabs.find_element(By.CLASS_NAME, 'reviewer-progress')
+        assert len(tabs.find_element(By.ID, 'areachair-tasks').find_elements(By.CLASS_NAME, 'note')) == 0
+        reviews = tabs.find_elements(By.CLASS_NAME, 'reviewer-progress')
         assert reviews
         assert len(reviews) == 1
         headers = reviews[0].find_elements(By.TAG_NAME, 'h4')

--- a/tests/test_single_blind_private_conference.py
+++ b/tests/test_single_blind_private_conference.py
@@ -169,20 +169,20 @@ class TestSingleBlindPrivateConference():
 
         request_page(selenium, "http://localhost:3030/group?id=MICCAI.org/2021/Challenges", wait_for_element='tabs-container')
         assert "MICCAI 2021 Challenges | OpenReview" in selenium.title
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert "MICCAI.org/2021/Challenges" == header.find_element_by_tag_name("h1").text
-        invitation_panel = selenium.find_element_by_id('invitation')
+        assert "MICCAI.org/2021/Challenges" == header.find_element(By.TAG_NAME, "h1").text
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 0
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         with pytest.raises(NoSuchElementException):
-            notes_panel.find_element_by_class_name('spinner-container')
-        assert tabs.find_element_by_id('oral')
-        assert tabs.find_element_by_id('poster')
+            notes_panel.find_element(By.CLASS_NAME, 'spinner-container')
+        assert tabs.find_element(By.ID, 'oral')
+        assert tabs.find_element(By.ID, 'poster')
 
     def test_enable_public_comments(self, conference, helpers, test_client, client):
         notes = test_client.get_notes(invitation='MICCAI.org/2021/Challenges/-/Submission', sort='tmdate')

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -514,7 +514,7 @@ class TestVenueRequest():
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
         reviewer_details = '''(reviewer_candidate1@email.com, Reviewer One)\nreviewer_candidate2@email.com, Reviewer Two\n '''
         recruitment_note = test_client.post_note(openreview.Note(
@@ -569,7 +569,7 @@ class TestVenueRequest():
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
         reviewer_details = '''reviewer_candidate1@email.com, Reviewer One\nreviewer_candidate2@email.com, Reviewer Two'''
         recruitment_note = test_client.post_note(openreview.Note(
@@ -691,7 +691,7 @@ class TestVenueRequest():
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Remind Recruitment']
 
         remind_recruitment_note = test_client.post_note(openreview.Note(
@@ -2179,7 +2179,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         author_page_url = 'http://localhost:3030/forum?id={}'.format(blind_submissions[0].forum, by=By.CLASS_NAME, wait_for_element='edit_button')
         request_page(selenium, author_page_url, token=author_client.token)
 
-        meta_actions = selenium.find_element(By.CLASS_NAME, 'meta_actions')
+        meta_actions = selenium.find_elements(By.CLASS_NAME, 'meta_actions')
         assert len(meta_actions) == 2
         ## Edit and trash buttons, the submission invitation is still open
         assert meta_actions[0].find_element(By.CLASS_NAME, 'edit_button')
@@ -2651,12 +2651,12 @@ url={https://openreview.net/forum?id='''+ note_id + '''}
         assert tabs
         accepted_panel = selenium.find_element(By.ID, 'accept')
         assert accepted_panel
-        accepted_notes = accepted_panel.find_element(By.CLASS_NAME, 'note')
+        accepted_notes = accepted_panel.find_elements(By.CLASS_NAME, 'note')
         assert accepted_notes
         assert len(accepted_notes) == 1
         rejected_panel = selenium.find_element(By.ID, 'reject')
         assert rejected_panel
-        rejected_notes = rejected_panel.find_element(By.CLASS_NAME, 'note')
+        rejected_notes = rejected_panel.find_elements(By.CLASS_NAME, 'note')
         assert rejected_notes
         assert len(rejected_notes) == 2
 

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -129,9 +129,9 @@ class TestVenueRequest():
 
         helpers.await_queue()
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(support_group_id), client.token)
-        header_div = selenium.find_element_by_id('header')
+        header_div = selenium.find_element(By.ID, 'header')
         assert header_div
-        title_tag = header_div.find_element_by_tag_name('h1')
+        title_tag = header_div.find_element(By.TAG_NAME, 'h1')
         assert title_tag
         assert title_tag.text == 'Host a Venue'
 
@@ -357,9 +357,9 @@ class TestVenueRequest():
 
         # Test Revision
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token, wait_for_element='header')
-        header_div = selenium.find_element_by_id('header')
+        header_div = selenium.find_element(By.ID, 'header')
         assert header_div
-        title_tag = header_div.find_element_by_tag_name('h1')
+        title_tag = header_div.find_element(By.TAG_NAME, 'h1')
         assert title_tag
         assert title_tag.text == venue['request_form_note'].content['title']
 
@@ -424,9 +424,9 @@ class TestVenueRequest():
 
         # Test Revision
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token, wait_for_element='header')
-        header_div = selenium.find_element_by_id('header')
+        header_div = selenium.find_element(By.ID, 'header')
         assert header_div
-        title_tag = header_div.find_element_by_tag_name('h1')
+        title_tag = header_div.find_element(By.TAG_NAME, 'h1')
         assert title_tag
         assert title_tag.text == venue['request_form_note'].content['title']
 
@@ -483,9 +483,9 @@ class TestVenueRequest():
         assert process_logs[0]['invitation'] == '{}/-/Request{}/Revision'.format(venue['support_group_id'], venue['request_form_note'].number)
 
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token, wait_for_element='header')
-        header_div = selenium.find_element_by_id('header')
+        header_div = selenium.find_element(By.ID, 'header')
         assert header_div
-        title_tag = header_div.find_element_by_tag_name('h1')
+        title_tag = header_div.find_element(By.TAG_NAME, 'h1')
         assert title_tag
         assert title_tag.text == '{} Updated'.format(venue['request_form_note'].content['title'])
 
@@ -510,11 +510,11 @@ class TestVenueRequest():
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token, wait_for_element=f"note_{venue['request_form_note'].id}")
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(venue['request_form_note'].id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(venue['request_form_note'].id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
         reviewer_details = '''(reviewer_candidate1@email.com, Reviewer One)\nreviewer_candidate2@email.com, Reviewer Two\n '''
         recruitment_note = test_client.post_note(openreview.Note(
@@ -565,11 +565,11 @@ class TestVenueRequest():
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token, wait_for_element=f"note_{venue['request_form_note'].id}")
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(venue['request_form_note'].id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(venue['request_form_note'].id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
         reviewer_details = '''reviewer_candidate1@email.com, Reviewer One\nreviewer_candidate2@email.com, Reviewer Two'''
         recruitment_note = test_client.post_note(openreview.Note(
@@ -622,11 +622,11 @@ class TestVenueRequest():
 
         # Test Reviewer Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token, wait_for_element=f"note_{venue['request_form_note'].id}")
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(venue['request_form_note'].id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(venue['request_form_note'].id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
         helpers.create_user('reviewer_one_tilde@mail.com', 'Reviewer', 'OneTilde')
         helpers.create_user('reviewer_two_tilde@mail.com', 'Reviewer', 'TwoTilde')
@@ -687,11 +687,11 @@ class TestVenueRequest():
 
         # Test Reviewer Remind Recruitment
         request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token, wait_for_element=f"note_{venue['request_form_note'].id}")
-        recruitment_div = selenium.find_element_by_id('note_{}'.format(venue['request_form_note'].id))
+        recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(venue['request_form_note'].id))
         assert recruitment_div
-        reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_elements_by_class_name('btn-xs')
+        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Remind Recruitment']
 
         remind_recruitment_note = test_client.post_note(openreview.Note(
@@ -984,7 +984,7 @@ class TestVenueRequest():
         reviewer_url = 'http://localhost:3030/group?id={}#reviewer-tasks'.format(reviewer_group_id)
         request_page(selenium, reviewer_url, reviewer_client.token)
         with pytest.raises(NoSuchElementException):
-            assert selenium.find_element_by_link_text('Reviewer Bid')
+            assert selenium.find_element(By.LINK_TEXT, 'Reviewer Bid')
 
         now = datetime.datetime.utcnow()
         start_date = now - datetime.timedelta(days=2)
@@ -1012,7 +1012,7 @@ class TestVenueRequest():
         assert process_logs[0]['status'] == 'ok'
 
         request_page(selenium, reviewer_url, reviewer_client.token, By.LINK_TEXT, wait_for_element='Reviewer Bid')
-        assert selenium.find_element_by_link_text('Reviewer Bid')
+        assert selenium.find_element(By.LINK_TEXT, 'Reviewer Bid')
 
     def test_venue_matching_setup(self, client, test_client, selenium, request_page, helpers, venue):
         # add a member to PC group
@@ -1400,9 +1400,9 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         reviewer_page_url = 'http://localhost:3030/group?id={}/Reviewers#assigned-papers'.format(venue['venue_id'])
         request_page(selenium, reviewer_page_url, token=reviewer_client.token, by=By.LINK_TEXT, wait_for_element='test submission')
 
-        note_div = selenium.find_element_by_id('note-summary-1')
+        note_div = selenium.find_element(By.ID, 'note-summary-1')
         assert note_div
-        assert 'test submission' == note_div.find_element_by_link_text('test submission').text
+        assert 'test submission' == note_div.find_element(By.LINK_TEXT, 'test submission').text
 
         review_invitations = client.get_invitations(super='{}/-/Official_Review'.format(venue['venue_id']))
         assert review_invitations and len(review_invitations) == 2
@@ -1460,13 +1460,13 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         ac_page_url = 'http://localhost:3030/group?id={}/Area_Chairs'.format(venue['venue_id'])
         request_page(selenium, ac_page_url, token=meta_reviewer_client.token, wait_for_element='1-metareview-status')
 
-        submit_div_1 = selenium.find_element_by_id('1-metareview-status')
+        submit_div_1 = selenium.find_element(By.ID, '1-metareview-status')
         with pytest.raises(NoSuchElementException):
-            assert submit_div_1.find_element_by_link_text('Submit')
+            assert submit_div_1.find_element(By.LINK_TEXT, 'Submit')
 
-        submit_div_2 = selenium.find_element_by_id('2-metareview-status')
+        submit_div_2 = selenium.find_element(By.ID, '2-metareview-status')
         with pytest.raises(NoSuchElementException):
-            assert submit_div_2.find_element_by_link_text('Submit')
+            assert submit_div_2.find_element(By.LINK_TEXT, 'Submit')
 
         # Post a meta review stage note
         now = datetime.datetime.utcnow()
@@ -1516,18 +1516,18 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         # Assert that AC now see the Submit button for assigned papers
         request_page(selenium, ac_page_url, token=meta_reviewer_client.token, wait_for_element='note-summary-2')
 
-        note_div_1 = selenium.find_element_by_id('note-summary-1')
+        note_div_1 = selenium.find_element(By.ID, 'note-summary-1')
         assert note_div_1
-        note_div_2 = selenium.find_element_by_id('note-summary-2')
+        note_div_2 = selenium.find_element(By.ID, 'note-summary-2')
         assert note_div_2
-        assert 'test submission' == note_div_1.find_element_by_link_text('test submission').text
-        assert 'test submission 2' == note_div_2.find_element_by_link_text('test submission 2').text
+        assert 'test submission' == note_div_1.find_element(By.LINK_TEXT, 'test submission').text
+        assert 'test submission 2' == note_div_2.find_element(By.LINK_TEXT, 'test submission 2').text
 
-        submit_div_1 = selenium.find_element_by_id('1-metareview-status')
-        assert submit_div_1.find_element_by_link_text('Submit')
+        submit_div_1 = selenium.find_element(By.ID, '1-metareview-status')
+        assert submit_div_1.find_element(By.LINK_TEXT, 'Submit')
 
-        submit_div_2 = selenium.find_element_by_id('2-metareview-status')
-        assert submit_div_2.find_element_by_link_text('Submit')
+        submit_div_2 = selenium.find_element(By.ID, '2-metareview-status')
+        assert submit_div_2.find_element(By.LINK_TEXT, 'Submit')
 
         meta_review_invitations = client.get_invitations(super='{}/-/Meta_Review'.format(venue['venue_id']))
         assert meta_review_invitations and len(meta_review_invitations) == 2
@@ -2179,13 +2179,13 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         author_page_url = 'http://localhost:3030/forum?id={}'.format(blind_submissions[0].forum, by=By.CLASS_NAME, wait_for_element='edit_button')
         request_page(selenium, author_page_url, token=author_client.token)
 
-        meta_actions = selenium.find_elements_by_class_name('meta_actions')
+        meta_actions = selenium.find_element(By.CLASS_NAME, 'meta_actions')
         assert len(meta_actions) == 2
         ## Edit and trash buttons, the submission invitation is still open
-        assert meta_actions[0].find_element_by_class_name('edit_button')
-        assert meta_actions[0].find_element_by_class_name('trash_button')
+        assert meta_actions[0].find_element(By.CLASS_NAME, 'edit_button')
+        assert meta_actions[0].find_element(By.CLASS_NAME, 'trash_button')
         ## Reference invitations
-        assert 'Revision' == meta_actions[1].find_element_by_class_name('edit_button').text
+        assert 'Revision' == meta_actions[1].find_element(By.CLASS_NAME, 'edit_button').text
 
         # Post revision note for a submission
         revision_note = author_client.post_note(openreview.Note(
@@ -2645,18 +2645,18 @@ url={https://openreview.net/forum?id='''+ note_id + '''}
 
         #make sure homepage webfield was not overwritten after doing get_conference()
         request_page(selenium, "http://localhost:3030/group?id=TEST.cc/2030/Conference", wait_for_element='reject')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        accepted_panel = selenium.find_element_by_id('accept')
+        accepted_panel = selenium.find_element(By.ID, 'accept')
         assert accepted_panel
-        accepted_notes = accepted_panel.find_elements_by_class_name('note')
+        accepted_notes = accepted_panel.find_element(By.CLASS_NAME, 'note')
         assert accepted_notes
         assert len(accepted_notes) == 1
-        rejected_panel = selenium.find_element_by_id('reject')
+        rejected_panel = selenium.find_element(By.ID, 'reject')
         assert rejected_panel
-        rejected_notes = rejected_panel.find_elements_by_class_name('note')
+        rejected_notes = rejected_panel.find_element(By.CLASS_NAME, 'note')
         assert rejected_notes
         assert len(rejected_notes) == 2
 

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -626,7 +626,7 @@ class TestVenueRequest():
         assert recruitment_div
         reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         assert reply_row
-        buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         assert [btn for btn in buttons if btn.text == 'Recruitment']
         helpers.create_user('reviewer_one_tilde@mail.com', 'Reviewer', 'OneTilde')
         helpers.create_user('reviewer_two_tilde@mail.com', 'Reviewer', 'TwoTilde')

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -447,7 +447,7 @@ class TestVenueRequest():
         # assert recruitment_div
         # reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         # assert reply_row
-        # buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        # buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Recruitment']
         reviewer_details = '''reviewer_candidate1_v2@mail.com, Reviewer One\nreviewer_candidate2_v2@mail.com, Reviewer Two'''
         recruitment_note = test_client.post_note(openreview.Note(
@@ -532,7 +532,7 @@ class TestVenueRequest():
         # assert recruitment_div
         # reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         # assert reply_row
-        # buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        # buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Recruitment']
         reviewer_details = '''reviewer_candidate1_v2@mail.com, Reviewer One\nreviewer_error@mail.com;, Reviewer Error\nReviewer_Candidate2_v2@mail.com, Reviewer Two'''
         recruitment_note = test_client.post_note(openreview.Note(
@@ -645,7 +645,7 @@ class TestVenueRequest():
         # assert recruitment_div
         # reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         # assert reply_row
-        # buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        # buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Recruitment']
         helpers.create_user('reviewer_one_tilde_v2@mail.com', 'Reviewer', 'OneTildeV')
         helpers.create_user('reviewer_two_tilde_v2@mail.com', 'Reviewer', 'TwoTildeV')
@@ -758,7 +758,7 @@ class TestVenueRequest():
         # assert recruitment_div
         # reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         # assert reply_row
-        # buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
+        # buttons = reply_row.find_elements(By.CLASS_NAME, 'btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Remind Recruitment']
 
         remind_recruitment_note = test_client.post_note(openreview.Note(
@@ -2875,6 +2875,6 @@ Best,
 #         assert len(accepted_notes) == 1
 #         rejected_panel = selenium.find_element(By.ID, 'reject')
 #         assert rejected_panel
-#         rejected_notes = rejected_panel.find_element(By.CLASS_NAME, 'note')
+#         rejected_notes = rejected_panel.find_elements(By.CLASS_NAME, 'note')
 #         assert rejected_notes
 #         assert len(rejected_notes) == 2

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -322,9 +322,9 @@ class TestVenueRequest():
 
 #         # Test Revision
 #         request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token, wait_for_element='header')
-#         header_div = selenium.find_element_by_id('header')
+#         header_div = selenium.find_element(By.ID, 'header')
 #         assert header_div
-#         title_tag = header_div.find_element_by_tag_name('h1')
+#         title_tag = header_div.find_element(By.TAG_NAME, 'h1')
 #         assert title_tag
 #         assert title_tag.text == venue['request_form_note'].content['title']
 
@@ -388,9 +388,9 @@ class TestVenueRequest():
 
         # Test Revision
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token, wait_for_element='header')
-        header_div = selenium.find_element_by_id('header')
+        header_div = selenium.find_element(By.ID, 'header')
         assert header_div
-        title_tag = header_div.find_element_by_tag_name('h1')
+        title_tag = header_div.find_element(By.TAG_NAME, 'h1')
         assert title_tag
         assert title_tag.text == venue['request_form_note'].content['title']
 
@@ -433,9 +433,9 @@ class TestVenueRequest():
         assert process_logs[0]['invitation'] == '{}/-/Request{}/Revision'.format(venue['support_group_id'], venue['request_form_note'].number)
 
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token, wait_for_element='header')
-        header_div = selenium.find_element_by_id('header')
+        header_div = selenium.find_element(By.ID, 'header')
         assert header_div
-        title_tag = header_div.find_element_by_tag_name('h1')
+        title_tag = header_div.find_element(By.TAG_NAME, 'h1')
         assert title_tag
         assert title_tag.text == '{} Updated'.format(venue['request_form_note'].content['title'])
 
@@ -443,11 +443,11 @@ class TestVenueRequest():
 
         # Test Reviewer Recruitment
         # request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token, wait_for_element=f"note_{venue['request_form_note'].id}")
-        # recruitment_div = selenium.find_element_by_id('note_{}'.format(venue['request_form_note'].id))
+        # recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(venue['request_form_note'].id))
         # assert recruitment_div
-        # reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        # reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         # assert reply_row
-        # buttons = reply_row.find_elements_by_class_name('btn-xs')
+        # buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Recruitment']
         reviewer_details = '''reviewer_candidate1_v2@mail.com, Reviewer One\nreviewer_candidate2_v2@mail.com, Reviewer Two'''
         recruitment_note = test_client.post_note(openreview.Note(
@@ -528,11 +528,11 @@ class TestVenueRequest():
 
         # Test Reviewer Recruitment
         # request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token, wait_for_element=f"note_{venue['request_form_note'].id}")
-        # recruitment_div = selenium.find_element_by_id('note_{}'.format(venue['request_form_note'].id))
+        # recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(venue['request_form_note'].id))
         # assert recruitment_div
-        # reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        # reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         # assert reply_row
-        # buttons = reply_row.find_elements_by_class_name('btn-xs')
+        # buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Recruitment']
         reviewer_details = '''reviewer_candidate1_v2@mail.com, Reviewer One\nreviewer_error@mail.com;, Reviewer Error\nReviewer_Candidate2_v2@mail.com, Reviewer Two'''
         recruitment_note = test_client.post_note(openreview.Note(
@@ -586,13 +586,13 @@ class TestVenueRequest():
         invalid_accept_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1].replace('user=reviewer_candidate2_v2%40mail.com', 'user=reviewer_candidate2_v1%40mail.com')
         print(invalid_accept_url)
         helpers.respond_invitation(selenium, request_page, invalid_accept_url, accept=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'Wrong key, please refer back to the recruitment email' == error_message.text
 
         openreview_client.remove_members_from_group('V2.cc/2030/Conference/Reviewers/Invited', 'reviewer_candidate2_v2@mail.com')
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
-        error_message = selenium.find_element_by_class_name('important_message')
+        error_message = selenium.find_element(By.CLASS_NAME, 'important_message')
         assert 'User not in invited group, please accept the invitation using the email address you were invited with' == error_message.text
 
         openreview_client.add_members_to_group('V2.cc/2030/Conference/Reviewers/Invited', 'reviewer_candidate2_v2@mail.com')
@@ -641,11 +641,11 @@ class TestVenueRequest():
 
         # Test Reviewer Recruitment
         # request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token, wait_for_element=f"note_{venue['request_form_note'].id}")
-        # recruitment_div = selenium.find_element_by_id('note_{}'.format(venue['request_form_note'].id))
+        # recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(venue['request_form_note'].id))
         # assert recruitment_div
-        # reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        # reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         # assert reply_row
-        # buttons = reply_row.find_elements_by_class_name('btn-xs')
+        # buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Recruitment']
         helpers.create_user('reviewer_one_tilde_v2@mail.com', 'Reviewer', 'OneTildeV')
         helpers.create_user('reviewer_two_tilde_v2@mail.com', 'Reviewer', 'TwoTildeV')
@@ -754,11 +754,11 @@ class TestVenueRequest():
 
         # Test Reviewer Remind Recruitment
         # request_page(selenium, 'http://localhost:3030/forum?id={}'.format(venue['request_form_note'].id), test_client.token, wait_for_element=f"note_{venue['request_form_note'].id}")
-        # recruitment_div = selenium.find_element_by_id('note_{}'.format(venue['request_form_note'].id))
+        # recruitment_div = selenium.find_element(By.ID, 'note_{}'.format(venue['request_form_note'].id))
         # assert recruitment_div
-        # reply_row = recruitment_div.find_element_by_class_name('reply_row')
+        # reply_row = recruitment_div.find_element(By.CLASS_NAME, 'reply_row')
         # assert reply_row
-        # buttons = reply_row.find_elements_by_class_name('btn-xs')
+        # buttons = reply_row.find_element(By.CLASS_NAME, 'btn-xs')
         # assert [btn for btn in buttons if btn.text == 'Remind Recruitment']
 
         remind_recruitment_note = test_client.post_note(openreview.Note(
@@ -935,7 +935,7 @@ class TestVenueRequest():
         # reviewer_url = 'http://localhost:3030/group?id={}#reviewer-tasks'.format(reviewer_group_id)
         # request_page(selenium, reviewer_url, reviewer_client.token)
         # with pytest.raises(NoSuchElementException):
-        #     assert selenium.find_element_by_link_text('Reviewer Bid')
+        #     assert selenium.find_element(By.LINK_TEXT, 'Reviewer Bid')
 
         now = datetime.datetime.utcnow()
         start_date = now - datetime.timedelta(days=2)
@@ -969,7 +969,7 @@ class TestVenueRequest():
         assert bid_invitation
 
         # request_page(selenium, reviewer_url, reviewer_client.token, By.LINK_TEXT, wait_for_element='Reviewer Bid')
-        # assert selenium.find_element_by_link_text('Reviewer Bid')
+        # assert selenium.find_element(By.LINK_TEXT, 'Reviewer Bid')
 
     def test_venue_matching_setup(self, client, test_client, selenium, request_page, helpers, venue, openreview_client):
 
@@ -1418,9 +1418,9 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         reviewer_page_url = 'http://localhost:3030/group?id=V2.cc/2030/Conference/Reviewers#assigned-papers'
         request_page(selenium, reviewer_page_url, token=reviewer_client.token, by=By.LINK_TEXT, wait_for_element='test submission')
 
-        note_div = selenium.find_element_by_class_name('note')
+        note_div = selenium.find_element(By.CLASS_NAME, 'note')
         assert note_div
-        assert 'test submission' == note_div.find_element_by_link_text('test submission').text
+        assert 'test submission' == note_div.find_element(By.LINK_TEXT, 'test submission').text
 
         review_invitations = openreview_client.get_invitations(invitation='{}/-/Official_Review'.format(venue['venue_id']))
         assert review_invitations and len(review_invitations) == 3
@@ -1700,13 +1700,13 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         # ac_page_url = 'http://localhost:3030/group?id={}/Area_Chairs'.format(venue['venue_id'])
         # request_page(selenium, ac_page_url, token=meta_reviewer_client.token, wait_for_element='1-metareview-status')
 
-        # submit_div_1 = selenium.find_element_by_id('1-metareview-status')
+        # submit_div_1 = selenium.find_element(By.ID, '1-metareview-status')
         # with pytest.raises(NoSuchElementException):
-        #     assert submit_div_1.find_element_by_link_text('Submit')
+        #     assert submit_div_1.find_element(By.LINK_TEXT, 'Submit')
 
-        # submit_div_2 = selenium.find_element_by_id('2-metareview-status')
+        # submit_div_2 = selenium.find_element(By.ID, '2-metareview-status')
         # with pytest.raises(NoSuchElementException):
-        #     assert submit_div_2.find_element_by_link_text('Submit')
+        #     assert submit_div_2.find_element(By.LINK_TEXT, 'Submit')
 
         # Post a meta review stage note
         now = datetime.datetime.utcnow()
@@ -1772,18 +1772,18 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         # # Assert that AC now see the Submit button for assigned papers
         # request_page(selenium, ac_page_url, token=meta_reviewer_client.token, wait_for_element='note-summary-2')
 
-        # note_div_1 = selenium.find_element_by_id('note-summary-1')
+        # note_div_1 = selenium.find_element(By.ID, 'note-summary-1')
         # assert note_div_1
-        # note_div_2 = selenium.find_element_by_id('note-summary-2')
+        # note_div_2 = selenium.find_element(By.ID, 'note-summary-2')
         # assert note_div_2
-        # assert 'test submission' == note_div_1.find_element_by_link_text('test submission').text
-        # assert 'test submission 2' == note_div_2.find_element_by_link_text('test submission 2').text
+        # assert 'test submission' == note_div_1.find_element(By.LINK_TEXT, 'test submission').text
+        # assert 'test submission 2' == note_div_2.find_element(By.LINK_TEXT, 'test submission 2').text
 
-        # submit_div_1 = selenium.find_element_by_id('1-metareview-status')
-        # assert submit_div_1.find_element_by_link_text('Submit')
+        # submit_div_1 = selenium.find_element(By.ID, '1-metareview-status')
+        # assert submit_div_1.find_element(By.LINK_TEXT, 'Submit')
 
-        # submit_div_2 = selenium.find_element_by_id('2-metareview-status')
-        # assert submit_div_2.find_element_by_link_text('Submit')
+        # submit_div_2 = selenium.find_element(By.ID, '2-metareview-status')
+        # assert submit_div_2.find_element(By.LINK_TEXT, 'Submit')
 
         meta_review_invitation = openreview_client.get_invitation(id='{}/Submission1/-/Meta_Review'.format(venue['venue_id']))
         assert meta_review_invitation
@@ -2670,9 +2670,9 @@ Best,
         assert f"https://openreview.net/forum?id={submissions[0].id}" in last_message['content']['text']
 
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(venue['venue_id']), test_client.token, wait_for_element='header')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         assert tabs.find_element(By.LINK_TEXT, "Your Consoles")
         assert tabs.find_element(By.LINK_TEXT, "Accept")
@@ -2864,17 +2864,17 @@ Best,
 
 #         #make sure homepage webfield was not overwritten after doing get_conference()
 #         request_page(selenium, "http://localhost:3030/group?id=TEST.cc/2030/Conference", wait_for_element='reject')
-#         notes_panel = selenium.find_element_by_id('notes')
+#         notes_panel = selenium.find_element(By.ID, 'notes')
 #         assert notes_panel
-#         tabs = notes_panel.find_element_by_class_name('tabs-container')
+#         tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
 #         assert tabs
-#         accepted_panel = selenium.find_element_by_id('accept')
+#         accepted_panel = selenium.find_element(By.ID, 'accept')
 #         assert accepted_panel
-#         accepted_notes = accepted_panel.find_elements_by_class_name('note')
+#         accepted_notes = accepted_panel.find_element(By.CLASS_NAME, 'note')
 #         assert accepted_notes
 #         assert len(accepted_notes) == 1
-#         rejected_panel = selenium.find_element_by_id('reject')
+#         rejected_panel = selenium.find_element(By.ID, 'reject')
 #         assert rejected_panel
-#         rejected_notes = rejected_panel.find_elements_by_class_name('note')
+#         rejected_notes = rejected_panel.find_element(By.CLASS_NAME, 'note')
 #         assert rejected_notes
 #         assert len(rejected_notes) == 2

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -56,25 +56,25 @@ class TestWorkshop():
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP", wait_for_element='recent-activity')
 
         assert "ICAPS 2019 Workshop HSDIP | OpenReview" in selenium.title
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert "Heuristics and Search for Domain-independent Planning" == header.find_element_by_tag_name("h1").text
-        assert "ICAPS 2019 Workshop" == header.find_element_by_tag_name("h3").text
-        assert "Berkeley, CA, USA" == header.find_element_by_xpath(".//span[@class='venue-location']").text
-        assert "July 11-15, 2019" == header.find_element_by_xpath(".//span[@class='venue-date']").text
-        assert "https://icaps19.icaps-conference.org/workshops/HSDIP/index" in header.find_element_by_xpath(".//span[@class='venue-website']/a").text
-        invitation_panel = selenium.find_element_by_id('invitation')
+        assert "Heuristics and Search for Domain-independent Planning" == header.find_element(By.TAG_NAME, "h1").text
+        assert "ICAPS 2019 Workshop" == header.find_element(By.TAG_NAME, "h3").text
+        assert "Berkeley, CA, USA" == header.find_element(By.XPATH, ".//span[@class='venue-location']").text
+        assert "July 11-15, 2019" == header.find_element(By.XPATH, ".//span[@class='venue-date']").text
+        assert "https://icaps19.icaps-conference.org/workshops/HSDIP/index" in header.find_element(By.XPATH, ".//span[@class='venue-website']/a").text
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'ICAPS 2019 Workshop HSDIP Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'ICAPS 2019 Workshop HSDIP Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 0
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_tag_name('ul')) == 0
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 0
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.TAG_NAME, 'ul')) == 0
 
     def test_post_submissions(self, client, conference, test_client, peter_client, selenium, request_page):
 
@@ -95,68 +95,68 @@ class TestWorkshop():
 
         # Author user
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP", test_client.token, wait_for_element='recent-activity')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'ICAPS 2019 Workshop HSDIP Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'ICAPS 2019 Workshop HSDIP Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Author Console' == console.find_element_by_tag_name('a').text
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 1
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 1
 
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Authors", test_client.token, wait_for_element='your-submissions')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 2
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 2
 
         # Guest user
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP", wait_for_element='your-consoles')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'ICAPS 2019 Workshop HSDIP Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'ICAPS 2019 Workshop HSDIP Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 0
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 0
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 0
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 0
 
         # Co-author user
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP", peter_client.token, wait_for_element='recent-activity')
-        invitation_panel = selenium.find_element_by_id('invitation')
+        invitation_panel = selenium.find_element(By.ID, 'invitation')
         assert invitation_panel
-        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
-        assert 'ICAPS 2019 Workshop HSDIP Submission' == invitation_panel.find_element_by_class_name('btn').text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert len(invitation_panel.find_elements(By.TAG_NAME, 'div')) == 1
+        assert 'ICAPS 2019 Workshop HSDIP Submission' == invitation_panel.find_element(By.CLASS_NAME, 'btn').text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('your-consoles')
-        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
-        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
-        assert 'Author Console' == console.find_element_by_tag_name('a').text
-        assert tabs.find_element_by_id('recent-activity')
-        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 1
+        assert tabs.find_element(By.ID, 'your-consoles')
+        assert len(tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')) == 1
+        console = tabs.find_element(By.ID, 'your-consoles').find_elements(By.TAG_NAME, 'ul')[0]
+        assert 'Author Console' == console.find_element(By.TAG_NAME, 'a').text
+        assert tabs.find_element(By.ID, 'recent-activity')
+        assert len(tabs.find_element(By.ID, 'recent-activity').find_elements(By.CLASS_NAME, 'activity-list')) == 1
 
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Authors", peter_client.token, wait_for_element='your-submissions')
-        tabs = selenium.find_element_by_class_name('tabs-container')
+        tabs = selenium.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('author-tasks')
-        assert tabs.find_element_by_id('your-submissions')
-        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('console-table')
-        assert len(papers.find_elements_by_tag_name('tr')) == 2
+        assert tabs.find_element(By.ID, 'author-tasks')
+        assert tabs.find_element(By.ID, 'your-submissions')
+        papers = tabs.find_element(By.ID, 'your-submissions').find_element(By.CLASS_NAME, 'console-table')
+        assert len(papers.find_elements(By.TAG_NAME, 'tr')) == 2
 
     def test_create_blind_submissions(self, client, test_client, conference):
 
@@ -265,16 +265,16 @@ class TestWorkshop():
         conference.set_assignment('reviewer4@mail.com', submission.number)
 
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Official Review' == reply_row.find_elements_by_class_name('btn')[0].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert 'Official Review' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         # Author
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
-        reply_row = selenium.find_element_by_class_name('reply_row')
-        assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Withdraw' == reply_row.find_elements_by_class_name('btn')[0].text
+        reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
+        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert 'Withdraw' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         anon_reviewers_group_id = reviewer_client.get_groups(regex=f'{conference.id}/Paper1/Reviewer_', signatory='reviewer4@mail.com')[0].id
 
@@ -545,26 +545,26 @@ class TestWorkshop():
 
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP#oral-presentations", client.token, wait_for_element='oral-presentations')
         assert "ICAPS 2019 Workshop HSDIP | OpenReview" in selenium.title
-        header = selenium.find_element_by_id('header')
+        header = selenium.find_element(By.ID, 'header')
         assert header
-        assert "Heuristics and Search for Domain-independent Planning" == header.find_element_by_tag_name("h1").text
-        assert "ICAPS 2019 Workshop" == header.find_element_by_tag_name("h3").text
-        assert "Berkeley, CA, USA" == header.find_element_by_xpath(".//span[@class='venue-location']").text
-        assert "July 11-15, 2019" == header.find_element_by_xpath(".//span[@class='venue-date']").text
-        assert "https://icaps19.icaps-conference.org/workshops/HSDIP/index" in header.find_element_by_xpath(".//span[@class='venue-website']/a").text
-        notes_panel = selenium.find_element_by_id('notes')
+        assert "Heuristics and Search for Domain-independent Planning" == header.find_element(By.TAG_NAME, "h1").text
+        assert "ICAPS 2019 Workshop" == header.find_element(By.TAG_NAME, "h3").text
+        assert "Berkeley, CA, USA" == header.find_element(By.XPATH, ".//span[@class='venue-location']").text
+        assert "July 11-15, 2019" == header.find_element(By.XPATH, ".//span[@class='venue-date']").text
+        assert "https://icaps19.icaps-conference.org/workshops/HSDIP/index" in header.find_element(By.XPATH, ".//span[@class='venue-website']/a").text
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        accepted_panel = selenium.find_element_by_id('oral-presentations')
+        accepted_panel = selenium.find_element(By.ID, 'oral-presentations')
         assert accepted_panel
-        accepted_notes = accepted_panel.find_elements_by_class_name('note')
+        accepted_notes = accepted_panel.find_element(By.CLASS_NAME, 'note')
         assert accepted_notes
         assert len(accepted_notes) == 1
 
         pc_client = openreview.Client(username='program_chairs@hsdip.org', password=helpers.strong_password)
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP", pc_client.token, wait_for_element='your-consoles')
-        consoles_tab = selenium.find_element_by_id('your-consoles')
+        consoles_tab = selenium.find_element(By.ID, 'your-consoles')
         assert consoles_tab
 
     def test_pc_console(self, client, conference, selenium, request_page, helpers):
@@ -573,22 +573,22 @@ class TestWorkshop():
 
         request_page(selenium, "http://localhost:3030/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs#paper-status", pc_client.token, wait_for_element='paper-status')
         assert "ICAPS 2019 Workshop HSDIP Program Chairs | OpenReview" in selenium.title
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
-        assert tabs.find_element_by_id('paper-status')
-        assert tabs.find_element_by_id('reviewer-status')
+        assert tabs.find_element(By.ID, 'paper-status')
+        assert tabs.find_element(By.ID, 'reviewer-status')
         with pytest.raises(NoSuchElementException):
-            assert tabs.find_element_by_id('areachair-status')
+            assert tabs.find_element(By.ID, 'areachair-status')
 
-        assert '#' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-1').text
-        assert 'Paper Summary' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-2').text
-        assert 'Review Progress' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-3').text
-        assert 'Decision' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-4').text
+        assert '#' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-1').text
+        assert 'Paper Summary' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-2').text
+        assert 'Review Progress' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-3').text
+        assert 'Decision' == tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-4').text
 
         with pytest.raises(NoSuchElementException):
-            assert tabs.find_element_by_id('paper-status').find_element_by_class_name('row-5')
+            assert tabs.find_element(By.ID, 'paper-status').find_element(By.CLASS_NAME, 'row-5')
 
     def test_accepted_papers(self, client, conference, test_client, helpers):
 

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -266,14 +266,14 @@ class TestWorkshop():
 
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, reviewer_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
         assert 'Official Review' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         # Author
         request_page(selenium, "http://localhost:3030/forum?id=" + submission.id, test_client.token, by=By.CLASS_NAME, wait_for_element='reply_row')
 
         reply_row = selenium.find_element(By.CLASS_NAME, 'reply_row')
-        assert len(reply_row.find_element(By.CLASS_NAME, 'btn')) == 1
+        assert len(reply_row.find_elements(By.CLASS_NAME, 'btn')) == 1
         assert 'Withdraw' == reply_row.find_elements(By.CLASS_NAME, 'btn')[0].text
 
         anon_reviewers_group_id = reviewer_client.get_groups(regex=f'{conference.id}/Paper1/Reviewer_', signatory='reviewer4@mail.com')[0].id
@@ -558,7 +558,7 @@ class TestWorkshop():
         assert tabs
         accepted_panel = selenium.find_element(By.ID, 'oral-presentations')
         assert accepted_panel
-        accepted_notes = accepted_panel.find_element(By.CLASS_NAME, 'note')
+        accepted_notes = accepted_panel.find_elements(By.CLASS_NAME, 'note')
         assert accepted_notes
         assert len(accepted_notes) == 1
 

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -458,8 +458,8 @@ Best,
         assert len(invitations) == 6
 
         request_page(selenium, 'http://localhost:3030/group?id=PRL/2023/ICAPS/Publication_Chairs', publication_chair_client.token, wait_for_element='header')
-        notes_panel = selenium.find_element_by_id('notes')
+        notes_panel = selenium.find_element(By.ID, 'notes')
         assert notes_panel
-        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        tabs = notes_panel.find_element(By.CLASS_NAME, 'tabs-container')
         assert tabs
         assert tabs.find_element(By.LINK_TEXT, "Accepted Submissions")


### PR DESCRIPTION
- Update the tests to use the version 4.9.1 of selenium. 
- Using version 4.10 and higher throws an error, I'm waiting for a response here: https://github.com/pytest-dev/pytest-selenium/issues/315