### PR TITLE
Feature/allow author select license

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -29,7 +29,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.area_chair_roles = note.content.get('area_chair_roles', ['Area_Chairs'])
         venue.reviewer_roles = note.content.get('reviewer_roles', ['Reviewers'])
         venue.allow_gurobi_solver = venue_content.get('allow_gurobi_solver', {}).get('value', False)
-        venue.submission_license = note.content.get('submission_license', 'CC BY 4.0')
+        venue.submission_license = note.content.get('submission_license', [])
         set_homepage_options(note, venue)
         venue.reviewer_identity_readers = get_identity_readers(note, 'reviewer_identity')
         venue.area_chair_identity_readers = get_identity_readers(note, 'area_chair_identity')

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -29,7 +29,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.area_chair_roles = note.content.get('area_chair_roles', ['Area_Chairs'])
         venue.reviewer_roles = note.content.get('reviewer_roles', ['Reviewers'])
         venue.allow_gurobi_solver = venue_content.get('allow_gurobi_solver', {}).get('value', False)
-        venue.submission_license = note.content.get('submission_license', [])
+        venue.submission_license = note.content.get('submission_license', ['CC BY 4.0'])
         set_homepage_options(note, venue)
         venue.reviewer_identity_readers = get_identity_readers(note, 'reviewer_identity')
         venue.area_chair_identity_readers = get_identity_readers(note, 'area_chair_identity')

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -174,8 +174,16 @@ class InvitationBuilder(object):
             process=self.get_process_content('process/submission_process.py')
         )
 
-        if submission_license:
-            submission_invitation.edit['note']['license'] = submission_license
+        # Set license for all submissions or allow authors to set license
+        if len(submission_license) == 1:
+            submission_invitation.edit['note']['license'] = submission_license[0]
+        elif len(submission_license) > 1:
+            license_options = [ { "value": license, "description": license } for license in submission_license ]
+            submission_invitation.edit['note']['license'] = {
+                "param": {
+                    "enum": license_options
+                }
+            }
 
         submission_invitation = self.save_invitation(submission_invitation, replacement=False)
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -175,15 +175,16 @@ class InvitationBuilder(object):
         )
 
         # Set license for all submissions or allow authors to set license
-        if len(submission_license) == 1:
-            submission_invitation.edit['note']['license'] = submission_license[0]
-        elif len(submission_license) > 1:
-            license_options = [ { "value": license, "description": license } for license in submission_license ]
-            submission_invitation.edit['note']['license'] = {
-                "param": {
-                    "enum": license_options
+        if submission_license:
+            if len(submission_license) == 1:
+                submission_invitation.edit['note']['license'] = submission_license[0]
+            else:
+                license_options = [ { "value": license, "description": license } for license in submission_license ]
+                submission_invitation.edit['note']['license'] = {
+                    "param": {
+                        "enum": license_options
+                    }
                 }
-            }
 
         submission_invitation = self.save_invitation(submission_invitation, replacement=False)
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -176,7 +176,9 @@ class InvitationBuilder(object):
 
         # Set license for all submissions or allow authors to set license
         if submission_license:
-            if len(submission_license) == 1:
+            if isinstance(submission_license, str): # Existing venues have license as a string
+                submission_invitation.edit['note']['license'] = submission_license
+            elif len(submission_license) == 1:
                 submission_invitation.edit['note']['license'] = submission_license[0]
             else:
                 license_options = [ { "value": license, "description": license } for license in submission_license ]

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1219,9 +1219,9 @@ class VenueRequest():
                 'order': 17
             },
             'submission_license': {
-                'value-radio': ['CC BY 4.0', 'CC BY-SA 4.0', 'CC BY-NC 4.0', 'CC BY-ND 4.0', 'CC BY-NC-SA 4.0', 'CC BY-NC-ND 4.0', 'CC0 1.0'],
-                'description': 'Which license would you like to use for each submission? If you are unsure, we recommend "CC BY 4.0". If your license is not listed, please let us know and we can add it. Please refer to https://openreview.net/legal/terms for more information.',
-                'default': 'CC BY 4.0',
+                'values-checkbox': ['CC BY 4.0', 'CC BY-SA 4.0', 'CC BY-NC 4.0', 'CC BY-ND 4.0', 'CC BY-NC-SA 4.0', 'CC BY-NC-ND 4.0', 'CC0 1.0'],
+                'description': 'Which license should be applied to each submission? We recommend "CC BY 4.0". If you select multiple licenses, you allow authors to choose their license upon submission. If your license is not listed, please contact us. Refer to https://openreview.net/legal/terms for more information.',
+                'required': True,
                 'order': 18
             },
             'submission_deadline_author_reorder': {

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -81,7 +81,8 @@ class TestARRVenue():
                 'submission_readers': 'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)',
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
-                'use_recruitment_template': 'Yes'
+                'use_recruitment_template': 'Yes',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_cvpr_conference.py
+++ b/tests/test_cvpr_conference.py
@@ -80,7 +80,8 @@ class TestCVPRSConference():
                 'Expected Submissions': '100',
                 'use_recruitment_template': 'Yes',
                 'include_expertise_selection': 'Yes',
-                'submission_deadline_author_reorder': 'Yes'
+                'submission_deadline_author_reorder': 'Yes',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_cvpr_conference_v2.py
+++ b/tests/test_cvpr_conference_v2.py
@@ -66,7 +66,7 @@ class TestCVPRConference():
                 'include_expertise_selection': 'Yes',
                 'submission_deadline_author_reorder': 'Yes',
                 'api_version': '2',
-                'submission_license': 'CC BY-SA 4.0'
+                'submission_license': ['CC BY-SA 4.0']
             }
         ))
 
