### PR TITLE
Fix/ Rebuttal Stage: change naming convention of rebuttal invitations

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -439,10 +439,10 @@ class InvitationBuilder(object):
         reply_to = '${4/content/noteId/value}'
 
         if not review_rebuttal_stage.single_rebuttal and not review_rebuttal_stage.unlimited_rebuttals:
-            submission_prefix = self.venue_id + '/' + self.venue.submission_stage.name + '${2/content/noteNumber/value}/'
+            submission_prefix = venue_id + '/' + self.venue.submission_stage.name + '${2/content/noteNumber/value}/'
             review_prefix = self.venue.review_stage.name + '${2/content/replyNumber/value}'
             paper_invitation_id = self.venue.get_invitation_id(name=review_rebuttal_stage.name, prefix=submission_prefix+review_prefix)
-            submission_prefix = self.venue_id + '/' + self.venue.submission_stage.name + '${6/content/noteNumber/value}/'
+            submission_prefix = venue_id + '/' + self.venue.submission_stage.name + '${6/content/noteNumber/value}/'
             review_prefix = self.venue.review_stage.name + '${6/content/replyNumber/value}'
             with_invitation = self.venue.get_invitation_id(name=review_rebuttal_stage.name, prefix=submission_prefix+review_prefix)
             reply_to = '${4/content/replyto/value}'
@@ -2040,9 +2040,21 @@ class InvitationBuilder(object):
                         'withForum': '${6/content/noteId/value}'
                     }
                 }
-            else:
-                paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, prefix='${2/content/replytoSignatures/value}')
-                with_invitation = self.venue.get_invitation_id(name=custom_stage.name, prefix='${6/content/replytoSignatures/value}')
+            elif custom_stage_replyto == 'reviews':
+                submission_prefix = venue_id + '/' + self.venue.submission_stage.name + '${2/content/noteNumber/value}/'
+                review_prefix = self.venue.review_stage.name + '${2/content/reviewNumber/value}'
+                paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, prefix=submission_prefix+review_prefix)
+                submission_prefix = venue_id + '/' + self.venue.submission_stage.name + '${6/content/noteNumber/value}/'
+                review_prefix = self.venue.review_stage.name + '${6/content/reviewNumber/value}'
+                with_invitation = self.venue.get_invitation_id(name=custom_stage.name, prefix=submission_prefix+review_prefix)
+                reply_to = '${4/content/replyto/value}'
+            elif custom_stage_replyto == 'metareviews':
+                submission_prefix = venue_id + '/' + self.venue.submission_stage.name + '${2/content/noteNumber/value}/'
+                metareview_prefix = self.venue.meta_review_stage.name + '${2/content/reviewNumber/value}'
+                paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, prefix=submission_prefix+metareview_prefix)
+                submission_prefix = venue_id + '/' + self.venue.submission_stage.name + '${6/content/noteNumber/value}/'
+                metareview_prefix = self.venue.review_stage.name + '${6/content/reviewNumber/value}'
+                with_invitation = self.venue.get_invitation_id(name=custom_stage.name, prefix=submission_prefix+metareview_prefix)
                 reply_to = '${4/content/replyto/value}'
 
         elif custom_stage_reply_type == 'revision':

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -439,8 +439,12 @@ class InvitationBuilder(object):
         reply_to = '${4/content/noteId/value}'
 
         if not review_rebuttal_stage.single_rebuttal and not review_rebuttal_stage.unlimited_rebuttals:
