### PR TITLE
Journal: save email template in the group content

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1198,7 +1198,7 @@ class OpenReviewClient(object):
 
         return list(tools.efficient_iterget(self.get_notes, desc='Getting V2 Notes', **params))
 
-    def get_note_edit(self, id):
+    def get_note_edit(self, id, trash=None):
         """
         Get a single edit by id if available
 
@@ -1208,12 +1208,12 @@ class OpenReviewClient(object):
         :return: edit matching the passed id
         :rtype: Note
         """
-        response = self.session.get(self.note_edits_url, params = {'id':id}, headers = self.headers)
+        response = self.session.get(self.note_edits_url, params = {'id':id, 'trash': 'true' if trash == True else 'false'}, headers = self.headers)
         response = self.__handle_response(response)
         n = response.json()['edits'][0]
         return Edit.from_json(n)
 
-    def get_note_edits(self, note_id = None, invitation = None, with_count=False, sort=None):
+    def get_note_edits(self, note_id = None, invitation = None, with_count=False, sort=None, trash=None):
         """
         Gets a list of edits for a note. The edits that will be returned match all the criteria passed in the parameters.
 
@@ -1227,6 +1227,7 @@ class OpenReviewClient(object):
             params['invitation'] = invitation
         if sort:
             params['sort'] = sort
+        params['trash'] = 'true' if trash == True else 'false'
 
         response = self.session.get(self.note_edits_url, params=tools.format_params(params), headers = self.headers)
         response = self.__handle_response(response)

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -346,12 +346,19 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
         authors_id = self.journal.get_authors_id()
         authors_group = openreview.tools.get_group(self.client, authors_id)
         if not authors_group:
+            content = {}
+            content['discussion_starts_email_template_script'] = { 'value': author_discussion_starts_email_template }            
+            content['decision_accept_as_is_email_template_script'] = { 'value': author_decision_accept_as_is_email_template }
+            content['decision_accept_revision_email_template_script'] = { 'value': author_decision_accept_revision_email_template }
+            content['decision_reject_email_template_script'] = { 'value': author_decision_reject_email_template }
+            content['desk_reject_email_template_script'] = { 'value': author_desk_reject_email_template }
             authors_group = Group(id=authors_id,
                             readers=[venue_id, authors_id],
                             writers=[venue_id],
                             signatures=[venue_id],
                             signatories=[venue_id],
-                            members=[])
+                            members=[],
+                            content=content)
 
         with open(os.path.join(os.path.dirname(__file__), 'webfield/authorsWebfield.js')) as f:
             content = f.read()

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -276,12 +276,18 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
         reviewers_id = self.journal.get_reviewers_id()
         reviewer_group = openreview.tools.get_group(self.client, reviewers_id)
         if not reviewer_group:
+            content = {}
+            content['assignment_email_template_script'] = { 'value': reviewer_assignment_email_template }            
+            content['unassignment_email_template_script'] = { 'value': reviewer_unassignment_email_template }
+            content['discussion_starts_email_template_script'] = { 'value': reviewer_discussion_starts_email_template }
+            content['official_recommendation_starts_email_template_script'] = { 'value': reviewer_official_recommendation_starts_email_template }
             reviewer_group = Group(id=reviewers_id,
                             readers=[venue_id, action_editors_id, reviewers_id] + additional_committee,
                             writers=[venue_id],
                             signatures=[venue_id],
                             signatories=[venue_id],
-                            members=[]
+                            members=[],
+                            content=content
                             )
         with open(os.path.join(os.path.dirname(__file__), 'webfield/reviewersWebfield.js')) as f:
             content = f.read()

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -1,5 +1,6 @@
 from .. import openreview
 from openreview.api import Group
+from openreview.journal.templates import *
 
 import os
 import json
@@ -176,12 +177,24 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
         action_editors_id = self.journal.get_action_editors_id()
         action_editor_group = openreview.tools.get_group(self.client, action_editors_id)
         if not action_editor_group:
+            content = {}
+            content['assignment_email_template_script'] = { 'value': ae_assignment_email_template }            
+            content['unassignment_email_template_script'] = { 'value': ae_unassignment_email_template }
+            content['eic_as_author_email_template_script'] = { 'value': ae_assignment_eic_as_author_email_template }
+            content['camera_ready_verification_email_template_script'] = { 'value': ae_camera_ready_verification_email_template }       
+            content['official_recommendation_starts_email_template_script'] = { 'value': ae_official_recommendation_starts_email_template }
+            content['official_recommendation_ends_email_template_script'] = { 'value': ae_official_recommendation_ends_email_template } 
+            content['discussion_starts_email_template_script'] = { 'value': ae_discussion_starts_email_template }
+            content['discussion_too_many_reviewers_email_template_script'] = { 'value': ae_discussion_too_many_reviewers_email_template }
+            content['reviewwer_assignment_starts_email_template_script'] = { 'value': ae_reviewer_assignment_starts_email_template }
             action_editor_group=self.post_group(Group(id=action_editors_id,
                             readers=['everyone'],
                             writers=[venue_id],
                             signatures=[venue_id],
                             signatories=[venue_id],
-                            members=[]))
+                            members=[],
+                            content=content))
+
         with open(os.path.join(os.path.dirname(__file__), 'webfield/actionEditorWebfield.js')) as f:
             content = f.read()
             content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")

--- a/openreview/journal/process/camera_ready_revision_process.py
+++ b/openreview/journal/process/camera_ready_revision_process.py
@@ -28,23 +28,17 @@ def process(client, edit, invitation):
 
     ## Send email to AE
     print('Send email to AE')
+    ae_group = client.get_group(journal.get_action_editors_id())
+    message=ae_group.content['camera_ready_verification_email_template_script']['value'].format(
+        short_name=journal.short_name,
+        submission_number=submission.number,
+        submission_title=submission.content['title']['value'],
+        invitation_url=f"https://openreview.net/forum?id={submission.id}&invitationId={journal.get_camera_ready_verification_id(number=submission.number)}",
+        contact_info=journal.contact_info
+    )    
     client.post_message(
         recipients=[journal.get_action_editors_id(number=submission.number)],
         subject=f'''[{journal.short_name}] Review camera ready version for {journal.short_name} paper {submission.number}: {submission.content['title']['value']}''',
-        message=f'''Hi {{{{fullname}}}},
-
-The authors of {journal.short_name} paper {submission.number}: {submission.content['title']['value']} have now submitted the deanonymized camera ready version of their work.
-
-As your final task for this submission, please verify that the camera ready manuscript complies with the {journal.short_name} stylefile, with all author information inserted in the manuscript as well as the link to the OpenReview page for the submission.
-
-Moreover, if the paper was accepted with minor revision, verify that the changes requested have been followed.
-
-Visit the following link to perform this task: https://openreview.net/forum?id={submission.id}&invitationId={journal.get_camera_ready_verification_id(number=submission.number)}
-
-If any correction is needed, you may contact the authors directly by email or through OpenReview.
-
-The {journal.short_name} Editors-in-Chief
-
-''',
+        message=message,
         replyTo=journal.contact_info
     )

--- a/openreview/journal/process/desk_rejection_approval_process.py
+++ b/openreview/journal/process/desk_rejection_approval_process.py
@@ -22,21 +22,20 @@ def process(client, edit, invitation):
                                 note=openreview.api.Note(id=edit.note.forum))
 
         ## send email to authors
+        author_group = client.get_group(journal.get_authors_id())
+        message=author_group.content['desk_reject_email_template_script']['value'].format(
+            short_name=journal.short_name,
+            submission_id=submission.id,
+            submission_number=submission.number,
+            submission_title=submission.content['title']['value'],
+            website=journal.website,
+            contact_info=journal.contact_info,
+            role='assigned Action Editor'
+        )        
         client.post_message(
             recipients=submission.signatures,
             subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-            message=f'''Hi {{{{fullname}}}},
-
-We are sorry to inform you that, after consideration by the assigned Action Editor, your {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}" has been rejected without further review.
-
-Cases of desk rejection include submissions that are not anonymized, submissions that do not use the unmodified {journal.short_name} stylefile and submissions that clearly overlap with work already published in proceedings (or currently under review for publication).
-
-To know more about the decision, please follow this link: https://openreview.net/forum?id={submission.forum}
-
-For more details and guidelines on the {journal.short_name} review process, visit {journal.website}.
-
-The {journal.short_name} Editors-in-Chief
-''',
+            message=message,
             replyTo=journal.contact_info
         )
 

--- a/openreview/journal/process/desk_rejection_submission_process.py
+++ b/openreview/journal/process/desk_rejection_submission_process.py
@@ -12,21 +12,20 @@ def process(client, edit, invitation):
     ))
 
     ## send email to authors
+    author_group = client.get_group(journal.get_authors_id())
+    message=author_group.content['desk_reject_email_template_script']['value'].format(
+        short_name=journal.short_name,
+        submission_id=submission.id,
+        submission_number=submission.number,
+        submission_title=submission.content['title']['value'],
+        website=journal.website,
+        contact_info=journal.contact_info,
+        role='Editors-in-Chief'
+    )    
     client.post_message(
         recipients=submission.signatures,
         subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-        message=f'''Hi {{{{fullname}}}},
-
-We are sorry to inform you that, after consideration by the Editors-in-Chief, your {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}" has been rejected without further review.
-
-Cases of desk rejection include submissions that are not anonymized, submissions that do not use the unmodified {journal.short_name} stylefile and submissions that clearly overlap with work already published in proceedings (or currently under review for publication).
-
-To know more about the decision, please follow this link: https://openreview.net/forum?id={submission.forum}
-
-For more details and guidelines on the {journal.short_name} review process, visit {journal.website}.
-
-The {journal.short_name} Editors-in-Chief
-''',
+        message=message,
         replyTo=journal.contact_info
     )
 

--- a/openreview/journal/process/official_recommendation_cdate_process.py
+++ b/openreview/journal/process/official_recommendation_cdate_process.py
@@ -31,19 +31,20 @@ note: replies to this email will go to the AE, {assigned_action_editor.get_prefe
 
     ## send email to action editos
     print('send email to action editors')
+    ae_group = client.get_group(journal.get_action_editors_id())
+    message=ae_group.content['official_recommendation_starts_email_template_script']['value'].format(
+        short_name=journal.short_name,
+        submission_number=submission.number,
+        submission_title=submission.content['title']['value'],
+        website=journal.website,
+        recommendation_period_length=journal.get_recommendation_period_length(),
+        recommendation_duedate=duedate.strftime("%b %d"),
+        contact_info=journal.contact_info
+    )    
     client.post_message(
         recipients=[journal.get_action_editors_id(number=submission.number)],
         subject=f'''[{journal.short_name}] Reviewers must submit official recommendation for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-        message=f'''Hi {{{{fullname}}}},
-
-This email is to let you know, as AE for {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}", that the reviewers for the submission must now submit their official recommendation for the submission, within the next {journal.get_recommendation_period_length()} weeks ({duedate.strftime("%b %d")}). They have received a separate email from us, informing them of this task.
-
-For more details and guidelines on performing your review, visit {journal.website}.
-
-We thank you for your essential contribution to {journal.short_name}!
-
-The {journal.short_name} Editors-in-Chief
-''',
+        message=message,
         replyTo=journal.contact_info
     )
 

--- a/openreview/journal/process/official_recommendation_cdate_process.py
+++ b/openreview/journal/process/official_recommendation_cdate_process.py
@@ -8,24 +8,22 @@ def process(client, invitation):
     ## send email to reviewers
     print('send email to reviewers')
     assigned_action_editor = client.search_profiles(ids=[submission.content['assigned_action_editor']['value']])[0]
+    reviewer_group = client.get_group(journal.get_reviewers_id())
+    message=reviewer_group.content['official_recommendation_starts_email_template_script']['value'].format(
+        short_name=journal.short_name,
+        submission_number=submission.number,
+        submission_title=submission.content['title']['value'],
+        website=journal.website,
+        invitation_url=f'https://openreview.net/forum?id={submission.id}&invitationId={invitation.id}',
+        recommendation_period_length=journal.get_recommendation_period_length(),
+        recommendation_duedate=duedate.strftime("%b %d"),
+        contact_info=journal.contact_info,
+        assigned_action_editor=assigned_action_editor.get_preferred_name(pretty=True)
+    )
     client.post_message(
         recipients=[journal.get_reviewers_id(number=submission.number)],
         subject=f'''[{journal.short_name}] Submit official recommendation for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-        message=f'''Hi {{{{fullname}}}},
-
-Thank you for submitting your review and engaging with the authors of {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}".
-
-You may now submit your official recommendation for the submission. Before doing so, make sure you have sufficiently discussed with the authors (and possibly the other reviewers and AE) any concerns you may have about the submission.
-
-We ask that you submit your recommendation within {journal.get_recommendation_period_length()} weeks ({duedate.strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={submission.id}&invitationId={invitation.id}
-
-For more details and guidelines on performing your review, visit {journal.website}.
-
-We thank you for your essential contribution to {journal.short_name}!
-
-The {journal.short_name} Editors-in-Chief
-note: replies to this email will go to the AE, {assigned_action_editor.get_preferred_name(pretty=True)}.
-''',
+        message=message,
         replyTo=assigned_action_editor.get_preferred_email()
     )
 

--- a/openreview/journal/process/official_recommendation_process.py
+++ b/openreview/journal/process/official_recommendation_process.py
@@ -24,33 +24,21 @@ def process(client, edit, invitation):
 
         ## send email to action editors
         print('Send email to AEs')
+        ae_group = client.get_group(journal.get_action_editors_id())
+        message=ae_group.content['official_recommendation_ends_email_template_script']['value'].format(
+            short_name=journal.short_name,
+            submission_number=submission.number,
+            submission_title=submission.content['title']['value'],
+            website=journal.website,
+            decision_period_length=journal.get_decision_period_length(),
+            decision_duedate=duedate.strftime("%b %d"),
+            invitation_url=f'https://openreview.net/forum?id={submission.id}&invitationId={journal.get_ae_decision_id(number=submission.number)}',
+            contact_info=journal.contact_info
+        )        
         client.post_message(
             recipients=[journal.get_action_editors_id(number=submission.number)],
             subject=f'''[{journal.short_name}] Evaluate reviewers and submit decision for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-            message=f'''Hi {{{{fullname}}}},
-
-Thank you for overseeing the review process for {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}".
-
-All reviewers have submitted their official recommendation of a decision for the submission. Therefore it is now time for you to determine a decision for the submission. Before doing so:
-
-- Make sure you have sufficiently discussed with the authors (and possibly the reviewers) any concern you may have about the submission.
-- Rate the quality of the reviews submitted by the reviewers. **You will not be able to submit your decision until these ratings have been submitted**. To rate a review, go on the submission's page and click on button "Rating" for each of the reviews.
-
-We ask that you submit your decision **within {journal.get_decision_period_length()} week** ({duedate.strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={submission.id}&invitationId={journal.get_ae_decision_id(number=submission.number)}
-
-The possible decisions are:
-- **Accept as is**: once its camera ready version is submitted, the manuscript will be marked as accepted.
-- **Accept with minor revision**: to use if you wish to request some specific revisions to the manuscript, to be specified explicitly in your decision comments. These revisions will be expected from the authors when they submit their camera ready version.
-- **Reject**: the paper is rejected, but you may indicate whether you would be willing to consider a significantly revised version of the manuscript. Such a revised submission will need to be entered as a new submission, that will also provide a link to this rejected submission as well as a description of the changes made since.
-
-Your decision may also include certification(s) recommendations for the submission (in case of an acceptance).
-
-For more details and guidelines on performing your review, visit {journal.website}.
-
-We thank you for your essential contribution to {journal.short_name}!
-
-The {journal.short_name} Editors-in-Chief
-''',
+            message=message,
             replyTo=journal.contact_info
         )
 

--- a/openreview/journal/process/rejected_submission_process.py
+++ b/openreview/journal/process/rejected_submission_process.py
@@ -7,23 +7,19 @@ def process(client, edit, invitation):
 
     ## Send email to authors
     print('Send email to authors')
+    author_group = client.get_group(journal.get_authors_id())
+    message=author_group.content['decision_reject_email_template_script']['value'].format(
+        short_name=journal.short_name,
+        submission_id=submission.id,
+        submission_number=submission.number,
+        submission_title=submission.content['title']['value'],
+        website=journal.website,
+        contact_info=journal.contact_info
+    )     
     client.post_message(
         recipients=[journal.get_authors_id(number=submission.number)],
         subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-        message=f'''Hi {{{{fullname}}}},
-
-We are sorry to inform you that, based on the evaluation of the reviewers and the recommendation of the assigned Action Editor, your {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}" is rejected.
-
-To know more about the decision, please follow this link: https://openreview.net/forum?id={submission.id}
-
-The action editor might have indicated that they would be willing to consider a significantly revised version of the manuscript. If so, a revised submission will need to be entered as a new submission, that must also provide a link to this previously rejected submission as well as a description of the changes made since.
-
-In any case, your submission will remain publicly available on OpenReview. You may decide to reveal your identity and deanonymize your submission on the OpenReview page. Doing so will however preclude you from submitting any revised version of the manuscript to {journal.short_name}.
-
-For more details and guidelines on the {journal.short_name} review process, visit {journal.website}.
-
-The {journal.short_name} Editors-in-Chief
-''',
+        message=message,
         replyTo=journal.contact_info
     )
 

--- a/openreview/journal/process/review_process.py
+++ b/openreview/journal/process/review_process.py
@@ -77,22 +77,23 @@ def process(client, edit, invitation):
 
         ## Send email notifications to reviewers
         print('Send emails to reviewers')
+        reviewer_group = client.get_group(journal.get_reviewers_id())
+        message=reviewer_group.content['discussion_starts_email_template_script']['value'].format(
+            short_name=journal.short_name,
+            submission_id=submission.id,
+            submission_number=submission.number,
+            submission_title=submission.content['title']['value'],
+            website=journal.website,
+            number_of_reviewers=number_of_reviewers,
+            review_visibility=review_visibility,
+            discussion_period_length=journal.get_discussion_period_length(),
+            contact_info=journal.contact_info,
+            assigned_action_editor=assigned_action_editor.get_preferred_name(pretty=True)
+        )
         client.post_message(
             recipients=[journal.get_reviewers_id(number=submission.number)],
             subject=f'''[{journal.short_name}] Start of author discussion for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-            message=f'''Hi {{{{fullname}}}},
-
-There are now {number_of_reviewers} reviews that have been submitted for your assigned submission "{submission.number}: {submission.content['title']['value']}" and all reviews have been made {review_visibility}. Please read the other reviews and start engaging with the authors (and possibly the other reviewers and AE) in order to address any concern you may have about the submission. Your goal should be to gather all the information you need **within the next {journal.get_discussion_period_length()} weeks** to be comfortable submitting a decision recommendation for this paper. You will receive an upcoming notification on how to enter your recommendation in OpenReview.
-
-You will find the OpenReview page for this submission at this link: https://openreview.net/forum?id={submission.id}
-
-For more details and guidelines on the {journal.short_name} review process, visit {journal.website}.
-
-We thank you for your essential contribution to {journal.short_name}!
-
-The {journal.short_name} Editors-in-Chief
-note: replies to this email will go to the AE, {assigned_action_editor.get_preferred_name(pretty=True)}.
-''',
+            message=message,
             replyTo=assigned_action_editor.get_preferred_email()
         )
 

--- a/openreview/journal/process/review_process.py
+++ b/openreview/journal/process/review_process.py
@@ -52,22 +52,26 @@ def process(client, edit, invitation):
 
         ## Send email notifications to authors
         print('Send emails to authors')
+        author_group = client.get_group(journal.get_authors_id())
+        message=author_group.content['discussion_starts_email_template_script']['value'].format(
+            short_name=journal.short_name,
+            submission_id=submission.id,
+            submission_number=submission.number,
+            submission_title=submission.content['title']['value'],
+            website=journal.website,
+            number_of_reviewers=number_of_reviewers,
+            review_visibility=review_visibility,
+            discussion_period_length=journal.get_discussion_period_length(),
+            discussion_cdate=cdate.strftime("%b %d"),
+            recommendation_period_length=journal.get_discussion_period_length() + journal.get_recommendation_period_length(),
+            recommendation_duedate=duedate.strftime("%b %d"),
+            contact_info=journal.contact_info,
+            assigned_action_editor=assigned_action_editor.get_preferred_name(pretty=True)
+        )        
         client.post_message(
             recipients=[journal.get_authors_id(number=submission.number)],
             subject=f'''[{journal.short_name}] Reviewer responses and discussion for your {journal.short_name} submission''',
-            message=f'''Hi {{{{fullname}}}},
-
-Now that {number_of_reviewers} reviews have been submitted for your submission  {submission.number}: {submission.content['title']['value']}, all reviews have been made {review_visibility}. If you haven't already, please read the reviews and start engaging with the reviewers to attempt to address any concern they may have about your submission.
-
-You will have {journal.get_discussion_period_length()} weeks to respond to the reviewers. To maximise the period of interaction and discussion, please respond as soon as possible. The reviewers will be using this time period to hear from you and gather all the information they need. In about {journal.get_discussion_period_length()} weeks ({cdate.strftime("%b %d")}), and no later than {journal.get_discussion_period_length() + journal.get_recommendation_period_length()} weeks ({duedate.strftime("%b %d")}), reviewers will submit their formal decision recommendation to the Action Editor in charge of your submission.
-
-Visit the following link to respond to the reviews: https://openreview.net/forum?id={submission.id}
-
-For more details and guidelines on the {journal.short_name} review process, visit {journal.website}.
-
-The {journal.short_name} Editors-in-Chief
-note: replies to this email will go to the AE, {assigned_action_editor.get_preferred_name(pretty=True)}.
-''',
+            message=message,
             replyTo=assigned_action_editor.get_preferred_email()
         )
 

--- a/openreview/journal/process/review_rating_enabling_process.py
+++ b/openreview/journal/process/review_rating_enabling_process.py
@@ -11,7 +11,7 @@ def process(client, edit, invitation):
     ## send email to action editors
     print('Send email to AEs')
     ae_group = client.get_group(journal.get_action_editors_id())
-    message=ae_group.content['ae_official_recommendation_ends_email_template']['value'].format(
+    message=ae_group.content['official_recommendation_ends_email_template_script']['value'].format(
         short_name=journal.short_name,
         submission_number=submission.number,
         submission_title=submission.content['title']['value'],

--- a/openreview/journal/process/review_rating_enabling_process.py
+++ b/openreview/journal/process/review_rating_enabling_process.py
@@ -10,33 +10,21 @@ def process(client, edit, invitation):
 
     ## send email to action editors
     print('Send email to AEs')
+    ae_group = client.get_group(journal.get_action_editors_id())
+    message=ae_group.content['ae_official_recommendation_ends_email_template']['value'].format(
+        short_name=journal.short_name,
+        submission_number=submission.number,
+        submission_title=submission.content['title']['value'],
+        website=journal.website,
+        decision_period_length=journal.get_decision_period_length(),
+        decision_duedate=duedate.strftime("%b %d"),
+        invitation_url=f'https://openreview.net/forum?id={submission.id}&invitationId={journal.get_ae_decision_id(number=submission.number)}',
+        contact_info=journal.contact_info
+    )     
     client.post_message(
         recipients=[journal.get_action_editors_id(number=submission.number)],
         subject=f'''[{journal.short_name}] Evaluate reviewers and submit decision for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-        message=f'''Hi {{{{fullname}}}},
-
-Thank you for overseeing the review process for {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}".
-
-All reviewers have submitted their official recommendation of a decision for the submission. Therefore it is now time for you to determine a decision for the submission. Before doing so:
-
-- Make sure you have sufficiently discussed with the authors (and possibly the reviewers) any concern you may have about the submission.
-- Rate the quality of the reviews submitted by the reviewers. **You will not be able to submit your decision until these ratings have been submitted**. To rate a review, go on the submission's page and click on button "Rating" for each of the reviews.
-
-We ask that you submit your decision **within {journal.get_decision_period_length()} week** ({duedate.strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={submission.id}&invitationId={journal.get_ae_decision_id(number=submission.number)}
-
-The possible decisions are:
-- **Accept as is**: once its camera ready version is submitted, the manuscript will be marked as accepted.
-- **Accept with minor revision**: to use if you wish to request some specific revisions to the manuscript, to be specified explicitly in your decision comments. These revisions will be expected from the authors when they submit their camera ready version.
-- **Reject**: the paper is rejected, but you may indicate whether you would be willing to consider a significantly revised version of the manuscript. Such a revised submission will need to be entered as a new submission, that will also provide a link to this rejected submission as well as a description of the changes made since.
-
-Your decision may also include certification(s) recommendations for the submission (in case of an acceptance).
-
-For more details and guidelines on performing your review, visit {journal.website}.
-
-We thank you for your essential contribution to {journal.short_name}!
-
-The {journal.short_name} Editors-in-Chief
-''',
+        message=message,
         replyTo=journal.contact_info
     )
 

--- a/openreview/journal/process/reviewer_assignment_process.py
+++ b/openreview/journal/process/reviewer_assignment_process.py
@@ -45,6 +45,8 @@ def process_update(client, edge, invitation, existing_edge):
     if pending_review_edges:
         pending_review_edge = pending_review_edges[0]
 
+    reviewer_group = client.get_group(journal.get_reviewers_id())
+
     ## Unassignment action
     if edge.ddate and edge.tail in group.members:
         print(f'Remove member {edge.tail} from {group.id}')
@@ -53,19 +55,15 @@ def process_update(client, edge, invitation, existing_edge):
         recipients=[edge.tail]
         subject=f'[{journal.short_name}] You have been unassigned from {journal.short_name} submission {note.number}: {note.content["title"]["value"]}'
 
-        message=f'''Hi {{{{fullname}}}},
-
-We recently informed you that your help was requested to review a {journal.short_name} submission "{note.number}: {note.content['title']['value']}".
-
-However, it was just determined that your help is no longer needed for this submission and you have been unassigned as a reviewer for it.
-
-If you have any questions, don't hesitate to reach out directly to the Action Editor (AE) for the submission, for example by leaving a comment readable by the AE only, on the OpenReview page for the submission: https://openreview.net/forum?id={note.id}
-
-Apologies for the change and thank you for your continued involvement with {journal.short_name}!
-
-The {journal.short_name} Editors-in-Chief
-note: replies to this email will go to the AE, {assigned_action_editor.get_preferred_name(pretty=True)}.
-'''
+        message=reviewer_group.content['unassignment_email_template_script']['value'].format(
+            short_name=journal.short_name,
+            submission_id=note.id,
+            submission_number=note.number,
+            submission_title=note.content['title']['value'],
+            website=journal.website,
+            contact_info=journal.contact_info,
+            assigned_action_editor=assigned_action_editor.get_preferred_name(pretty=True)
+        )
 
         client.post_message(subject, recipients, message, replyTo=assigned_action_editor.get_preferred_email())
 
@@ -110,23 +108,24 @@ note: replies to this email will go to the AE, {assigned_action_editor.get_prefe
         recipients = [edge.tail]
         ignoreRecipients = [journal.get_solicit_reviewers_id(number=note.number)]
         subject=f'''[{journal.short_name}] Assignment to review new {journal.short_name} submission {note.number}: {note.content['title']['value']}'''
-        message=f'''Hi {{{{fullname}}}},
-
-With this email, we request that you submit, within {review_period_length} weeks ({duedate.strftime("%b %d")}) a review for your newly assigned {journal.short_name} submission "{note.number}: {note.content['title']['value']}".{submission_length}
-
-Please acknowledge on OpenReview that you have received this review assignment by following this link: https://openreview.net/forum?id={note.id}&invitationId={ack_invitation_edit['invitation']['id']}
-
-As a reminder, reviewers are **expected to accept all assignments** for submissions that fall within their expertise and annual quota ({journal.get_reviewers_max_papers()} papers). Acceptable exceptions are 1) if you have an active, unsubmitted review for another {journal.short_name} submission or 2) situations where exceptional personal circumstances (e.g. vacation, health problems) render you incapable of performing your reviewing duties. Based on the above, if you think you should not review this submission, contact your AE directly (you can do so by leaving a comment on OpenReview, with only the Action Editor as Reader).
-
-To submit your review, please follow this link: https://openreview.net/forum?id={note.id}&invitationId={journal.get_review_id(number=note.number)} or check your tasks in the Reviewers Console: https://openreview.net/group?id={journal.venue_id}/Reviewers#reviewer-tasks
-
-Once submitted, your review will become privately visible to the authors and AE. Then, as soon as {number_of_reviewers} reviews have been submitted, all reviews will become {review_visibility}. For more details and guidelines on performing your review, visit {journal.website}.
-
-We thank you for your essential contribution to {journal.short_name}!
-
-The {journal.short_name} Editors-in-Chief
-note: replies to this email will go to the AE, {assigned_action_editor.get_preferred_name(pretty=True)}.
-'''
+        message=reviewer_group.content['assignment_email_template_script']['value'].format(
+            short_name=journal.short_name,
+            venue_id=venue_id,
+            submission_id=note.id,
+            submission_number=note.number,
+            submission_title=note.content['title']['value'],
+            submission_length=submission_length,
+            website=journal.website,
+            contact_info=journal.contact_info,
+            review_period_length=review_period_length,
+            review_duedate=duedate.strftime("%b %d"),
+            ack_invitation_url=f'https://openreview.net/forum?id={note.id}&invitationId={ack_invitation_edit["invitation"]["id"]}',
+            invitation_url=f'https://openreview.net/forum?id={note.id}&invitationId={journal.get_review_id(number=note.number)}',
+            number_of_reviewers=number_of_reviewers,
+            review_visibility=review_visibility,
+            reviewers_max_papers=journal.get_reviewers_max_papers(),
+            assigned_action_editor=assigned_action_editor.get_preferred_name(pretty=True)
+        )
 
         client.post_message(subject, recipients, message, ignoreRecipients=ignoreRecipients, parentGroup=group.id, replyTo=assigned_action_editor.get_preferred_email())
 

--- a/openreview/journal/process/submission_decision_approval_process.py
+++ b/openreview/journal/process/submission_decision_approval_process.py
@@ -46,47 +46,40 @@ def process(client, edit, invitation):
 
     ## Send email to authors
     print('Send email to authors')
+    author_group = client.get_group(journal.get_authors_id())
     if decision.content['recommendation']['value'] == 'Accept as is':
+        message=author_group.content['decision_accept_as_is_email_template_script']['value'].format(
+            short_name=journal.short_name,
+            submission_id=submission.id,
+            submission_number=submission.number,
+            submission_title=submission.content['title']['value'],
+            website=journal.website,
+            camera_ready_period_length=journal.get_camera_ready_period_length(),
+            camera_ready_duedate=duedate.strftime("%b %d"),
+            contact_info=journal.contact_info
+        )
         client.post_message(
             recipients=[journal.get_authors_id(number=submission.number)],
             subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-            message=f'''Hi {{{{fullname}}}},
-
-We are happy to inform you that, based on the evaluation of the reviewers and the recommendation of the assigned Action Editor, your {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}" is accepted as is.
-
-To know more about the decision and submit the deanonymized camera ready version of your manuscript, please follow this link and click on button "Camera Ready Revision": https://openreview.net/forum?id={submission.id}. Please submit the final version of your paper within {journal.get_camera_ready_period_length()} weeks ({duedate.strftime("%b %d")}).
-
-In addition to your final manuscript, we strongly encourage you to submit a link to 1) code associated with your and 2) a short video presentation of your work. You can provide these links to the corresponding entries on the revision page.
-
-For more details and guidelines on the {journal.short_name} review process, visit {journal.website}.
-
-We thank you for your contribution to {journal.short_name} and congratulate you for your successful submission!
-
-The {journal.short_name} Editors-in-Chief
-''',
+            message=message,
             replyTo=journal.contact_info
         )
         return
 
     if decision.content['recommendation']['value'] == 'Accept with minor revision':
+        message=author_group.content['decision_accept_revision_email_template_script']['value'].format(
+            short_name=journal.short_name,
+            submission_id=submission.id,
+            submission_number=submission.number,
+            submission_title=submission.content['title']['value'],
+            website=journal.website,
+            camera_ready_period_length=journal.get_camera_ready_period_length(),
+            camera_ready_duedate=duedate.strftime("%b %d"),
+            contact_info=journal.contact_info
+        )        
         client.post_message(
             recipients=[journal.get_authors_id(number=submission.number)],
             subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
-            message=f'''Hi {{{{fullname}}}},
-
-We are happy to inform you that, based on the evaluation of the reviewers and the recommendation of the assigned Action Editor, your {journal.short_name} submission "{submission.number}: {submission.content['title']['value']}" is accepted with minor revision.
-
-To know more about the decision and submit the deanonymized camera ready version of your manuscript, please follow this link and click on button "Camera Ready Revision": https://openreview.net/forum?id={submission.id}. Please submit the final version of your paper, including the minor revisions requested by the Action Editor, within {journal.get_camera_ready_period_length()} weeks ({duedate.strftime("%b %d")}).
-
-The Action Editor responsible for your submission will have provided a description of the revision expected for accepting your final manuscript.
-
-In addition to your final manuscript, we strongly encourage you to submit a link to 1) code associated with your and 2) a short video presentation of your work. You can provide these links to the corresponding entries on the revision page.
-
-For more details and guidelines on the {journal.short_name} review process, visit {journal.website}.
-
-We thank you for your contribution to {journal.short_name} and congratulate you for your successful submission!
-
-The {journal.short_name} Editors-in-Chief
-''',
+            message=message,
             replyTo=journal.contact_info
         )

--- a/openreview/journal/process/under_review_submission_process.py
+++ b/openreview/journal/process/under_review_submission_process.py
@@ -11,21 +11,23 @@ def process(client, edit, invitation):
     reviewers_max_papers = journal.get_reviewers_max_papers()
 
     journal.invitation_builder.set_reviewer_assignment_invitation(note, duedate)
-
+    ae_group = client.get_group(journal.get_action_editors_id())
+    message=ae_group.content['reviewwer_assignment_starts_email_template_script']['value'].format(
+        short_name=journal.short_name,
+        submission_number=note.number,
+        submission_title=note.content['title']['value'],
+        website=journal.website,
+        number_of_reviewers=number_of_reviewers,
+        reviewers_max_papers=reviewers_max_papers,
+        reviewer_assignment_period_length=journal.get_reviewer_assignment_period_length(),
+        reviewer_assignment_duedate=duedate.strftime("%b %d"),
+        decision_duedate=duedate.strftime("%b %d"),
+        invitation_url=f'https://openreview.net/group?id={journal.get_action_editors_id()}',
+        contact_info=journal.contact_info
+    )
     client.post_message(
         recipients=[journal.get_action_editors_id(number=note.number)],
         subject=f'''[{journal.short_name}] Perform reviewer assignments for {journal.short_name} submission {note.number}: {note.content['title']['value']}''',
-        message=f'''Hi {{{{fullname}}}},
-
-With this email, we request that you assign {number_of_reviewers} reviewers to your assigned {journal.short_name} submission "{note.number}: {note.content['title']['value']}". The assignments must be completed **within {journal.get_reviewer_assignment_period_length()} week** ({duedate.strftime("%b %d")}). To do so, please follow this link: https://openreview.net/group?id={journal.get_action_editors_id()} and click on "Edit Assignment" for that paper in your "Assigned Papers" console.
-
-As a reminder, up to their annual quota of {'six' if reviewers_max_papers == 6 else reviewers_max_papers} reviews per year, reviewers are expected to review all assigned submissions that fall within their expertise. Acceptable exceptions are 1) if they have an unsubmitted review for another {journal.short_name} submission or 2) situations where exceptional personal circumstances (e.g. vacation, health problems) render them incapable of fully performing their reviewing duties.
-
-Once assigned, reviewers will be asked to acknowledge on OpenReview their responsibility to review this submission. This acknowledgement will be made visible to you on the OpenReview page of the submission. If the reviewer has not acknowledged their responsibility a couple of days after their assignment, consider reaching out to them directly to confirm.
-
-We thank you for your essential contribution to {journal.short_name}!
-
-The {journal.short_name} Editors-in-Chief
-''',
+        message=message,
         replyTo=journal.contact_info
     )

--- a/openreview/journal/templates.py
+++ b/openreview/journal/templates.py
@@ -1,0 +1,129 @@
+ae_assignment_email_template = '''Hi {{{{fullname}}}},
+
+With this email, we request that you manage the review process for a new {short_name} submission "{submission_number}: {submission_title}".
+
+As a reminder, {short_name} Action Editors (AEs) are **expected to accept all AE requests** to manage submissions that fall within your expertise and quota. Reasonable exceptions are 1) situations where exceptional personal circumstances (e.g. vacation, health problems) render you incapable of fully performing your AE duties or 2) you have a conflict of interest with one of the authors. If any such exception applies to you, contact us at {contact_info}.
+
+Your first task is to make sure the submitted preprint is appropriate for {short_name} and respects our submission guidelines. Clear cases of desk rejection include submissions that are not anonymized, submissions that do not use the unmodified {short_name} stylefile and submissions that clearly overlap with work already published in proceedings (or currently under review for publication). If you suspect but are unsure about whether a submission might need to be desk rejected for any other reasons (e.g. lack of fit with the scope of {short_name} or lack of technical depth), please email us.
+
+Please follow this link to perform this task: {invitation_url}
+
+If you think the submission can continue through {short_name}'s review process, click the button "Under Review". Otherwise, click on "Desk Reject". Once the submission has been confirmed, then the review process will begin, and your next step will be to assign {number_of_reviewers} reviewers to the paper. You will get a follow up email when OpenReview is ready for you to assign these {number_of_reviewers} reviewers.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+'''
+
+ae_unassignment_email_template = '''Hi {{{{fullname}}}},
+
+We recently informed you that your help was requested to manage the review process for a new {short_name} submission "{submission_number}: {submission_title}".
+
+However, we've just determined that your help was no longer needed for this submission and have unassigned you as the AE for it.
+
+Apologies for the change and thank you for your continued involvement with {short_name}!
+
+The {short_name} Editors-in-Chief
+'''
+
+ae_assignment_eic_as_author_email_template = '''Hi {{{{fullname}}}},
+
+You have just been assigned a submission that is authored by one (or more) {short_name} Editors-in-Chief. OpenReview is set up such that the EIC in question will not have access through OpenReview to the identity of the reviewers you'll be assigning. 
+
+However, be mindful not to discuss the submission by email through {short_name}'s EIC mailing lists ({contact_info} or {editors_in_chief_email}), since all EICs receive these emails. Instead, if you need to reach out to EICs by email, only contact the non-conflicted EICs, directly.
+
+We thank you for your cooperation.
+
+The {short_name} Editors-in-Chief
+'''
+
+ae_camera_ready_verification_email_template = '''Hi {{{{fullname}}}},
+
+The authors of {short_name} paper {submission_number}: {submission_title} have now submitted the deanonymized camera ready version of their work.
+
+As your final task for this submission, please verify that the camera ready manuscript complies with the {short_name} stylefile, with all author information inserted in the manuscript as well as the link to the OpenReview page for the submission.
+
+Moreover, if the paper was accepted with minor revision, verify that the changes requested have been followed.
+
+Visit the following link to perform this task: {invitation_url}
+
+If any correction is needed, you may contact the authors directly by email or through OpenReview.
+
+The {short_name} Editors-in-Chief
+
+'''
+
+ae_official_recommendation_starts_email_template = '''Hi {{{{fullname}}}},
+
+This email is to let you know, as AE for {short_name} submission "{submission_number}: {submission_title}", that the reviewers for the submission must now submit their official recommendation for the submission, within the next {recommendation_period_length} weeks ({recommendation_duedate}). They have received a separate email from us, informing them of this task.
+
+For more details and guidelines on performing your review, visit {website}.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+'''
+
+ae_official_recommendation_ends_email_template = '''Hi {{{{fullname}}}},
+
+Thank you for overseeing the review process for {short_name} submission "{submission_number}: {submission_title}".
+
+All reviewers have submitted their official recommendation of a decision for the submission. Therefore it is now time for you to determine a decision for the submission. Before doing so:
+
+- Make sure you have sufficiently discussed with the authors (and possibly the reviewers) any concern you may have about the submission.
+- Rate the quality of the reviews submitted by the reviewers. **You will not be able to submit your decision until these ratings have been submitted**. To rate a review, go on the submission's page and click on button "Rating" for each of the reviews.
+
+We ask that you submit your decision **within {decision_period_length} week** ({decision_duedate}). To do so, please follow this link: {invitation_url}
+
+The possible decisions are:
+- **Accept as is**: once its camera ready version is submitted, the manuscript will be marked as accepted.
+- **Accept with minor revision**: to use if you wish to request some specific revisions to the manuscript, to be specified explicitly in your decision comments. These revisions will be expected from the authors when they submit their camera ready version.
+- **Reject**: the paper is rejected, but you may indicate whether you would be willing to consider a significantly revised version of the manuscript. Such a revised submission will need to be entered as a new submission, that will also provide a link to this rejected submission as well as a description of the changes made since.
+
+Your decision may also include certification(s) recommendations for the submission (in case of an acceptance).
+
+For more details and guidelines on performing your review, visit {website}.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+'''
+
+ae_discussion_starts_email_template = '''Hi {{{{fullname}}}},
+
+Now that {number_of_reviewers} reviews have been submitted for submission {submission_number}: {submission_title}, all reviews have been made {review_visibility} and authors and reviewers have been notified that the discussion phase has begun. Please read the reviews and oversee the discussion between the reviewers and the authors. The goal of the reviewers should be to gather all the information they need to be comfortable submitting a decision recommendation to you for this submission. Reviewers will be able to submit their formal decision recommendation starting in **{discussion_period_length} weeks**.
+
+You will find the OpenReview page for this submission at this link: https://openreview.net/forum?id={submission_id}
+
+For more details and guidelines on the {short_name} review process, visit {website}.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+''',
+
+ae_discussion_too_many_reviewers_email_template = '''Hi {{{{fullname}}}},
+
+It appears that, while submission {submission_number}: {submission_title} now has its minimum of {number_of_reviewers} reviews submitted, there are some additional assigned reviewers who have pending reviews. This may be because you had assigned additional emergency reviewers, e.g. because some of the initially assigned reviewers were late or unresponsive. If that is the case, or generally if these additional reviews are no longer needed, please unassign the extra reviewers and let them know that their review is no longer needed.
+
+Additionally, if any extra reviewer corresponds to a reviewer who was unresponsive, please consider submitting a reviewer report, so we can track such undesirable behavior. You can submit a report through link "Reviewers Report" at the top of your AE console.
+
+For more details and guidelines on the {short_name} review process, visit {website}.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+'''
+
+ae_reviewer_assignment_starts_email_template = '''Hi {{{{fullname}}}},
+
+With this email, we request that you assign {number_of_reviewers} reviewers to your assigned {short_name} submission "{submission_number}: {submission_title}". The assignments must be completed **within {reviewer_assignment_period_length} week** ({reviewer_assignment_duedate}). To do so, please follow this link: {invitation_url} and click on "Edit Assignment" for that paper in your "Assigned Papers" console.
+
+As a reminder, up to their annual quota of {reviewers_max_papers} reviews per year, reviewers are expected to review all assigned submissions that fall within their expertise. Acceptable exceptions are 1) if they have an unsubmitted review for another {short_name} submission or 2) situations where exceptional personal circumstances (e.g. vacation, health problems) render them incapable of fully performing their reviewing duties.
+
+Once assigned, reviewers will be asked to acknowledge on OpenReview their responsibility to review this submission. This acknowledgement will be made visible to you on the OpenReview page of the submission. If the reviewer has not acknowledged their responsibility a couple of days after their assignment, consider reaching out to them directly to confirm.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+'''

--- a/openreview/journal/templates.py
+++ b/openreview/journal/templates.py
@@ -100,7 +100,7 @@ For more details and guidelines on the {short_name} review process, visit {websi
 We thank you for your essential contribution to {short_name}!
 
 The {short_name} Editors-in-Chief
-''',
+'''
 
 ae_discussion_too_many_reviewers_email_template = '''Hi {{{{fullname}}}},
 

--- a/openreview/journal/templates.py
+++ b/openreview/journal/templates.py
@@ -127,3 +127,78 @@ We thank you for your essential contribution to {short_name}!
 
 The {short_name} Editors-in-Chief
 '''
+
+author_discussion_starts_email_template = '''Hi {{{{fullname}}}},
+
+Now that {number_of_reviewers} reviews have been submitted for your submission  {submission_number}: {submission_title}, all reviews have been made {review_visibility}. If you haven't already, please read the reviews and start engaging with the reviewers to attempt to address any concern they may have about your submission.
+
+You will have {discussion_period_length} weeks to respond to the reviewers. To maximise the period of interaction and discussion, please respond as soon as possible. The reviewers will be using this time period to hear from you and gather all the information they need. In about {discussion_period_length} weeks ({discussion_cdate}), and no later than {recommendation_period_length} weeks ({recommendation_duedate}), reviewers will submit their formal decision recommendation to the Action Editor in charge of your submission.
+
+Visit the following link to respond to the reviews: https://openreview.net/forum?id={submission_id}
+
+For more details and guidelines on the {short_name} review process, visit {website}.
+
+The {short_name} Editors-in-Chief
+note: replies to this email will go to the AE, {assigned_action_editor}.
+'''
+
+author_decision_accept_as_is_email_template = '''Hi {{{{fullname}}}},
+
+We are happy to inform you that, based on the evaluation of the reviewers and the recommendation of the assigned Action Editor, your {short_name} submission "{submission_number}: {submission_title}" is accepted as is.
+
+To know more about the decision and submit the deanonymized camera ready version of your manuscript, please follow this link and click on button "Camera Ready Revision": https://openreview.net/forum?id={submission_id}. Please submit the final version of your paper within {camera_ready_period_length} weeks ({camera_ready_duedate}).
+
+In addition to your final manuscript, we strongly encourage you to submit a link to 1) code associated with your and 2) a short video presentation of your work. You can provide these links to the corresponding entries on the revision page.
+
+For more details and guidelines on the {short_name} review process, visit {website}.
+
+We thank you for your contribution to {short_name} and congratulate you for your successful submission!
+
+The {short_name} Editors-in-Chief
+'''
+
+
+author_decision_accept_revision_email_template = '''Hi {{{{fullname}}}},
+
+We are happy to inform you that, based on the evaluation of the reviewers and the recommendation of the assigned Action Editor, your {short_name} submission "{submission_number}: {submission_title}" is accepted with minor revision.
+
+To know more about the decision and submit the deanonymized camera ready version of your manuscript, please follow this link and click on button "Camera Ready Revision": https://openreview.net/forum?id={submission_id}. Please submit the final version of your paper, including the minor revisions requested by the Action Editor, within {camera_ready_period_length} weeks ({camera_ready_duedate}).
+
+The Action Editor responsible for your submission will have provided a description of the revision expected for accepting your final manuscript.
+
+In addition to your final manuscript, we strongly encourage you to submit a link to 1) code associated with your and 2) a short video presentation of your work. You can provide these links to the corresponding entries on the revision page.
+
+For more details and guidelines on the {short_name} review process, visit {website}.
+
+We thank you for your contribution to {short_name} and congratulate you for your successful submission!
+
+The {short_name} Editors-in-Chief
+'''
+
+author_decision_reject_email_template = '''Hi {{{{fullname}}}},
+
+We are sorry to inform you that, based on the evaluation of the reviewers and the recommendation of the assigned Action Editor, your {short_name} submission "{submission_number}: {submission_title}" is rejected.
+
+To know more about the decision, please follow this link: https://openreview.net/forum?id={submission_id}
+
+The action editor might have indicated that they would be willing to consider a significantly revised version of the manuscript. If so, a revised submission will need to be entered as a new submission, that must also provide a link to this previously rejected submission as well as a description of the changes made since.
+
+In any case, your submission will remain publicly available on OpenReview. You may decide to reveal your identity and deanonymize your submission on the OpenReview page. Doing so will however preclude you from submitting any revised version of the manuscript to {short_name}.
+
+For more details and guidelines on the {short_name} review process, visit {website}.
+
+The {short_name} Editors-in-Chief
+'''
+
+author_desk_reject_email_template = '''Hi {{{{fullname}}}},
+
+We are sorry to inform you that, after consideration by the {role}, your {short_name} submission "{submission_number}: {submission_title}" has been rejected without further review.
+
+Cases of desk rejection include submissions that are not anonymized, submissions that do not use the unmodified {short_name} stylefile and submissions that clearly overlap with work already published in proceedings (or currently under review for publication).
+
+To know more about the decision, please follow this link: https://openreview.net/forum?id={submission_id}
+
+For more details and guidelines on the {short_name} review process, visit {website}.
+
+The {short_name} Editors-in-Chief
+'''

--- a/openreview/journal/templates.py
+++ b/openreview/journal/templates.py
@@ -202,3 +202,65 @@ For more details and guidelines on the {short_name} review process, visit {websi
 
 The {short_name} Editors-in-Chief
 '''
+
+reviewer_assignment_email_template = '''Hi {{{{fullname}}}},
+
+With this email, we request that you submit, within {review_period_length} weeks ({review_duedate}) a review for your newly assigned {short_name} submission "{submission_number}: {submission_title}".{submission_length}
+
+Please acknowledge on OpenReview that you have received this review assignment by following this link: {ack_invitation_url}
+
+As a reminder, reviewers are **expected to accept all assignments** for submissions that fall within their expertise and annual quota ({reviewers_max_papers} papers). Acceptable exceptions are 1) if you have an active, unsubmitted review for another {short_name} submission or 2) situations where exceptional personal circumstances (e.g. vacation, health problems) render you incapable of performing your reviewing duties. Based on the above, if you think you should not review this submission, contact your AE directly (you can do so by leaving a comment on OpenReview, with only the Action Editor as Reader).
+
+To submit your review, please follow this link: {invitation_url} or check your tasks in the Reviewers Console: https://openreview.net/group?id={venue_id}/Reviewers#reviewer-tasks
+
+Once submitted, your review will become privately visible to the authors and AE. Then, as soon as {number_of_reviewers} reviews have been submitted, all reviews will become {review_visibility}. For more details and guidelines on performing your review, visit {website}.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+note: replies to this email will go to the AE, {assigned_action_editor}.
+'''
+
+reviewer_unassignment_email_template = '''Hi {{{{fullname}}}},
+
+We recently informed you that your help was requested to review a {short_name} submission "{submission_number}: {submission_title}".
+
+However, it was just determined that your help is no longer needed for this submission and you have been unassigned as a reviewer for it.
+
+If you have any questions, don't hesitate to reach out directly to the Action Editor (AE) for the submission, for example by leaving a comment readable by the AE only, on the OpenReview page for the submission: https://openreview.net/forum?id={submission_id}
+
+Apologies for the change and thank you for your continued involvement with {short_name}!
+
+The {short_name} Editors-in-Chief
+note: replies to this email will go to the AE, {assigned_action_editor}.
+'''
+
+reviewer_discussion_starts_email_template = '''Hi {{{{fullname}}}},
+
+There are now {number_of_reviewers} reviews that have been submitted for your assigned submission "{submission_number}: {submission_title}" and all reviews have been made {review_visibility}. Please read the other reviews and start engaging with the authors (and possibly the other reviewers and AE) in order to address any concern you may have about the submission. Your goal should be to gather all the information you need **within the next {discussion_period_length} weeks** to be comfortable submitting a decision recommendation for this paper. You will receive an upcoming notification on how to enter your recommendation in OpenReview.
+
+You will find the OpenReview page for this submission at this link: https://openreview.net/forum?id={submission_id}
+
+For more details and guidelines on the {short_name} review process, visit {website}.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+note: replies to this email will go to the AE, {assigned_action_editor}.
+'''
+
+reviewer_official_recommendation_starts_email_template = '''Hi {{{{fullname}}}},
+
+Thank you for submitting your review and engaging with the authors of {short_name} submission "{submission_number}: {submission_title}".
+
+You may now submit your official recommendation for the submission. Before doing so, make sure you have sufficiently discussed with the authors (and possibly the other reviewers and AE) any concerns you may have about the submission.
+
+We ask that you submit your recommendation within {recommendation_period_length} weeks ({recommendation_duedate}). To do so, please follow this link: {invitation_url}
+
+For more details and guidelines on performing your review, visit {website}.
+
+We thank you for your essential contribution to {short_name}!
+
+The {short_name} Editors-in-Chief
+note: replies to this email will go to the AE, {assigned_action_editor}.
+'''

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -687,7 +687,7 @@ note={Under review}
 
 With this email, we request that you assign 3 reviewers to your assigned TMLR submission "1: Paper title UPDATED". The assignments must be completed **within 1 week** ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 1)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/group?id=TMLR/Action_Editors and click on "Edit Assignment" for that paper in your "Assigned Papers" console.
 
-As a reminder, up to their annual quota of six reviews per year, reviewers are expected to review all assigned submissions that fall within their expertise. Acceptable exceptions are 1) if they have an unsubmitted review for another TMLR submission or 2) situations where exceptional personal circumstances (e.g. vacation, health problems) render them incapable of fully performing their reviewing duties.
+As a reminder, up to their annual quota of 6 reviews per year, reviewers are expected to review all assigned submissions that fall within their expertise. Acceptable exceptions are 1) if they have an unsubmitted review for another TMLR submission or 2) situations where exceptional personal circumstances (e.g. vacation, health problems) render them incapable of fully performing their reviewing duties.
 
 Once assigned, reviewers will be asked to acknowledge on OpenReview their responsibility to review this submission. This acknowledgement will be made visible to you on the OpenReview page of the submission. If the reviewer has not acknowledged their responsibility a couple of days after their assignment, consider reaching out to them directly to confirm.
 


### PR DESCRIPTION
Store the email templates in the different role group content so organizers can edit them more easily