@@ -133,7 +133,7 @@ class TestCVPRConference():
         assert ['thecvf.com/CVPR/2024/Conference', '~SomeFirstName_User1', 'peter@mail.com', 'andrew@amazon.com', '~SAC_CVPROne1'] == submissions[0].readers
         assert ['~SomeFirstName_User1', 'peter@mail.com', 'andrew@amazon.com', '~SAC_CVPROne1'] == submissions[0].content['authorids']['value']
 
-        # Check that submission license is same as request form
+        # Check that submission note has license
         assert submissions[0].license == 'CC BY-SA 4.0'
 
         authors_group = openreview_client.get_group(id='thecvf.com/CVPR/2024/Conference/Authors')

--- a/tests/test_emnlp_conference.py
+++ b/tests/test_emnlp_conference.py
@@ -65,7 +65,8 @@ class TestEMNLPConference():
                 'Expected Submissions': '1000',
                 'use_recruitment_template': 'Yes',
                 'api_version': '2',
-                'ethics_chairs_and_reviewers': 'Yes, our venue has Ethics Chairs and Reviewers'
+                'ethics_chairs_and_reviewers': 'Yes, our venue has Ethics Chairs and Reviewers',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_iclr_conference_v2.py
+++ b/tests/test_iclr_conference_v2.py
@@ -77,7 +77,7 @@ class TestICLRConference():
                 'Expected Submissions': '100',
                 'use_recruitment_template': 'Yes',
                 'api_version': '2',
-                'submission_license': 'CC BY-SA 4.0'
+                'submission_license': ['CC BY 4.0', 'CC BY-SA 4.0', 'CC0 1.0'] # Allow authors to select license
             }))
 
         helpers.await_queue()
@@ -180,10 +180,12 @@ class TestICLRConference():
     def test_submissions(self, client, openreview_client, helpers, test_client):
 
         test_client = openreview.api.OpenReviewClient(token=test_client.token)
+        request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         domains = ['umass.edu', 'amazon.com', 'fb.com', 'cs.umass.edu', 'google.com', 'mit.edu', 'deepmind.com', 'co.ux', 'apple.com', 'nvidia.com']
         for i in range(1,12):
             note = openreview.api.Note(
+                license = 'CC BY-SA 4.0',
                 content = {
                     'title': { 'value': 'Paper title ' + str(i) },
                     'abstract': { 'value': 'This is an abstract ' + str(i) },
@@ -208,8 +210,9 @@ class TestICLRConference():
         assert ['ICLR.cc/2024/Conference', '~SomeFirstName_User1', 'peter@mail.com', 'andrew@amazon.com', '~SAC_ICLROne1'] == submissions[0].readers
         assert ['~SomeFirstName_User1', 'peter@mail.com', 'andrew@amazon.com', '~SAC_ICLROne1'] == submissions[0].content['authorids']['value']
 
-        # Check that submission license is same as request form
-        assert submissions[0].license == 'CC BY-SA 4.0'
+        # Check that note.license is from license list
+        licenses = request_form.content['submission_license']
+        assert submissions[0].license in licenses
 
         authors_group = openreview_client.get_group(id='ICLR.cc/2024/Conference/Authors')
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -75,7 +75,8 @@ class TestICMLConference():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
                 'use_recruitment_template': 'Yes',
-                'api_version': '2'
+                'api_version': '2',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_multiple_roles.py
+++ b/tests/test_multiple_roles.py
@@ -70,7 +70,8 @@ class TestMultipleRoles():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
                 'reviewer_roles': ['Program_Committee', 'Senior_Program_Committee'],
-                'area_chair_roles': ['First_Group_AC', 'Second_Group_AC']
+                'area_chair_roles': ['First_Group_AC', 'Second_Group_AC'],
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -83,7 +83,8 @@ class TestNeurIPSConference():
                 'submission_readers': 'Program chairs and paper authors only',
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
-                'use_recruitment_template': 'Yes'
+                'use_recruitment_template': 'Yes',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -79,7 +79,8 @@ class TestNeurIPSConference():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
                 'api_version': '2',
-                'submission_deadline_author_reorder': 'Yes'
+                'submission_deadline_author_reorder': 'Yes',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_neurips_track_conference.py
+++ b/tests/test_neurips_track_conference.py
@@ -78,7 +78,8 @@ class TestNeurIPSTrackConference():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
                 'api_version': '2',
-                'submission_deadline_author_reorder': 'No'
+                'submission_deadline_author_reorder': 'No',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_single_blind_conference_v2.py
+++ b/tests/test_single_blind_conference_v2.py
@@ -79,7 +79,8 @@ class TestSingleBlindVenueV2():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
                 'submission_name': 'Submission',
-                'api_version': '2'
+                'api_version': '2',
+                'submission_license': ['CC BY 4.0']
             })
 
         request_form_note=test_client.post_note(request_form_note)

