### PR TITLE
Paper Matching: allow gurobi solver

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -10,6 +10,8 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         urls = openreview.tools.get_base_urls(client)
         openreview_client = openreview.api.OpenReviewClient(baseurl = urls[1], token=client.token)
         venue = openreview.venue.Venue(openreview_client, note.content['venue_id'], support_user)
+        venue_group = openreview.tools.get_group(openreview_client, note.content['venue_id'])
+        venue_content = venue_group.content if venue_group else {}
         
         ## Run test faster
         if 'openreview.net' in support_user:
@@ -26,6 +28,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.senior_area_chair_roles = note.content.get('senior_area_chair_roles', ['Senior_Area_Chairs'])
         venue.area_chair_roles = note.content.get('area_chair_roles', ['Area_Chairs'])
         venue.reviewer_roles = note.content.get('reviewer_roles', ['Reviewers'])
+        venue.allow_gurobi_solver = venue_content.get('allow_gurobi_solver', {}).get('value', False)
         set_homepage_options(note, venue)
         venue.reviewer_identity_readers = get_identity_readers(note, 'reviewer_identity')
         venue.area_chair_identity_readers = get_identity_readers(note, 'area_chair_identity')

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -254,6 +254,9 @@ class GroupBuilder(object):
         if venue_group.content.get('reviewers_proposed_assignment_title'):
             content['reviewers_proposed_assignment_title'] = venue_group.content.get('reviewers_proposed_assignment_title')
 
+        if venue_group.content.get('allow_gurobi_solver'):
+            content['allow_gurobi_solver'] = venue_group.content.get('allow_gurobi_solver')
+
         if venue_group.content.get('reviewers_conflict_policy'):
             content['reviewers_conflict_policy'] = venue_group.content.get('reviewers_conflict_policy')
 

--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -194,6 +194,26 @@ class Matching(object):
             }
             edge_label = None
 
+        if venue.get_constraint_label_id(self.match_group.id) == edge_id:
+            edge_head = {
+                'param': {
+                    'type': 'group',
+                    'const': self.match_group.id
+                }
+            }
+
+            edge_weight = {
+                'param': {
+                    'minimum': -1,
+                    'optional': True
+                }
+            }
+            edge_label = {
+                "param": {
+                    "regex": ".*",
+                }                
+            }            
+
         if self.alternate_matching_group:
             edge_head = {
                 'param': {
@@ -892,6 +912,19 @@ class Matching(object):
             }
         )
 
+        if venue.allow_gurobi_solver:
+            config_inv.edit['note']['content']['solver']['value']['param']['enum'].append('FairIR')
+            config_inv.edit['note']['content']["constraints_specification"] = {
+                "order": 8,
+                "description": "Manually entered JSON constraints specification",
+                "value": {
+                "param": {
+                    "type": "json",
+                    "optional": True
+                }
+                }
+            }
+
         invitation = venue.invitation_builder.save_invitation(config_inv)
 
     def setup(self, compute_affinity_scores=False, compute_conflicts=False, compute_conflicts_n_years=None):
@@ -991,6 +1024,9 @@ class Matching(object):
                     'weight': 1,
                     'default': 0
                 }
+
+            if venue.allow_gurobi_solver:
+                self._create_edge_invitation(self.venue.get_constraint_label_id(self.match_group.id))
 
             self._build_config_invitation(score_spec)            
         else:

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -70,6 +70,7 @@ class Venue(object):
         self.automatic_reviewer_assignment = False
         self.decision_heading_map = {}
         self.use_publication_chairs = False
+        self.allow_gurobi_solver = False
 
     def get_id(self):
         return self.venue_id
@@ -145,6 +146,9 @@ class Venue(object):
 
     def get_custom_max_papers_id(self, committee_id):
         return self.get_invitation_id('Custom_Max_Papers', prefix=committee_id)
+    
+    def get_constraint_label_id(self, committee_id):
+        return self.get_invitation_id('Constraint_Label', prefix=committee_id)
 
     def get_recommendation_id(self, committee_id=None):
         if not committee_id:

--- a/tests/test_venue_with_tracks.py
+++ b/tests/test_venue_with_tracks.py
@@ -268,6 +268,16 @@ class TestVenueWithTracks():
         invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form_note.number}/Paper_Matching_Setup')
         assert 'ACM.org/TheWebConf/2024/Conference/COI_Senior_Area_Chairs' in invitation.reply['content']['matching_group']['value-dropdown']
 
+        openreview_client.post_group_edit(
+            invitation='ACM.org/TheWebConf/2024/Conference/-/Edit',
+            signatures=['ACM.org/TheWebConf/2024/Conference'],
+            group=openreview.api.Group(
+                id='ACM.org/TheWebConf/2024/Conference',
+                content={
+                    'allow_gurobi_solver': { 'value': True }
+                }
+            )
+        )
 
     def test_recruit_sacs(self, client, openreview_client, helpers, selenium, request_page):
 
@@ -613,17 +623,17 @@ ac{ac_counter + 1}@{'gmail' if ac_counter == 21 else 'webconf'}.com, Area ChairT
             ac_id = f'ACM.org/TheWebConf/2024/Conference/{ac_role}'
             track = tracks[index]
             openreview.tools.replace_members_with_ids(openreview_client, openreview_client.get_group(ac_id))
+            track_acs = openreview_client.get_group(ac_id).members
 
             with open(os.path.join(os.path.dirname(__file__), 'data/rev_scores_venue.csv'), 'w') as file_handle:
                 writer = csv.writer(file_handle)
                 for submission in submissions:
                     if track == submission.content['track']['value']:
