### PR TITLE
Fix/venue add reply to param

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "args": [ "tests/test_iclr_conference_v2.py" ],
+            "name": "pytests",
+            "type": "python",
+            "request": "launch",
+            "program": "/opt/homebrew/bin/pytest",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "purpose": [ "debug-test" ],
+            "env": {"PYTEST_ADDOPTS": "--no-cov"}
+        }
+    ]
+}

--- a/openreview/venue/process/assignment_post_process.py
+++ b/openreview/venue/process/assignment_post_process.py
@@ -3,6 +3,7 @@ def process_update(client, edge, invitation, existing_edge):
     domain = client.get_group(edge.domain)
     venue_id = domain.id
     short_phrase = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     program_chairs_id = domain.content['program_chairs_id']['value']
     submission_name = domain.content['submission_name']['value']
     reviewers_name = invitation.content['reviewers_name']['value']
@@ -60,4 +61,4 @@ Thank you,
 
 {signature}'''
 
-        client.post_message(subject, recipients, message, parentGroup=group.id)
+        client.post_message(subject, recipients, message, parentGroup=group.id, replyTo=contact)

--- a/openreview/venue/process/comment_process.py
+++ b/openreview/venue/process/comment_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     domain = client.get_group(edit.domain)
     venue_id = domain.id
     short_name = domain.get_content_value('subtitle')
+    contact = domain.get_content_value('contact')
     authors_name = domain.get_content_value('authors_name')
     submission_name = domain.get_content_value('submission_name')
     reviewers_name = domain.get_content_value('reviewers_name')
@@ -51,7 +52,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             recipients=[paper_senior_area_chairs_id],
             ignoreRecipients = ignore_groups,
             subject=f'''[{short_name}] {pretty_signature} commented on a paper in your area. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-            message=f'''{pretty_signature} commented on a paper for which you are serving as Senior Area Chair.{content}'''
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Senior Area Chair.{content}''',
+            replyTo=contact
         )
 
     area_chairs_name = domain.get_content_value('area_chairs_name')
@@ -61,7 +63,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             recipients=[paper_area_chairs_id],
             ignoreRecipients=ignore_groups,
             subject=f'''[{short_name}] {pretty_signature} commented on a paper in your area. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-            message=f'''{pretty_signature} commented on a paper for which you are serving as Area Chair.{content}'''
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Area Chair.{content}''',
+            replyTo=contact
         )
 
     paper_reviewers_id = f'{paper_group_id}/{reviewers_name}'
@@ -71,14 +74,16 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             recipients=[paper_reviewers_id],
             ignoreRecipients=ignore_groups,
             subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-            message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}'''
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
+            replyTo=contact
         )
     elif paper_reviewers_submitted_id in comment.readers:
         client.post_message(
             recipients=[paper_reviewers_submitted_id],
             ignoreRecipients=ignore_groups,
             subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-            message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}'''
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
+            replyTo=contact
         )
     else:
         anon_reviewers = [reader for reader in comment.readers if reader.find(reviewers_anon_name) >=0]
@@ -87,14 +92,16 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
                 recipients=anon_reviewers,
                 ignoreRecipients=ignore_groups,
                 subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-                message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}'''
+                message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
+                replyTo=contact
             )
 
     #send email to author of comment
     client.post_message(
         recipients=[edit.tauthor] if edit.tauthor != 'OpenReview.net' else [],
         subject=f'''[{short_name}] Your comment was received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-        message=f'''Your comment was received on a submission to {short_name}.{content}'''
+        message=f'''Your comment was received on a submission to {short_name}.{content}''',
+        replyTo=contact
     )
 
     #send email to paper authors
@@ -104,5 +111,6 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             recipients=submission.content['authorids']['value'],
             ignoreRecipients=ignore_groups,
             subject=f'''[{short_name}] {pretty_signature} commented on your submission. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-            message=f'''{pretty_signature} commented on your submission.{content}'''
+            message=f'''{pretty_signature} commented on your submission.{content}''',
+            replyTo=contact
         )

--- a/openreview/venue/process/custom_stage_process.py
+++ b/openreview/venue/process/custom_stage_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     domain = client.get_group(edit.domain)
     venue_id = domain.id
     short_name = domain.get_content_value('subtitle')
