### PR TITLE
Journal: support archived reviewers

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -281,6 +281,29 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
             reviewer_group.web = content
             self.post_group(reviewer_group)
 
+        ## archived reviewers group
+        if self.journal.has_archived_reviewers:
+            archived_reviewers_id = self.journal.get_reviewers_archived_id()
+            reviewer_group = openreview.tools.get_group(self.client, archived_reviewers_id)
+            if not reviewer_group:
+                reviewer_group = Group(id=archived_reviewers_id,
+                                readers=[venue_id, action_editors_id, archived_reviewers_id] + additional_committee,
+                                writers=[venue_id],
+                                signatures=[venue_id],
+                                signatories=[venue_id],
+                                members=[]
+                                )
+            with open(os.path.join(os.path.dirname(__file__), 'webfield/reviewersWebfield.js')) as f:
+                content = f.read()
+                content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
+                content = content.replace("var SHORT_PHRASE = '';", f'var SHORT_PHRASE = "{self.journal.short_name}";')
+                content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + self.journal.get_author_submission_id() + "';")
+                content = content.replace("var ACTION_EDITOR_NAME = '';", "var ACTION_EDITOR_NAME = '" + self.journal.action_editors_name + "';")
+                content = content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + self.journal.reviewers_name + "';")
+                content = content.replace("var WEBSITE = '';", "var WEBSITE = '" + self.journal.website + "';")
+                reviewer_group.web = content
+                self.post_group(reviewer_group)
+
         ## reviewers invited group
         reviewers_invited_id = f'{reviewers_id}/Invited'
         reviewers_invited_group = openreview.tools.get_group(self.client, reviewers_invited_id)

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -85,6 +85,9 @@ class Journal(object):
     def get_reviewers_id(self, number=None, anon=False):
         return self.__get_group_id('Reviewer_' if anon else self.reviewers_name, number)
 
+    def get_reviewers_archived_id(self):
+        return f'{self.get_reviewers_id()}/Archived' 
+    
     def get_reviewers_reported_id(self):
         return self.get_reviewers_id() + '/Reported'
     
@@ -454,6 +457,9 @@ class Journal(object):
     
     def has_archived_action_editors(self):
         return self.settings.get('archived_action_editors', False)
+
+    def has_archived_reviewers(self):
+        return self.settings.get('archived_reviewers', False)
 
     def has_expert_reviewers(self):
         return self.settings.get('expert_reviewers', False)        

--- a/openreview/journal/webfield/editorsInChiefWebfield.js
+++ b/openreview/journal/webfield/editorsInChiefWebfield.js
@@ -188,6 +188,7 @@ var loadData = function() {
     Webfield2.api.getGroup(VENUE_ID + '/' + ACTION_EDITOR_NAME, { withProfiles: true}),
     Webfield2.api.getGroup(VENUE_ID + '/' + ACTION_EDITOR_NAME + '/Archived', { withProfiles: true}),
     Webfield2.api.getGroup(VENUE_ID + '/' + REVIEWERS_NAME, { withProfiles: true}),
+    Webfield2.api.getGroup(VENUE_ID + '/' + REVIEWERS_NAME + '/Archived', { withProfiles: true}),
     Webfield2.api.getAll('/invitations', {
       prefix: VENUE_ID + '/' + SUBMISSION_GROUP_NAME,
       type: 'all',
@@ -228,6 +229,7 @@ var formatData = function(
   actionEditors,
   archivedActionEditors,
   reviewers,
+  archivedReviewers,
   invitationsById,
   superInvitationIds,
   reviewerInvitationIds,
@@ -237,13 +239,13 @@ var formatData = function(
   var referrerUrl = encodeURIComponent('[Editors-in-Chief Console](/group?id=' + EDITORS_IN_CHIEF_ID + '#paper-status)');
 
   var reviewerStatusById = {};
-  reviewers.members.forEach(function(reviewer, index) {
+  var getReviewerStatus = function(reviewer, index, isArchived) {
     var responsibility = responsibilityNotes.find(function(reply) {
       return reply.invitations[0] === REVIEWERS_ID + '/-/' + reviewer.id + '/' + RESPONSIBILITY_ACK_NAME;
     });
     var reviewerReports = reviewerReportByReviewerId[reviewer.id] || [];
 
-    reviewerStatusById[reviewer.id] = {
+    return {
       index: { number: index + 1 },
       summary: {
         id: reviewer.id,
@@ -253,7 +255,8 @@ var formatData = function(
           Profile: reviewer.id.startsWith('~') ? 'Yes' : 'No',
           Publications: '-',
           'Responsibility Acknowledgement': responsibility ? 'Yes' : 'No',
-          'Reviewer Report': reviewerReports.length
+          'Reviewer Report': reviewerReports.length,
+          Archived: isArchived ? 'Yes' : 'No'
         }
       },
       reviewerProgressData: {
@@ -274,6 +277,13 @@ var formatData = function(
         referrer: referrerUrl
       }
     };
+  }
+  reviewers.members.forEach(function(reviewer, index) {
+    reviewerStatusById[reviewer.id] = getReviewerStatus(reviewer, index, false);
+  });
+
+  (archivedReviewers?.members || []).forEach(function(reviewer, index) {
+    reviewerStatusById[reviewer.id] = getReviewerStatus(reviewer, index, true);
   });
 
   var actionEditorStatusById = {};

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -124,6 +124,7 @@ class TestJournal():
                             'camera_ready_period': 4,
                             'camera_ready_verification_period': 1,
                             'archived_action_editors': True,
+                            'archived_reviewers': True,
                             'expert_reviewers': True,
                             'official_recommendation_additional_fields': {
                                 'pilot_recommendation_to_iclr_track': {
@@ -209,6 +210,7 @@ class TestJournal():
             "Expert Certification"
         ]
         assert 'expert_reviewers' in invitation.edit['note']['content']
+        assert openreview_client.get_group('TMLR/Reviewers/Archived')
 
     def test_invite_action_editors(self, journal, openreview_client, request_page, selenium, helpers):
 
@@ -4525,6 +4527,10 @@ note={Under review}
         ))
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
+
+        ## Archive David
+        raia_client.remove_members_from_group(raia_client.get_group('TMLR/Reviewers'), '~David_Belanger1')
+        raia_client.add_members_to_group(raia_client.get_group('TMLR/Reviewers/Archived'), '~David_Belanger1')
 
         ## Carlos Mondragon
         paper_assignment_edge = joelle_client.post_edge(openreview.Edge(invitation='TMLR/Reviewers/-/Assignment',


### PR DESCRIPTION
Let EICs move reviewers to archive reviewers and keep seeing their tasks in the reviewers console.