### PR TITLE
Journal fixes: release authors, submission and reviews to the public

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3345,7 +3345,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             process=self.get_process_content('process/accepted_submission_process.py')
         )
 
-        if self.journal.should_release_authors():
+        if self.journal.are_authors_anonymous():
             invitation.edit['note']['content']['authors'] = {
                 'readers': { 'param': { 'const': { 'delete': True } } }
             }
@@ -3354,7 +3354,11 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             }
             invitation.edit['note']['content']['supplementary_material'] = {
                 'readers': { 'param': { 'const': { 'delete': True } } }
-            }            
+            }
+
+        if not self.journal.is_submission_public():
+            invitation.edit['note']['readers'] = ['everyone']
+            invitation.edit['note']['nonreaders'] = []     
 
         if self.journal.get_certifications():
             invitation.edit['note']['content']['certifications'] = {

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3345,20 +3345,22 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             process=self.get_process_content('process/accepted_submission_process.py')
         )
 
-        if self.journal.are_authors_anonymous():
-            invitation.edit['note']['content']['authors'] = {
-                'readers': { 'param': { 'const': { 'delete': True } } }
-            }
-            invitation.edit['note']['content']['authorids'] = {
-                'readers': { 'param': { 'const': { 'delete': True } } }
-            }
-            invitation.edit['note']['content']['supplementary_material'] = {
-                'readers': { 'param': { 'const': { 'delete': True } } }
-            }
+        if self.journal.release_submission_after_acceptance():
+            
+            if self.journal.are_authors_anonymous():
+                invitation.edit['note']['content']['authors'] = {
+                    'readers': { 'param': { 'const': { 'delete': True } } }
+                }
+                invitation.edit['note']['content']['authorids'] = {
+                    'readers': { 'param': { 'const': { 'delete': True } } }
+                }
+                invitation.edit['note']['content']['supplementary_material'] = {
+                    'readers': { 'param': { 'const': { 'delete': True } } }
+                }
 
-        if not self.journal.is_submission_public():
-            invitation.edit['note']['readers'] = ['everyone']
-            invitation.edit['note']['nonreaders'] = []     
+            if not self.journal.is_submission_public():
+                invitation.edit['note']['readers'] = ['everyone']
+                invitation.edit['note']['nonreaders'] = []     
 
         if self.journal.get_certifications():
             invitation.edit['note']['content']['certifications'] = {

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -520,9 +520,7 @@ class Journal(object):
         return [self.get_editors_in_chief_id(), self.get_action_editors_id(), self.get_reviewers_id(number), self.get_authors_id(number)]        
 
     def get_release_authors_readers(self, number):
-        if self.is_submission_public():
-            return ['everyone']
-        return [self.get_editors_in_chief_id(), self.get_action_editors_id(), self.get_authors_id(number)]        
+        return ['everyone']
 
     def get_official_comment_readers(self, number):
         readers = []

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -431,6 +431,9 @@ class Journal(object):
     def are_authors_anonymous(self):
         return self.settings.get('author_anonymity', True)
     
+    def release_submission_after_acceptance(self):
+        return self.settings.get('release_submission_after_acceptance', True)
+    
     def should_eic_submission_notification(self):
         return self.settings.get('eic_submission_notification', False)
     
@@ -520,7 +523,9 @@ class Journal(object):
         return [self.get_editors_in_chief_id(), self.get_action_editors_id(), self.get_reviewers_id(number), self.get_authors_id(number)]        
 
     def get_release_authors_readers(self, number):
-        return ['everyone']
+        if self.is_submission_public() or self.release_submission_after_acceptance():
+            return ['everyone']
+        return [self.get_editors_in_chief_id(), self.get_action_editors_id(), self.get_authors_id(number)]          
 
     def get_official_comment_readers(self, number):
         readers = []

--- a/openreview/journal/process/accepted_submission_process.py
+++ b/openreview/journal/process/accepted_submission_process.py
@@ -10,4 +10,19 @@ def process(client, edit, invitation):
 
     journal.invitation_builder.set_note_eic_revision_invitation(note)
 
+    if not journal.is_submission_public() and journal.release_submission_after_acceptance():
+        reviews = client.get_notes(invitation=journal.get_review_id(number=note.number))
+        for review in reviews:
+            client.post_note_edit(
+                invitation=journal.get_meta_invitation_id(),
+                signatures=[journal.venue_id],
+                readers=['everyone'],
+                writers=[journal.venue_id],
+                note = openreview.api.Note(
+                    id = review.id,
+                    readers = ['everyone'],
+                    nonreaders = []
+                )
+            )
+
 

--- a/openreview/journal/process/official_recommendation_cdate_process.py
+++ b/openreview/journal/process/official_recommendation_cdate_process.py
@@ -7,7 +7,7 @@ def process(client, invitation):
 
     ## send email to reviewers
     print('send email to reviewers')
-    assigned_action_editor = client.search_profiles(ids=[submission.content['assigned_action_editor']['value']])[0]
+    assigned_action_editor = client.search_profiles(ids=[submission.content['assigned_action_editor']['value'].split(',')[0]])[0]
     reviewer_group = client.get_group(journal.get_reviewers_id())
     message=reviewer_group.content['official_recommendation_starts_email_template_script']['value'].format(
         short_name=journal.short_name,

--- a/openreview/journal/process/review_process.py
+++ b/openreview/journal/process/review_process.py
@@ -48,7 +48,7 @@ def process(client, edit, invitation):
         cdate = journal.get_due_date(weeks = journal.get_discussion_period_length())
         duedate = cdate + datetime.timedelta(weeks = journal.get_recommendation_period_length())
         journal.invitation_builder.set_note_official_recommendation_invitation(submission, cdate, duedate)
-        assigned_action_editor = client.search_profiles(ids=[submission.content['assigned_action_editor']['value']])[0]
+        assigned_action_editor = client.search_profiles(ids=[submission.content['assigned_action_editor']['value'].split(',')[0]])[0]
         review_visibility = 'public' if journal.is_submission_public() else 'visible to all the reviewers'
 
         ## Send email notifications to authors

--- a/openreview/journal/process/reviewer_assignment_process.py
+++ b/openreview/journal/process/reviewer_assignment_process.py
@@ -8,7 +8,7 @@ def process_update(client, edge, invitation, existing_edge):
 
     venue_id = journal.venue_id
     note = client.get_note(edge.head)
-    assigned_action_editor = client.search_profiles(ids=[note.content['assigned_action_editor']['value']])[0]
+    assigned_action_editor = client.search_profiles(ids=[note.content['assigned_action_editor']['value'].split(',')[0]])[0]
     group = client.get_group(journal.get_reviewers_id(number=note.number))
     tail_assignment_edges = client.get_edges(invitation=journal.get_reviewer_assignment_id(), tail=edge.tail)
     head_assignment_edges = client.get_edges(invitation=journal.get_reviewer_assignment_id(), head=edge.head)

--- a/openreview/journal/process/reviewer_invitation_assignment_pre_process.py
+++ b/openreview/journal/process/reviewer_invitation_assignment_pre_process.py
@@ -3,7 +3,7 @@ def process(client, edge, invitation):
     journal = openreview.journal.Journal()
     
     reviewers_id = journal.get_reviewers_id()
-    assignment_invitation_id = journal.get_reviewer_invite_assignment_id()
+    assignment_invitation_id = journal.get_reviewer_assignment_id()
     invite_label = 'Invitation Sent'
     conflict_policy = 'NeurIPS'
     conflict_n_years = 3

--- a/openreview/journal/process/reviewer_invitation_assignment_process.py
+++ b/openreview/journal/process/reviewer_invitation_assignment_process.py
@@ -64,3 +64,10 @@ Thanks,
         
         ## - Send email
         response = client.post_message(subject, [user_profile.id], message, replyTo=inviter_profile.get_preferred_name())
+
+        ## - Update edge to INVITED_LABEL
+        edge.label=invite_label
+        edge.readers=[r if r != edge.tail else user_profile.id for r in edge.readers]
+        edge.tail=user_profile.id
+        edge.cdate=None 
+        client.post_edge(edge)

--- a/openreview/journal/process/solicit_review_approval_process.py
+++ b/openreview/journal/process/solicit_review_approval_process.py
@@ -29,7 +29,7 @@ def process(client, edit, invitation):
         print('Send email to solicit reviewer')
         review_period_length = journal.get_review_period_length(submission)
         duedate = journal.get_due_date(weeks = review_period_length)
-        assigned_action_editor = client.search_profiles(ids=[submission.content['assigned_action_editor']['value']])[0]
+        assigned_action_editor = client.search_profiles(ids=[submission.content['assigned_action_editor']['value'].split(',')[0]])[0]
 
         client.post_message(
             recipients=solicit_request.signatures,

--- a/tests/test_dmlr_journal.py
+++ b/tests/test_dmlr_journal.py
@@ -781,6 +781,7 @@ note: replies to this email will go to the AE, Andrew Ng.
                             ))
 
         helpers.await_queue_edit(openreview_client, edit_id=verification_note['id'])
+        helpers.await_queue_edit(openreview_client, invitation='DMLR/-/Accepted')
 
         note = openreview_client.get_note(note_id_1)
         assert note
@@ -810,6 +811,12 @@ issn={XXXX-XXXX},
 year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},
 note={Featured Certification, Reproducibility Certification}