+    contact = domain.get_content_value('contact')
     submission_name = domain.get_content_value('submission_name')
     invitation_name = invitation.id.split('/-/')[-1].replace('_', ' ').lower()
     meta_invitation = client.get_invitation(invitation.invitations[0])
@@ -53,6 +54,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
     #email tauthor
     client.post_message(
         recipients=note.signatures,
+        replyTo=contact,
         subject=f'''[{short_name}] Your {invitation_name} has been received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
         message=f'''We have received your {invitation_name} on a submission to {short_name}.
 
@@ -68,6 +70,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             recipients=[paper_senior_area_chairs_id],
             ignoreRecipients = ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] A {invitation_name} has been received on your assigned Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''We have received a {invitation_name} on a submission to {short_name} for which you are serving as Senior Area Chair.
 
@@ -82,6 +85,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             recipients=[paper_area_chairs_id],
             ignoreRecipients = ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] A {invitation_name} has been received on your assigned Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''We have received a {invitation_name} on a submission to {short_name} for which you are an official area chair.
 
@@ -98,6 +102,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             recipients=[paper_reviewers_id],
             ignoreRecipients=ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] A {invitation_name} has been received on your assigned Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''We have received a {invitation_name} on a submission to {short_name} for which you are serving as reviewer.
 
@@ -108,6 +113,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             recipients=[paper_reviewers_submitted_id],
             ignoreRecipients=ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] A {invitation_name} has been received on your assigned Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''We have received a {invitation_name} on a submission to {short_name} for which you are serving as reviewer.
 
@@ -122,6 +128,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             recipients=submission.content['authorids']['value'],
             ignoreRecipients=ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] A {invitation_name} has been received on your Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''We have recieved a {invitation_name} on your submission to {short_name}
 

--- a/openreview/venue/process/decision_process.py
+++ b/openreview/venue/process/decision_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     domain = client.get_group(edit.domain)
     venue_id = domain.id
     short_name = domain.get_content_value('subtitle')
+    contact = domain.get_content_value('contact')
     authors_name = domain.get_content_value('authors_name')
     submission_name = domain.get_content_value('submission_name')    
     authors_accepted_id = domain.get_content_value('authors_accepted_id')    
@@ -20,7 +21,8 @@ def process(client, edit, invitation):
         client.post_message(
             recipients=[paper_authors_id],
             subject=f'''[{short_name}] Decision {action} your submission - Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-            message=f'''To view the decision, click here: https://openreview.net/forum?id={submission.id}&noteId={decision.id}'''
+            message=f'''To view the decision, click here: https://openreview.net/forum?id={submission.id}&noteId={decision.id}''',
+            replyTo=contact
         )
 
     if (authors_accepted_id):      

--- a/openreview/venue/process/desk_rejected_submission_process.py
+++ b/openreview/venue/process/desk_rejected_submission_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     domain = client.get_group(edit.domain)
     venue_id = domain.id
     short_name = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     desk_rejection_reversion_id = domain.content['desk_rejection_reversion_id']['value']
     desk_reject_expiration_id = domain.content['desk_reject_expiration_id']['value']
     desk_reject_committee = domain.content['desk_reject_committee']['value']
@@ -63,4 +64,4 @@ def process(client, edit, invitation):
 For more information, click here https://openreview.net/forum?id={submission.id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body, ignoreRecipients=ignoreRecipients)
+    client.post_message(email_subject, final_committee, email_body, ignoreRecipients=ignoreRecipients, replyTo=contact)

--- a/openreview/venue/process/desk_rejection_reversion_submission_process.py
+++ b/openreview/venue/process/desk_rejection_reversion_submission_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     domain = client.get_group(edit.domain)
     venue_id = domain.id
     short_name = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     desk_rejected_submission_id = domain.content['desk_rejected_submission_id']['value']
     desk_reject_expiration_id = domain.content['desk_reject_expiration_id']['value']
     desk_reject_committee = domain.content['desk_reject_committee']['value']
@@ -46,7 +47,7 @@ def process(client, edit, invitation):
 For more information, click here https://openreview.net/forum?id={submission.id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body)
