### PR TITLE
Fix/ Venue: area chairs assignment

### DIFF
--- a/openreview/venue/process/assignment_post_process.py
+++ b/openreview/venue/process/assignment_post_process.py
@@ -16,6 +16,9 @@ def process_update(client, edge, invitation, existing_edge):
     note=client.get_note(edge.head)
     group=client.get_group(f'{venue_id}/{submission_name}{note.number}/{reviewers_name}')
     if edge.ddate and edge.tail in group.members:
+        assignment_edges = client.get_edges(invitation=edge.invitation, head=edge.head, tail=edge.tail)
+        if assignment_edges:
+            return
         print(f'Remove member {edge.tail} from {group.id}')
         client.remove_members_from_group(group.id, edge.tail)
 

--- a/openreview/venue/process/assignment_post_process.py
+++ b/openreview/venue/process/assignment_post_process.py
@@ -8,7 +8,7 @@ def process_update(client, edge, invitation, existing_edge):
     reviewers_name = invitation.content['reviewers_name']['value']
     reviewers_id = invitation.content['reviewers_id']['value']
     sync_sac_id = invitation.content['sync_sac_id']['value']
-    sac_assingment_id = invitation.content['sac_assignment_id']['value']
+    sac_assignment_id = invitation.content['sac_assignment_id']['value']
     pretty_name = openreview.tools.pretty_id(reviewers_name)
     pretty_name = pretty_name[:-1] if pretty_name.endswith('s') else pretty_name
 
@@ -21,17 +21,11 @@ def process_update(client, edge, invitation, existing_edge):
 
         if sync_sac_id and sync_sac_id.format(number=note.number) not in edge.signatures:
             print(f'Remove member from SAC group')
-            group = client.get_group(sync_sac_id.format(number=note.number))
-            client.post_group_edit(
-                invitation=f'{venue_id}/-/Edit',
-                readers = [venue_id],
-                writers = [venue_id],
-                signatures = [venue_id],
-                group = openreview.api.Group(
-                    id = group.id,
-                    members = []
-                )
-            )
+            assignments = client.get_edges(invitation=sac_assignment_id, head=edge.tail)
+            if assignments:
+                client.remove_members_from_group(sync_sac_id.format(number=note.number), assignments[0].tail)
+            else:
+                print('No SAC assignments found')
 
     if not edge.ddate and edge.tail not in group.members:
         print(f'Add member {edge.tail} to {group.id}')
@@ -40,7 +34,7 @@ def process_update(client, edge, invitation, existing_edge):
 
         if sync_sac_id:
             print('Add the SAC to the paper group')
-            assignments = client.get_edges(invitation=sac_assingment_id, head=edge.tail)
+            assignments = client.get_edges(invitation=sac_assignment_id, head=edge.tail)
             if assignments:
                 client.add_members_to_group(sync_sac_id.format(number=note.number), assignments[0].tail)
             else:

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -1302,6 +1302,16 @@ To view your submission, click here: https://openreview.net/forum?id={submission
                 label = 'ac-matching'
             ))
 
+        # post duplicate AC Proposed_Assignment edge
+        openreview_client.post_edge(openreview.api.Edge(
+                invitation = 'ICML.cc/2023/Conference/Area_Chairs/-/Proposed_Assignment',
+                head = submissions[0].id,
+                tail = '~AC_ICMLOne1',
+                signatures = ['ICML.cc/2023/Conference/Program_Chairs'],
+                weight = 1,
+                label = 'ac-matching'
+            ))
+
         for i in range(20,40):
             for r in ['~Reviewer_ICMLTwo1', '~Reviewer_ICMLThree1', '~Reviewer_ICMLFour1']:
                 reviewers_proposed_edges.append(openreview.api.Edge(
@@ -1410,6 +1420,26 @@ To view your submission, click here: https://openreview.net/forum?id={submission
 
         sac_group = pc_client_v2.get_group('ICML.cc/2023/Conference/Submission100/Senior_Area_Chairs')
         assert ['~SAC_ICMLOne1'] == sac_group.members
+
+        assignment_edges = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[0].id, tail='~AC_ICMLOne1')
+        assert assignment_edges and len(assignment_edges) == 2
+
+        # remove duplicate edge and make sure assignment still remains
+        assignment_edge = assignment_edges[0]
+        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment_edge.cdate = None
+        edge = pc_client_v2.post_edge(assignment_edge)
+
+        helpers.await_queue_edit(openreview_client, edit_id=edge.id)
+
+        ac_group = pc_client_v2.get_group('ICML.cc/2023/Conference/Submission1/Area_Chairs')
+        assert ['~AC_ICMLOne1'] == ac_group.members
+
+        sac_group = pc_client_v2.get_group('ICML.cc/2023/Conference/Submission1/Senior_Area_Chairs')
+        assert ['~SAC_ICMLOne1'] == sac_group.members
+
+        assignment_edges = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[0].id, tail='~AC_ICMLOne1')
+        assert assignment_edges and len(assignment_edges) == 1
 
         ### Reviewers reassignment of proposed assignments
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -1667,20 +1667,7 @@ OpenReview Team'''
         sac_group = pc_client_v2.get_group('ICML.cc/2023/Conference/Submission100/Senior_Area_Chairs')
         assert ['~SAC_ICMLTwo1'] == sac_group.members
 
-        ## Change assigned AC
-        assignment_edge = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[0].id, tail='~AC_ICMLOne1')[0]
-        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
-        assignment_edge.cdate = None
-        edge = pc_client_v2.post_edge(assignment_edge)
-
-        helpers.await_queue_edit(openreview_client, edit_id=edge.id)
-
-        ac_group = pc_client_v2.get_group('ICML.cc/2023/Conference/Submission1/Area_Chairs')
-        assert [] == ac_group.members
-
-        sac_group = pc_client_v2.get_group('ICML.cc/2023/Conference/Submission1/Senior_Area_Chairs')
-        assert [] == sac_group.members
-
+        ## Change assigned AC, add new AC first and then remove old AC
         edge = pc_client_v2.post_edge(openreview.api.Edge(
             invitation = 'ICML.cc/2023/Conference/Area_Chairs/-/Assignment',
             head = submissions[0].id,
@@ -1688,6 +1675,19 @@ OpenReview Team'''
             signatures = ['ICML.cc/2023/Conference/Program_Chairs'],
             weight = 1
         ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=edge.id)
+
+        ac_group = pc_client_v2.get_group('ICML.cc/2023/Conference/Submission1/Area_Chairs')
+        assert ['~AC_ICMLOne1', '~AC_ICMLTwo1'] == ac_group.members
+
+        sac_group = pc_client_v2.get_group('ICML.cc/2023/Conference/Submission1/Senior_Area_Chairs')
+        assert ['~SAC_ICMLOne1','~SAC_ICMLTwo1'] == sac_group.members
+
+        assignment_edge = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[0].id, tail='~AC_ICMLOne1')[0]
+        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment_edge.cdate = None
+        edge = pc_client_v2.post_edge(assignment_edge)
 
         helpers.await_queue_edit(openreview_client, edit_id=edge.id)
 


### PR DESCRIPTION
Fixes two issues:
- when an AC assignment is deleted, the corresponding SAC is removed from the group, instead of posting the group with empty members
- when an assignment is deleted, check if there exists another edge for the same assignment. If there is, do not remove member from group