### PR TITLE
Feat/ Custom Stage: create invitations to revise reviews

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1322,12 +1322,16 @@ class CustomStage(object):
         WITHFORUM = 1
         REVIEWS = 2
         METAREVIEWS = 3
-        REVIEW_REVISIONS = 4
 
-    def __init__(self, name, reply_to, source, start_date=None, due_date=None, exp_date=None, invitees=[], readers=[], content={}, multi_reply = False, email_pcs = False, email_sacs = False, notify_readers=False, email_template=None, allow_de_anonymization=False):
+    class ReplyType(Enum):
+        REPLY = 0
+        REVISION = 1
+
+    def __init__(self, name, reply_to, source, reply_type=ReplyType.REPLY, start_date=None, due_date=None, exp_date=None, invitees=[], readers=[], content={}, multi_reply = False, email_pcs = False, email_sacs = False, notify_readers=False, email_template=None, allow_de_anonymization=False):
         self.name = name
         self.reply_to = reply_to
         self.source = source
+        self.reply_type = reply_type
         self.start_date = start_date
         self.due_date = due_date
         self.exp_date = exp_date
@@ -1448,10 +1452,17 @@ class CustomStage(object):
             reply_to = 'reviews'
         elif self.reply_to == self.ReplyTo.METAREVIEWS:
             reply_to = 'metareviews'
-        elif self.reply_to == self.ReplyTo.REVIEW_REVISIONS:
-            reply_to = 'review_revisions'
-        
+
         return reply_to
+
+    def get_reply_type(self):
+
+        if self.reply_type == self.ReplyType.REPLY:
+            reply_type = 'reply'
+        elif self.reply_type == self.ReplyType.REVISION:
+            reply_type = 'revision'
+
+        return reply_type
 
     def get_content(self, api_version='2', conference=None):
         

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1322,6 +1322,7 @@ class CustomStage(object):
         WITHFORUM = 1
         REVIEWS = 2
         METAREVIEWS = 3
+        REVIEW_REVISIONS = 4
 
     def __init__(self, name, reply_to, source, start_date=None, due_date=None, exp_date=None, invitees=[], readers=[], content={}, multi_reply = False, email_pcs = False, email_sacs = False, notify_readers=False, email_template=None, allow_de_anonymization=False):
         self.name = name
@@ -1447,6 +1448,8 @@ class CustomStage(object):
             reply_to = 'reviews'
         elif self.reply_to == self.ReplyTo.METAREVIEWS:
             reply_to = 'metareviews'
+        elif self.reply_to == self.ReplyTo.REVIEW_REVISIONS:
+            reply_to = 'review_revisions'
         
         return reply_to
 

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1080,7 +1080,7 @@ class MetaReviewStage(object):
         if self.public:
             return ['everyone']
 
-        readers = []
+        readers = [conference.get_program_chairs_id()]
 
         if conference.use_senior_area_chairs:
             readers.append(conference.get_senior_area_chairs_id(number = number))
@@ -1093,7 +1093,6 @@ class MetaReviewStage(object):
 
         if self.release_to_reviewers is not MetaReviewStage.Readers.NO_REVIEWERS:
             readers.append(self._get_reviewer_readers(conference, number))
-        readers.append(conference.get_program_chairs_id())
 
         return readers
     

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1080,7 +1080,7 @@ class MetaReviewStage(object):
         if self.public:
             return ['everyone']
 
-        readers = [conference.get_program_chairs_id()]
+        readers = []
 
         if conference.use_senior_area_chairs:
             readers.append(conference.get_senior_area_chairs_id(number = number))
@@ -1093,6 +1093,7 @@ class MetaReviewStage(object):
 
         if self.release_to_reviewers is not MetaReviewStage.Readers.NO_REVIEWERS:
             readers.append(self._get_reviewer_readers(conference, number))
