### PR TITLE
Fix: Desk-reject: check if PCs should be notified

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -410,6 +410,8 @@ def get_submission_stage(request_forum, venue):
     hide_fields = request_forum.content.get('hide_fields', [])
     force_profiles = 'Yes' in request_forum.content.get('force_profiles_only', '')
     author_reorder_after_first_deadline = request_forum.content.get('submission_deadline_author_reorder', 'No') == 'Yes'
+    email_pcs_on_withdraw = 'Yes' in request_forum.content.get('email_pcs_for_withdrawn_submissions', '')
+    email_pcs_on_desk_reject = 'Yes' in request_forum.content.get('email_pcs_for_desk_rejected_submissions', '')
 
     second_deadline_additional_fields = request_forum.content.get('second_deadline_additional_options', {})
     if isinstance(second_deadline_additional_fields, str):
@@ -441,6 +443,8 @@ def get_submission_stage(request_forum, venue):
         papers_released=papers_released,
         readers=readers,
         email_pcs=email_pcs,
+        email_pcs_on_withdraw=email_pcs_on_withdraw,
+        email_pcs_on_desk_reject=email_pcs_on_desk_reject,
         author_reorder_after_first_deadline = author_reorder_after_first_deadline,
         submission_email=submission_email,
         force_profiles=force_profiles,

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -185,6 +185,7 @@ class GroupBuilder(object):
             'desk_rejection_reversion_id': { 'value': self.venue.get_invitation_id('Desk_Rejection_Reversion') },
             'desk_reject_committee': { 'value': self.venue.get_participants(number="{number}", with_authors=True, with_program_chairs=True)},
             'desk_rejection_name': { 'value': 'Desk_Rejection'},
+            'desk_rejection_email_pcs': { 'value': self.venue.submission_stage.email_pcs_on_desk_reject },
             'desk_rejected_submission_reveal_authors': { 'value': self.venue.submission_stage.desk_rejected_submission_reveal_authors },
             'automatic_reviewer_assignment': { 'value': self.venue.automatic_reviewer_assignment },
             'decision_heading_map': { 'value': self.venue.decision_heading_map }

--- a/openreview/venue/process/desk_rejected_submission_process.py
+++ b/openreview/venue/process/desk_rejected_submission_process.py
@@ -9,6 +9,8 @@ def process(client, edit, invitation):
     desk_rejection_name = domain.content['desk_rejection_name']['value']
     submission_name = domain.content['submission_name']['value']
     authors_name = domain.content['authors_name']['value']
+    desk_rejection_email_pcs = domain.content.get('desk_rejection_email_pcs', {}).get('value')
+    program_chairs_id = domain.content['program_chairs_id']['value']
 
     submission = client.get_note(edit.note.id)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'
@@ -52,10 +54,13 @@ def process(client, edit, invitation):
     for group in formatted_committee:
         if openreview.tools.get_group(client, group):
             final_committee.append(group)
+
+    ignoreRecipients = [program_chairs_id] if not desk_rejection_email_pcs else []
+
     email_subject = f'''[{short_name}]: Paper #{submission.number} desk-rejected by {pretty_signature}'''
     email_body = f'''The {short_name} paper "{submission.content.get('title', {}).get('value', '#'+str(submission.number))}" has been desk-rejected by {pretty_signature}.
 
 For more information, click here https://openreview.net/forum?id={submission.id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body)
+    client.post_message(email_subject, final_committee, email_body, ignoreRecipients=ignoreRecipients)

--- a/tests/test_emnlp_conference.py
+++ b/tests/test_emnlp_conference.py
@@ -60,6 +60,8 @@ class TestEMNLPConference():
                 'senior_area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair'],
                 'submission_readers': 'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)',
                 'How did you hear about us?': 'ML conferences',
+                'email_pcs_for_withdrawn_submissions': 'Yes, email PCs.',
+                'email_pcs_for_desk_rejected_submissions': 'Yes, email PCs.',
                 'Expected Submissions': '1000',
                 'use_recruitment_template': 'Yes',
                 'api_version': '2',
@@ -364,6 +366,11 @@ url={https://openreview.net/forum?id='''
 }'''
 
         assert '_bibtex' in withdrawn_submission[0].content and withdrawn_submission[0].content['_bibtex']['value'] == valid_bibtex
+
+        messages = client.get_messages(subject='[EMNLP 2023]: Paper #5 withdrawn by paper authors')
+        assert messages and len(messages) == 3
+        recipients = [msg['content']['to'] for msg in messages]
+        assert 'pc@emnlp.org' in recipients
 
         pc_openreview_client = openreview.api.OpenReviewClient(username='pc@emnlp.org', password=helpers.strong_password)
 
@@ -774,6 +781,8 @@ url={https://openreview.net/forum?id='''
 
         messages = client.get_messages(subject='[EMNLP 2023]: Paper #1 desk-rejected by Senior Area Chairs')
         assert messages and len(messages) == 5
+        recipients = [msg['content']['to'] for msg in messages]
+        assert 'pc@emnlp.org' in recipients
 
         ac_client = openreview.api.OpenReviewClient(username = 'ac2@emnlp.org', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='EMNLP/2023/Conference/-/Submission', sort='number:asc')

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -42,7 +42,8 @@ class TestVenueSubmission():
             withdrawn_submission_reveal_authors=True, 
             desk_rejected_submission_public=True,
             force_profiles=True,
-            remove_fields=['abstract']
+            remove_fields=['abstract'],
+            email_pcs_on_desk_reject=True
         )
 
         venue.bid_stages = [


### PR DESCRIPTION
Fixes #1917

It looks like we were not reading these values from the request form and:
1. PCs were never emailed about withdrawals
2. PCs were always emailed about desk-rejections