### PR TITLE
Fix/ Custom Stage: set note id to id of note being revised

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2039,6 +2039,12 @@ class InvitationBuilder(object):
         if custom_stage_reply_type == 'reply':
             paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, number='${2/content/noteNumber/value}')
             with_invitation = self.venue.get_invitation_id(name=custom_stage.name, number='${6/content/noteNumber/value}')
+            note_id = {
+                'param': {
+                    'withInvitation': with_invitation,
+                    'optional': True
+                }
+            }
             edit_readers = ['${2/note/readers}']
             note_readers = custom_stage.get_readers(self.venue, '${5/content/noteNumber/value}')
             invitees = custom_stage.get_invitees(self.venue, number='${3/content/noteNumber/value}')
@@ -2063,10 +2069,16 @@ class InvitationBuilder(object):
             submission_prefix = venue_id + '/' + self.venue.submission_stage.name + '${6/content/noteNumber/value}/'
             reply_prefix = stage_name + '${6/content/replyNumber/value}'
             with_invitation = self.venue.get_invitation_id(name=custom_stage.name, prefix=submission_prefix+reply_prefix)
+            note_id = {
+                'param': {
+                    'withInvitation': with_invitation,
+                    'optional': True
+                }
+            }
             reply_to = '${4/content/replyto/value}'
 
             if custom_stage_reply_type == 'revision':
-                with_invitation = self.venue.get_invitation_id(name=stage_name, number='${6/content/noteNumber/value}')
+                note_id = '${4/content/replyto/value}'
                 reply_to = None
                 edit_readers = [venue_id, '${2/signatures}']
                 note_readers = None
@@ -2140,12 +2152,7 @@ class InvitationBuilder(object):
                         'readers': edit_readers,
                         'writers': [venue_id],
                         'note': {
-                            'id': {
-                                'param': {
-                                    'withInvitation': with_invitation,
-                                    'optional': True
-                                }
-                            },
+                            'id': note_id,
                             'forum': '${4/content/noteId/value}',
                             'ddate': {
                                 'param': {

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -1840,7 +1840,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert invitation.edit['note']['forum'] == review_note['note']['forum']
         assert invitation.edit['note']['replyto'] == review_note['note']['id']
 
-    def test_review_rating(self, client, helpers, venue, openreview_client):
+    def test_review_revision(self, client, helpers, venue, openreview_client):
 
         venue = openreview.get_conference(client, venue['request_form_note'].id, support_user='openreview.net/Support')
 
@@ -1902,6 +1902,9 @@ Please refer to the documentation for instructions on how to run the matcher: ht
                                   'V2.cc/2030/Conference/Submission1/Reviewers',
                                   'V2.cc/2030/Conference/Submission1/Authors']
         assert 'readers' in review.content['review_rating']
+
+        assert invitation.edit['note']['forum'] == review.forum
+        assert invitation.edit['note']['id'] == review.id
 
         review_revision = reviewer_client.post_note_edit(
             invitation='V2.cc/2030/Conference/Submission1/Official_Review1/-/Review_Revision',
@@ -1975,6 +1978,12 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert 'review_quality' in invitation.edit['note']['content']
         assert invitation.edit['note']['forum'] == submissions[0].id
         assert invitation.edit['note']['replyto'] == reviews[0]['id']
+        assert invitation.edit['note']['id'] == {
+            'param': {
+                'withInvitation': 'V2.cc/2030/Conference/Submission1/Official_Review1/-/Author_Review_Rating',
+                'optional': True
+            }
+        }
         assert invitation.edit['note']['readers'] == [
             'V2.cc/2030/Conference/Program_Chairs',
             '${3/signatures}'


### PR DESCRIPTION
Only for the case where `reply_type=='revision`, set the id of the note to the id of the note (review or metareview) being edited. For all other cases, we still use `withInvitation`