+        readers.append(conference.get_program_chairs_id())
 
         return readers
     

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2037,8 +2037,12 @@ class InvitationBuilder(object):
         elif custom_stage_reply_type == 'revision':
             if custom_stage_reply_type in ['forum', 'withForum']:
                 raise openreview.OpenReviewException('Custom stage cannot be used for revisions to submissions. Use the Submission Revision Stage instead.')
+            if custom_stage_replyto == 'reviews':
+                invitation_name = self.venue.review_stage.name
+            elif custom_stage_replyto == 'metareviews':
+                invitation_name = self.venue.meta_review_stage.name
             paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, prefix='${2/content/replytoSignatures/value}')
-            with_invitation = self.venue.get_invitation_id(name=self.venue.review_stage.name, number='${6/content/noteNumber/value}')
+            with_invitation = self.venue.get_invitation_id(name=invitation_name, number='${6/content/noteNumber/value}')
             reply_to = None
             edit_readers = [venue_id, '${2/signatures}']
             note_readers = None

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2013,31 +2013,36 @@ class InvitationBuilder(object):
 
         custom_stage_replyto = custom_stage.get_reply_to()
         custom_stage_source = custom_stage.get_source_submissions()
+        custom_stage_reply_type = custom_stage.get_reply_type()
 
-        paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, number='${2/content/noteNumber/value}')
-        with_invitation = self.venue.get_invitation_id(name=custom_stage.name, number='${6/content/noteNumber/value}')
-        edit_readers = ['${2/note/readers}']
-        note_readers = custom_stage.get_readers(self.venue, '${5/content/noteNumber/value}')
-        invitees = custom_stage.get_invitees(self.venue, number='${3/content/noteNumber/value}')
-        if custom_stage_replyto == 'forum':
-            reply_to = '${4/content/noteId/value}'
-        elif custom_stage_replyto == 'withForum':
-            reply_to = {
-                'param': {
-                    'withForum': '${6/content/noteId/value}'
+        if custom_stage_reply_type == 'reply':
+            paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, number='${2/content/noteNumber/value}')
+            with_invitation = self.venue.get_invitation_id(name=custom_stage.name, number='${6/content/noteNumber/value}')
+            edit_readers = ['${2/note/readers}']
+            note_readers = custom_stage.get_readers(self.venue, '${5/content/noteNumber/value}')
+            invitees = custom_stage.get_invitees(self.venue, number='${3/content/noteNumber/value}')
+            if custom_stage_replyto == 'forum':
+                reply_to = '${4/content/noteId/value}'
+            elif custom_stage_replyto == 'withForum':
+                reply_to = {
+                    'param': {
+                        'withForum': '${6/content/noteId/value}'
+                    }
                 }
-            }
-        elif custom_stage_replyto == 'review_revisions':
+            else:
+                paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, prefix='${2/content/replytoSignatures/value}')
+                with_invitation = self.venue.get_invitation_id(name=custom_stage.name, prefix='${6/content/replytoSignatures/value}')
+                reply_to = '${4/content/replyto/value}'
+
+        elif custom_stage_reply_type == 'revision':
+            if custom_stage_reply_type in ['forum', 'withForum']:
+                raise openreview.OpenReviewException('Custom stage cannot be used for revisions to submissions. Use the Submission Revision Stage instead.')
             paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, prefix='${2/content/replytoSignatures/value}')
             with_invitation = self.venue.get_invitation_id(name=self.venue.review_stage.name, number='${6/content/noteNumber/value}')
             reply_to = None
-            edit_readers = [venue_id]
+            edit_readers = [venue_id, '${2/signatures}']
             note_readers = None
             invitees = ['${3/content/replytoSignatures/value}']