+    client.post_message(email_subject, final_committee, email_body, replyTo=contact)
 
     print(f'Add {paper_group_id}/{authors_name} to {venue_id}/{authors_name}')
     client.add_members_to_group(f'{venue_id}/{authors_name}', f'{paper_group_id}/{authors_name}')

--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -2,6 +2,7 @@ def process(client, edge, invitation):
 
     domain = client.get_group(invitation.domain)
     short_phrase = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     recruitment_invitation_id = invitation.content['recruitment_invitation_id']['value']
     committee_invited_id = invitation.content['committee_invited_id']['value']
     invite_label = invitation.content['invite_label']['value']
@@ -12,6 +13,8 @@ def process(client, edge, invitation):
     email_template = invitation.content['email_template']['value']
     is_reviewer = 'Reviewers' in assignment_invitation_id
     action_string = 'to review' if is_reviewer else 'to serve as area chair for'
+    area_chair_identity_readers = domain.content['area_chair_identity_readers']['value']
+    reviewer_identity = domain.content['reviewers_id']['value']
     print(edge.id)
 
     if edge.ddate is None and edge.label == invite_label:
@@ -93,7 +96,7 @@ Thanks,
             client.add_members_to_group(committee_invited_id, [user_profile.id])
 
         ## - Send email
-        response = client.post_message(subject, [user_profile.id], message, parentGroup=committee_invited_id)
+        response = client.post_message(subject, [user_profile.id], message, parentGroup=committee_invited_id, replyTo=contact)
 
         ## - Update edge to INVITED_LABEL
         edge.label=invited_label

--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -13,8 +13,6 @@ def process(client, edge, invitation):
     email_template = invitation.content['email_template']['value']
     is_reviewer = 'Reviewers' in assignment_invitation_id
     action_string = 'to review' if is_reviewer else 'to serve as area chair for'
-    area_chair_identity_readers = domain.content['area_chair_identity_readers']['value']
-    reviewer_identity = domain.content['reviewers_id']['value']
     print(edge.id)
 
     if edge.ddate is None and edge.label == invite_label:

--- a/openreview/venue/process/pc_submission_revision_process.py
+++ b/openreview/venue/process/pc_submission_revision_process.py
@@ -4,6 +4,7 @@ def process(client, edit, invitation):
     venue_id = domain.id
     meta_invitation_id = domain.content['meta_invitation_id']['value']
     short_name = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     authors_name = domain.content['authors_name']['value']
     submission_name = domain.content['submission_name']['value']
 
@@ -24,7 +25,8 @@ To view your submission, click here: https://openreview.net/forum?id={submission
     client.post_message(
         subject=subject,
         recipients=submission.content['authorids']['value'],
-        message=message
+        message=message,
+        replyTo=contact
     )
 
     if 'authorids' in submission.content:

--- a/openreview/venue/process/recruitment_process.py
+++ b/openreview/venue/process/recruitment_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     import urllib.parse
     domain = client.get_group(invitation.domain)
     short_phrase = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     committee_name = invitation.content['committee_name']['value']
     committee_invited_id = invitation.content['committee_invited_id']['value']
     committee_id = invitation.content['committee_id']['value']
@@ -38,7 +39,7 @@ def process(client, edit, invitation):
 
                 subject = f'[{short_phrase}] {committee_name} Invitation not accepted'
                 message = f'''It seems like you already accepted an invitation to serve as a {overlap_committee_name} for {short_phrase}. If you would like to change your decision and serve as a {committee_name}, please decline the invitation to be {overlap_committee_name} and then accept the inviation to be {committee_name}.'''
-                client.post_message(subject, [user], message)
+                client.post_message(subject, [user], message, replyTo=contact)
                 return
 
             client.remove_members_from_group(committee_declined_id, members_to_remove)
@@ -55,7 +56,7 @@ The {short_phrase} program chairs will be contacting you with more information r
 
 If you would like to change your decision, please follow the link in the previous invitation email and click on the "Decline" button.'''
 
-            client.post_message(subject, [user], message, parentGroup=committee_id)
+            client.post_message(subject, [user], message, parentGroup=committee_id, replyTo=contact)
             return
 
         if (response == 'No'):
@@ -67,7 +68,7 @@ If you would like to change your decision, please follow the link in the previou
 
 If you would like to change your decision, please follow the link in the previous invitation email and click on the "Accept" button.'''
 