-            paper_invitation_id = self.venue.get_invitation_id(name=review_rebuttal_stage.name, prefix='${2/content/replytoSignatures/value}')
-            with_invitation = self.venue.get_invitation_id(name=review_rebuttal_stage.name, prefix='${6/content/replytoSignatures/value}')
+            submission_prefix = self.venue_id + '/' + self.venue.submission_stage.name + '${2/content/noteNumber/value}/'
+            review_prefix = self.venue.review_stage.name + '${2/content/reviewNumber/value}'
+            paper_invitation_id = self.venue.get_invitation_id(name=review_rebuttal_stage.name, prefix=submission_prefix+review_prefix)
+            submission_prefix = self.venue_id + '/' + self.venue.submission_stage.name + '${6/content/noteNumber/value}/'
+            review_prefix = self.venue.review_stage.name + '${6/content/reviewNumber/value}'
+            with_invitation = self.venue.get_invitation_id(name=review_rebuttal_stage.name, prefix=submission_prefix+review_prefix)
             reply_to = '${4/content/replyto/value}'
 
         if review_rebuttal_stage.unlimited_rebuttals:
@@ -487,10 +491,10 @@ class InvitationBuilder(object):
                             }
                         }
                     },
-                    'replytoSignatures': {
+                    'reviewNumber': {
                         'value': {
                             'param': {
-                                'regex': '.*', 'type': 'string',
+                                'regex': '.*', 'type': 'integer',
                                 'optional': True
                             }
                         }

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -440,10 +440,10 @@ class InvitationBuilder(object):
 
         if not review_rebuttal_stage.single_rebuttal and not review_rebuttal_stage.unlimited_rebuttals:
             submission_prefix = self.venue_id + '/' + self.venue.submission_stage.name + '${2/content/noteNumber/value}/'
-            review_prefix = self.venue.review_stage.name + '${2/content/reviewNumber/value}'
+            review_prefix = self.venue.review_stage.name + '${2/content/replyNumber/value}'
             paper_invitation_id = self.venue.get_invitation_id(name=review_rebuttal_stage.name, prefix=submission_prefix+review_prefix)
             submission_prefix = self.venue_id + '/' + self.venue.submission_stage.name + '${6/content/noteNumber/value}/'
-            review_prefix = self.venue.review_stage.name + '${6/content/reviewNumber/value}'
+            review_prefix = self.venue.review_stage.name + '${6/content/replyNumber/value}'
             with_invitation = self.venue.get_invitation_id(name=review_rebuttal_stage.name, prefix=submission_prefix+review_prefix)
             reply_to = '${4/content/replyto/value}'
 
@@ -490,23 +490,7 @@ class InvitationBuilder(object):
                                 'regex': '.*', 'type': 'string'
                             }
                         }