-        else:
-            paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, prefix='${2/content/replytoSignatures/value}')
-            with_invitation = self.venue.get_invitation_id(name=custom_stage.name, prefix='${6/content/replytoSignatures/value}')
-            reply_to = '${4/content/replyto/value}'
 
         invitation_content = {
             'source': { 'value': custom_stage_source },

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2016,7 +2016,7 @@ class InvitationBuilder(object):
 
         paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, number='${2/content/noteNumber/value}')
         with_invitation = self.venue.get_invitation_id(name=custom_stage.name, number='${6/content/noteNumber/value}')
-        edit_readers = ['$2/note/readers']
+        edit_readers = ['${2/note/readers}']
         note_readers = custom_stage.get_readers(self.venue, '${5/content/noteNumber/value}')
         invitees = custom_stage.get_invitees(self.venue, number='${3/content/noteNumber/value}')
         if custom_stage_replyto == 'forum':

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -65,7 +65,7 @@ def process(client, invitation):
             if source == 'flagged_for_ethics_review':
                 source_submissions = [s for s in source_submissions if s.content.get('flagged_for_ethics_review', {}).get('value', False)]
 
-        if reply_to in ['reviews','review_revisions']:
+        if reply_to == 'reviews':
             children_notes = [openreview.api.Note.from_json(reply) for s in source_submissions for reply in s.details['directReplies'] if f'{venue_id}/{submission_name}{s.number}/-/{review_name}' in reply['invitations']]
         elif reply_to == 'metareviews':
             children_notes = [openreview.api.Note.from_json(reply) for s in source_submissions for reply in s.details['directReplies'] if f'{venue_id}/{submission_name}{s.number}/-/{meta_review_name}' in reply['invitations']]

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -85,10 +85,11 @@ def process(client, invitation):
 
         def updated_content_readers(note, paper_inv):
             updated_content = {}
-            for key in note.content.keys():
-                content_readers = paper_inv.edit['note']['content'].get(key, {}).get('readers', [])
+            invitation_content = paper_inv.edit['note']['content']
+            for key in invitation_content.keys():
+                content_readers = invitation_content[key].get('readers', [])
                 final_content_readers = list(dict.fromkeys([note.signatures[0] if 'signatures' in r else r for r in content_readers]))
-                if note.content[key].get('readers', []) != final_content_readers:
+                if note.content.get(key, {}).get('readers', []) != final_content_readers:
                     updated_content[key] = {
                         'readers': final_content_readers if final_content_readers else { 'delete': True }
                     }

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -65,7 +65,7 @@ def process(client, invitation):
             if source == 'flagged_for_ethics_review':
                 source_submissions = [s for s in source_submissions if s.content.get('flagged_for_ethics_review', {}).get('value', False)]
 
-        if reply_to == 'reviews':
+        if reply_to in ['reviews','review_revisions']:
             children_notes = [openreview.api.Note.from_json(reply) for s in source_submissions for reply in s.details['directReplies'] if f'{venue_id}/{submission_name}{s.number}/-/{review_name}' in reply['invitations']]
         elif reply_to == 'metareviews':
             children_notes = [openreview.api.Note.from_json(reply) for s in source_submissions for reply in s.details['directReplies'] if f'{venue_id}/{submission_name}{s.number}/-/{meta_review_name}' in reply['invitations']]

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -1856,8 +1856,9 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         now = datetime.datetime.utcnow()
         due_date = now + datetime.timedelta(days=2)
         venue.custom_stage = openreview.stages.CustomStage(name='Review_Revision',
-            reply_to=openreview.stages.CustomStage.ReplyTo.REVIEW_REVISIONS,
+            reply_to=openreview.stages.CustomStage.ReplyTo.REVIEWS,
             source=openreview.stages.CustomStage.Source.ALL_SUBMISSIONS,
+            reply_type=openreview.stages.CustomStage.ReplyType.REVISION,
             due_date=due_date,
             exp_date=due_date + datetime.timedelta(days=1),
             invitees=[openreview.stages.CustomStage.Participants.REVIEWERS_ASSIGNED],
@@ -1922,6 +1923,8 @@ Please refer to the documentation for instructions on how to run the matcher: ht
             )
         )
         helpers.await_queue_edit(openreview_client, edit_id=review_revision['id'])
