### PR TITLE
Anonymous Preprint Server: use API 2 invitation and groups to setup the anonymous preprint server

### DIFF
--- a/openreview/profile/process/anonymous_preprint_comment_process.py
+++ b/openreview/profile/process/anonymous_preprint_comment_process.py
@@ -1,0 +1,32 @@
+def process(client, edit, invitation):
+
+    submission = client.get_note(edit.note.forum)
+    comment = client.get_note(edit.note.id)
+    paper_group_id=f'{submission.domain}/Submission{submission.number}'
+
+    ### TODO: Fix this, we should notify the use when the review is updated
+    if comment.tcdate != comment.tmdate:
+        return    
+
+    signature = comment.signatures[0].split('/')[-1]
+    pretty_signature = openreview.tools.pretty_id(signature)
+    pretty_signature = 'An author' if pretty_signature == 'Authors' else pretty_signature
+
+    content = f'''
+    
+Paper number: {submission.number}
+
+Paper title: {submission.content['title']['value']}
+
+Comment: {comment.content['comment']['value']}
+
+To view the comment, click here: https://openreview.net/forum?id={submission.id}&noteId={comment.id}'''
+
+    #send email to paper authors
+    paper_authors_id = f'{paper_group_id}/Authors'
+    client.post_message(
+        recipients=[paper_authors_id],
+        ignoreRecipients=[edit.tauthor],
+        subject=f'''[Anonymous Preprint Server] {pretty_signature} commented on your submission. Paper Title: "{submission.content['title']['value']}"''',
+        message=f'''{pretty_signature} commented on your submission.{content}'''
+    )

--- a/openreview/profile/process/anonymous_preprint_submission_process.py
+++ b/openreview/profile/process/anonymous_preprint_submission_process.py
@@ -1,0 +1,72 @@
+def process(client, edit, invitation):
+
+    note = client.get_note(edit.note.id)
+    venue_id = note.domain
+    submission_name = 'Submission'
+    authors_name = 'Authors'
+    meta_invitation_id = f'{venue_id}/-/Edit'
+
+    author_subject = f'''Anonymous Preprint Server has received your submission titled {note.content['title']['value']}'''
+    note_abstract = f'''\n\nAbstract: {note.content['abstract']['value']}''' if 'abstract' in note.content else ''
+
+    action = 'posted' if note.tcdate == note.tmdate else 'updated'
+    if note.ddate:
+        action = 'deleted'
+
+    author_message = f'''Your submission to the Anonymous Preprint Server has been {action}.
+
+Submission Number: {note.number}
+
+Title: {note.content['title']['value']} {note_abstract}
+
+To view your submission, click here: https://openreview.net/forum?id={note.forum}'''
+    
+    paper_group_id=f'{venue_id}/{submission_name}{note.number}'
+    paper_group=openreview.tools.get_group(client, paper_group_id)
+    if not paper_group:
+        client.post_group_edit(
+            invitation = meta_invitation_id,
+            readers = [venue_id],
+            writers = [venue_id],
+            signatures = [venue_id],
+            group = openreview.api.Group(
+                id = paper_group_id,
+                readers=[venue_id],
+                writers=[venue_id],
+                signatures=[venue_id],
+                signatories=[venue_id]
+            )
+        )        
+
+    authors_group_id=f'{paper_group_id}/{authors_name}'
+    client.post_group_edit(
+        invitation = meta_invitation_id,
+        readers = [venue_id],
+        writers = [venue_id],
+        signatures = [venue_id],
+        group = openreview.api.Group(
+            id = authors_group_id,
+            readers=[venue_id, authors_group_id],
+            writers=[venue_id],
+            signatures=[venue_id],
+            signatories=[venue_id, authors_group_id],
+            members=list(set(note.content['authorids']['value'])) ## always update authors
+        )
+    )
+
+    #send tauthor email
+    if edit.tauthor.lower() != 'openreview.net':
+        client.post_message(
+            subject=author_subject,
+            message=author_message,
+            recipients=[edit.tauthor]
+        )
+
+    # send co-author emails
+    author_message += f'''\n\nIf you are not an author of this submission and would like to be removed, please contact the author who added you at {edit.tauthor}'''
+    client.post_message(
+        subject=author_subject,
+        message=author_message,
+        recipients=note.content['authorids']['value'],
+        ignoreRecipients=[edit.tauthor]
+    )

--- a/openreview/profile/webfield/anonymousWebfield.js
+++ b/openreview/profile/webfield/anonymousWebfield.js
@@ -1,0 +1,63 @@
+// Webfield component
+const tabs = []
+
+tabs.push({
+  name: 'All Submissions',
+  query: {
+    invitation: `${entity.id}/-/Submission`,
+    details: 'presentation',
+    sort: 'odate:desc'    
+  }
+},
+{
+  name: 'Previous Submissions',
+  query: {
+    invitation: `${entity.id}/-/Blind_Submission`,
+    details: 'invitation',
+    sort: 'cdate:desc'
+  },
+  apiVersion: 1
+})
+
+return {
+  component: 'VenueHomepage',
+  version: 1,
+  properties: {
+    header: {
+      title: 'OpenReview',
+      subtitle: 'OpenReview Anonymous Preprint Server',
+      website: 'https://openreview.net',
+      instructions: `
+**Important Information about Anonymity:**
+
+- When you post a submission to this anonymous preprint server, please provide the real names and email addresses of authors in the submission form below. 
+- An anonymous record of your paper will appear in the list below, and will be visible to the public.
+- The real name(s) are privately revealed to you and all the co-authors.
+- The PDF in your submission should not contain the names of the authors.
+
+**Revise your submission:**
+
+- To add a new version of your paper, go to the forum page of your paper and click on the "Edit" button.
+- Edit history is not public and it is only visible to the authors of the paper.
+
+**Delete your submission:**
+
+- To withdraw your paper, navigate to the forum page and click on the "Trash" icon.
+- Withdrawn submissions remain private and can be restored.
+
+**Public comments:**
+
+- Public comments will be enabled on request, please use the contact information to request it.
+
+**Questions?**
+
+Please contact the OpenReview support team at [info@openreview.net](info@openreview.net) with any questions or concerns about the OpenReview platform.
+`  
+    },
+    submissionId: `${entity.id}/-/Submission`,
+    submissionConfirmationMessage: 'Your anonymous preprint submission has been uploaded.',
+    parentGroupId: entity.parent,
+    tabs: tabs
+  }
+}
+


### PR DESCRIPTION
- Use a single API 2 invitation to submit, edit and delete anonymous preprints.
- Comment invitations are enabled on request

Fixes https://github.com/openreview/openreview-py/issues/1875
