### PR TITLE
Assignment edge invitations: use options to define the group for tails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
     default: "master"
   openreview-api-v2-branch:
     type: string
-    default: "feature/not-in-group"
+    default: "main"
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
     default: "master"
   openreview-api-v2-branch:
     type: string
-    default: "main"
+    default: "feature/not-in-group"
 
 jobs:
   build:

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2349,7 +2349,9 @@ class InvitationBuilder(object):
                 'tail': {
                     'param': {
                         'type': 'profile',
-                        'inGroup': committee_id
+                        'options': {
+                            'group': committee_id
+                        }
                     }                
                 },
                 'weight': {

--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -229,7 +229,9 @@ class Matching(object):
         edge_tail = {
             'param': {
                 'type': 'profile',
-                'inGroup': self.match_group.id
+                'options': {
+                    'group': self.match_group.id
+                }
             }
         }
 

--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -989,6 +989,7 @@ class Matching(object):
             raise openreview.OpenReviewException(f'The match group is empty: {self.match_group.id}')
         if self.alternate_matching_group:
             other_matching_group = self.client.get_group(self.alternate_matching_group)
+            other_matching_group = openreview.tools.replace_members_with_ids(client, other_matching_group)
             if not other_matching_group.members:
                 raise openreview.OpenReviewException(f'The alternate match group is empty: {self.alternate_matching_group}')
         elif not submissions:

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -959,6 +959,7 @@ The OpenReview Team.
         submission = openreview_client.get_note(note_id_2)
 
         helpers.create_user('carlos@cabj.org', 'Carlos', 'Tevez')
+        openreview_client.add_members_to_group('CABJ/Action_Editors', ['~Carlos_Tevez1'])
                        
         paper_assignment_edge = openreview_client.post_edge(openreview.Edge(invitation='CABJ/Action_Editors/-/Assignment',
             readers=['CABJ', 'CABJ/Editors_In_Chief', '~Carlos_Tevez1'],


### PR DESCRIPTION
We need to make these changes in order for this PR to work: https://github.com/openreview/openreview-api/pull/323

`inGroup` should be used we want the API to validate if tail is member of the group, otherwise use the `options` keywords that doesn't validate that and tells the edge browser how to load the group profiles. 