-                    },
-                    'reviewNumber': {
-                        'value': {
-                            'param': {
-                                'regex': '.*', 'type': 'integer',
-                                'optional': True
-                            }
-                        }
-                    },
-                    'replyto': {
-                        'value': {
-                            'param': {
-                                'regex': '.*', 'type': 'string',
-                                'optional': True
-                            }
-                        }
-                    },
+                    }
                 },
                 'replacement': True,
                 'invitation': {
@@ -565,7 +549,25 @@ class InvitationBuilder(object):
             invitation.edit['invitation']['duedate'] = review_rebuttal_duedate
 
         if review_rebuttal_expdate:
-            invitation.edit['invitation']['expdate'] = review_rebuttal_expdate            
+            invitation.edit['invitation']['expdate'] = review_rebuttal_expdate
+
+        if not review_rebuttal_stage.single_rebuttal and not review_rebuttal_stage.unlimited_rebuttals:
+            invitation.edit['content']['replyNumber'] = {
+                'value': {
+                    'param': {
+                        'regex': '.*', 'type': 'integer',
+                        'optional': True
+                    }
+                }
+            }
+            invitation.edit['content']['replyto'] = {
+                'value': {
+                    'param': {
+                        'regex': '.*', 'type': 'string',
+                        'optional': True
+                    }
+                }
+            }
 
         self.save_invitation(invitation, replacement=False)
         return invitation

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -135,12 +135,12 @@ def process(client, invitation):
             content['replyto'] = { 'value': note.id }
             content['replytoSignatures'] = { 'value': note.signatures[0] }
 
-        if 'replyto' in invitation.edit['content'] and 'reviewNumber' in invitation.edit['content']:
+        if 'replyto' in invitation.edit['content'] and 'replyNumber' in invitation.edit['content']:
             paper_number = note.invitations[0].split(submission_name)[-1].split('/')[0]
             content['noteId'] = { 'value': note.forum }
             content['noteNumber'] = { 'value': int(paper_number) }
             content['replyto'] = { 'value': note.id }
-            content['reviewNumber'] = { 'value': note.number }
+            content['replyNumber'] = { 'value': note.number }
 
         if 'noteReaders' in invitation.edit['content']:
             paper_readers = invitation.content.get('review_readers',{}).get('value') or invitation.content.get('comment_readers',{}).get('value')

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -135,6 +135,13 @@ def process(client, invitation):
             content['replyto'] = { 'value': note.id }
             content['replytoSignatures'] = { 'value': note.signatures[0] }
 
+        if 'replyto' in invitation.edit['content'] and 'reviewNumber' in invitation.edit['content']:
+            paper_number = note.invitations[0].split(submission_name)[-1].split('/')[0]
+            content['noteId'] = { 'value': note.forum }
+            content['noteNumber'] = { 'value': int(paper_number) }
+            content['replyto'] = { 'value': note.id }
+            content['reviewNumber'] = { 'value': note.number }
+
         if 'noteReaders' in invitation.edit['content']:
             paper_readers = invitation.content.get('review_readers',{}).get('value') or invitation.content.get('comment_readers',{}).get('value')
             final_readers = []

--- a/openreview/venue/process/metareview_process.py
+++ b/openreview/venue/process/metareview_process.py
@@ -14,14 +14,18 @@ def process(client, edit, invitation):
         print('processing invitation: ', invitation.id)
         metareview_reply = invitation.content.get('reply_to', {}).get('value', False) if invitation.content else False
         content_keys = invitation.edit.get('content', {}).keys()
-        if 'metareviews' == metareview_reply and 'replytoSignatures' in content_keys and 'replyto' in content_keys and len(content_keys) == 4:
+        if 'metareviews' == metareview_reply and 'replyto' in content_keys and len(content_keys) >= 4:
             print('create invitation: ', invitation.id)
+            content = {
+                'noteId': { 'value': metareview.forum },
+                'noteNumber': { 'value': submission.number },
+                'replyto': { 'value': metareview.id }
+            }
+            if 'replytoSignatures' in content_keys:
+                content['replytoSignatures'] = { 'value': metareview.signatures[0] }
+            elif 'replyNumber' in content_keys:
+                content['replyNumber'] = { 'value': metareview.number }
             client.post_invitation_edit(invitations=invitation.id,
-                content={
-                    'noteId': { 'value': metareview.forum },
-                    'noteNumber': { 'value': submission.number },
-                    'replytoSignatures': { 'value': metareview.signatures[0] },
-                    'replyto': { 'value': metareview.id }
-                },
+                content=content,
                 invitation=openreview.api.Invitation()
             )

--- a/openreview/venue/process/metareview_process.py
+++ b/openreview/venue/process/metareview_process.py
@@ -23,7 +23,7 @@ def process(client, edit, invitation):
             }
             if 'replytoSignatures' in content_keys:
                 content['replytoSignatures'] = { 'value': metareview.signatures[0] }
-            elif 'replyNumber' in content_keys:
+            if 'replyNumber' in content_keys:
                 content['replyNumber'] = { 'value': metareview.number }
             client.post_invitation_edit(invitations=invitation.id,
                 content=content,

--- a/openreview/venue/process/review_process.py
+++ b/openreview/venue/process/review_process.py
@@ -153,8 +153,8 @@ Paper title: {submission.content['title']['value']}
             }
             if 'replytoSignatures' in content_keys:
                 content['replytoSignatures'] = { 'value': review.signatures[0] }
