### PR TITLE
Fix/ tools.get_profiles with_relations 

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -222,10 +222,10 @@ def get_profiles(client, ids_or_emails, with_publications=False, with_relations=
 
         relation_profile_ids = set()
         for profile in profiles:
-            usernames = [relation.get('username') for relation in profile.content.get('relations', []) if relation.get('username')]
-            emails = [relation.get('email') for relation in profile.content.get('relations', []) if relation.get('email')]
-            relation_profile_ids.update(usernames)
-            relation_profile_ids.update(emails)
+            relation_usernames = [relation.get('username') for relation in profile.content.get('relations', []) if relation.get('username')]
+            relation_emails = [relation.get('email') for relation in profile.content.get('relations', []) if relation.get('email')]
+            relation_profile_ids.update(relation_usernames)
+            relation_profile_ids.update(relation_emails)
 
         relation_profiles_by_id = get_profiles(client, list(relation_profile_ids), as_dict=True)
 


### PR DESCRIPTION
In line 226, we were overriding the `emails` array we initialize [here](https://github.com/openreview/openreview-py/blob/cd366c20ce08d84fe1a3fdb8049b09e33643273d/openreview/tools.py#L147) so we were missing some profiles in the output.  