### PR TITLE
Fix/ Venue: revert submission revision edit readers

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -1978,7 +1978,7 @@ class InvitationBuilder(object):
                                 ] 
                             }
                         },
-                        'readers': ['${{2/note/id}/readers}'],
+                        'readers': [ venue_id, self.venue.get_authors_id(number='${4/content/noteNumber/value}')],
                         'writers': [ venue_id, self.venue.get_authors_id(number='${4/content/noteNumber/value}')],
                         'note': {
                             'id': '${4/content/noteId/value}',

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -2875,9 +2875,6 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         helpers.await_queue_edit(openreview_client, edit_id=revision_edit['id'])
 
         assert revision_edit['readers'] == ['V2.cc/2030/Conference',
-            'V2.cc/2030/Conference/Senior_Area_Chairs',
-            'V2.cc/2030/Conference/Area_Chairs',
-            'V2.cc/2030/Conference/Reviewers',
             'V2.cc/2030/Conference/Submission3/Authors']
 
         updated_note = author_client.get_note(id=submissions[2].forum)
@@ -3276,19 +3273,14 @@ Best,
 
         revision_invitation = openreview.tools.get_invitation(openreview_client, 'V2.cc/2030/Conference/Submission1/-/Supplementary_Material')
         assert revision_invitation
-        assert revision_invitation.edit['readers'] == ['everyone']
+        assert revision_invitation.edit['readers'] == ['V2.cc/2030/Conference',
+            'V2.cc/2030/Conference/Submission1/Authors']
         revision_invitation = openreview.tools.get_invitation(openreview_client, 'V2.cc/2030/Conference/Submission2/-/Supplementary_Material')
         assert revision_invitation.edit['readers'] == ['V2.cc/2030/Conference',
-            'V2.cc/2030/Conference/Submission2/Senior_Area_Chairs',
-            'V2.cc/2030/Conference/Submission2/Area_Chairs',
-            'V2.cc/2030/Conference/Submission2/Reviewers',
             'V2.cc/2030/Conference/Submission2/Authors']
         revision_invitation = openreview.tools.get_invitation(openreview_client, 'V2.cc/2030/Conference/Submission3/-/Supplementary_Material')
         assert revision_invitation
         assert revision_invitation.edit['readers'] == ['V2.cc/2030/Conference',
-            'V2.cc/2030/Conference/Submission3/Senior_Area_Chairs',
-            'V2.cc/2030/Conference/Submission3/Area_Chairs',
-            'V2.cc/2030/Conference/Submission3/Reviewers',
             'V2.cc/2030/Conference/Submission3/Authors']
 
         assert all(x not in revision_invitation.edit['note']['content'] for x in ['title','authors', 'authorids','abstract','keywords', 'TLDR'])


### PR DESCRIPTION
Revert this change until we can figure out how to reveal edits without revealing author names and other hidden fields