### PR TITLE
Feat/ Post decision stage: add parentGroup to decision emails

### DIFF
--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -778,7 +778,7 @@ Total Errors: {len(errors)}
                 message = messages[decision_note['content']['decision']['value']]
                 final_message = message.replace("{{submission_title}}", note.content['title']['value'])
                 final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={note.id}')
-                self.client.post_message(subject, recipients=note.content['authorids']['value'], message=final_message, parentGroup=self.get_authors_id())
+                self.client.post_message(subject, recipients=[self.get_authors_id(note.number)], message=final_message, parentGroup=self.get_authors_id())
 
         tools.concurrent_requests(send_notification, paper_notes)
 

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -778,7 +778,7 @@ Total Errors: {len(errors)}
                 message = messages[decision_note['content']['decision']['value']]
                 final_message = message.replace("{{submission_title}}", note.content['title']['value'])
                 final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={note.id}')
-                self.client.post_message(subject, recipients=note.content['authorids']['value'], message=final_message)
+                self.client.post_message(subject, recipients=note.content['authorids']['value'], message=final_message, parentGroup=self.get_authors_id())
 
         tools.concurrent_requests(send_notification, paper_notes)
 

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -871,7 +871,7 @@ class VenueStages():
                 'required': True
             },
             'send_decision_notifications': {
-                'description': 'Would you like to notify the authors regarding the decision? If yes, please carefully review the template below for each decision option before you click submit to send out the emails.',
+                'description': 'Would you like to notify the authors regarding the decision? If yes, please carefully review the template below for each decision option before you click submit to send out the emails. Note that you can only send email notifications from the OpenReview UI once. If you need to send additional emails, you can do so by using the python client.',
                 'value-radio': [
                     'Yes, send an email notification to the authors',
                     'No, I will send the emails to the authors'

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4660,6 +4660,11 @@ Best,
         assert 'andrew@amazon.com' in recipients
         assert 'We are delighted to inform you that your submission has been accepted.' in messages[0]['content']['text']
 
+        replies = pc_client.get_notes(forum=request_form.id, invitation=f'openreview.net/Support/-/Request{request_form.number}/Comment')
+        assert len(replies) == 2
+        assert replies[0].content['title'] == 'Decision Notification Status'
+        assert 'Decision notifications have been sent to the authors. You can check the status of the emails by clicking on this link: https://openreview.net/messages?parentGroup=ICML.cc/2023/Conference/Authors' in replies[0].content['comment']
+
         for submission in accepted_submissions:
             assert submission.readers == ['everyone']
             assert 'readers' not in submission.content['authors']
@@ -4758,6 +4763,67 @@ url={https://openreview.net/forum?id='''
         # check members have not changed
         authors_accepted_group = openreview_client.get_group('ICML.cc/2023/Conference/Authors/Accepted')
         assert len(authors_accepted_group.members) == num_accepted_papers
+
+        #Post another post decision note
+        now = datetime.datetime.utcnow()
+        short_name = 'ICML 2023'
+        post_decision_stage_note = pc_client.post_note(openreview.Note(
+            content={
+                'reveal_authors': 'Reveal author identities of only accepted submissions to the public',
+                'submission_readers': 'Make accepted submissions public and hide rejected submissions',
+                'hide_fields': ['supplementary_material', 'pdf'],
+                'home_page_tab_names': {
+                    'Accept': 'Accept',
+                    'Revision Needed': 'Revision Needed',
+                    'Reject': 'Submitted'
+                },
+                'send_decision_notifications': 'Yes, send an email notification to the authors',
+                'accept_email_content': f'''Dear {{{{fullname}}}},
+
+Thank you for submitting your paper, {{{{submission_title}}}}, to {short_name}. We are delighted to inform you that your submission has been accepted. Congratulations!
+You can find the final reviews for your paper on the submission page in OpenReview at: {{{{forum_url}}}}
+
+Best,
+{short_name} Program Chairs
+''',
+                'reject_email_content': f'''Dear {{{{fullname}}}},
+
+Thank you for submitting your paper, {{{{submission_title}}}}, to {short_name}. We regret to inform you that your submission was not accepted.
+You can find the final reviews for your paper on the submission page in OpenReview at: {{{{forum_url}}}}
+
+Best,
+{short_name} Program Chairs
+''',
+                'revision_needed_email_content': f'''Dear {{{{fullname}}}},
+
+Thank you for submitting your paper, {{{{submission_title}}}}, to {short_name}.
+You can find the final reviews for your paper on the submission page in OpenReview at: {{{{forum_url}}}}
+
+Best,
+{short_name} Program Chairs
+'''
+            },
+            forum=request_form.forum,
+            invitation=invitation.id,
+            readers=['ICML.cc/2023/Conference/Program_Chairs', 'openreview.net/Support'],
+            replyto=request_form.forum,
+            referent=request_form.forum,
+            signatures=['~Program_ICMLChair1'],
+            writers=[]
+        ))
+        assert post_decision_stage_note
+        helpers.await_queue()
+
+        process_logs = client.get_process_logs(id = post_decision_stage_note.id)
+        assert len(process_logs) == 1
+        assert process_logs[0]['status'] == 'ok'
+
+        # check emails were not resent and decision emails status comment was not re-posted
+        messages = client.get_messages(subject='[ICML 2023] Decision notification for your submission 1: Paper title 1 Version 2')
+        assert len(messages) == 5
+
+        replies = pc_client.get_notes(forum=request_form.id, invitation=f'openreview.net/Support/-/Request{request_form.number}/Comment')
+        assert len(replies) == 2
 
     def test_forum_chat(self, openreview_client, helpers):
 


### PR DESCRIPTION
This PR adds the /Authors group ad parentGroup for decision notifications. It also adds a comment to the request form if the emails were sent successfully with a link to the messages UI for PCs to see emails that were sent. 