-            elif 'reviewNumber' in content_keys:
-                content['reviewNumber'] = { 'value': review.number }
+            elif 'replyNumber' in content_keys:
+                content['replyNumber'] = { 'value': review.number }
             client.post_invitation_edit(invitations=invitation.id,
                 content=content,
                 invitation=openreview.api.Invitation()

--- a/openreview/venue/process/review_process.py
+++ b/openreview/venue/process/review_process.py
@@ -153,7 +153,7 @@ Paper title: {submission.content['title']['value']}
             }
             if 'replytoSignatures' in content_keys:
                 content['replytoSignatures'] = { 'value': review.signatures[0] }
-            elif 'replyNumber' in content_keys:
+            if 'replyNumber' in content_keys:
                 content['replyNumber'] = { 'value': review.number }
             client.post_invitation_edit(invitations=invitation.id,
                 content=content,

--- a/openreview/venue/process/review_process.py
+++ b/openreview/venue/process/review_process.py
@@ -144,14 +144,18 @@ Paper title: {submission.content['title']['value']}
         print('processing invitation: ', invitation.id)
         review_reply = invitation.content.get('reply_to', {}).get('value', False) if invitation.content else False
         content_keys = invitation.edit.get('content', {}).keys()
-        if 'reviews' == review_reply and 'replytoSignatures' in content_keys and 'replyto' in content_keys and len(content_keys) == 4:
+        if 'reviews' == review_reply and 'replyto' in content_keys and len(content_keys) == 4:
             print('create invitation: ', invitation.id)
+            content  = {
+                'noteId': { 'value': review.forum },
+                'noteNumber': { 'value': submission.number },
+                'replyto': { 'value': review.id }
+            }
+            if 'replytoSignatures' in content_keys:
+                content['replytoSignatures'] = { 'value': review.signatures[0] }
+            elif 'reviewNumber' in content_keys:
+                content['reviewNumber'] = { 'value': review.number }
             client.post_invitation_edit(invitations=invitation.id,
-                content={
-                    'noteId': { 'value': review.forum },
-                    'noteNumber': { 'value': submission.number },
-                    'replytoSignatures': { 'value': review.signatures[0] },
-                    'replyto': { 'value': review.id }
-                },
+                content=content,
                 invitation=openreview.api.Invitation()
             )

--- a/openreview/venue/process/review_process.py
+++ b/openreview/venue/process/review_process.py
@@ -144,7 +144,7 @@ Paper title: {submission.content['title']['value']}
         print('processing invitation: ', invitation.id)
         review_reply = invitation.content.get('reply_to', {}).get('value', False) if invitation.content else False
         content_keys = invitation.edit.get('content', {}).keys()
-        if 'reviews' == review_reply and 'replyto' in content_keys and len(content_keys) == 4:
+        if 'reviews' == review_reply and 'replyto' in content_keys and len(content_keys) >= 4:
             print('create invitation: ', invitation.id)
             content  = {
                 'noteId': { 'value': review.forum },

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -3046,7 +3046,7 @@ ICML 2023 Conference Program Chairs'''
 
         assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Review_Rating')) == 3
 
-        invitation = openreview_client.get_invitation(f'{anon_group_id}/-/Review_Rating')
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/Official_Review1/-/Review_Rating')
         assert invitation.invitees == ['ICML.cc/2023/Conference/Program_Chairs', 'ICML.cc/2023/Conference/Submission1/Area_Chairs']
         assert 'review_quality' in invitation.edit['note']['content']
         assert invitation.edit['note']['forum'] == submissions[0].id
@@ -3077,7 +3077,7 @@ ICML 2023 Conference Program Chairs'''
         reviewer_client = openreview.api.OpenReviewClient(username='reviewer2@icml.cc', password=helpers.strong_password)
         anon_groups = reviewer_client.get_groups(prefix='ICML.cc/2023/Conference/Submission1/Reviewer_', signatory='~Reviewer_ICMLTwo1')
         anon_group_id = anon_groups[0].id
-        invitation = openreview_client.get_invitation(f'{anon_group_id}/-/Review_Rating')
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/Official_Review2/-/Review_Rating')
 
         #post another review rating to same paper
         rating_edit = ac_client.post_note_edit(
@@ -3175,7 +3175,7 @@ ICML 2023 Conference Program Chairs'''
 
         assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Review_Rating')) == 4
 
-        invitation = openreview_client.get_invitation(f'{anon_group_id}/-/Review_Rating')
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission3/Official_Review1/-/Review_Rating')
         assert invitation.invitees == ['ICML.cc/2023/Conference/Program_Chairs', 'ICML.cc/2023/Conference/Submission3/Area_Chairs']
         assert 'review_quality' in invitation.edit['note']['content']
         assert invitation.edit['note']['forum'] == review_edit['note']['forum']
@@ -4468,7 +4468,7 @@ ICML 2023 Conference Program Chairs'''
         anon_groups = ac_client.get_groups(prefix='ICML.cc/2023/Conference/Submission1/Area_Chair_', signatory='~AC_ICMLTwo1')
         anon_group_id = anon_groups[0].id
 
-        invitation_id = f'{anon_group_id}/-/Meta_Review_Agreement'
+        invitation_id = 'ICML.cc/2023/Conference/Submission1/Meta_Review1/-/Meta_Review_Agreement'
 
         agreement_edit = sac_client.post_note_edit(
             invitation=invitation_id,
@@ -4513,7 +4513,7 @@ ICML 2023 Conference Program Chairs'''
 
         assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_Agreement')) == 2
 
-        invitation_id = f'{anon_group_id}/-/Meta_Review_Agreement'
+        invitation_id = 'ICML.cc/2023/Conference/Submission2/Meta_Review1/-/Meta_Review_Agreement'
         sac_client = openreview.api.OpenReviewClient(username = 'sac1@gmail.com', password=helpers.strong_password)
 
         agreement_edit = sac_client.post_note_edit(

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -2087,18 +2087,18 @@ If you would like to change your decision, please follow the link in the previou
         helpers.await_queue()
 
         submissions = openreview_client.get_notes(invitation='NeurIPS.cc/2023/Conference/-/Submission', sort='number:asc')
-        reviews = pc_client_v2.get_notes(invitation='NeurIPS.cc/2023/Conference/Submission1/-/Official_Review')
+        reviews = pc_client_v2.get_notes(invitation='NeurIPS.cc/2023/Conference/Submission1/-/Official_Review', sort='number:asc')
         review = reviews[0]
 
         assert len(openreview_client.get_invitations(invitation='NeurIPS.cc/2023/Conference/-/Rebuttal')) == 2
-        invitation = openreview_client.get_invitation(f'{review.signatures[0]}/-/Rebuttal')
+        invitation = openreview_client.get_invitation('NeurIPS.cc/2023/Conference/Submission1/Official_Review1/-/Rebuttal')
         assert invitation.maxReplies == 1
         assert invitation.edit['note']['replyto'] == review.id
 
         test_client = openreview.api.OpenReviewClient(username='test@mail.com', password=helpers.strong_password)
 
         rebuttal_edit = test_client.post_note_edit(
-            invitation=f'{review.signatures[0]}/-/Rebuttal',
+            invitation='NeurIPS.cc/2023/Conference/Submission1/Official_Review1/-/Rebuttal',
             signatures=['NeurIPS.cc/2023/Conference/Submission1/Authors'],
             note=openreview.api.Note(
                 replyto = review.id,
@@ -2120,7 +2120,7 @@ If you would like to change your decision, please follow the link in the previou
 
         with pytest.raises(openreview.OpenReviewException, match=r'.*You have reached the maximum number \(1\) of replies for this Invitation.*'):
             rebuttal_edit = test_client.post_note_edit(
-                invitation=f'{review.signatures[0]}/-/Rebuttal',
+                invitation='NeurIPS.cc/2023/Conference/Submission1/Official_Review1/-/Rebuttal',
                 signatures=['NeurIPS.cc/2023/Conference/Submission1/Authors'],
                 note=openreview.api.Note(
                     replyto = review.id,
@@ -2265,11 +2265,7 @@ If you would like to change your decision, please follow the link in the previou
 
         helpers.await_queue()
 
-
-        reviews = pc_client_v2.get_notes(invitation='NeurIPS.cc/2023/Conference/Submission1/-/Official_Review')
-        review = reviews[0]
-
-        rebuttal = openreview_client.get_notes(invitation=f'{review.signatures[0]}/-/Rebuttal')[0]
+        rebuttal = openreview_client.get_notes(invitation='NeurIPS.cc/2023/Conference/Submission1/Official_Review1/-/Rebuttal')[0]
         assert rebuttal.readers == [
             'NeurIPS.cc/2023/Conference/Program_Chairs',
             'NeurIPS.cc/2023/Conference/Submission1/Senior_Area_Chairs',

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -1890,7 +1890,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         anon_groups = reviewer_client.get_groups(prefix='V2.cc/2030/Conference/Submission1/Reviewer_', signatory='~VenueThree_Reviewer1')
         anon_group_id = anon_groups[0].id
 
-        invitation = openreview_client.get_invitation(f'{anon_group_id}/-/Review_Revision')
+        invitation = openreview_client.get_invitation('V2.cc/2030/Conference/Submission1/Official_Review1/-/Review_Revision')
         assert invitation and anon_group_id in invitation.invitees
 
         review = reviewer_client.get_notes(invitation='V2.cc/2030/Conference/Submission1/-/Official_Review', sort='number:asc')[0]
@@ -1902,7 +1902,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert 'readers' in review.content['review_rating']
 
         review_revision = reviewer_client.post_note_edit(
-            invitation=f'{anon_group_id}/-/Review_Revision',
+            invitation='V2.cc/2030/Conference/Submission1/Official_Review1/-/Review_Revision',
             signatures=[anon_group_id],
             note=Note(
                 id=review.id,
@@ -1968,7 +1968,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         anon_groups = reviewer_client.get_groups(prefix='V2.cc/2030/Conference/Submission1/Reviewer_', signatory='~VenueThree_Reviewer1')
         anon_group_id = anon_groups[0].id
 
-        invitation = openreview_client.get_invitation(f'{anon_group_id}/-/Author_Review_Rating')
+        invitation = openreview_client.get_invitation('V2.cc/2030/Conference/Submission1/Official_Review1/-/Author_Review_Rating')
         assert invitation.invitees == ['V2.cc/2030/Conference/Program_Chairs', 'V2.cc/2030/Conference/Submission1/Authors']
         assert 'review_quality' in invitation.edit['note']['content']
         assert invitation.edit['note']['forum'] == submissions[0].id
@@ -2151,7 +2151,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert len(ac_anon_groups) == 1
         ac_anon_group_id = ac_anon_groups[0].id
 
-        invitation = openreview_client.get_invitation(f'{ac_anon_group_id}/-/Meta_Review_Revision')
+        invitation = openreview_client.get_invitation('V2.cc/2030/Conference/Submission1/Meta_Review1/-/Meta_Review_Revision')
         assert invitation and ac_anon_group_id in invitation.invitees
 
         meta_review = meta_reviewer_client.get_notes(invitation='V2.cc/2030/Conference/Submission1/-/Meta_Review')[0]
@@ -2161,7 +2161,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                                   'V2.cc/2030/Conference/Program_Chairs']
 
         meta_review_revision = meta_reviewer_client.post_note_edit(
-            invitation=f'{ac_anon_group_id}/-/Meta_Review_Revision',
+            invitation='V2.cc/2030/Conference/Submission1/Meta_Review1/-/Meta_Review_Revision',
             signatures=[ac_anon_group_id],
             note=Note(
                 id=meta_review.id,


### PR DESCRIPTION
Rebuttal invitations will now be named as follows (the last two remain unchanged):
- one rebuttal per review: `MICCAI.org/2023/STS/Submission1/Official_Review1/-/Rebuttal`
- one rebuttal per paper: `MICCAI.org/2023/STS/Submission1/-/Rebuttal`
- multiple rebuttals per paper: `MICCAI.org/2023/STS/Submission1/-/Rebuttal`