-            client.post_message(subject, [user], message, parentGroup=committee_declined_id)
+            client.post_message(subject, [user], message, parentGroup=committee_declined_id, replyTo=contact)
 
         else:
             raise openreview.OpenReviewException('Invalid response')

--- a/openreview/venue/process/review_process.py
+++ b/openreview/venue/process/review_process.py
@@ -4,6 +4,7 @@ def process(client, edit, invitation):
     venue_id = domain.id
     meta_invitation_id = domain.content['meta_invitation_id']['value']
     short_name = domain.get_content_value('subtitle')
+    contact = domain.get_content_value('contact')
     authors_name = domain.get_content_value('authors_name')
     submission_name = domain.get_content_value('submission_name')
     reviewers_name = domain.get_content_value('reviewers_name')
@@ -69,6 +70,7 @@ def process(client, edit, invitation):
 
     client.post_message(
         recipients=review.signatures,
+        replyTo=contact,
         subject=f'''[{short_name}] Your {review_name} has been received on your assigned Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
         message=f''''We have received a review on a submission to {short_name}.
 
@@ -83,6 +85,7 @@ Paper title: {submission.content['title']['value']}
         client.post_message(
             recipients=[paper_area_chairs_id],
             ignoreRecipients=ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] {capital_review_name} posted to your assigned Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
             message=f''''A submission to {short_name}, for which you are an official area chair, has received a review.
 
@@ -99,6 +102,7 @@ Paper title: {submission.content['title']['value']}
         client.post_message(
             recipients=[paper_reviewers_id],
             ignoreRecipients=ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] {capital_review_name} posted to your assigned Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
             message=f''''A submission to {short_name}, for which you are a reviewer, has received a review.
 
@@ -113,6 +117,7 @@ Paper title: {submission.content['title']['value']}
         client.post_message(
             recipients=[paper_reviewers_submitted_id],
             ignoreRecipients=ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] {capital_review_name} posted to your assigned Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
             message=f''''A submission to {short_name}, for which you are a reviewer, has received a review.
 
@@ -129,6 +134,7 @@ Paper title: {submission.content['title']['value']}
         client.post_message(
             recipients=[paper_authors_id],
             ignoreRecipients=ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] {capital_review_name} posted to your submission - Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
             message=f''''Your submission to {short_name} has received a review.
 

--- a/openreview/venue/process/review_rebuttal_process.py
+++ b/openreview/venue/process/review_rebuttal_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     domain = client.get_group(edit.domain)
     venue_id = domain.id
     short_name = domain.get_content_value('subtitle')
+    contact = domain.get_content_value('contact')
     submission_name = domain.get_content_value('submission_name')
     program_chairs_id = domain.get_content_value('program_chairs_id')
     email_pcs = domain.get_content_value('rebuttal_email_pcs')
@@ -31,7 +32,8 @@ Title: {submission.content['title']['value']}
     client.post_message(
         recipients=[edit.tauthor] if edit.tauthor != 'OpenReview.net' else [],
         subject=f'''[{short_name}] Your author rebuttal was {action} on Submission Number: {submission.number}, Submission Title: "{submission.content['title']['value']}"''',
-        message=author_message
+        message=author_message,
+        replyTo=contact
     )
 
     #send email to paper authors
@@ -39,7 +41,8 @@ Title: {submission.content['title']['value']}
         recipients=submission.content['authorids']['value'],
         ignoreRecipients=ignore_groups,
         subject=f'''[{short_name}] An author rebuttal was {action} on Submission Number: {submission.number}, Submission Title: "{submission.content['title']['value']}"''',
-        message=author_message
+        message=author_message,
+        replyTo=contact
     )
 
     if email_pcs:
@@ -63,6 +66,7 @@ Title: {submission.content['title']['value']}
         client.post_message(
             recipients=[paper_area_chairs_id],
             ignoreRecipients=ignore_groups,
+            replyTo=contact,
             subject=f'''[{short_name}] An author rebuttal was {action} on Submission Number: {submission.number}, Submission Title: "{submission.content['title']['value']}"''',
             message=f'''An author rebuttal was {action} on a submission for which you are serving as Area Chair.
 
@@ -92,14 +96,16 @@ Title: {submission.content['title']['value']}
             recipients=[paper_reviewers_id],
             ignoreRecipients=ignore_groups,
             subject=reviewer_subject,
-            message=reviewer_message
+            message=reviewer_message,
+            replyTo=contact
         )
     elif paper_reviewers_submitted_id in rebuttal.readers:
         client.post_message(
             recipients=[paper_reviewers_submitted_id],
             ignoreRecipients=ignore_groups,
             subject=reviewer_subject,
-            message=reviewer_message
+            message=reviewer_message,
+            replyTo=contact
         )
 
     

--- a/openreview/venue/process/submission_process.py
+++ b/openreview/venue/process/submission_process.py
@@ -7,6 +7,7 @@ def process(client, edit, invitation):
     authors_name = domain.content['authors_name']['value']
     submission_name = domain.content['submission_name']['value']
     short_phrase = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     submission_email = domain.content['submission_email_template']['value']
     email_pcs = domain.content['submission_email_pcs']['value']
     program_chairs_id = domain.content['program_chairs_id']['value']
@@ -121,7 +122,8 @@ To view your submission, click here: https://openreview.net/forum?id={note.forum
         client.post_message(
             subject=author_subject,
             message=author_message,
-            recipients=[edit.tauthor]
+            recipients=[edit.tauthor],
+            replyTo=contact
         )
 
     # send co-author emails
@@ -131,7 +133,8 @@ To view your submission, click here: https://openreview.net/forum?id={note.forum
             subject=author_subject,
             message=author_message,
             recipients=note.content['authorids']['value'],
-            ignoreRecipients=[edit.tauthor]
+            ignoreRecipients=[edit.tauthor],
+            replyTo=contact
         )
 
     if email_pcs:

--- a/openreview/venue/process/submission_revision_process.py
+++ b/openreview/venue/process/submission_revision_process.py
@@ -4,6 +4,7 @@ def process(client, edit, invitation):
     venue_id = domain.id
     meta_invitation_id = domain.content['meta_invitation_id']['value']
     short_name = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     authors_name = domain.content['authors_name']['value']
     submission_name = domain.content['submission_name']['value']
 
@@ -24,7 +25,8 @@ To view your submission, click here: https://openreview.net/forum?id={submission
     client.post_message(
         subject=subject,
         recipients=submission.content['authorids']['value'],
-        message=message
+        message=message,
+        replyTo=contact
     )
 
     if 'authorids' in submission.content:

--- a/openreview/venue/process/withdrawal_reversion_submission_process.py
+++ b/openreview/venue/process/withdrawal_reversion_submission_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     domain = client.get_group(edit.domain)
     venue_id = domain.id
     short_name = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     withdrawn_submission_id = domain.content['withdrawn_submission_id']['value']
     withdraw_expiration_id = domain.content['withdraw_expiration_id']['value']
     withdraw_committee = domain.content['withdraw_committee']['value']
@@ -46,7 +47,7 @@ def process(client, edit, invitation):
 For more information, click here https://openreview.net/forum?id={submission.id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body)
+    client.post_message(email_subject, final_committee, email_body, replyTo=contact)
 
     print(f'Add {paper_group_id}/{authors_name} to {venue_id}/{authors_name}')
     client.add_members_to_group(f'{venue_id}/{authors_name}', f'{paper_group_id}/{authors_name}')

--- a/openreview/venue/process/withdrawn_submission_process.py
+++ b/openreview/venue/process/withdrawn_submission_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     domain = client.get_group(edit.domain)
     venue_id = domain.id
     short_name = domain.content['subtitle']['value']
+    contact = domain.content['contact']['value']
     withdraw_reversion_id = domain.content['withdraw_reversion_id']['value']
     withdraw_expiration_id = domain.content['withdraw_expiration_id']['value']
     withdraw_committee = domain.content['withdraw_committee']['value']
@@ -60,4 +61,4 @@ def process(client, edit, invitation):
 For more information, click here https://openreview.net/forum?id={submission.id}&noteId={withdrawal_notes[0].id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body, ignoreRecipients=ignoreRecipients)
+    client.post_message(email_subject, final_committee, email_body, ignoreRecipients=ignoreRecipients, replyTo=contact)

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -80,9 +80,6 @@ class Venue(object):
     def get_short_name(self):
         return self.short_name
     
-    def get_contact(self):
-        return self.contact
-    
     def get_edges_archive_date(self):
         archive_date = datetime.datetime.utcnow()
         if self.date:
@@ -798,7 +795,7 @@ Total Errors: {len(errors)}
                 message = messages[decision_note['content']['decision']['value']]
                 final_message = message.replace("{{submission_title}}", note.content['title']['value'])
                 final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={note.id}')
-                self.client.post_message(subject, recipients=[self.get_authors_id(note.number)], message=final_message, parentGroup=self.get_authors_id(), replyTo=self.get_contact())
+                self.client.post_message(subject, recipients=[self.get_authors_id(note.number)], message=final_message, parentGroup=self.get_authors_id(), replyTo=self.contact)
 
         tools.concurrent_requests(send_notification, paper_notes)
 

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -80,6 +80,9 @@ class Venue(object):
     def get_short_name(self):
         return self.short_name
     
+    def get_contact(self):
+        return self.contact
+    
     def get_edges_archive_date(self):
         archive_date = datetime.datetime.utcnow()
         if self.date:
@@ -795,7 +798,7 @@ Total Errors: {len(errors)}
                 message = messages[decision_note['content']['decision']['value']]
                 final_message = message.replace("{{submission_title}}", note.content['title']['value'])
                 final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={note.id}')
-                self.client.post_message(subject, recipients=[self.get_authors_id(note.number)], message=final_message, parentGroup=self.get_authors_id())
+                self.client.post_message(subject, recipients=[self.get_authors_id(note.number)], message=final_message, parentGroup=self.get_authors_id(), replyTo=self.get_contact())
 
         tools.concurrent_requests(send_notification, paper_notes)
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -1062,6 +1062,7 @@ reviewer6@gmail.com, Reviewer ICMLSix
 
         messages = openreview_client.get_messages(to = 'melisa@yahoo.com', subject = 'ICML 2023 has received a new revision of your submission titled Paper title 1 Version 2')
         assert len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'pc@icml.cc'
         assert messages[0]['content']['text'] == f'''Your new revision of the submission to ICML 2023 has been posted.
 
 Title: Paper title 1 Version 2
@@ -1960,6 +1961,7 @@ OpenReview Team'''
 
         messages = openreview_client.get_messages(to='celeste@icml.cc', subject='[ICML 2023] You have been assigned as a Reviewer for paper number 1')
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'pc@icml.cc'
         assert messages[0]['content']['text'] == f'''This is to inform you that you have been assigned as a Reviewer for paper number 1 for ICML 2023.
 
 To review this new assignment, please login to OpenReview and go to https://openreview.net/forum?id={submissions[0].id}.
@@ -2634,6 +2636,7 @@ ICML 2023 Conference Program Chairs'''
 
         messages = openreview_client.get_messages(to='reviewer1@icml.cc', subject='[ICML 2023] Your official review has been received on your assigned Paper number: 1, Paper title: "Paper title 1 Version 2"')
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'pc@icml.cc'
 
         ## check how the description is rendered
         note = review_edit['note']
@@ -3823,9 +3826,11 @@ ICML 2023 Conference Program Chairs'''
         pretty_signature = openreview.tools.pretty_id(signature)
         messages = openreview_client.get_messages(to='ac2@icml.cc', subject=f'[ICML 2023] {pretty_signature} commented on a paper in your area. Paper Number: 1, Paper Title: "Paper title 1 Version 2"')
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'pc@icml.cc'
 
         messages = openreview_client.get_messages(to='reviewer1@icml.cc', subject='[ICML 2023] Your comment was received on Paper Number: 1, Paper Title: "Paper title 1 Version 2"')
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'pc@icml.cc'
 
         comment_edit = reviewer_client.post_note_edit(
             invitation='ICML.cc/2023/Conference/Submission1/-/Official_Comment',
@@ -4239,6 +4244,7 @@ ICML 2023 Conference Program Chairs'''
         messages = openreview_client.get_messages(subject = '[ICML 2023] Your author rebuttal was posted on Submission Number: 1, Submission Title: "Paper title 1 Version 2"')
         assert len(messages) == 2
         assert 'test@mail.com' in messages[0]['content']['to']
+        assert messages[0]['content']['replyTo'] == 'pc@icml.cc'
         messages = openreview_client.get_messages(subject = '[ICML 2023] An author rebuttal was posted on Submission Number: 1, Submission Title: "Paper title 1 Version 2"')
         assert len(messages) == 8
         assert f'https://openreview.net/forum?id={review.forum}&noteId={rebuttal_id}' in messages[4]['content']['text']
@@ -4874,6 +4880,7 @@ Best,
 
         messages = client.get_messages(subject='[ICML 2023] Decision notification for your submission 1: Paper title 1 Version 2')
         assert len(messages) == 5
+        assert messages[0]['content']['replyTo'] == 'pc@icml.cc'
         recipients = [msg['content']['to'] for msg in messages]
         assert 'sac1@gmail.com' in recipients
         assert 'test@mail.com' in recipients

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -215,6 +215,7 @@ Please see our [call for papers](https://nips.cc/Conferences/2023/CallForPapers)
 
         messages = client.get_messages(to='sac1@google.com', subject='[NeurIPS 2023] Senior Area Chair Invitation accepted')
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'pc@neurips.cc'
         assert messages[0]['content']['text'] == '''Thank you for accepting the invitation to be a Senior Area Chair for NeurIPS 2023.
 
 The NeurIPS 2023 program chairs will be contacting you with more information regarding next steps soon. In the meantime, please add noreply@openreview.net to your email contacts to ensure that you receive all communications.
@@ -223,7 +224,6 @@ If you would like to change your decision, please follow the link in the previou
 
         messages = client.get_messages(to='sac2@gmail.com', subject='[NeurIPS 2023] Invitation to serve as Senior Area Chair')
         assert messages and len(messages) == 1
-        assert messages[0]['content']['replyTo'] == 'pc@neurips.cc'
         assert messages[0]['content']['subject'] == '[NeurIPS 2023] Invitation to serve as Senior Area Chair'
         assert messages[0]['content']['text'].startswith('Dear SAC Two,\n\nYou have been nominated by the program chair committee of NeurIPS 2023 to serve as Senior Area Chair.')
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -223,6 +223,7 @@ If you would like to change your decision, please follow the link in the previou
 
         messages = client.get_messages(to='sac2@gmail.com', subject='[NeurIPS 2023] Invitation to serve as Senior Area Chair')
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'pc@neurips.cc'
         assert messages[0]['content']['subject'] == '[NeurIPS 2023] Invitation to serve as Senior Area Chair'
         assert messages[0]['content']['text'].startswith('Dear SAC Two,\n\nYou have been nominated by the program chair committee of NeurIPS 2023 to serve as Senior Area Chair.')
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -1156,6 +1156,7 @@ class TestVenueRequest():
         #check co-author email
         messages = client.get_messages(to='venue_author_v2@mail.com', subject="TestVenue@OR'2030V2 has received your submission titled test submission 2")
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'test@mail.com'
         assert 'If you have any questions, please contact the PCs at test@mail.com' in messages[0]['content']['text']
         assert 'If you are not an author of this submission and would like to be removed, please contact the author who added you at venue_author_v2_2@mail.com' in messages[0]['content']['text']
 
@@ -2423,6 +2424,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
             to='venue_author_v2@mail.com',
             subject="[TestVenue@OR'2030V2] Decision posted to your submission - Paper Number: 1, Paper Title: \"test submission\"")
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'test@mail.com'
         assert messages[0]['content']['text'] == f'''To view the decision, click here: https://openreview.net/forum?id={submission.id}&noteId={decision_note['note']['id']}'''
 
         with open(os.path.join(os.path.dirname(__file__), 'data/decisions_more.csv'), 'w') as file_handle:

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -611,6 +611,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
 
         messages = openreview_client.get_messages(to='celeste@maileleven.com', subject='[TV 22]: Paper #2 withdrawn by paper authors')
         assert len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'testvenue@contact.com'
         assert messages[0]['content']['text'] == f'The TV 22 paper \"Paper 2 Title\" has been withdrawn by the paper authors.\n\nFor more information, click here https://openreview.net/forum?id={note.id}&noteId={withdraw_note["note"]["id"]}\n'
 
         assert openreview_client.get_invitation('TestVenue.cc/Submission2/-/Withdrawal_Reversion')
@@ -649,6 +650,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
 
         messages = openreview_client.get_messages(to='celeste@maileleven.com', subject='[TV 22]: Paper #2 restored by venue organizers')
         assert len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'testvenue@contact.com'
         assert messages[0]['content']['text'] == f'The TV 22 paper \"Paper 2 Title\" has been restored by the venue organizers.\n\nFor more information, click here https://openreview.net/forum?id={note.id}\n'
 
         authors_group = openreview_client.get_group('TestVenue.cc/Authors')
@@ -695,6 +697,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         messages = openreview_client.get_messages(to='celeste@maileleven.com', subject='[TV 22]: Paper #2 desk-rejected by Program Chairs')
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'The TV 22 paper \"Paper 2 Title\" has been desk-rejected by Program Chairs.\n\nFor more information, click here https://openreview.net/forum?id={note.id}\n'
+        assert messages[0]['content']['replyTo'] == 'testvenue@contact.com'
 
         messages = openreview_client.get_messages(to='venue_pc@mail.com', subject='[TV 22]: Paper #2 desk-rejected by Program Chairs')
         assert len(messages) == 1
@@ -736,6 +739,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         messages = openreview_client.get_messages(to='celeste@maileleven.com', subject='[TV 22]: Paper #2 restored by venue organizers')
         assert len(messages) == 2
         assert messages[0]['content']['text'] == f'The TV 22 paper \"Paper 2 Title\" has been restored by the venue organizers.\n\nFor more information, click here https://openreview.net/forum?id={note.id}\n'
+        assert messages[0]['content']['replyTo'] == 'testvenue@contact.com'
 
         messages = openreview_client.get_messages(to='venue_pc@mail.com', subject='[TV 22]: Paper #2 restored by venue organizers')
         assert len(messages) == 2
@@ -817,6 +821,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
 
         messages = client.get_messages(to = 'celeste@maileleven.com', subject='TV 22 has received a new revision of your submission titled Paper 1 Title REVISED AGAIN')
         assert messages and len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'testvenue@contact.com'
 
         message_text = f'''Your new revision of the submission to TV 22 has been posted.
 
@@ -881,6 +886,7 @@ To view your submission, click here: https://openreview.net/forum?id={updated_no
 
         messages = openreview_client.get_messages(subject='[TV 22] A camera ready verification has been received on your Paper Number: 1, Paper Title: "Paper 1 Title REVISED AGAIN"')
         assert len(messages) == 1
+        assert messages[0]['content']['replyTo'] == 'testvenue@contact.com'
         assert 'celeste@maileleven.com' in messages[0]['content']['to']
         assert messages[0]['content']['text'] == f'''The camera ready verification for submission number {str(submissions[0].number)} has been posted.
 Please follow this link: https://openreview.net/forum?id={submissions[0].id}&noteId={verification_note.id}'''

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -343,6 +343,7 @@ class TestWorkshopV2():
         assert messages and len(messages) == 1
         # Test that abstract doesn't appear in Invite Assignment email
         assert messages[0]['content']['text'].startswith('Hi External Reviewer Adobe,\n\nYou were invited to review the paper number: 12, title: "Paper title No Abstract Version 2".\n\nPlease respond the invitation clicking the following link:')
+        assert messages[0]['content']['replyTo'] == 'pc@icaps.cc'
 
     def test_publication_chair(self, client, openreview_client, helpers):
 


### PR DESCRIPTION
- Resolves #1553 

This adds the domain contact email as the `replyTo` for `post_message` calls. Not affected are the emails that tell the user to contact us directly, that are signed off with "OpenReview Team", or emails that are already sent to the PCs.