### PR TITLE
Feature/journal feature request

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -383,7 +383,8 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
                 writers=[venue_id],
                 signatures=[venue_id],
                 signatories=[venue_id, action_editors_group_id],
-                members=[]
+                members=[],
+                anonids=True
             ))
 
         reviewers_group=openreview.tools.get_group(self.client, reviewers_group_id)

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -2213,7 +2213,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     'param': { 
                         'items': [
                             { 'value': editors_in_chief_id, 'optional': True },
-                            { 'value': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True }
+                            { 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True }
                         ]
                     }
                 },
@@ -3463,7 +3463,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     'param': { 
                         'items': [
                             { 'prefix': self.journal.get_reviewers_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True },
-                            { 'value': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True } 
+                            { 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True } 
                         ]
                     }
                 },
@@ -3695,7 +3695,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     'param': { 
                         'items': [
                             { 'prefix': self.journal.get_reviewers_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True },
-                            { 'value': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True } 
+                            { 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True } 
                         ]
                     }
                 },
@@ -4392,7 +4392,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     'param': { 
                         'items': [ 
                             { 'value': editors_in_chief_id, 'optional': True },
-                            { 'value': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True },
+                            { 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True },
                             { 'prefix': self.journal.get_reviewers_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True }, 
                             { 'value': self.journal.get_authors_id(number='${7/content/noteNumber/value}'), 'optional': True } ]
                     }
@@ -4472,7 +4472,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     'param': { 
                         'items': [
                             { 'value': editors_in_chief_id, 'optional': True },
-                            { 'value': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True },
+                            { 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True), 'optional': True },
                         ] 
                     }
                 },

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3714,7 +3714,11 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'input': 'checkbox'
                     }
                 }
-            }        
+            }
+
+        if self.journal.get_official_recommendation_additional_fields():
+            for key, value in self.journal.get_official_recommendation_additional_fields().items():
+                invitation['edit']['note']['content'][key] = value                       
 
         self.save_super_invitation(self.journal.get_reviewer_recommendation_id(), invitation_content, edit_content, invitation)
 
@@ -4643,6 +4647,10 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     }
                 }
             }
+
+        if self.journal.get_decision_additional_fields():
+            for key, value in self.journal.get_decision_additional_fields().items():
+                invitation['edit']['note']['content'][key] = value             
 
         self.save_super_invitation(self.journal.get_ae_decision_id(), invitation_content, edit_content, invitation)
 

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -992,6 +992,11 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                 'order': 6                
             }
 
+        if self.journal.get_submission_additional_fields():
+            for key, value in self.journal.get_submission_additional_fields().items():
+                invitation.edit['note']['content'][key] = value             
+
+        print(invitation.edit['note']['content'])
         self.save_invitation(invitation)
 
     def set_ae_assignment(self, assignment_delay):
@@ -3498,6 +3503,10 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             }
         }
 
+        if self.journal.get_review_additional_fields():
+            for key, value in self.journal.get_review_additional_fields().items():
+                invitation['edit']['note']['content'][key] = value         
+
         self.save_super_invitation(self.journal.get_review_id(), invitation_content, edit_content, invitation)
 
         invitation = {
@@ -5221,6 +5230,10 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'process': self.process_script
         }
 
+        if self.journal.get_submission_additional_fields():
+            for key, value in self.journal.get_submission_additional_fields().items():
+                invitation['edit']['note']['content'][key] = value         
+
         self.save_super_invitation(self.journal.get_camera_ready_revision_id(), invitation_content, edit_content, invitation)
 
     def set_note_camera_ready_revision_invitation(self, note, duedate):
@@ -5523,7 +5536,11 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         "input": "select"
                     }
                 }
-            }            
+            }
+
+        if self.journal.get_submission_additional_fields():
+            for key, value in self.journal.get_submission_additional_fields().items():
+                invitation['edit']['note']['content'][key] = value                        
 
         self.save_super_invitation(self.journal.get_eic_revision_id(), invitation_content, edit_content, invitation)
 

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -1841,7 +1841,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                 'writers': [venue_id, self.journal.get_action_editors_id(number='${{2/head}/number}')],
                 'signatures': {
                     'param': {
-                        'regex': venue_id + '|' + editor_in_chief_id + '|' + self.journal.get_action_editors_id(number='.*')
+                        'regex': venue_id + '|' + editor_in_chief_id + '|' + self.journal.get_action_editors_id(number='.*', anon=True)
                     }
                 },
                 'head': {
@@ -2171,7 +2171,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'process': self.process_script,
             'dateprocesses': [self.ae_reminder_process],
             'edit': {
-                'signatures': { 'param': { 'regex': f"{editors_in_chief_id}|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')}" }},
+                'signatures': { 'param': { 'regex': f"{editors_in_chief_id}|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}', anon=True)}" }},
                 'readers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                 'writers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                 'note': {
@@ -3400,7 +3400,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'process': self.process_script,
             'dateprocesses': [self.reviewer_reminder_process_with_EIC],
             'edit': {
-                'signatures': { 'param': { 'regex': f"{self.journal.get_reviewers_id(number='${5/content/noteNumber/value}', anon=True)}.*|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')}" }},
+                'signatures': { 'param': { 'regex': f"{self.journal.get_reviewers_id(number='${5/content/noteNumber/value}', anon=True)}.*|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}', anon=True)}" }},
                 'readers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}'), '${2/signatures}'],
                 'writers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}'), '${2/signatures}'],
                 'note': {
@@ -3621,7 +3621,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                 'script': self.get_super_dateprocess_content('cdate_script')
             }, self.reviewer_reminder_process_with_EIC],
             'edit': {
-                'signatures': { 'param': { 'regex': f"{self.journal.get_reviewers_id(number='${5/content/noteNumber/value}', anon=True)}.*|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')}" }},
+                'signatures': { 'param': { 'regex': f"{self.journal.get_reviewers_id(number='${5/content/noteNumber/value}', anon=True)}.*|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}', anon=True)}" }},
                 'readers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}'), '${2/signatures}'],
                 'nonreaders': [ self.journal.get_authors_id(number='${4/content/noteNumber/value}') ],
                 'writers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}'), '${2/signatures}'],