--- a/tests/test_submission_readers.py
+++ b/tests/test_submission_readers.py
@@ -54,7 +54,8 @@ class TestSubmissionReaders():
                 'reviewer_identity': ['Program Chairs', 'Assigned Area Chair', 'Assigned Senior Area Chair'],
                 'area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair'],
                 'senior_area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair'],
-                'Expected Submissions': '1000'
+                'Expected Submissions': '1000',
+                'submission_license': ['CC BY 4.0']
             })
 
         request_form_note=test_client.post_note(request_form_note)

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -68,7 +68,8 @@ class TestVenueRequest():
                 'area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair'],
                 'senior_area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair'],
                 'withdraw_submission_expiration': withdraw_exp_date.strftime('%Y/%m/%d'),
-                'use_recruitment_template': 'No'
+                'use_recruitment_template': 'No',
+                'submission_license': ['CC BY 4.0']
             })
 
         with pytest.raises(openreview.OpenReviewException, match=r'Assigned area chairs must see the reviewer identity'):

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -191,7 +191,8 @@ class TestVenueRequest():
                 'desk_rejected_submissions_author_anonymity': 'Yes, author identities of desk rejected submissions should be revealed.',
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
-                'submission_name': 'Submission_Test'
+                'submission_name': 'Submission_Test',
+                'submission_license': ['CC BY 4.0']
             }))
 
         assert request_form_note

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -74,7 +74,7 @@ class TestVenueRequest():
                 'area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair'],
                 'senior_area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair'],
                 'withdraw_submission_expiration': withdraw_exp_date.strftime('%Y/%m/%d'),
-                'submission_license': 'CC BY-NC 4.0',
+                'submission_license': ['CC BY-NC 4.0'],
                 'api_version': '2'
             })
 
@@ -212,7 +212,8 @@ class TestVenueRequest():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
                 'submission_name': 'Submission_Test',
-                'api_version': '2'
+                'api_version': '2',
+                'submission_license': ['CC BY 4.0'],
             }))
 
         assert request_form_note

--- a/tests/test_venue_with_tracks.py
+++ b/tests/test_venue_with_tracks.py
@@ -159,7 +159,8 @@ class TestVenueWithTracks():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '2000',
                 'use_recruitment_template': 'Yes',
-                'api_version': '2'
+                'api_version': '2',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_workshop_no_anonymity.py
+++ b/tests/test_workshop_no_anonymity.py
@@ -72,7 +72,8 @@ class TestWorkshopV2():
                 'desk_rejected_submissions_author_anonymity': 'Yes, author identities of desk rejected submissions should be revealed.',
                 'email_pcs_for_withdrawn_submissions': 'No, do not email PCs.',
                 'withdrawn_submissions_visibility': 'No, withdrawn submissions should not be made public.',
-                'desk_rejected_submissions_visibility': 'No, desk rejected submissions should not be made public.'               
+                'desk_rejected_submissions_visibility': 'No, desk rejected submissions should not be made public.'               ,
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -68,7 +68,8 @@ class TestWorkshopV2():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
                 'use_recruitment_template': 'Yes',
-                'api_version': '2'
+                'api_version': '2',
+                'submission_license': ['CC BY 4.0']
             }))
 
         helpers.await_queue()


### PR DESCRIPTION
This PR gives PCs the option to select a multiple submission licenses. Doing so will allow authors to choose their license upon submission. Otherwise, selecting 1 license will apply it to all submissions, which is the current functionality.

<img width="908" alt="Screenshot 2024-01-12 at 1 27 16 PM" src="https://github.com/openreview/openreview-py/assets/22416602/c486f83c-645d-4f15-9f81-b13d508a1736">

<img width="550" alt="Screenshot 2024-01-12 at 2 04 58 PM" src="https://github.com/openreview/openreview-py/assets/22416602/91303172-c20b-4e44-b43b-2cb6e674d481">

