### PR TITLE
Journal: fix comment invitation, notify AE for new comment, fix number of reviewer

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -122,6 +122,7 @@ class GroupBuilder(object):
             content = content.replace("var EDITORS_IN_CHIEF_EMAIL = '';", "var EDITORS_IN_CHIEF_EMAIL = '" + self.journal.get_editors_in_chief_email() + "';")
             content = content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + self.journal.reviewers_name + "';")
             content = content.replace("var ACTION_EDITOR_NAME = '';", "var ACTION_EDITOR_NAME = '" + self.journal.action_editors_name + "';")
+            content = content.replace("var NUMBER_OF_REVIEWERS = 3;", "var NUMBER_OF_REVIEWERS = " + str(self.journal.get_number_of_reviewers()) + ";")
             if self.journal.request_form_id:
                 content = content.replace("var JOURNAL_REQUEST_ID = '';", "var JOURNAL_REQUEST_ID = '" + self.journal.request_form_id + "';")
             if reviewer_report_form:
@@ -209,6 +210,7 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
             content = content.replace("var ACTION_EDITOR_NAME = '';", "var ACTION_EDITOR_NAME = '" + self.journal.action_editors_name + "';")
             content = content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + self.journal.reviewers_name + "';")
             content = content.replace("var SUBMISSION_GROUP_NAME = '';", "var SUBMISSION_GROUP_NAME = '" + self.journal.submission_group_name + "';")
+            content = content.replace("var NUMBER_OF_REVIEWERS = 3;", "var NUMBER_OF_REVIEWERS = " + str(self.journal.get_number_of_reviewers()) + ";")
             if self.journal.request_form_id:
                 content = content.replace("var JOURNAL_REQUEST_ID = '';", "var JOURNAL_REQUEST_ID = '" + self.journal.request_form_id + "';")
             if reviewer_report_form:
@@ -272,6 +274,7 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
             content = content.replace("var ACTION_EDITOR_NAME = '';", "var ACTION_EDITOR_NAME = '" + self.journal.action_editors_name + "';")
             content = content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + self.journal.reviewers_name + "';")
             content = content.replace("var SUBMISSION_GROUP_NAME = '';", "var SUBMISSION_GROUP_NAME = '" + self.journal.submission_group_name + "';")
+            content = content.replace("var NUMBER_OF_REVIEWERS = 3;", "var NUMBER_OF_REVIEWERS = " + str(self.journal.get_number_of_reviewers()) + ";")
             if reviewer_report_form:
                 content = content.replace("var REVIEWER_REPORT_ID = '';", "var REVIEWER_REPORT_ID = '" + reviewer_report_form + "';")
 

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -532,10 +532,12 @@ class Journal(object):
         if self.is_submission_public():
             readers.append('everyone')
 