+
+        assert review_revision['readers'] == ['V2.cc/2030/Conference', anon_group_id]
 
         review = reviewer_client.get_notes(invitation='V2.cc/2030/Conference/Submission1/-/Official_Review')[0]
         assert review.readers == ['V2.cc/2030/Conference/Program_Chairs',

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -2171,10 +2171,10 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert invitation and ac_anon_group_id in invitation.invitees
 
         meta_review = meta_reviewer_client.get_notes(invitation='V2.cc/2030/Conference/Submission1/-/Meta_Review')[0]
-        assert meta_review.readers == ['V2.cc/2030/Conference/Program_Chairs',
-                                  'V2.cc/2030/Conference/Submission1/Senior_Area_Chairs',
+        assert meta_review.readers == ['V2.cc/2030/Conference/Submission1/Senior_Area_Chairs',
                                   'V2.cc/2030/Conference/Submission1/Area_Chairs',
-                                  'V2.cc/2030/Conference/Submission1/Reviewers/Submitted']
+                                  'V2.cc/2030/Conference/Submission1/Reviewers/Submitted',
+                                  'V2.cc/2030/Conference/Program_Chairs']
 
         meta_review_revision = meta_reviewer_client.post_note_edit(
             invitation=f'{ac_anon_group_id}/-/Meta_Review_Revision',
@@ -2191,10 +2191,10 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert meta_review_revision['readers'] == ['V2.cc/2030/Conference', ac_anon_group_id]
 
         meta_review = meta_reviewer_client.get_notes(invitation='V2.cc/2030/Conference/Submission1/-/Meta_Review')[0]
-        assert meta_review.readers == ['V2.cc/2030/Conference/Program_Chairs',
-                                  'V2.cc/2030/Conference/Submission1/Senior_Area_Chairs',
+        assert meta_review.readers == ['V2.cc/2030/Conference/Submission1/Senior_Area_Chairs',
                                   'V2.cc/2030/Conference/Submission1/Area_Chairs',
-                                  'V2.cc/2030/Conference/Submission1/Reviewers/Submitted']
+                                  'V2.cc/2030/Conference/Submission1/Reviewers/Submitted',
+                                  'V2.cc/2030/Conference/Program_Chairs']
         assert 'final_recommendation' in meta_review.content
         assert 'readers' in meta_review.content['final_recommendation']
 

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -2031,18 +2031,6 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         ac_group = openreview_client.get_group('{}/Area_Chairs'.format(venue['venue_id']))
         assert ac_group and len(ac_group.members) == 2
 
-        # no AC console yet
-        # ac_page_url = 'http://localhost:3030/group?id={}/Area_Chairs'.format(venue['venue_id'])
-        # request_page(selenium, ac_page_url, token=meta_reviewer_client.token, wait_for_element='1-metareview-status')
-
-        # submit_div_1 = selenium.find_element(By.ID, '1-metareview-status')
-        # with pytest.raises(NoSuchElementException):
-        #     assert submit_div_1.find_element(By.LINK_TEXT, 'Submit')
-
-        # submit_div_2 = selenium.find_element(By.ID, '2-metareview-status')
-        # with pytest.raises(NoSuchElementException):
-        #     assert submit_div_2.find_element(By.LINK_TEXT, 'Submit')
-
         # Post a meta review stage note
         now = datetime.datetime.utcnow()
         start_date = now - datetime.timedelta(days=2)
@@ -2052,7 +2040,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                 'make_meta_reviews_public': 'Yes, meta reviews should be revealed publicly when they are posted',
                 'meta_review_start_date': start_date.strftime('%Y/%m/%d'),
                 'meta_review_deadline': due_date.strftime('%Y/%m/%d'),
-                'recommendation_options': 'Accept, Reject',
+                'recommendation_options': 'Accept, Reject, Conditional Accept',
                 'release_meta_reviews_to_authors': 'No, meta reviews should NOT be revealed when they are posted to the paper\'s authors',
                 'release_meta_reviews_to_reviewers': 'Meta reviews should be immediately revealed to the paper\'s reviewers who have already submitted their review',
                 'additional_meta_review_form_options': {
@@ -2061,7 +2049,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                         'value': {
                             'param': {
                                 'type': 'string',
-                                'enum': ['Accept', 'Reject'],
+                                'enum': ['Accept', 'Reject', 'Conditional Accept'],
                                 'input': 'radio'
                             }
                         },
@@ -2104,23 +2092,6 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert len(process_logs) == 1
         assert process_logs[0]['status'] == 'ok'
 
-        # add AC console
-        # # Assert that AC now see the Submit button for assigned papers
-        # request_page(selenium, ac_page_url, token=meta_reviewer_client.token, wait_for_element='note-summary-2')
-
-        # note_div_1 = selenium.find_element(By.ID, 'note-summary-1')
-        # assert note_div_1
-        # note_div_2 = selenium.find_element(By.ID, 'note-summary-2')
-        # assert note_div_2
-        # assert 'test submission' == note_div_1.find_element(By.LINK_TEXT, 'test submission').text
-        # assert 'test submission 2' == note_div_2.find_element(By.LINK_TEXT, 'test submission 2').text
-
-        # submit_div_1 = selenium.find_element(By.ID, '1-metareview-status')
-        # assert submit_div_1.find_element(By.LINK_TEXT, 'Submit')
-
-        # submit_div_2 = selenium.find_element(By.ID, '2-metareview-status')
-        # assert submit_div_2.find_element(By.LINK_TEXT, 'Submit')
-
         meta_review_invitation = openreview_client.get_invitation(id='{}/Submission1/-/Meta_Review'.format(venue['venue_id']))
         assert meta_review_invitation
         meta_review_invitation = openreview_client.get_invitation(id='{}/Submission2/-/Meta_Review'.format(venue['venue_id']))
@@ -2139,8 +2110,8 @@ Please refer to the documentation for instructions on how to run the matcher: ht
             signatures=[ac_anon_groups[0].id],
             note=Note(
                 content={
-                    'metareview': { 'value': 'This is a metarview' },
-                    'recommendation': { 'value': 'Accept' }
+                    'metareview': { 'value': 'This is a metareview' },
+                    'recommendation': { 'value': 'Conditional Accept' }
                 }
             )
         )
@@ -2152,6 +2123,75 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert 'V2.cc/2030/Conference/Submission1/Area_Chairs' in meta_reviews[0].readers
         assert 'V2.cc/2030/Conference/Submission1/Reviewers/Submitted' in meta_reviews[0].readers
         assert 'V2.cc/2030/Conference/Submission1/Authors' not in meta_reviews[0].readers
+
+    def test_meta_review_revision_stage(self, client, test_client, helpers, venue, openreview_client):
+
+        venue = openreview.get_conference(client, venue['request_form_note'].id, support_user='openreview.net/Support')
+
+        now = datetime.datetime.utcnow()
+        due_date = now + datetime.timedelta(days=2)
+        venue.custom_stage = openreview.stages.CustomStage(name='Meta_Review_Revision',
+            reply_to=openreview.stages.CustomStage.ReplyTo.METAREVIEWS,
+            source=openreview.stages.CustomStage.Source.ALL_SUBMISSIONS,
+            reply_type=openreview.stages.CustomStage.ReplyType.REVISION,
+            invitees=[openreview.stages.CustomStage.Participants.AREA_CHAIRS_ASSIGNED],
+            due_date=due_date,
+            exp_date=due_date + datetime.timedelta(days=1),
+            content={
+                'final_recommendation': {
+                        'description': 'Please select a recommendation for the paper',
+                        'value': {
+                            'param': {
+                                'type': 'string',
+                                'enum': ['Accept', 'Reject'],
+                                'input': 'radio'
+                            }
+                        },
+                        'order': 2,
+                        'readers': ['V2.cc/2030/Conference', 'V2.cc/2030/Conference/Submission${7/content/noteNumber/value}/Area_Chairs']
+                    }   
+            })
+
+        venue.create_custom_stage()
+
+        invitations = openreview_client.get_all_invitations(invitation='V2.cc/2030/Conference/-/Meta_Review_Revision')
+        assert len(invitations) == 1
+
+        meta_reviewer_client = openreview.api.OpenReviewClient(username='venue_ac_v2@mail.com', password=helpers.strong_password)
+        ac_anon_groups=meta_reviewer_client.get_groups(prefix=f'V2.cc/2030/Conference/Submission1/Area_Chair_.*', signatory='~VenueTwo_Ac1')
+        assert len(ac_anon_groups) == 1
+        ac_anon_group_id = ac_anon_groups[0].id
+
+        invitation = openreview_client.get_invitation(f'{ac_anon_group_id}/-/Meta_Review_Revision')
+        assert invitation and ac_anon_group_id in invitation.invitees
+
+        meta_review = meta_reviewer_client.get_notes(invitation='V2.cc/2030/Conference/Submission1/-/Meta_Review')[0]
+        assert meta_review.readers == ['V2.cc/2030/Conference/Program_Chairs',
+                                  'V2.cc/2030/Conference/Submission1/Senior_Area_Chairs',
+                                  'V2.cc/2030/Conference/Submission1/Area_Chairs',
+                                  'V2.cc/2030/Conference/Submission1/Reviewers/Submitted']
+
+        meta_review_revision = meta_reviewer_client.post_note_edit(
+            invitation=f'{ac_anon_group_id}/-/Meta_Review_Revision',
+            signatures=[ac_anon_group_id],
+            note=Note(
+                id=meta_review.id,
+                content={
+                    'final_recommendation': { 'value': 'Accept' }
+                }
+            )
+        )
+        helpers.await_queue_edit(openreview_client, edit_id=meta_review_revision['id'])
+
+        assert meta_review_revision['readers'] == ['V2.cc/2030/Conference', ac_anon_group_id]
+
+        meta_review = meta_reviewer_client.get_notes(invitation='V2.cc/2030/Conference/Submission1/-/Meta_Review')[0]
+        assert meta_review.readers == ['V2.cc/2030/Conference/Program_Chairs',
+                                  'V2.cc/2030/Conference/Submission1/Senior_Area_Chairs',
+                                  'V2.cc/2030/Conference/Submission1/Area_Chairs',
+                                  'V2.cc/2030/Conference/Submission1/Reviewers/Submitted']
+        assert 'final_recommendation' in meta_review.content
+        assert 'readers' in meta_review.content['final_recommendation']
 
     def test_release_meta_reviews_to_authors_and_reviewers(self, test_client, helpers, venue, openreview_client):
 
@@ -2217,6 +2257,9 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert 'V2.cc/2030/Conference/Submission1/Reviewers' in meta_reviews[0].readers
         assert 'V2.cc/2030/Conference/Submission1/Authors' in meta_reviews[0].readers
         assert len(meta_reviews[0].nonreaders) == 0
+
+        assert 'final_recommendation' in meta_reviews[0].content
+        assert 'readers' in meta_reviews[0].content['final_recommendation']
 
     def test_venue_comment_stage(self, client, test_client, selenium, request_page, helpers, venue, openreview_client):
 


### PR DESCRIPTION
This PR allows us to use the CustomStage to create the Review_Revision stage. 

One issue: this stage adds a field to the review form. However, if the Review Stage is run again from the request form, any readers this field had will be removed unless we add them to the review additional fields. We would need to be careful when adding extra fields and when wanting to use the Review Stage button. 