-}'''               
+}'''
+
+        reviews = openreview_client.get_notes(forum=note_id_1, invitation='DMLR/Paper1/-/Review', sort= 'number:asc')
+
+        for review in reviews:
+            assert review.readers == ['everyone']
+            assert review.signatures == [review.signatures[0]]
 
 

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -4996,16 +4996,20 @@ note={Expert Certification}
 
         helpers.await_queue_edit(openreview_client, invitation='TMLR/-/Under_Review')
 
-        ## Invite external reviewer
+        ## Invite external reviewer with profile
         paper_assignment_edge = samy_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Invite_Assignment',
             signatures=[joelle_paper13_anon_group.id],
             head=note_id_13,
-            tail='~Melisa_Bok1',
+            tail='melisa@mailten.com',
             weight=1,
             label='Invitation Sent'
         ))
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
+
+        invite_edges=openreview_client.get_edges(invitation='TMLR/Reviewers/-/Invite_Assignment', head=note_id_13, tail='~Melisa_Bok1')
+        assert len(invite_edges) == 1
+        assert invite_edges[0].label == 'Invitation Sent'         
 
         messages = openreview_client.get_messages(to = 'melisa@mailten.com', subject = '[TMLR] Invitation to review paper titled "Paper title 14"')
         assert len(messages) == 1

--- a/tests/test_tacl_journal.py
+++ b/tests/test_tacl_journal.py
@@ -46,6 +46,7 @@ class TestTACLJournal():
                     'settings': {
                         'value': {
                             'submission_public': False,
+                            'release_submission_after_acceptance': False,
                             'skip_ac_recommendation': True,
                             'skip_reviewer_responsibility_acknowledgement': True,
                             'assignment_delay': 0,


### PR DESCRIPTION
A few fixes for the Journal workflow:

- add a property `release_submission_after_acceptance` to release the submission, reveal authors and release reviews to the public if the journal was originally private.
- fix index error when the submission has more than one AE assigned
- fix invite assignment process function, we forgot to update the tail if the email address has a profile associated with.  