### PR TITLE
Fix/ Venue: rebuttal and review readers

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -584,7 +584,7 @@ def get_rebuttal_stage(request_forum):
         readers.append(openreview.stages.ReviewRebuttalStage.Readers.REVIEWERS_SUBMITTED)
 
     if 'Everyone' in rebuttal_readers:
-        readers = [openreview.stages.CommentStage.Readers.EVERYONE]
+        readers = [openreview.stages.ReviewRebuttalStage.Readers.EVERYONE]
 
     email_pcs = 'Yes' in request_forum.content.get('email_program_chairs_about_rebuttals', '')
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -416,7 +416,7 @@ class InvitationBuilder(object):
                 'value': review_stage.get_readers(self.venue, '{number}')
             }
             note_readers = ['${5/content/noteReaders/value}']
-            if review_stage.release_to_reviewers in [openreview.stages.ReviewStage.Readers.REVIEWER_SIGNATURE, openreview.stages.ReviewStage.Readers.REVIEWERS_SUBMITTED]:
+            if review_stage.release_to_reviewers in [openreview.stages.ReviewStage.Readers.REVIEWER_SIGNATURE, openreview.stages.ReviewStage.Readers.REVIEWERS_SUBMITTED] and not review_stage.public:
                 note_readers.append('${3/signatures}')
             invitation.edit['invitation']['edit']['note']['readers'] = note_readers
 


### PR DESCRIPTION
Two fixes:
- releasing rebuttals to the public from the request form is not working. This is because we were mistakenly using the CommentStage readers instead of the ReviewRebuttalStage readers
- releasing reviews to the public when the venue already ran the ethics review stage will result in reviews having `["everyone", anon_group_id]` as readers because we add the reviewer signature to the readers. We should not add it if readers is everyone