-                        for ac in openreview_client.get_group(ac_id).members:
+                        for ac in track_acs:
                             writer.writerow([submission.id, ac, round(random.random(), 2)])                   
 
             affinity_scores_url = client.put_attachment(os.path.join(os.path.dirname(__file__), 'data/rev_scores_venue.csv'), f'openreview.net/Support/-/Request{request_form.number}/Paper_Matching_Setup', 'upload_affinity_scores')
 
-            ## setup matching data before starting bidding
             client.post_note(openreview.Note(
                 content={
                     'title': 'Paper Matching Setup',
@@ -646,6 +656,7 @@ ac{ac_counter + 1}@{'gmail' if ac_counter == 21 else 'webconf'}.com, Area ChairT
             assert openreview_client.get_invitation(f'{ac_id}/-/Conflict')
             assert openreview_client.get_invitation(f'{ac_id}/-/Affinity_Score')
             assert openreview_client.get_invitation(f'{ac_id}/-/Proposed_Assignment')
+            assert openreview_client.get_invitation(f'{ac_id}/-/Constraint_Label')
             assignment_configuration_invitation = openreview_client.get_invitation(f'{ac_id}/-/Assignment_Configuration')
             assert assignment_configuration_invitation.edit['note']['content']['paper_invitation']['value']['param']['default'] == 'ACM.org/TheWebConf/2024/Conference/-/Submission&content.venueid=ACM.org/TheWebConf/2024/Conference/Submission&content.track=' + tracks[index]                  
             proposed_assignment_invitation = openreview_client.get_invitation(f'{ac_id}/-/Proposed_Assignment')
@@ -657,7 +668,51 @@ ac{ac_counter + 1}@{'gmail' if ac_counter == 21 else 'webconf'}.com, Area ChairT
             assert affinity_score_invitation.readers == ['ACM.org/TheWebConf/2024/Conference', f'ACM.org/TheWebConf/2024/Conference/{ac_role.replace("Area_Chairs", "Senior_Area_Chairs")}']
             assert affinity_score_invitation.edit['readers'] == ["ACM.org/TheWebConf/2024/Conference", f'ACM.org/TheWebConf/2024/Conference/{ac_role.replace("Area_Chairs", "Senior_Area_Chairs")}', "${2/tail}"]
 
+            ## Build constraints
+            labels = ['NA+EUR', 'ASIA', 'Africa', 'SA']
+            for index, ac in enumerate(track_acs):
+                openreview_client.post_edge(openreview.api.Edge(
+                    invitation=f'{ac_id}/-/Constraint_Label',
+                    signatures=['ACM.org/TheWebConf/2024/Conference'],
+                    head=ac_id,
+                    tail=ac,
+                    label=labels[index % 4],
+                ))
 
+            # Post assignment config note
+            assignment_config_note = openreview_client.post_note_edit(invitation=f'{ac_id}/-/Assignment_Configuration',
+                signatures=[ 'ACM.org/TheWebConf/2024/Conference' ],
+                note=openreview.api.Note(
+                    content={
+                        'title': { 'value': f'ac-assignment' },
+                        'user_demand': { 'value': '1' },
+                        'max_papers': { 'value': '1' },
+                        'min_papers': { 'value': '0' },
+                        'alternates': { 'value': '2' },
+                        'paper_invitation': { 'value': 'ACM.org/TheWebConf/2024/Conference/-/Submission&content.venueid=ACM.org/TheWebConf/2024/Conference/Submission&content.track=' + tracks[index] },
+                        'match_group': { 'value': ac_id },
+                        'scores_specification': { 'value': { f'{ac_id}/-/Affinity_Score': { 'weight': 1, 'default': 0 }} },
+                        'constraints_specification': { 'value': {
+                            f"{ac_id}/-/Constraint_Label": [
+                                {
+                                    "label": "NA+EUR",
+                                    "min_users": 1
+                                },
+                                {
+                                    "label": "ASIA",
+                                    "min_users": 1
+                                }
+                            ]                            
+                        }},
+                        'conflicts_invitation': { 'value': f'{ac_id}/-/Conflict' },
+                        'custom_max_papers_invitation': { 'value': f'{ac_id}/-/Custom_Max_Papers'},
+                        'aggregate_score_invitation': { 'value': f'{ac_id}/-/Aggregate_Score'},
+                        'solver': { 'value': 'FairIR' },
+                        'allow_zero_score_assignments': { 'value': 'No' },
+                        'status': { 'value': 'Complete' },
+                    }
+                ))                                
+        
         ## Build proposed assignments
         for submission in submissions:
             index = submission.number % 10
@@ -832,7 +887,6 @@ reviewer{reviewer_counter + 1}@{'gmail' if reviewer_counter == 21 else 'webconf'
 
             affinity_scores_url = client.put_attachment(os.path.join(os.path.dirname(__file__), 'data/rev_scores_venue.csv'), f'openreview.net/Support/-/Request{request_form.number}/Paper_Matching_Setup', 'upload_affinity_scores')
 
-            ## setup matching data before starting bidding
             client.post_note(openreview.Note(
                 content={
                     'title': 'Paper Matching Setup',


### PR DESCRIPTION
The gurobi solver is still under development so we don't want to offer it to all the venues. Because the web conference wants to use it, this PR lets you to enable it adding a setting to the venue.group content:

```
'allow_gurobi_solver': { 'value': True }
```

- You need to set this value before running any paper matching setup. 
- The paper matching setup will add the constraints_specification and FairIR solver to the assignment configuration invitation.
- The paper matching setup will create a Constraint_Label edge invitation to store the constraints for reviewers.
- openreview-web will show the constraints label when browsing the assignments: https://github.com/openreview/openreview-web/pull/1645