-        return readers + [
-            self.get_editors_in_chief_id(), 
-            self.get_action_editors_id(), 
-            self.get_action_editors_id(number), 
+        readers.append(self.get_editors_in_chief_id())
+
+        if not self.is_submission_public():
+            readers.append(self.get_action_editors_id())
+            
+        return readers + [self.get_action_editors_id(number), 
             self.get_reviewers_id(number), 
             self.get_reviewers_id(number, anon=True) + '.*', 
             self.get_authors_id(number)
@@ -786,7 +788,7 @@ Your {lower_formatted_invitation} on a submission has been {action}
 
 
         ## Notify action editors
-        if is_public or self.get_action_editors_id(number=forum.number) in readers:
+        if is_public or self.get_action_editors_id(number=forum.number) in readers or self.get_action_editors_id() in readers:
             message = f'''Hi {{{{fullname}}}},
 
 {before_invitation} {lower_formatted_invitation} has been {action} on a submission for which you are an Action Editor.

--- a/openreview/journal/webfield/actionEditorWebfield.js
+++ b/openreview/journal/webfield/actionEditorWebfield.js
@@ -15,6 +15,7 @@ var DECISION_NAME = 'Decision';
 var UNDER_REVIEW_STATUS = VENUE_ID + '/Under_Review';
 var JOURNAL_REQUEST_ID = '';
 var REVIEWER_REPORT_ID = '';
+var NUMBER_OF_REVIEWERS = 3;
 
 var REVIEWERS_ID = VENUE_ID + '/' + REVIEWERS_NAME;
 var REVIEWERS_ASSIGNMENT_ID = REVIEWERS_ID + '/-/Assignment';
@@ -265,7 +266,7 @@ var formatData = function(reviewersByNumber, invitations, submissions, invitatio
         id: reviewerAssignmentInvitation.id,
         cdate: reviewerAssignmentInvitation.cdate,
         duedate: reviewerAssignmentInvitation.duedate,
-        complete: reviewers.length >= 3,
+        complete: reviewers.length >= NUMBER_OF_REVIEWERS,
         replies: reviewers
       });
     }
@@ -275,7 +276,7 @@ var formatData = function(reviewersByNumber, invitations, submissions, invitatio
         id: reviewInvitation.id,
         cdate: reviewInvitation.cdate,
         duedate: reviewInvitation.duedate,
-        complete: reviewNotes.length >= 3,
+        complete: reviewNotes.length >= NUMBER_OF_REVIEWERS,
         replies: reviewNotes
       });
     }
@@ -285,7 +286,7 @@ var formatData = function(reviewersByNumber, invitations, submissions, invitatio
         id: officialRecommendationInvitation.id,
         cdate: officialRecommendationInvitation.cdate,
         duedate: officialRecommendationInvitation.duedate,
-        complete: officialRecommendationNotes.length >= 3,
+        complete: officialRecommendationNotes.length >= NUMBER_OF_REVIEWERS,
         replies: officialRecommendationNotes
       });
     }

--- a/openreview/journal/webfield/editorsInChiefWebfield.js
+++ b/openreview/journal/webfield/editorsInChiefWebfield.js
@@ -16,6 +16,7 @@ var REVIEWERS_NAME = '';
 var ACTION_EDITOR_NAME = '';
 var JOURNAL_REQUEST_ID = '';
 var REVIEWER_REPORT_ID = '';
+var NUMBER_OF_REVIEWERS = 3;
 var REVIEWER_ACKOWNLEDGEMENT_RESPONSIBILITY_ID = '';
 var ACTION_EDITOR_ID = VENUE_ID + '/' + ACTION_EDITOR_NAME;
 var REVIEWERS_ID = VENUE_ID + '/' + REVIEWERS_NAME;
@@ -431,7 +432,7 @@ var formatData = function(
         id: aeRecommendationInvitation.id,
         cdate: aeRecommendationInvitation.cdate,
         duedate: aeRecommendationInvitation.duedate,
-        complete: recommendationCount >= 3,
+        complete: recommendationCount >= NUMBER_OF_REVIEWERS,
         replies: Array(recommendationCount).fill(1)
       };
       earlylateTaskDueDate = updateEarlyLateTaskDuedate(earlylateTaskDueDate, task);
@@ -477,7 +478,7 @@ var formatData = function(
         id: reviewerAssignmentInvitation.id,
         cdate: reviewerAssignmentInvitation.cdate,
         duedate: reviewerAssignmentInvitation.duedate,
-        complete: reviewers.length >= 3,
+        complete: reviewers.length >= NUMBER_OF_REVIEWERS,
         replies: reviewers
       };
       earlylateTaskDueDate = updateEarlyLateTaskDuedate(earlylateTaskDueDate, task);
@@ -489,7 +490,7 @@ var formatData = function(
         id: reviewInvitation.id,
         cdate: reviewInvitation.cdate,
         duedate: reviewInvitation.duedate,
-        complete: reviewNotes.length >= 3,
+        complete: reviewNotes.length >= NUMBER_OF_REVIEWERS,
         replies: reviewNotes
       };
       earlylateTaskDueDate = updateEarlyLateTaskDuedate(earlylateTaskDueDate, task);
@@ -501,7 +502,7 @@ var formatData = function(
         id: officialRecommendationInvitation.id,
         cdate: officialRecommendationInvitation.cdate,
         duedate: officialRecommendationInvitation.duedate,
-        complete: officialRecommendationNotes.length >= 3,
+        complete: officialRecommendationNotes.length >= NUMBER_OF_REVIEWERS,
         replies: officialRecommendationNotes
       };
       earlylateTaskDueDate = updateEarlyLateTaskDuedate(earlylateTaskDueDate, task);
@@ -778,8 +779,8 @@ var formatData = function(
         actionEditor: actionEditor,
         metaReview: metaReview,
         referrer: referrerUrl,
-        reviewPending: reviewInvitation && reviewNotes.length < 3,
-        recommendationPending: officialRecommendationInvitation && officialRecommendationNotes.length < 3 && decisionNotes.length == 0,
+        reviewPending: reviewInvitation && reviewNotes.length < NUMBER_OF_REVIEWERS,
+        recommendationPending: officialRecommendationInvitation && officialRecommendationNotes.length < NUMBER_OF_REVIEWERS && decisionNotes.length == 0,
         ratingPending: reviewerRatingInvitations.length && reviewerRatingReplies.length < reviewNotes.length,
         decisionPending: decisionInvitation && decisionNotes.length == 0,
         decisionApprovalPending: metaReview && decisionApprovalNotes.length == 0,

--- a/tests/test_dmlr_journal.py
+++ b/tests/test_dmlr_journal.py
@@ -68,7 +68,7 @@ class TestDMLRJournal():
                             },
                             "editors_email": "dmlr@jmlr.org",
                             "skip_ac_recommendation": True,
-                            "number_of_reviewers": 3,
+                            "number_of_reviewers": 2,
                             "reviewers_max_papers": 6,
                             "ae_recommendation_period": 1,
                             "under_review_approval_period": 2,
@@ -359,7 +359,7 @@ Your first task is to make sure the submitted preprint is appropriate for DMLR a
 
 Please follow this link to perform this task: https://openreview.net/forum?id={note_id_1}&invitationId=DMLR/Paper1/-/Review_Approval
 
-If you think the submission can continue through DMLR's review process, click the button "Under Review". Otherwise, click on "Desk Reject". Once the submission has been confirmed, then the review process will begin, and your next step will be to assign 3 reviewers to the paper. You will get a follow up email when OpenReview is ready for you to assign these 3 reviewers.
+If you think the submission can continue through DMLR's review process, click the button "Under Review". Otherwise, click on "Desk Reject". Once the submission has been confirmed, then the review process will begin, and your next step will be to assign 2 reviewers to the paper. You will get a follow up email when OpenReview is ready for you to assign these 2 reviewers.
 
 We thank you for your essential contribution to DMLR!
 
@@ -424,7 +424,6 @@ note={Under review}
 
         david_client = OpenReviewClient(username='david@dmlrone.com', password=helpers.strong_password)
         carlos_client = OpenReviewClient(username='carlos@dmlrthree.com', password=helpers.strong_password)
-        javier_client = OpenReviewClient(username='javier@dmlrtwo.com', password=helpers.strong_password)
 
         andrew_paper1_anon_groups = andrew_client.get_groups(prefix=f'DMLR/Paper1/Action_Editor_.*', signatory='~Andrew_Ng1')
         assert len(andrew_paper1_anon_groups) == 1
@@ -455,7 +454,7 @@ As a reminder, reviewers are **expected to accept all assignments** for submissi
 
 To submit your review, please follow this link: https://openreview.net/forum?id={note_id_1}&invitationId=DMLR/Paper1/-/Review or check your tasks in the Reviewers Console: https://openreview.net/group?id=DMLR/Reviewers#reviewer-tasks
 
-Once submitted, your review will become privately visible to the authors and AE. Then, as soon as 3 reviews have been submitted, all reviews will become visible to all the reviewers. For more details and guidelines on performing your review, visit data.mlr.press.
+Once submitted, your review will become privately visible to the authors and AE. Then, as soon as 2 reviews have been submitted, all reviews will become visible to all the reviewers. For more details and guidelines on performing your review, visit data.mlr.press.
 
 We thank you for your essential contribution to DMLR!
 
@@ -477,21 +476,10 @@ note: replies to this email will go to the AE, Andrew Ng.
             weight=1
         ))
 
-        ## Javier Barden
-        paper_assignment_edge = andrew_client.post_edge(openreview.Edge(invitation='DMLR/Reviewers/-/Assignment',
-            readers=["DMLR", "DMLR/Paper1/Action_Editors", '~Javier_Ba1'],
-            nonreaders=["DMLR/Paper1/Authors"],
-            writers=["DMLR", "DMLR/Paper1/Action_Editors"],
-            signatures=[graham_paper1_anon_group.id],
-            head=note_id_1,
-            tail='~Javier_Ba1',
-            weight=1
-        ))
-
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
         reviewerrs_group = ce_client.get_group('DMLR/Paper1/Reviewers')
-        assert reviewerrs_group.members == ['~David_Bo1', '~Carlos_Ge1', '~Javier_Ba1']
+        assert reviewerrs_group.members == ['~David_Bo1', '~Carlos_Ge1']
 
         david_anon_groups=david_client.get_groups(prefix='DMLR/Paper1/Reviewer_.*', signatory='~David_Bo1')
         assert len(david_anon_groups) == 1
@@ -543,46 +531,19 @@ note: replies to this email will go to the AE, Andrew Ng.
 
         helpers.await_queue_edit(openreview_client, edit_id=carlos_review_note['id'])
 
-        javier_anon_groups=javier_client.get_groups(prefix='DMLR/Paper1/Reviewer_.*', signatory='~Javier_Ba1')
-        assert len(javier_anon_groups) == 1
-
-        ## Post a review edit
-        javier_review_note = javier_client.post_note_edit(invitation='DMLR/Paper1/-/Review',
-            signatures=[javier_anon_groups[0].id],
-            note=Note(
-                content={
-                    'summary_of_contributions': { 'value': 'summary_of_contributions' },
-                    'strengths_and_weaknesses': { 'value': 'strengths_and_weaknesses' },
-                    'requested_changes': { 'value': 'requested_changes' },
-                    'limitations': { 'value': 'limitations' },
-                    'broader_impact_concerns': { 'value': 'broader_impact_concerns' },
-                    'claims_and_evidence': { 'value': 'Yes' },
-                    'extended_submissions': { 'value': 'extended_submissions' },
-                    'audience': { 'value': 'Yes' },
-                    'datasets_and_benchmarks': { 'value': 'datasets_and_benchmarks' },
-                    'recommendation': { 'value': '4: Accept.' },
-                    'confidence': { 'value': '3: You are very confident in your assessment.' }
-                }
-            )
-        )
-
-        helpers.await_queue_edit(openreview_client, edit_id=javier_review_note['id'])
-
         ## All the reviewes should be visible to all the reviewers now
         reviews=openreview_client.get_notes(forum=note_id_1, invitation='DMLR/Paper1/-/Review', sort= 'number:asc')
-        assert len(reviews) == 3
+        assert len(reviews) == 2
         assert reviews[0].readers == ['DMLR/Editors_In_Chief', 'DMLR/Action_Editors', 'DMLR/Paper1/Reviewers', 'DMLR/Paper1/Authors']
         assert reviews[0].signatures == [david_anon_groups[0].id]
         assert reviews[1].readers == ['DMLR/Editors_In_Chief', 'DMLR/Action_Editors', 'DMLR/Paper1/Reviewers', 'DMLR/Paper1/Authors']
         assert reviews[1].signatures == [carlos_anon_groups[0].id]
-        assert reviews[2].readers == ['DMLR/Editors_In_Chief', 'DMLR/Action_Editors', 'DMLR/Paper1/Reviewers', 'DMLR/Paper1/Authors']
-        assert reviews[2].signatures == [javier_anon_groups[0].id]
 
         ## Post a review edit
-        javier_review_note = javier_client.post_note_edit(invitation='DMLR/Paper1/-/Review',
-            signatures=[javier_anon_groups[0].id],
+        carlos_review_note = carlos_client.post_note_edit(invitation='DMLR/Paper1/-/Review',
+            signatures=[carlos_anon_groups[0].id],
             note=Note(
-                id=javier_review_note['note']['id'],
+                id=carlos_review_note['note']['id'],
                 content={
                     'summary_of_contributions': { 'value': 'summary_of_contributions VERSION 2' },
                     'strengths_and_weaknesses': { 'value': 'strengths_and_weaknesses' },
@@ -599,10 +560,9 @@ note: replies to this email will go to the AE, Andrew Ng.
             )
         )
 
-        review_note = javier_client.get_note(javier_review_note['note']['id'])
+        review_note = carlos_client.get_note(carlos_review_note['note']['id'])
         assert review_note.content['summary_of_contributions']['value'] == 'summary_of_contributions VERSION 2'
         assert review_note.readers == ['DMLR/Editors_In_Chief', 'DMLR/Action_Editors', 'DMLR/Paper1/Reviewers', 'DMLR/Paper1/Authors']
-
 
         invitations = openreview_client.get_invitations(replyForum=note_id_1, prefix='DMLR/Paper1')
         assert len(invitations) == 6
@@ -614,7 +574,35 @@ note: replies to this email will go to the AE, Andrew Ng.
         assert "DMLR/Paper1/-/Official_Recommendation" in [i.id for i in invitations]
 
         official_comment_invitation = openreview_client.get_invitation("DMLR/Paper1/-/Official_Comment")
-        assert 'everyone' not in official_comment_invitation.edit['note']['readers']['param']['enum']
+        assert official_comment_invitation.edit['note']['readers']['param']['enum'] == [
+            "DMLR/Editors_In_Chief",
+            "DMLR/Action_Editors",
+            "DMLR/Paper1/Action_Editors",
+            "DMLR/Paper1/Reviewers",
+            "DMLR/Paper1/Reviewer_.*",
+            "DMLR/Paper1/Authors"
+        ]
+
+        ## Make a comment before approving the submission to be under review
+        comment_note = carlos_client.post_note_edit(invitation='DMLR/Paper1/-/Official_Comment',
+            signatures=[carlos_anon_groups[0].id],
+            note=Note(
+                signatures=[carlos_anon_groups[0].id],
+                readers=['DMLR/Editors_In_Chief', 'DMLR/Action_Editors', carlos_anon_groups[0].id],
+                forum=note_id_1,
+                replyto=note_id_1,
+                content={
+                    'comment': { 'value': 'My review was posted thanks for your patiente' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=comment_note['id'])               
+
+        messages = openreview_client.get_messages(to = 'andrew@dmlrzero.com', subject = '[DMLR] Official Comment posted on submission 1: Paper title')
+        assert len(messages) == 1
+        assert 'Hi Andrew Ng,\n\nAn official comment has been posted on a submission for which you are an Action Editor.\n\nSubmission: Paper title\nTitle: \nComment: My review was posted thanks for your patiente\n\nTo view the official comment, click here' in messages[0]['content']['text']
+
 
         assert openreview.tools.get_invitation(openreview_client, 'DMLR/Paper1/-/Official_Recommendation')
 
@@ -625,7 +613,6 @@ note: replies to this email will go to the AE, Andrew Ng.
         ce_client = OpenReviewClient(username='ce@mailseven.com', password=helpers.strong_password)
         david_client = OpenReviewClient(username='david@dmlrone.com', password=helpers.strong_password)
         carlos_client = OpenReviewClient(username='carlos@dmlrthree.com', password=helpers.strong_password)
-        javier_client = OpenReviewClient(username='javier@dmlrtwo.com', password=helpers.strong_password)        
         note_id_1 = openreview_client.get_notes(invitation='DMLR/-/Submission')[0].id
         
         ce_client.post_invitation_edit(
@@ -676,20 +663,6 @@ note: replies to this email will go to the AE, Andrew Ng.
         )
 
         helpers.await_queue_edit(openreview_client, edit_id=official_recommendation_note['id']) 
-
-        javier_anon_groups=javier_client.get_groups(prefix='DMLR/Paper1/Reviewer_.*', signatory='~Javier_Ba1')
-        assert len(javier_anon_groups) == 1
-
-        official_recommendation_note = javier_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Official_Recommendation',
-            signatures=[javier_anon_groups[0].id],
-            note=Note(
-                content={
-                    'recommendation_confirmation': { 'value': 'Yes' }
-                }
-            )
-        )
-
-        helpers.await_queue_edit(openreview_client, edit_id=official_recommendation_note['id'])                                     
     
     def test_decision(self, journal, openreview_client, helpers):
 

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -417,7 +417,15 @@ The TMLR Editors-in-Chief
         assert note.content['venue']['value'] == 'Submitted to TMLR'
         assert note.content['venueid']['value'] == 'TMLR/Submitted'
 
-        assert openreview_client.get_invitation(f"{venue_id}/Paper1/-/Official_Comment")
+        invitation = openreview_client.get_invitation(f"{venue_id}/Paper1/-/Official_Comment")
+        assert invitation.edit['note']['readers']['param']['enum'] == [
+            "everyone",
+            "TMLR/Editors_In_Chief",
+            "TMLR/Paper1/Action_Editors",
+            "TMLR/Paper1/Reviewers",
+            "TMLR/Paper1/Reviewer_.*",
+            "TMLR/Paper1/Authors"
+        ]
 
         invitations = openreview_client.get_invitations(replyForum=note_id_1)
         assert len(invitations) == 10, ", ".join([i.id for i in invitations])


### PR DESCRIPTION
- Fix TMLR issue where TMLR/Action_Editors shouldn't participate in the official comments, it should be only for non public journals.
- Notify the assigned AE when there is a comment visible to all the AEs.
- Parametrize number of reviewers in the EIC and AE consoles.