@@ -3906,14 +3906,18 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'preprocess': self.preprocess_script,
             'dateprocesses': [self.ae_reminder_process],
             'edit': {
-                'signatures': [ self.journal.get_action_editors_id(number='${4/content/noteNumber/value}') ],
+                'signatures': { 
+                    'param': { 
+                        'items': [{ 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True) }] 
+                    }
+                },
                 'readers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}') ],
                 'nonreaders': [ self.journal.get_authors_id(number='${4/content/noteNumber/value}') ],
                 'writers': [ venue_id ],
                 'note': {
                     'forum': '${4/content/noteId/value}',
                     'replyto': '${4/content/replytoId/value}',
-                    'signatures': [ self.journal.get_action_editors_id(number='${5/content/noteNumber/value}') ],
+                    'signatures': ['${3/signatures}'],
                     'readers': [ editors_in_chief_id, self.journal.get_action_editors_id(number='${5/content/noteNumber/value}'), '${5/content/soliciter/value}' ],
                     'nonreaders': [ self.journal.get_authors_id(number='${5/content/noteNumber/value}') ],
                     'writers': [ venue_id ],
@@ -4285,7 +4289,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'writers': [venue_id],
             'signatures': [venue_id],
             'edit': {
-                'signatures': { 'param': { 'regex': f"{editors_in_chief_id}|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')}|{self.journal.get_reviewers_id(number='${5/content/noteNumber/value}', anon=True)}.*|{self.journal.get_authors_id(number='${5/content/noteNumber/value}')}" }},
+                'signatures': { 'param': { 'regex': f"{editors_in_chief_id}|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}', anon=True)}|{self.journal.get_reviewers_id(number='${5/content/noteNumber/value}', anon=True)}.*|{self.journal.get_authors_id(number='${5/content/noteNumber/value}')}" }},
                 'readers': [ venue_id, '${2/signatures}' ],
                 'writers': [ venue_id, '${2/signatures}' ],
                 'note': {
@@ -4356,7 +4360,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'writers': [venue_id],
             'signatures': [venue_id],
             'edit': {
-                'signatures': { 'param': { 'regex': f"{editors_in_chief_id}|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')}" }},
+                'signatures': { 'param': { 'regex': f"{editors_in_chief_id}|{self.journal.get_action_editors_id(number='${5/content/noteNumber/value}', anon=True)}" }},
                 'readers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                 'writers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                 'note': {
@@ -4537,7 +4541,11 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'maxReplies': 1,
             'minReplies': 1,
             'edit': {
-                'signatures': [self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
+                'signatures': { 
+                    'param': { 
+                        'items': [{ 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True) }] 
+                    }
+                },
                 'readers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                 'nonreaders': [ self.journal.get_authors_id(number='${4/content/noteNumber/value}') ],
                 'writers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
@@ -4557,7 +4565,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                             'deletable': True
                         }
                     },
-                    'signatures': [self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')],
+                    'signatures': ['${3/signatures}'],
                     'readers': [ editors_in_chief_id, self.journal.get_action_editors_id(number='${5/content/noteNumber/value}') ],
                     'nonreaders': [ self.journal.get_authors_id(number='${5/content/noteNumber/value}') ],
                     'writers': [ venue_id, self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')],
@@ -4884,7 +4892,11 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'signatures': [editors_in_chief_id],
             'maxReplies': 1,
             'edit': {
-                    'signatures': [self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
+                    'signatures': { 
+                        'param': { 
+                            'items': [{ 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True) }] 
+                        }
+                    },
                     'readers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                     'nonreaders': [ self.journal.get_authors_id(number='${4/content/noteNumber/value}') ],
                     'writers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
@@ -4897,7 +4909,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         },            
                         'forum': '${4/content/noteId/value}',
                         'replyto': '${4/content/replytoId/value}',
-                        'signatures': [self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')],
+                        'signatures': ['${3/signatures}'],
                         'readers': [ editors_in_chief_id, self.journal.get_action_editors_id(number='${5/content/noteNumber/value}') ],
                         'nonreaders': [ self.journal.get_authors_id(number='${5/content/noteNumber/value}') ],
                         'writers': [ venue_id, self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')],
@@ -5264,11 +5276,15 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             'writers': [venue_id],
             'signatures': [venue_id],
             'edit': {
-                'signatures': [self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
+                'signatures': { 
+                    'param': { 
+                        'items': [{ 'prefix': self.journal.get_action_editors_id(number='${7/content/noteNumber/value}', anon=True) }] 
+                    }
+                },
                 'readers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                 'writers': [ venue_id, self.journal.get_action_editors_id(number='${4/content/noteNumber/value}')],
                 'note': {
-                    'signatures': [self.journal.get_action_editors_id(number='${5/content/noteNumber/value}')],
+                    'signatures': ['${3/signatures}'],
                     'forum': '${4/content/noteId/value}',
                     'replyto': '${4/content/noteId/value}',
                     'readers': [ editors_in_chief_id, self.journal.get_action_editors_id(number='${5/content/noteNumber/value}'), self.journal.get_authors_id(number='${5/content/noteNumber/value}') ],

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -469,6 +469,9 @@ class InvitationBuilder(object):
         )
         self.save_invitation(invitation)
 
+        if self.journal.should_skip_reviewer_responsibility_acknowledgement():
+            return        
+
         forum_note_id = self.journal.get_acknowledgement_responsibility_form()
         if not forum_note_id:
             forum_edit = self.client.post_note_edit(invitation=self.journal.get_form_id(),

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -79,8 +79,8 @@ class Journal(object):
     def get_action_editors_archived_id(self):
         return f'{self.get_action_editors_id()}/Archived'    
 
-    def get_action_editors_id(self, number=None):
-        return self.__get_group_id(self.action_editors_name, number)
+    def get_action_editors_id(self, number=None, anon=False):
+        return self.__get_group_id('Action_Editor_' if anon else self.action_editors_name, number)
 
     def get_reviewers_id(self, number=None, anon=False):
         return self.__get_group_id('Reviewer_' if anon else self.reviewers_name, number)

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -488,17 +488,17 @@ class Journal(object):
     def get_release_review_readers(self, number):
         if self.is_submission_public():
             return ['everyone']
-        return [self.get_editors_in_chief_id(), self.get_action_editors_id(number), self.get_reviewers_id(number), self.get_authors_id(number)]        
+        return [self.get_editors_in_chief_id(), self.get_action_editors_id(), self.get_reviewers_id(number), self.get_authors_id(number)]        
     
     def get_release_decision_readers(self, number):
         if self.is_submission_public():
             return ['everyone']
-        return [self.get_editors_in_chief_id(), self.get_action_editors_id(number), self.get_reviewers_id(number), self.get_authors_id(number)]        
+        return [self.get_editors_in_chief_id(), self.get_action_editors_id(), self.get_reviewers_id(number), self.get_authors_id(number)]        
 
     def get_release_authors_readers(self, number):
         if self.is_submission_public():
             return ['everyone']
-        return [self.get_editors_in_chief_id(), self.get_action_editors_id(number), self.get_authors_id(number)]        
+        return [self.get_editors_in_chief_id(), self.get_action_editors_id(), self.get_authors_id(number)]        
 
     def get_official_comment_readers(self, number):
         readers = []
@@ -507,6 +507,7 @@ class Journal(object):
 
         return readers + [
             self.get_editors_in_chief_id(), 
+            self.get_action_editors_id(), 
             self.get_action_editors_id(number), 
             self.get_reviewers_id(number), 
             self.get_reviewers_id(number, anon=True) + '.*', 

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -424,6 +424,9 @@ class Journal(object):
     
     def should_skip_ac_recommendation(self):
         return self.settings.get('skip_ac_recommendation', False)
+    
+    def should_skip_reviewer_responsibility_acknowledgement(self):
+        return self.settings.get('skip_reviewer_responsibility_acknowledgement', False)    
 
     def get_certifications(self):
         return self.settings.get('certifications', []) 
@@ -474,7 +477,7 @@ class Journal(object):
     def get_under_review_submission_readers(self, number):
         if self.is_submission_public():
             return ['everyone']
-        return [self.venue_id, self.get_action_editors_id(number), self.get_reviewers_id(number), self.get_authors_id(number)]
+        return [self.venue_id, self.get_action_editors_id(), self.get_reviewers_id(number), self.get_authors_id(number)]
 
     def get_release_review_readers(self, number):
         if self.is_submission_public():

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -467,6 +467,12 @@ class Journal(object):
     def get_ae_max_papers(self):
         return self.settings.get('action_editors_max_papers', 12)
 
+    def get_submission_additional_fields(self):
+        return self.settings.get('submission_additional_fields', {})
+    
+    def get_review_additional_fields(self):
+        return self.settings.get('review_additional_fields', {})
+    
     def get_official_recommendation_additional_fields(self):
         return self.settings.get('official_recommendation_additional_fields', {}) 
 

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -465,7 +465,13 @@ class Journal(object):
         return self.settings.get('reviewers_max_papers', 6)
 
     def get_ae_max_papers(self):
-        return self.settings.get('action_editors_max_papers', 12)       
+        return self.settings.get('action_editors_max_papers', 12)
+
+    def get_official_recommendation_additional_fields(self):
+        return self.settings.get('official_recommendation_additional_fields', {}) 
+
+    def get_decision_additional_fields(self):
+        return self.settings.get('decision_additional_fields', {})        
 
     def should_release_authors(self):
         return self.is_submission_public() and self.are_authors_anonymous()

--- a/openreview/journal/process/ae_assignment_pre_process.py
+++ b/openreview/journal/process/ae_assignment_pre_process.py
@@ -4,6 +4,11 @@ def process(client, edge, invitation):
 
     submission = client.get_note(edge.head)
 
+    ## authors should not be able to edit assignments
+    authors_group_id = journal.get_authors_id(number=submission.number)
+    if client.get_groups(id=authors_group_id, member=edge.tauthor):
+        raise openreview.OpenReviewException(f'Authors can not edit assignments for this submission: {submission.number}')
+
     venue_id = submission.content.get('venueid', {}).get('value')
     if not journal.is_active_submission(submission):
         raise openreview.OpenReviewException(f'Can not edit assignments for this submission: {venue_id}')

--- a/openreview/journal/process/reviewer_assignment_pre_process.py
+++ b/openreview/journal/process/reviewer_assignment_pre_process.py
@@ -4,6 +4,11 @@ def process(client, edge, invitation):
 
     submission = client.get_note(edge.head)
 
+    ## authors should not be able to edit assignments
+    authors_group_id = journal.get_authors_id(number=submission.number)
+    if client.get_groups(id=authors_group_id, member=edge.tauthor):
+        raise openreview.OpenReviewException(f'Authors can not edit assignments for this submission: {submission.number}')    
+
     venue_id = submission.content.get('venueid', {}).get('value')
     if venue_id not in [journal.under_review_venue_id]:
         raise openreview.OpenReviewException(f'Can not edit assignments for this submission: {venue_id}')

--- a/openreview/journal/process/reviewer_assignment_process.py
+++ b/openreview/journal/process/reviewer_assignment_process.py
@@ -36,7 +36,7 @@ def process_update(client, edge, invitation, existing_edge):
             client.post_edge(submission_edge)
 
     ## Enable reviewer responsibility task
-    if len(tail_assignment_edges) == 1 and not edge.ddate and not client.get_groups(member=edge.tail, id=journal.get_solicit_reviewers_id(number=note.number)):
+    if not journal.should_skip_reviewer_responsibility_acknowledgement() and len(tail_assignment_edges) == 1 and not edge.ddate and not client.get_groups(member=edge.tail, id=journal.get_solicit_reviewers_id(number=note.number)):
         print('Enable reviewer responsibility task for', edge.tail)
         responsiblity_invitation_edit = journal.invitation_builder.set_single_reviewer_responsibility_invitation(edge.tail, journal.get_due_date(weeks = 1))
 

--- a/openreview/journal/process/submission_decision_process.py
+++ b/openreview/journal/process/submission_decision_process.py
@@ -16,7 +16,7 @@ def process(client, edit, invitation):
     ## Update submission and set the decision submitted status
     client.post_note_edit(
         invitation = journal.get_meta_invitation_id(),
-        readers = [journal.venue_id, journal.get_action_editors_id(submission.number), journal.get_reviewers_id(submission.number), journal.get_authors_id(submission.number)],
+        readers = journal.get_under_review_submission_readers(submission.number),
         writers = [journal.venue_id],
         signatures = [journal.venue_id],
         note = openreview.api.Note(

--- a/openreview/journal/webfield/editorsInChiefWebfield.js
+++ b/openreview/journal/webfield/editorsInChiefWebfield.js
@@ -947,7 +947,8 @@ var renderTable = function(container, rows) {
       numRecommendationsDone: ['reviewProgressData.numSubmittedRecommendations'],
       decision: ['actionEditorProgressData.recommendation'],
       status: ['status'],
-      default: ['submissionNumber.number', 'submission.content.title']
+      default: ['submissionNumber.number', 'submission.content.title'],
+      certifications: ['submission.content.certifications'],
     },
     reminderOptions: {
       container: 'a.send-reminder-link',

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -609,11 +609,15 @@ The TMLR Editors-in-Chief
         assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
         assert openreview_client.get_invitation('TMLR/Paper1/-/Review_Approval')
 
+        joelle_paper1_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper1/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper1_anon_groups) == 1
+        joelle_paper1_anon_group = joelle_paper1_anon_groups[0]        
+
         ## Make a comment before approving the submission to be under review
         comment_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Official_Comment',
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             note=Note(
-                signatures=[f"{venue_id}/Paper1/Action_Editors"],
+                signatures=[joelle_paper1_anon_group.id],
                 readers=['TMLR/Editors_In_Chief', 'TMLR/Paper1/Action_Editors'],
                 forum=note_id_1,
                 replyto=note_id_1,
@@ -625,7 +629,7 @@ The TMLR Editors-in-Chief
         
         ## Accept the submission 1
         under_review_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper1/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper1/Action_Editors'],
+                                    signatures=[joelle_paper1_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -670,7 +674,7 @@ note={Under review}
         #         readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~David_Belanger1'],
         #         nonreaders=[f"{venue_id}/Paper1/Authors"],
         #         writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-        #         signatures=[f"{venue_id}/Paper1/Action_Editors"],
+        #         signatures=[joelle_paper1_anon_group.id],
         #         head=note_id_1,
         #         tail='~David_Belanger1',
         #         weight=1
@@ -730,9 +734,13 @@ The TMLR Editors-in-Chief
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        joelle_paper2_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper2/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper2_anon_groups) == 1
+        joelle_paper2_anon_group = joelle_paper2_anon_groups[0]         
+
         ## Desk reject the submission 2
         desk_reject_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper2/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper2/Action_Editors'],
+                                    signatures=[joelle_paper2_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Desk Reject' },
                                         'comment': { 'value': 'missing PDF' }
@@ -805,7 +813,7 @@ The TMLR Editors-in-Chief
                 readers=[venue_id, f"{venue_id}/Paper2/Action_Editors", '~David_Belanger1'],
                 nonreaders=[f"{venue_id}/Paper2/Authors"],
                 writers=[venue_id, f"{venue_id}/Paper2/Action_Editors"],
-                signatures=[f"{venue_id}/Paper2/Action_Editors"],
+                signatures=[joelle_paper2_anon_group.id],
                 head=note_id_2,
                 tail='~David_Belanger1',
                 weight=1
@@ -857,7 +865,7 @@ note={Withdrawn}
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             head=note_id_1,
             tail='~David_Belanger1',
             weight=1
@@ -877,7 +885,7 @@ note={Withdrawn}
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             head=note_id_1,
             tail='~David_Belanger1',
             weight=1
@@ -920,7 +928,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             head=note_id_1,
             tail='~David_Belanger1',
             weight=1
@@ -946,7 +954,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~Carlos_Mondragon1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             head=note_id_1,
             tail='~Carlos_Mondragon1',
             weight=1
@@ -1013,7 +1021,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~Javier_Burroni1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             head=note_id_1,
             tail='~Javier_Burroni1',
             weight=1
@@ -1050,7 +1058,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", 'antony@irobot.com'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             head=note_id_1,
             tail='antony@irobot.com',
             weight=1
@@ -1248,7 +1256,7 @@ To view the public comment, click here: https://openreview.net/forum?id={note_id
 
         # Moderate a public comment
         moderated_comment_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Moderation',
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             note=Note(
                 id=comment_note_id,
                 content={
@@ -1761,7 +1769,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~Hugo_Larochelle1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             head=note_id_1,
             tail='~Hugo_Larochelle1',
             weight=1
@@ -2039,7 +2047,7 @@ The TMLR Editors-in-Chief
         for review in reviews:
             signature=review.signatures[0]
             rating_note=joelle_client.post_note_edit(invitation=f'{signature}/-/Rating',
-                signatures=[f"{venue_id}/Paper1/Action_Editors"],
+                signatures=[joelle_paper1_anon_group.id],
                 note=Note(
                     content={
                         'rating': { 'value': 'Exceeds expectations' }
@@ -2053,7 +2061,7 @@ The TMLR Editors-in-Chief
 
         ## edit last rating
         joelle_client.post_note_edit(invitation=rating_note['invitation'],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             note=Note(
                 id = rating_note['note']['id'],
                 content={
@@ -2067,7 +2075,7 @@ The TMLR Editors-in-Chief
         assert invitation.edit['note']['content']['certifications']['value']['param']['enum'] == ['Featured Certification', 'Reproducibility Certification', 'Survey Certification']
 
         decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Decision',
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[joelle_paper1_anon_group.id],
             note=Note(
                 content={
                     'claims_and_evidence': { 'value': 'Accept as is' },
@@ -2093,7 +2101,7 @@ The TMLR Editors-in-Chief
         ## Second decision note and get an error
         with pytest.raises(openreview.OpenReviewException, match=r'You have reached the maximum number \(1\) of replies for this Invitation'):
             decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Decision',
-                signatures=[f"{venue_id}/Paper1/Action_Editors"],
+                signatures=[joelle_paper1_anon_group.id],
                 note=Note(
                     content={
                         'claims_and_evidence': { 'value': 'Accept as is' },
@@ -2260,9 +2268,9 @@ OpenReview Team
 
         ## AE verifies the camera ready revision
         verification_note = joelle_client.post_note_edit(invitation='TMLR/Paper1/-/Camera_Ready_Verification',
-                            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+                            signatures=[joelle_paper1_anon_group.id],
                             note=Note(
-                                signatures=[f"{venue_id}/Paper1/Action_Editors"],
+                                signatures=[joelle_paper1_anon_group.id],
                                 content= {
                                     'verification': { 'value': 'I confirm that camera ready manuscript complies with the TMLR stylefile and, if appropriate, includes the minor revisions that were requested.' }
                                  }
@@ -2525,12 +2533,16 @@ note={Retracted after acceptance}
 
         helpers.await_queue_edit(openreview_client, edit_id=edits[0].id)
 
+        joelle_paper4_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper4/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper4_anon_groups) == 1
+        joelle_paper4_anon_group = joelle_paper4_anon_groups[0]         
+
         ## Assign David Belanger
         paper_assignment_edge = joelle_client.post_edge(openreview.Edge(invitation='TMLR/Reviewers/-/Assignment',
             readers=[venue_id, f"{venue_id}/Paper4/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper4/Authors"],
             writers=[venue_id, f"{venue_id}/Paper4/Action_Editors"],
-            signatures=[f"{venue_id}/Paper4/Action_Editors"],
+            signatures=[joelle_paper4_anon_group.id],
             head=note_id_4,
             tail='~David_Belanger1',
             weight=1
@@ -2563,7 +2575,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
             readers=[venue_id, f"{venue_id}/Paper4/Action_Editors", '~Carlos_Mondragon1'],
             nonreaders=[f"{venue_id}/Paper4/Authors"],
             writers=[venue_id, f"{venue_id}/Paper4/Action_Editors"],
-            signatures=[f"{venue_id}/Paper4/Action_Editors"],
+            signatures=[joelle_paper4_anon_group.id],
             head=note_id_4,
             tail='~Carlos_Mondragon1',
             weight=1
@@ -2576,7 +2588,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
             readers=[venue_id, f"{venue_id}/Paper4/Action_Editors", '~Javier_Burroni1'],
             nonreaders=[f"{venue_id}/Paper4/Authors"],
             writers=[venue_id, f"{venue_id}/Paper4/Action_Editors"],
-            signatures=[f"{venue_id}/Paper4/Action_Editors"],
+            signatures=[joelle_paper4_anon_group.id],
             head=note_id_4,
             tail='~Javier_Burroni1',
             weight=1
@@ -2677,7 +2689,7 @@ The TMLR Editors-in-Chief
         ## Post a response
         with pytest.raises(openreview.OpenReviewException, match=r'Can not approve this solicit review: conflict detected for ~Tom_Rain1'):
             Volunteer_to_Review_approval_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper4/-/~Tom_Rain1_Volunteer_to_Review_Approval',
-                signatures=[f"{venue_id}/Paper4/Action_Editors"],
+                signatures=[joelle_paper4_anon_group.id],
                 note=Note(
                     content={
                         'decision': { 'value': 'Yes, I approve the solicit review.' },
@@ -2704,7 +2716,7 @@ The TMLR Editors-in-Chief
 
         ## Post a response
         Volunteer_to_Review_approval_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper4/-/~Peter_Snow1_Volunteer_to_Review_Approval',
-            signatures=[f"{venue_id}/Paper4/Action_Editors"],
+            signatures=[joelle_paper4_anon_group.id],
             note=Note(
                 content={
                     'decision': { 'value': 'Yes, I approve the solicit review.' },
@@ -2811,7 +2823,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
             readers=[venue_id, f"{venue_id}/Paper4/Action_Editors", '~Hugo_Larochelle1'],
             nonreaders=[f"{venue_id}/Paper4/Authors"],
             writers=[venue_id, f"{venue_id}/Paper4/Action_Editors"],
-            signatures=[f"{venue_id}/Paper4/Action_Editors"],
+            signatures=[joelle_paper4_anon_group.id],
             head=note_id_4,
             tail='~Hugo_Larochelle1',
             weight=1
@@ -2894,7 +2906,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
         for review in reviews:
             signature=review.signatures[0]
             rating_note=joelle_client.post_note_edit(invitation=f'{signature}/-/Rating',
-                signatures=[f"{venue_id}/Paper4/Action_Editors"],
+                signatures=[joelle_paper4_anon_group.id],
                 note=Note(
                     content={
                         'rating': { 'value': 'Exceeds expectations' }
@@ -2905,7 +2917,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
 
         with pytest.raises(openreview.OpenReviewException, match=r'Decision Reject can not have certifications'):
             decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper4/-/Decision',
-                signatures=[f"{venue_id}/Paper4/Action_Editors"],
+                signatures=[joelle_paper4_anon_group.id],
                 note=Note(
                     content={
                         'claims_and_evidence': { 'value': 'Accept as is' },
@@ -2920,7 +2932,7 @@ note: replies to this email will go to the AE, Joelle Pineau.
             )
 
         decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper4/-/Decision',
-            signatures=[f"{venue_id}/Paper4/Action_Editors"],
+            signatures=[joelle_paper4_anon_group.id],
             note=Note(
                 content={
                     'claims_and_evidence': { 'value': 'Accept as is' },
@@ -3142,9 +3154,13 @@ The TMLR Editors-in-Chief
         messages = journal.client.get_messages(to= 'raia@mail.com', subject = '[TMLR] AE is late in performing a task for assigned paper 5: Paper title 5')
         assert len(messages) == 0
 
+        joelle_paper5_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper5/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper5_anon_groups) == 1
+        joelle_paper5_anon_group = joelle_paper5_anon_groups[0]         
+
         ## Accept the submission 5
         under_review_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper5/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper5/Action_Editors'],
+                                    signatures=[joelle_paper5_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -3160,7 +3176,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper5/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper5/Authors"],
             writers=[venue_id, f"{venue_id}/Paper5/Action_Editors"],
-            signatures=[f"{venue_id}/Paper5/Action_Editors"],
+            signatures=[joelle_paper5_anon_group.id],
             head=note_id_5,
             tail='~David_Belanger1',
             weight=1
@@ -3173,7 +3189,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper5/Action_Editors", '~Carlos_Mondragon1'],
             nonreaders=[f"{venue_id}/Paper5/Authors"],
             writers=[venue_id, f"{venue_id}/Paper5/Action_Editors"],
-            signatures=[f"{venue_id}/Paper5/Action_Editors"],
+            signatures=[joelle_paper5_anon_group.id],
             head=note_id_5,
             tail='~Carlos_Mondragon1',
             weight=1
@@ -3187,7 +3203,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper5/Action_Editors", '~Javier_Burroni1'],
             nonreaders=[f"{venue_id}/Paper5/Authors"],
             writers=[venue_id, f"{venue_id}/Paper5/Action_Editors"],
-            signatures=[f"{venue_id}/Paper5/Action_Editors"],
+            signatures=[joelle_paper5_anon_group.id],
             head=note_id_5,
             tail='~Javier_Burroni1',
             weight=1
@@ -3322,7 +3338,7 @@ The TMLR Editors-in-Chief
         for review in reviews:
             signature=review.signatures[0]
             rating_note=joelle_client.post_note_edit(invitation=f'{signature}/-/Rating',
-                signatures=[f"{venue_id}/Paper5/Action_Editors"],
+                signatures=[joelle_paper5_anon_group.id],
                 note=Note(
                     content={
                         'rating': { 'value': 'Exceeds expectations' }
@@ -3332,7 +3348,7 @@ The TMLR Editors-in-Chief
             helpers.await_queue_edit(openreview_client, edit_id=rating_note['id'])
 
         decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper5/-/Decision',
-            signatures=[f"{venue_id}/Paper5/Action_Editors"],
+            signatures=[joelle_paper5_anon_group.id],
             note=Note(
                 content={
                     'claims_and_evidence': { 'value': 'Accept as is' },
@@ -3456,9 +3472,13 @@ The TMLR Editors-in-Chief
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        joelle_paper6_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper6/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper6_anon_groups) == 1
+        joelle_paper6_anon_group = joelle_paper6_anon_groups[0]         
+
         ## Accept the submission 6
         under_review_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper6/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper6/Action_Editors'],
+                                    signatures=[joelle_paper6_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -3474,7 +3494,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper6/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper6/Authors"],
             writers=[venue_id, f"{venue_id}/Paper6/Action_Editors"],
-            signatures=[f"{venue_id}/Paper6/Action_Editors"],
+            signatures=[joelle_paper6_anon_group.id],
             head=note_id_6,
             tail='~David_Belanger1',
             weight=1
@@ -3487,7 +3507,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper6/Action_Editors", '~Carlos_Mondragon1'],
             nonreaders=[f"{venue_id}/Paper6/Authors"],
             writers=[venue_id, f"{venue_id}/Paper6/Action_Editors"],
-            signatures=[f"{venue_id}/Paper6/Action_Editors"],
+            signatures=[joelle_paper6_anon_group.id],
             head=note_id_6,
             tail='~Carlos_Mondragon1',
             weight=1
@@ -3500,7 +3520,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper6/Action_Editors", '~Javier_Burroni1'],
             nonreaders=[f"{venue_id}/Paper6/Authors"],
             writers=[venue_id, f"{venue_id}/Paper6/Action_Editors"],
-            signatures=[f"{venue_id}/Paper6/Action_Editors"],
+            signatures=[joelle_paper6_anon_group.id],
             head=note_id_6,
             tail='~Javier_Burroni1',
             weight=1
@@ -3632,7 +3652,7 @@ The TMLR Editors-in-Chief
         for review in reviews:
             signature=review.signatures[0]
             rating_note=joelle_client.post_note_edit(invitation=f'{signature}/-/Rating',
-                signatures=[f"{venue_id}/Paper6/Action_Editors"],
+                signatures=[joelle_paper6_anon_group.id],
                 note=Note(
                     content={
                         'rating': { 'value': 'Exceeds expectations' }
@@ -3759,9 +3779,13 @@ note={Withdrawn}
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        joelle_paper7_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper7/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper7_anon_groups) == 1
+        joelle_paper7_anon_group = joelle_paper7_anon_groups[0] 
+
         ## Accept the submission 7
         under_review_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper7/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper7/Action_Editors'],
+                                    signatures=[joelle_paper7_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -3777,7 +3801,7 @@ note={Withdrawn}
             readers=[venue_id, f"{venue_id}/Paper7/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper7/Authors"],
             writers=[venue_id, f"{venue_id}/Paper7/Action_Editors"],
-            signatures=[f"{venue_id}/Paper7/Action_Editors"],
+            signatures=[joelle_paper7_anon_group.id],
             head=note_id_7,
             tail='~David_Belanger1',
             weight=1
@@ -3800,7 +3824,7 @@ note={Withdrawn}
 
         ## Post a response
         Volunteer_to_Review_approval_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper7/-/~Tom_Rain1_Volunteer_to_Review_Approval',
-            signatures=[f"{venue_id}/Paper7/Action_Editors"],
+            signatures=[joelle_paper7_anon_group.id],
             note=Note(
                 forum=note_id_7,
                 replyto=Volunteer_to_Review_note['note']['id'],
@@ -3842,7 +3866,7 @@ The TMLR Editors-in-Chief
 
         ## Post a response
         Volunteer_to_Review_approval_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper7/-/~Peter_Snow1_Volunteer_to_Review_Approval',
-            signatures=[f"{venue_id}/Paper7/Action_Editors"],
+            signatures=[joelle_paper7_anon_group.id],
             note=Note(
                 forum=note_id_7,
                 replyto=Volunteer_to_Review_note['note']['id'],
@@ -3891,9 +3915,13 @@ The TMLR Editors-in-Chief
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        joelle_paper8_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper8/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper8_anon_groups) == 1
+        joelle_paper8_anon_group = joelle_paper8_anon_groups[0]         
+
         ## Accept the submission 8
         under_review_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper8/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper8/Action_Editors'],
+                                    signatures=[joelle_paper8_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -3910,7 +3938,7 @@ The TMLR Editors-in-Chief
                 readers=[venue_id, f"{venue_id}/Paper8/Action_Editors", '~David_Belanger1'],
                 nonreaders=[f"{venue_id}/Paper8/Authors"],
                 writers=[venue_id, f"{venue_id}/Paper8/Action_Editors"],
-                signatures=[f"{venue_id}/Paper8/Action_Editors"],
+                signatures=[joelle_paper8_anon_group.id],
                 head=note_id_8,
                 tail='~David_Belanger1',
                 weight=1
@@ -3930,7 +3958,7 @@ The TMLR Editors-in-Chief
         helpers.await_queue_edit(openreview_client, edit_id=volunteer_to_review_note['id'])
 
         volunteer_to_review_approval_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper8/-/~David_Belanger1_Volunteer_to_Review_Approval',
-            signatures=[f"{venue_id}/Paper8/Action_Editors"],
+            signatures=[joelle_paper8_anon_group.id],
             note=Note(
                 forum=note_id_8,
                 replyto=volunteer_to_review_note['note']['id'],
@@ -3959,7 +3987,7 @@ The TMLR Editors-in-Chief
 
         ## Post a response
         Volunteer_to_Review_approval_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper8/-/~Peter_Snow1_Volunteer_to_Review_Approval',
-            signatures=[f"{venue_id}/Paper8/Action_Editors"],
+            signatures=[joelle_paper8_anon_group.id],
             note=Note(
                 forum=note_id_8,
                 replyto=Volunteer_to_Review_note['note']['id'],
@@ -4148,9 +4176,13 @@ The TMLR Editors-in-Chief
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        joelle_paper10_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper10/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper10_anon_groups) == 1
+        joelle_paper10_anon_group = joelle_paper10_anon_groups[0]         
+
         ## Accept the submission 8
         under_review_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper10/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper10/Action_Editors'],
+                                    signatures=[joelle_paper10_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -4166,7 +4198,7 @@ The TMLR Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper10/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper10/Authors"],
             writers=[venue_id, f"{venue_id}/Paper10/Action_Editors"],
-            signatures=[f"{venue_id}/Paper10/Action_Editors"],
+            signatures=[joelle_paper10_anon_group.id],
             head=note_id_10,
             tail='~David_Belanger1',
             weight=1
@@ -4249,9 +4281,13 @@ The TMLR Editors-in-Chief
 
         note = openreview_client.get_note(note_id_11)
 
+        joelle_paper11_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper11/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper11_anon_groups) == 1
+        joelle_paper11_anon_group = joelle_paper11_anon_groups[0]         
+
         ## Accept the submission 8
         under_review_note = joelle_client.post_note_edit(invitation= f'TMLR/Paper{note.number}/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper{note.number}/Action_Editors'],
+                                    signatures=[joelle_paper11_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -4313,8 +4349,12 @@ The TMLR Editors-in-Chief
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        joelle_paper12_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper12/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper12_anon_groups) == 1
+        joelle_paper12_anon_group = joelle_paper12_anon_groups[0]         
+
         desk_reject_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper12/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper12/Action_Editors'],
+                                    signatures=[joelle_paper12_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Desk Reject' },
                                         'comment': { 'value': 'this paper is not ready' }
@@ -4440,12 +4480,15 @@ note={Under review}
         raia_client.remove_members_from_group(raia_client.get_group('TMLR/Action_Editors'), '~Joelle_Pineau1')
         raia_client.add_members_to_group(raia_client.get_group('TMLR/Action_Editors/Archived'), '~Joelle_Pineau1')
 
+        joelle_paper13_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper13/Action_Editor_.*', signatory='~Joelle_Pineau1')
+        assert len(joelle_paper13_anon_groups) == 1
+        joelle_paper13_anon_group = joelle_paper13_anon_groups[0]         
 
         ## Make a comment before approving the submission to be under review
         comment_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Official_Comment',
-            signatures=[f"{venue_id}/Paper13/Action_Editors"],
+            signatures=[joelle_paper13_anon_group.id],
             note=Note(
-                signatures=[f"{venue_id}/Paper13/Action_Editors"],
+                signatures=[joelle_paper13_anon_group.id],
                 readers=['TMLR/Editors_In_Chief', 'TMLR/Paper13/Action_Editors'],
                 forum=note_id_13,
                 replyto=note_id_13,
@@ -4457,7 +4500,7 @@ note={Under review}
         
         ## Accept the submission 1
         under_review_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper13/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper13/Action_Editors'],
+                                    signatures=[joelle_paper13_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -4474,7 +4517,7 @@ note={Under review}
             readers=[venue_id, f"{venue_id}/Paper13/Action_Editors", '~David_Belanger1'],
             nonreaders=[f"{venue_id}/Paper13/Authors"],
             writers=[venue_id, f"{venue_id}/Paper13/Action_Editors"],
-            signatures=[f"{venue_id}/Paper13/Action_Editors"],
+            signatures=[joelle_paper13_anon_group.id],
             head=note_id_13,
             tail='~David_Belanger1',
             weight=1
@@ -4487,7 +4530,7 @@ note={Under review}
             readers=[venue_id, f"{venue_id}/Paper13/Action_Editors", '~Carlos_Mondragon1'],
             nonreaders=[f"{venue_id}/Paper13/Authors"],
             writers=[venue_id, f"{venue_id}/Paper13/Action_Editors"],
-            signatures=[f"{venue_id}/Paper13/Action_Editors"],
+            signatures=[joelle_paper13_anon_group.id],
             head=note_id_13,
             tail='~Carlos_Mondragon1',
             weight=1
@@ -4500,7 +4543,7 @@ note={Under review}
             readers=[venue_id, f"{venue_id}/Paper13/Action_Editors", '~Javier_Burroni1'],
             nonreaders=[f"{venue_id}/Paper13/Authors"],
             writers=[venue_id, f"{venue_id}/Paper13/Action_Editors"],
-            signatures=[f"{venue_id}/Paper13/Action_Editors"],
+            signatures=[joelle_paper13_anon_group.id],
             head=note_id_13,
             tail='~Javier_Burroni1',
             weight=1
@@ -4633,7 +4676,7 @@ note={Under review}
         for review in reviews:
             signature=review.signatures[0]
             rating_note=joelle_client.post_note_edit(invitation=f'{signature}/-/Rating',
-                signatures=[f"{venue_id}/Paper13/Action_Editors"],
+                signatures=[joelle_paper13_anon_group.id],
                 note=Note(
                     content={
                         'rating': { 'value': 'Exceeds expectations' }
@@ -4646,7 +4689,7 @@ note={Under review}
             assert process_logs[0]['status'] == 'ok'
 
         decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper13/-/Decision',
-            signatures=[f"{venue_id}/Paper13/Action_Editors"],
+            signatures=[joelle_paper13_anon_group.id],
             note=Note(
                 content={
                     'claims_and_evidence': { 'value': 'Accept as is' },
@@ -4691,9 +4734,9 @@ note={Under review}
         helpers.await_queue_edit(openreview_client, edit_id=revision_note['id'])
 
         verification_note = joelle_client.post_note_edit(invitation='TMLR/Paper13/-/Camera_Ready_Verification',
-                            signatures=[f"{venue_id}/Paper13/Action_Editors"],
+                            signatures=[joelle_paper13_anon_group.id],
                             note=Note(
-                                signatures=[f"{venue_id}/Paper13/Action_Editors"],
+                                signatures=[joelle_paper13_anon_group.id],
                                 content= {
                                     'verification': { 'value': 'I confirm that camera ready manuscript complies with the TMLR stylefile and, if appropriate, includes the minor revisions that were requested.' }
                                  }

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -125,6 +125,64 @@ class TestJournal():
                             'camera_ready_verification_period': 1,
                             'archived_action_editors': True,
                             'expert_reviewers': True,
+                            'official_recommendation_additional_fields': {
+                                'pilot_recommendation_to_iclr_track': {
+                                    'order': 98,
+                                    'description': 'Would you recommend this work be invited for presentation at the ICLR Journal-to-Conference Track? Recall that TMLR\'s acceptance criteria are that a work must be sound and of interest to the TMLR audience. Above these requirements, a paper in the ICLR Journal-to-Conference Track should also stand out in novelty or predicted significance for the field (i.e., comparable to the level of a paper in ICLR\'s regular conference track). **Your anonymized response will be shared with ICLR**',
+                                    'value': {
+                                        'param': {
+                                            'fieldName': '[Pilot] Recommendation to ICLR Journal-to-Conference Track',
+                                            'type': 'string',
+                                            'enum': ['Strongly Recommend', 'Weakly Recommend', 'Weakly Oppose', 'Strongly Oppose'],
+                                            'input': 'radio',
+                                        }
+                                    },
+                                    'readers': ['TMLR', 'TMLR/Paper${7/content/noteNumber/value}/Action_Editors', '${5/signatures}']
+                                },
+                                'pilot_explain_recommendation_to_iclr_track': {
+                                    'order': 98,
+                                    'description': '**Your anonymized response will be shared with ICLR**',
+                                    'value': {
+                                        'param': {
+                                            'fieldName': '[Pilot] Explain your recommendation to the ICLR Journal-to-Conference Track',
+                                            'type': 'string',
+                                            'maxLength': 50000,
+                                            'markdown': True,
+                                            'input': 'textarea'
+                                        }
+                                    },
+                                    'readers': ['TMLR', 'TMLR/Paper${7/content/noteNumber/value}/Action_Editors', '${5/signatures}']
+                                }                                
+                            },
+                            'decision_additional_fields': {
+                                'pilot_recommendation_to_iclr_track': {
+                                    'order': 98,
+                                    'description': 'Would you recommend this work be invited for presentation at the ICLR Journal-to-Conference Track? Unlike TMLR, the ICLR Journal-to-Conference Track is intended to feature work that also stands out in their novelty or their predicted significance for the field, commensurate to papers in its regular conference track. Therefore, this recommendation should be made completely separately from the recommendation to accept at TMLR. **Your response will be shared with ICLR**',
+                                    'value': {
+                                        'param': {
+                                            'fieldName': '[Pilot] Recommendation to ICLR Journal-to-Conference Track',
+                                            'type': 'string',
+                                            'enum': ['Strongly Recommend', 'Weakly Recommend', 'Weakly Oppose', 'Strongly Oppose'],
+                                            'input': 'radio',
+                                        }
+                                    },
+                                    'readers': ['TMLR', 'TMLR/Paper${7/content/noteNumber/value}/Action_Editors']
+                                },
+                                'pilot_explain_recommendation_to_iclr_track': {
+                                    'order': 98,
+                                    'description': '**Your response will be shared with ICLR**',
+                                    'value': {
+                                        'param': {
+                                            'fieldName': '[Pilot] Explain your recommendation to the ICLR Journal-to-Conference Track',
+                                            'type': 'string',
+                                            'maxLength': 50000,
+                                            'markdown': True,
+                                            'input': 'textarea'
+                                        }
+                                    },
+                                    'readers': ['TMLR', 'TMLR/Paper${7/content/noteNumber/value}/Action_Editors']
+                                }                                
+                            }                            
                         }
                     }
                 }
@@ -1808,7 +1866,9 @@ note: replies to this email will go to the AE, Joelle Pineau.
                     'decision_recommendation': { 'value': 'Accept' },
                     'certification_recommendations': { 'value': ['Featured Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -1834,7 +1894,9 @@ note: replies to this email will go to the AE, Joelle Pineau.
                     'decision_recommendation': { 'value': 'Accept' },
                     'certification_recommendations': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -1860,7 +1922,9 @@ note: replies to this email will go to the AE, Joelle Pineau.
                     'decision_recommendation': { 'value': 'Accept' },
                     'certification_recommendations': { 'value': ['Survey Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -1874,7 +1938,9 @@ note: replies to this email will go to the AE, Joelle Pineau.
                     'decision_recommendation': { 'value': 'Accept' },
                     'certification_recommendations': { 'value': ['Survey Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -1934,7 +2000,9 @@ The TMLR Editors-in-Chief
                     'decision_recommendation': { 'value': 'Leaning Accept' },
                     'certification_recommendations': { 'value': ['Survey Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2006,7 +2074,9 @@ The TMLR Editors-in-Chief
                     'audience': { 'value': 'Accept as is' },
                     'recommendation': { 'value': 'Accept as is' },
                     'comment': { 'value': 'This is a nice paper!' },
-                    'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] }
+                    'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2030,7 +2100,9 @@ The TMLR Editors-in-Chief
                         'audience': { 'value': 'Accept as is' },
                         'recommendation': { 'value': 'Accept as is' },
                         'comment': { 'value': 'This is a nice paper!' },
-                        'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] }
+                        'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
+                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                     }
                 )
             )
@@ -2780,7 +2852,9 @@ note: replies to this email will go to the AE, Joelle Pineau.
                 content={
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2794,7 +2868,9 @@ note: replies to this email will go to the AE, Joelle Pineau.
                 content={
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2836,7 +2912,9 @@ note: replies to this email will go to the AE, Joelle Pineau.
                         'audience': { 'value': 'Accept as is' },
                         'recommendation': { 'value': 'Reject' },
                         'comment': { 'value': 'This is not a good paper' },
-                        'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] }
+                        'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
+                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                     }
                 )
             )
@@ -2849,7 +2927,9 @@ note: replies to this email will go to the AE, Joelle Pineau.
                     'audience': { 'value': 'Accept as is' },
                     'recommendation': { 'value': 'Reject' },
                     'comment': { 'value': 'This is not a good paper' },
-                    'resubmission_of_major_revision': { 'value': 'The authors may consider submitting a major revision at a later time.' }                    
+                    'resubmission_of_major_revision': { 'value': 'The authors may consider submitting a major revision at a later time.' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }                   
                 }
             )
         )
@@ -3185,7 +3265,9 @@ The TMLR Editors-in-Chief
                 content={
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3199,7 +3281,9 @@ The TMLR Editors-in-Chief
                 content={
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3213,7 +3297,9 @@ The TMLR Editors-in-Chief
                 content={
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3241,7 +3327,9 @@ The TMLR Editors-in-Chief
                     'claims_and_evidence': { 'value': 'Accept as is' },
                     'audience': { 'value': 'Accept as is' },
                     'recommendation': { 'value': 'Accept with minor revision' },
-                    'comment': { 'value': 'This is a good paper' }
+                    'comment': { 'value': 'This is a good paper' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3487,7 +3575,9 @@ The TMLR Editors-in-Chief
                 content={
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3501,7 +3591,9 @@ The TMLR Editors-in-Chief
                 content={
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3515,7 +3607,9 @@ The TMLR Editors-in-Chief
                 content={
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -4482,7 +4576,9 @@ note={Under review}
                     'decision_recommendation': { 'value': 'Accept' },
                     'certification_recommendations': { 'value': ['Featured Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -4496,7 +4592,9 @@ note={Under review}
                     'decision_recommendation': { 'value': 'Accept' },
                     'certification_recommendations': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -4510,7 +4608,9 @@ note={Under review}
                     'decision_recommendation': { 'value': 'Accept' },
                     'certification_recommendations': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -4541,7 +4641,9 @@ note={Under review}
                     'claims_and_evidence': { 'value': 'Accept as is' },
                     'audience': { 'value': 'Accept as is' },
                     'recommendation': { 'value': 'Accept with minor revision' },
-                    'comment': { 'value': 'This is a good paper' }
+                    'comment': { 'value': 'This is a good paper' },
+                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -3119,6 +3119,13 @@ We thank you for your cooperation.
 The TMLR Editors-in-Chief
 '''        
 
+        ## try editing the assignmente edge being the author and get an error
+        paper_assignment_edge.tail = '~Ryan_Adams1'
+        paper_assignment_edge.readers=[venue_id, editor_in_chief_group_id, '~Ryan_Adams1']
+        with pytest.raises(openreview.OpenReviewException, match=r'You cannot edit the tail of this edge'):
+            raia_client.post_edge(paper_assignment_edge)
+       
+        
         raia_client.post_invitation_edit(
             invitations='TMLR/-/Edit',
             readers=[venue_id],

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -3095,7 +3095,7 @@ note={Rejected}
         openreview_client.get_invitation('TMLR/Paper5/Action_Editors/-/Recommendation')        
 
         # Assign Action Editor
-        paper_assignment_edge = raia_client.post_edge(openreview.Edge(invitation='TMLR/Action_Editors/-/Assignment',
+        paper_assignment_edge = cho_client.post_edge(openreview.Edge(invitation='TMLR/Action_Editors/-/Assignment',
             readers=[venue_id, editor_in_chief_group_id, '~Joelle_Pineau1'],
             writers=[venue_id, editor_in_chief_group_id],
             signatures=[editor_in_chief_group_id],
@@ -3122,7 +3122,7 @@ The TMLR Editors-in-Chief
         ## try editing the assignmente edge being the author and get an error
         paper_assignment_edge.tail = '~Ryan_Adams1'
         paper_assignment_edge.readers=[venue_id, editor_in_chief_group_id, '~Ryan_Adams1']
-        with pytest.raises(openreview.OpenReviewException, match=r'You cannot edit the tail of this edge'):
+        with pytest.raises(openreview.OpenReviewException, match=r'Authors can not edit assignments for this submission: 5'):
             raia_client.post_edge(paper_assignment_edge)
        
         
@@ -3182,7 +3182,8 @@ The TMLR Editors-in-Chief
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
         ## Assign Javier Burroni
-        paper_assignment_edge = joelle_client.post_edge(openreview.Edge(invitation='TMLR/Reviewers/-/Assignment',
+        ## try editing the assignmente edge being the author and get an error
+        paper_assignment_edge = openreview.Edge(invitation='TMLR/Reviewers/-/Assignment',
             readers=[venue_id, f"{venue_id}/Paper5/Action_Editors", '~Javier_Burroni1'],
             nonreaders=[f"{venue_id}/Paper5/Authors"],
             writers=[venue_id, f"{venue_id}/Paper5/Action_Editors"],
@@ -3190,9 +3191,12 @@ The TMLR Editors-in-Chief
             head=note_id_5,
             tail='~Javier_Burroni1',
             weight=1
-        ))
+        )
+        with pytest.raises(openreview.OpenReviewException, match=r'Authors can not edit assignments for this submission: 5'):
+            raia_client.post_edge(paper_assignment_edge)
 
-        helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
+        paper_assignment_edge = joelle_client.post_edge(paper_assignment_edge)
+        helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)      
 
         ## Post a review edit
         david_anon_groups=david_client.get_groups(prefix=f'{venue_id}/Paper5/Reviewer_.*', signatory='~David_Belanger1')

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -157,7 +157,7 @@ class TestJournal():
                             'decision_additional_fields': {
                                 'pilot_recommendation_to_iclr_track': {
                                     'order': 98,
-                                    'description': 'Would you recommend this work be invited for presentation at the ICLR Journal-to-Conference Track? Unlike TMLR, the ICLR Journal-to-Conference Track is intended to feature work that also stands out in their novelty or their predicted significance for the field, commensurate to papers in its regular conference track. Therefore, this recommendation should be made completely separately from the recommendation to accept at TMLR. **Your response will be shared with ICLR**',
+                                    'description': 'Would you recommend this work be invited for presentation at the ICLR Journal-to-Conference Track? Recall that TMLR\'s acceptance criteria are that a work must be sound and of interest to the TMLR audience. Above these requirements, a paper in the ICLR Journal-to-Conference Track should also stand out in novelty or predicted significance for the field (i.e., comparable to the level of a paper in ICLR\'s regular conference track. **Your response will be shared with ICLR**',
                                     'value': {
                                         'param': {
                                             'fieldName': '[Pilot] Recommendation to ICLR Journal-to-Conference Track',

--- a/tests/test_melba_journal.py
+++ b/tests/test_melba_journal.py
@@ -70,7 +70,41 @@ class TestJournal():
                             'author_anonymity': True,
                             'assignment_delay': 0,
                             'show_conflict_details': True,
-                            'has_publication_chairs': True
+                            'has_publication_chairs': True,
+                            'submission_additional_fields': {
+                                # 'competing_interests': {
+                                #     'delete': True
+                                # },
+                                'additional_field': {
+                                    'order': 98,
+                                    'description': 'this is an additional field',
+                                    'value': {
+                                        'param': {
+                                            'fieldName': 'Enter your comments',
+                                            'type': 'string',
+                                            'maxLength': 50000,
+                                            'markdown': True,
+                                            'input': 'textarea'
+                                        }
+                                    }
+                                }                                
+                            },
+                            'review_additional_fields': {
+                                'confidential_comment': {
+                                    'order': 98,
+                                    'description': 'confidential comment',
+                                    'value': {
+                                        'param': {
+                                            'fieldName': 'confidential comment',
+                                            'type': 'string',
+                                            'maxLength': 50000,
+                                            'markdown': True,
+                                            'input': 'textarea'
+                                        }
+                                    },
+                                    'readers': ['MELBA', 'MELBA/Paper${7/content/noteNumber/value}/Action_Editors', '${5/signatures}']
+                                }                             
+                            }
                         }
                     }
                 }
@@ -154,6 +188,7 @@ class TestJournal():
                     'authorids': { 'value': ['~SomeFirstName_User1', '~Celeste_Martinez1']},
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
+                    'additional_field': { 'value': 'None beyond the authors normal conflict of interests'},
                     'human_subjects_reporting': { 'value': 'Not applicable'}
                 }
             ))
@@ -279,7 +314,8 @@ The MELBA Editors-in-Chief
                     'requested_changes': { 'value': 'requested_changes' },
                     'broader_impact_concerns': { 'value': 'broader_impact_concerns' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'confidential_comment': { 'value': 'confidential_comment' }
                 }
             )
         )
@@ -298,7 +334,8 @@ The MELBA Editors-in-Chief
                     'requested_changes': { 'value': 'requested_changes' },
                     'broader_impact_concerns': { 'value': 'broader_impact_concerns' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'confidential_comment': { 'value': 'confidential_comment' }
                 }
             )
         )
@@ -317,7 +354,8 @@ The MELBA Editors-in-Chief
                     'requested_changes': { 'value': 'requested_changes' },
                     'broader_impact_concerns': { 'value': 'broader_impact_concerns' },
                     'claims_and_evidence': { 'value': 'Yes' },
-                    'audience': { 'value': 'Yes' }
+                    'audience': { 'value': 'Yes' },
+                    'confidential_comment': { 'value': 'confidential_comment' }
                 }
             )
         )
@@ -449,7 +487,8 @@ The MELBA Editors-in-Chief
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
                     'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
                     'human_subjects_reporting': { 'value': 'Not applicable'},
-                    'video': { 'value': 'https://youtube.com/dfenxkw'}
+                    'video': { 'value': 'https://youtube.com/dfenxkw'},
+                    'additional_field': { 'value': 'None beyond the authors normal conflict of interests'}   
                 }
             )
         )

--- a/tests/test_melba_journal.py
+++ b/tests/test_melba_journal.py
@@ -211,9 +211,13 @@ The MELBA Editors-in-Chief
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        aasa_paper1_anon_groups = aasa_client.get_groups(prefix=f'MELBA/Paper1/Action_Editor_.*', signatory='~Aasa_Feragen1')
+        assert len(aasa_paper1_anon_groups) == 1
+        aasa_paper1_anon_group = aasa_paper1_anon_groups[0]         
+
         ## Accept the submission 1
         under_review_note = aasa_client.post_note_edit(invitation= 'MELBA/Paper1/-/Review_Approval',
-                                    signatures=[f'{venue_id}/Paper1/Action_Editors'],
+                                    signatures=[aasa_paper1_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -234,7 +238,7 @@ The MELBA Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~MELBARev_One1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[aasa_paper1_anon_group.id],
             head=note_id_1,
             tail='~MELBARev_One1',
             weight=1
@@ -245,7 +249,7 @@ The MELBA Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~MELBARev_Two1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[aasa_paper1_anon_group.id],
             head=note_id_1,
             tail='~MELBARev_Two1',
             weight=1
@@ -256,7 +260,7 @@ The MELBA Editors-in-Chief
             readers=[venue_id, f"{venue_id}/Paper1/Action_Editors", '~MELBARev_Three1'],
             nonreaders=[f"{venue_id}/Paper1/Authors"],
             writers=[venue_id, f"{venue_id}/Paper1/Action_Editors"],
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[aasa_paper1_anon_group.id],
             head=note_id_1,
             tail='~MELBARev_Three1',
             weight=1
@@ -322,9 +326,9 @@ The MELBA Editors-in-Chief
 
         reviews=openreview_client.get_notes(forum=note_id_1, invitation=f'{venue_id}/Paper1/-/Review', sort='number:desc')
         assert len(reviews) == 3
-        assert reviews[0].readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Paper1/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
-        assert reviews[1].readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Paper1/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
-        assert reviews[2].readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Paper1/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
+        assert reviews[0].readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
+        assert reviews[1].readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
+        assert reviews[2].readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
 
         invitation = eic_client.get_invitation(f'{venue_id}/Paper1/-/Official_Recommendation')
         assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
@@ -387,7 +391,7 @@ The MELBA Editors-in-Chief
         for review in reviews:
             signature=review.signatures[0]
             rating_note=aasa_client.post_note_edit(invitation=f'{signature}/-/Rating',
-                signatures=[f"{venue_id}/Paper1/Action_Editors"],
+                signatures=[aasa_paper1_anon_group.id],
                 note=Note(
                     content={
                         'rating': { 'value': 'Exceeds expectations' }
@@ -400,7 +404,7 @@ The MELBA Editors-in-Chief
             assert process_logs[0]['status'] == 'ok'
 
         decision_note = aasa_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Decision',
-            signatures=[f"{venue_id}/Paper1/Action_Editors"],
+            signatures=[aasa_paper1_anon_group.id],
             note=Note(
                 content={
                     'claims_and_evidence': { 'value': 'Accept as is' },
@@ -429,7 +433,7 @@ The MELBA Editors-in-Chief
         helpers.await_queue_edit(openreview_client, edit_id=approval_note['id'])
 
         decision_note = eic_client.get_note(decision_note.id)
-        assert decision_note.readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Paper1/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
+        assert decision_note.readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
         assert decision_note.nonreaders == []
 
         ## post a revision

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -938,8 +938,12 @@ The OpenReview Team.
 
         carlos_client = openreview.api.OpenReviewClient(username='carlos@cabj.org', password=helpers.strong_password)
 
+        carlos_paper2_anon_groups = carlos_client.get_groups(prefix=f'CABJ/Paper2/Action_Editor_.*', signatory='~Carlos_Tevez1')
+        assert len(carlos_paper2_anon_groups) == 1
+        carlos_paper2_anon_group = carlos_paper2_anon_groups[0]
+
         under_review_note = carlos_client.post_note_edit(invitation= 'CABJ/Paper2/-/Review_Approval',
-                                    signatures=['CABJ/Paper2/Action_Editors'],
+                                    signatures=[carlos_paper2_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))

--- a/tests/test_tacl_journal.py
+++ b/tests/test_tacl_journal.py
@@ -47,6 +47,7 @@ class TestTACLJournal():
                         'value': {
                             'submission_public': False,
                             'skip_ac_recommendation': True,
+                            'skip_reviewer_responsibility_acknowledgement': True,
                             'assignment_delay': 0,
                             'certifications': [
                                 'Featured Certification',
@@ -201,7 +202,7 @@ The TACL Editors-in-Chief
         note = graham_client.get_note(note_id_1)
         assert note
         assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Under_Review']
-        assert note.readers == ['TACL', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+        assert note.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert note.writers == ['TACL', 'TACL/Paper1/Authors']
         assert note.signatures == ['TACL/Paper1/Authors']
         assert note.content['authorids']['value'] == ['~SomeFirstName_User1', '~Melisa_Andersen1']
@@ -233,7 +234,7 @@ note={Under review}
         edits = openreview_client.get_note_edits(note.id)
         assert len(edits) == 3
         for edit in edits:
-            assert edit.readers == ['TACL', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+            assert edit.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
 
     def test_review(self, journal, openreview_client, helpers):
 
@@ -278,6 +279,8 @@ The TACL Editors-in-Chief
 note: replies to this email will go to the AE, Graham Neubig.
 '''
         assert messages[0]['content']['replyTo'] == 'graham@mailseven.com'
+
+        assert not openreview.tools.get_invitation(openreview_client, 'TACL/Reviewers/-/~David_Bensusan1/Responsibility/Acknowledgement')
 
         ## Carlos Gardel
         paper_assignment_edge = graham_client.post_edge(openreview.Edge(invitation='TACL/Reviewers/-/Assignment',
@@ -581,7 +584,7 @@ note: replies to this email will go to the AE, Graham Neubig.
         assert note.forum == note_id_1
         assert note.replyto is None
         assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Under_Review', 'TACL/-/Edit', 'TACL/Paper1/-/Camera_Ready_Revision']
-        assert note.readers == ['TACL', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+        assert note.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert note.writers == ['TACL', 'TACL/Paper1/Authors']
         assert note.signatures == ['TACL/Paper1/Authors']
         assert note.content['authorids']['value'] == ['~Melisa_Andersen1', '~SomeFirstName_User1']
@@ -608,7 +611,7 @@ note: replies to this email will go to the AE, Graham Neubig.
         assert note.forum == note_id_1
         assert note.replyto is None
         assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Under_Review', 'TACL/-/Edit', 'TACL/Paper1/-/Camera_Ready_Revision', 'TACL/-/Accepted']
-        assert note.readers == ['TACL', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+        assert note.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert note.writers == ['TACL']
         assert note.signatures == ['TACL/Paper1/Authors']
         assert note.content['authorids']['value'] == ['~Melisa_Andersen1', '~SomeFirstName_User1']
@@ -633,7 +636,7 @@ note={Featured Certification, Reproducibility Certification}
         edits = openreview_client.get_note_edits(note.id)
         assert len(edits) == 6
         for edit in edits:
-            assert edit.readers == ['TACL', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+            assert edit.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
 
     def test_withdrawn_submission(self, journal, openreview_client, test_client, helpers):
 
@@ -696,7 +699,7 @@ note={Featured Certification, Reproducibility Certification}
         note = test_client.get_note(note_id_2)
         assert note
         assert note.invitations == ['TACL/-/Submission', 'TACL/-/Under_Review', 'TACL/-/Withdrawn']
-        assert note.readers == ['TACL', 'TACL/Paper2/Action_Editors', 'TACL/Paper2/Reviewers', 'TACL/Paper2/Authors']
+        assert note.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper2/Reviewers', 'TACL/Paper2/Authors']
         assert note.writers == ['TACL', 'TACL/Paper2/Authors']
         assert note.signatures == ['TACL/Paper2/Authors']
         assert note.content['authorids']['value'] == ['~SomeFirstName_User1', '~Melisa_Andersen1']
@@ -717,7 +720,7 @@ note={Withdrawn}
         edits = openreview_client.get_note_edits(note.id)
         assert len(edits) == 3
         for edit in edits:
-            assert edit.readers == ['TACL', 'TACL/Paper2/Action_Editors', 'TACL/Paper2/Reviewers', 'TACL/Paper2/Authors']
+            assert edit.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper2/Reviewers', 'TACL/Paper2/Authors']
 
         invitations = openreview_client.get_invitations(replyForum=note_id_2, prefix='TACL/Paper2')
         assert len(invitations) == 1

--- a/tests/test_tacl_journal.py
+++ b/tests/test_tacl_journal.py
@@ -372,11 +372,11 @@ note: replies to this email will go to the AE, Graham Neubig.
         ## All the reviewes should be visible to all the reviewers now
         reviews=openreview_client.get_notes(forum=note_id_1, invitation='TACL/Paper1/-/Review', sort= 'number:asc')
         assert len(reviews) == 3
-        assert reviews[0].readers == ['TACL/Editors_In_Chief', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+        assert reviews[0].readers == ['TACL/Editors_In_Chief', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert reviews[0].signatures == [david_anon_groups[0].id]
-        assert reviews[1].readers == ['TACL/Editors_In_Chief', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+        assert reviews[1].readers == ['TACL/Editors_In_Chief', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert reviews[1].signatures == [carlos_anon_groups[0].id]
-        assert reviews[2].readers == ['TACL/Editors_In_Chief', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+        assert reviews[2].readers == ['TACL/Editors_In_Chief', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert reviews[2].signatures == [javier_anon_groups[0].id]
 
         invitations = openreview_client.get_invitations(replyForum=note_id_1, prefix='TACL/Paper1')
@@ -549,7 +549,7 @@ note: replies to this email will go to the AE, Graham Neubig.
 
 
         decision_note = brian_client.get_note(decision_note.id)
-        assert decision_note.readers == ['TACL/Editors_In_Chief', 'TACL/Paper1/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
+        assert decision_note.readers == ['TACL/Editors_In_Chief', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert decision_note.nonreaders == []
 
     def test_camera_ready_revision(self, journal, openreview_client, helpers):

--- a/tests/test_tacl_journal.py
+++ b/tests/test_tacl_journal.py
@@ -190,9 +190,13 @@ We thank you for your essential contribution to TACL!
 The TACL Editors-in-Chief
 '''
 
+        graham_paper1_anon_groups = graham_client.get_groups(prefix=f'TACL/Paper1/Action_Editor_.*', signatory='~Graham_Neubig1')
+        assert len(graham_paper1_anon_groups) == 1
+        graham_paper1_anon_group = graham_paper1_anon_groups[0]         
+
         ## Accept the submission 1
         under_review_note = graham_client.post_note_edit(invitation= 'TACL/Paper1/-/Review_Approval',
-                                    signatures=['TACL/Paper1/Action_Editors'],
+                                    signatures=[graham_paper1_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -246,12 +250,16 @@ note={Under review}
         carlos_client = OpenReviewClient(username='carlos@taclthree.com', password=helpers.strong_password)
         javier_client = OpenReviewClient(username='javier@tacltwo.com', password=helpers.strong_password)
 
+        graham_paper1_anon_groups = graham_client.get_groups(prefix=f'TACL/Paper1/Action_Editor_.*', signatory='~Graham_Neubig1')
+        assert len(graham_paper1_anon_groups) == 1
+        graham_paper1_anon_group = graham_paper1_anon_groups[0]
+
         # add David Belanger again
         paper_assignment_edge = graham_client.post_edge(openreview.Edge(invitation='TACL/Reviewers/-/Assignment',
             readers=["TACL", "TACL/Paper1/Action_Editors", '~David_Bensusan1'],
             nonreaders=["TACL/Paper1/Authors"],
             writers=["TACL", "TACL/Paper1/Action_Editors"],
-            signatures=["TACL/Paper1/Action_Editors"],
+            signatures=[graham_paper1_anon_group.id],
             head=note_id_1,
             tail='~David_Bensusan1',
             weight=1
@@ -287,7 +295,7 @@ note: replies to this email will go to the AE, Graham Neubig.
             readers=["TACL", "TACL/Paper1/Action_Editors", '~Carlos_Gardel1'],
             nonreaders=["TACL/Paper1/Authors"],
             writers=["TACL", "TACL/Paper1/Action_Editors"],
-            signatures=["TACL/Paper1/Action_Editors"],
+            signatures=[graham_paper1_anon_group.id],
             head=note_id_1,
             tail='~Carlos_Gardel1',
             weight=1
@@ -298,7 +306,7 @@ note: replies to this email will go to the AE, Graham Neubig.
             readers=["TACL", "TACL/Paper1/Action_Editors", '~Javier_Barden1'],
             nonreaders=["TACL/Paper1/Authors"],
             writers=["TACL", "TACL/Paper1/Action_Editors"],
-            signatures=["TACL/Paper1/Action_Editors"],
+            signatures=[graham_paper1_anon_group.id],
             head=note_id_1,
             tail='~Javier_Barden1',
             weight=1
@@ -505,10 +513,14 @@ note: replies to this email will go to the AE, Graham Neubig.
         note_id_1 = openreview_client.get_notes(invitation='TACL/-/Submission')[0].id
         reviews=openreview_client.get_notes(forum=note_id_1, invitation='TACL/Paper1/-/Review', sort= 'number:asc')
 
+        graham_paper1_anon_groups = graham_client.get_groups(prefix=f'TACL/Paper1/Action_Editor_.*', signatory='~Graham_Neubig1')
+        assert len(graham_paper1_anon_groups) == 1
+        graham_paper1_anon_group = graham_paper1_anon_groups[0]
+
         for review in reviews:
             signature=review.signatures[0]
             rating_note=graham_client.post_note_edit(invitation=f'{signature}/-/Rating',
-                signatures=["TACL/Paper1/Action_Editors"],
+                signatures=[graham_paper1_anon_group.id],
                 note=Note(
                     content={
                         'rating': { 'value': 'Exceeds expectations' }
@@ -518,7 +530,7 @@ note: replies to this email will go to the AE, Graham Neubig.
             helpers.await_queue_edit(openreview_client, edit_id=rating_note['id'])
 
         decision_note = graham_client.post_note_edit(invitation='TACL/Paper1/-/Decision',
-            signatures=["TACL/Paper1/Action_Editors"],
+            signatures=[graham_paper1_anon_group.id],
             note=Note(
                 content={
                     'claims_and_evidence': { 'value': 'Accept as is' },
@@ -594,11 +606,15 @@ note: replies to this email will go to the AE, Graham Neubig.
         assert note.content['title']['value'] == 'Paper title VERSION 2'
         assert note.content['abstract']['value'] == 'Paper abstract'
 
+        graham_paper1_anon_groups = graham_client.get_groups(prefix=f'TACL/Paper1/Action_Editor_.*', signatory='~Graham_Neubig1')
+        assert len(graham_paper1_anon_groups) == 1
+        graham_paper1_anon_group = graham_paper1_anon_groups[0]
+
         ## AE verifies the camera ready revision
         verification_note = graham_client.post_note_edit(invitation='TACL/Paper1/-/Camera_Ready_Verification',
-                            signatures=["TACL/Paper1/Action_Editors"],
+                            signatures=[graham_paper1_anon_group.id],
                             note=Note(
-                                signatures=["TACL/Paper1/Action_Editors"],
+                                signatures=[graham_paper1_anon_group.id],
                                 content= {
                                     'verification': { 'value': 'I confirm that camera ready manuscript complies with the TACL stylefile and, if appropriate, includes the minor revisions that were requested.' }
                                  }
@@ -676,9 +692,13 @@ note={Featured Certification, Reproducibility Certification}
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        graham_paper2_anon_groups = graham_client.get_groups(prefix=f'TACL/Paper2/Action_Editor_.*', signatory='~Graham_Neubig1')
+        assert len(graham_paper2_anon_groups) == 1
+        graham_paper2_anon_group = graham_paper2_anon_groups[0]
+
         ## Accept the submission 2
         under_review_note = graham_client.post_note_edit(invitation= 'TACL/Paper2/-/Review_Approval',
-                                    signatures=['TACL/Paper2/Action_Editors'],
+                                    signatures=[graham_paper2_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))


### PR DESCRIPTION
- Support additional fields for submission, review, official recommendation and decision invitations.
- Action Editors should use their anon group id to sign their note edits.
- Allow filtering by certifications in the EIC console.
- Allow skipping reviewer responsibility task.
- If the submissions are not public then they are visible to EICs, all AEs and authors.
- Validate that authors can not edit assignment edges.
