### PR TITLE
Feature/Venue: parametrize review stage

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -36,6 +36,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.area_chair_identity_readers = get_identity_readers(note, 'area_chair_identity')
         venue.senior_area_chair_identity_readers = get_identity_readers(note, 'senior_area_chair_identity')
         venue.decision_heading_map = get_decision_heading_map(venue.short_name, note)
+        venue.source_submissions_query_mapping = note.content.get('source_submissions_query_mapping', {})
 
         venue.submission_stage = get_submission_stage(note, venue)
         venue.review_stage = get_review_stage(note)

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -540,7 +540,7 @@ class ReviewStage(object):
         rating_field_name = 'rating',
         confidence_field_name = 'confidence',
         process_path = None,
-        content_query = {},
+        source_submissions_query = {},
         child_invitations_name = 'Official_Review'
     ):
 
@@ -560,7 +560,7 @@ class ReviewStage(object):
         self.rating_field_name = rating_field_name
         self.confidence_field_name = confidence_field_name
         self.process_path = process_path
-        self.content_query = content_query
+        self.source_submissions_query = source_submissions_query
         self.child_invitations_name = child_invitations_name
 
     def _get_reviewer_readers(self, conference, number, review_signature=None):

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -540,7 +540,8 @@ class ReviewStage(object):
         rating_field_name = 'rating',
         confidence_field_name = 'confidence',
         process_path = None,
-        content_query = {}
+        content_query = {},
+        child_invitations_name = 'Official_Review'
     ):
 
         self.start_date = start_date
@@ -560,6 +561,7 @@ class ReviewStage(object):
         self.confidence_field_name = confidence_field_name
         self.process_path = process_path
         self.content_query = content_query
+        self.child_invitations_name = child_invitations_name
 
     def _get_reviewer_readers(self, conference, number, review_signature=None):
         if self.release_to_reviewers is ReviewStage.Readers.REVIEWERS:

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -539,7 +539,8 @@ class ReviewStage(object):
         remove_fields = [],
         rating_field_name = 'rating',
         confidence_field_name = 'confidence',
-        process_path = None
+        process_path = None,
+        content_query = {}
     ):
 
         self.start_date = start_date
@@ -558,6 +559,7 @@ class ReviewStage(object):
         self.rating_field_name = rating_field_name
         self.confidence_field_name = confidence_field_name
         self.process_path = process_path
+        self.content_query = content_query
 
     def _get_reviewer_readers(self, conference, number, review_signature=None):
         if self.release_to_reviewers is ReviewStage.Readers.REVIEWERS:

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -271,7 +271,10 @@ class GroupBuilder(object):
             content['area_chairs_conflict_policy'] = venue_group.content.get('area_chairs_conflict_policy')
 
         if venue_group.content.get('area_chairs_conflict_n_years'):
-            content['area_chairs_conflict_n_years'] = venue_group.content.get('area_chairs_conflict_n_years')            
+            content['area_chairs_conflict_n_years'] = venue_group.content.get('area_chairs_conflict_n_years')
+
+        if self.venue.source_submissions_query_mapping:
+            content['source_submissions_query_mapping'] = { 'value': self.venue.source_submissions_query_mapping }    
 
         update_content = self.get_update_content(venue_group.content, content)
         if update_content:

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -319,6 +319,7 @@ class InvitationBuilder(object):
         
         content = review_stage.get_content(api_version='2', conference=self.venue)
 
+        previous_content_query = {}
         invitation = tools.get_invitation(self.client, review_invitation_id)
         if invitation:
             previous_content_query = invitation.content.get('content_query', {}).get('value', {})

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -319,6 +319,8 @@ class InvitationBuilder(object):
         
         content = review_stage.get_content(api_version='2', conference=self.venue)
 
+        content_query = review_stage.content_query
+
         invitation = Invitation(id=review_invitation_id,
             invitees=[venue_id],
             readers=[venue_id],
@@ -332,6 +334,9 @@ class InvitationBuilder(object):
             content={
                 'review_process_script': {
                     'value': self.get_process_content('process/review_process.py')
+                },
+                'content_query': {
+                    'value': content_query
                 }
             },
             edit={

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -319,12 +319,12 @@ class InvitationBuilder(object):
         
         content = review_stage.get_content(api_version='2', conference=self.venue)
 
-        previous_content_query = {}
+        previous_query = {}
         invitation = tools.get_invitation(self.client, review_invitation_id)
         if invitation:
-            previous_content_query = invitation.content.get('content_query', {}).get('value', {})
+            previous_query = invitation.content.get('source_submissions_query', {}).get('value', {})
 
-        content_query = review_stage.content_query if review_stage.content_query else previous_content_query
+        source_submissions_query = review_stage.source_submissions_query if review_stage.source_submissions_query else previous_query
 
         invitation = Invitation(id=review_invitation_id,
             invitees=[venue_id],
@@ -422,9 +422,9 @@ class InvitationBuilder(object):
         if review_expdate:
             invitation.edit['invitation']['expdate'] = review_expdate
 
-        if content_query:
-            invitation.content['content_query'] = {
-                'value': content_query
+        if source_submissions_query:
+            invitation.content['source_submissions_query'] = {
+                'value': source_submissions_query
             }
 
         if self.venue.ethics_review_stage:

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -31,58 +31,59 @@ def process(client, edit, invitation):
                 group=openreview.api.Group()
             )
         
-        # edit review invitation and reviews
-        review_readers = invitation.content['review_readers']['value']
-        final_readers = []
-        final_readers.extend(review_readers)
-        final_readers = [reader.replace('{number}', str(submission.number)) for reader in final_readers]
-        if '{signatures}' in final_readers:
-            final_readers.remove('{signatures}')
-        if 'everyone' not in final_readers:
-            final_readers.append(f'{venue_id}/{submission_name}{submission.number}/{ethics_reviewers_name}')
+        # edit review invitation and reviews if invitation exists
+        if openreview.tools.get_invitation(client, f'{venue_id}/-/{review_name}'):
+            review_readers = invitation.content['review_readers']['value']
+            final_readers = []
+            final_readers.extend(review_readers)
+            final_readers = [reader.replace('{number}', str(submission.number)) for reader in final_readers]
+            if '{signatures}' in final_readers:
+                final_readers.remove('{signatures}')
+            if 'everyone' not in final_readers:
+                final_readers.append(f'{venue_id}/{submission_name}{submission.number}/{ethics_reviewers_name}')
 
-        print('review_name:', review_name)
-        paper_invitation_edit = client.post_invitation_edit(
-                invitations=f'{venue_id}/-/{review_name}',
-                readers=[venue_id],
-                writers=[venue_id],
-                signatures=[venue_id],
-                content={
-                    'noteId': {
-                        'value': submission.id
+            print('review_name:', review_name)
+            paper_invitation_edit = client.post_invitation_edit(
+                    invitations=f'{venue_id}/-/{review_name}',
+                    readers=[venue_id],
+                    writers=[venue_id],
+                    signatures=[venue_id],
+                    content={
+                        'noteId': {
+                            'value': submission.id
+                        },
+                        'noteNumber': {
+                            'value': submission.number
+                        },
+                        'noteReaders': {
+                            'value': final_readers
+                        }
                     },
-                    'noteNumber': {
-                        'value': submission.number
-                    },
-                    'noteReaders': {
-                        'value': final_readers
-                    }
-                },
-                invitation=openreview.api.Invitation()
-            )
-
-        paper_invitation = client.get_invitation(paper_invitation_edit['invitation']['id'])
-        notes = client.get_notes(invitation=paper_invitation.id)
-        invitation_readers = paper_invitation.edit['note'].get('readers')
-
-        if type(invitation_readers) is list:
-            for note in notes:
-                final_invitation_readers = list(dict.fromkeys([note.signatures[0] if 'signatures' in r else r for r in invitation_readers]))
-                updated_note = openreview.api.Note(
-                    id = note.id
+                    invitation=openreview.api.Invitation()
                 )
-                if note.readers != final_invitation_readers:
-                    updated_note.readers = final_invitation_readers
-                    updated_note.nonreaders = paper_invitation.edit['note'].get('nonreaders')
-                if updated_note.content or updated_note.readers:
-                    client.post_note_edit(
-                        invitation = meta_invitation_id,
-                        readers = final_invitation_readers,
-                        nonreaders = paper_invitation.edit['note'].get('nonreaders'),
-                        writers = [venue_id],
-                        signatures = [venue_id],
-                        note = updated_note
+
+            paper_invitation = client.get_invitation(paper_invitation_edit['invitation']['id'])
+            notes = client.get_notes(invitation=paper_invitation.id)
+            invitation_readers = paper_invitation.edit['note'].get('readers')
+
+            if type(invitation_readers) is list:
+                for note in notes:
+                    final_invitation_readers = list(dict.fromkeys([note.signatures[0] if 'signatures' in r else r for r in invitation_readers]))
+                    updated_note = openreview.api.Note(
+                        id = note.id
                     )
+                    if note.readers != final_invitation_readers:
+                        updated_note.readers = final_invitation_readers
+                        updated_note.nonreaders = paper_invitation.edit['note'].get('nonreaders')
+                    if updated_note.content or updated_note.readers:
+                        client.post_note_edit(
+                            invitation = meta_invitation_id,
+                            readers = final_invitation_readers,
+                            nonreaders = paper_invitation.edit['note'].get('nonreaders'),
+                            writers = [venue_id],
+                            signatures = [venue_id],
+                            note = updated_note
+                        )
 
         # create ethics review invitation
         paper_invitation_edit = client.post_invitation_edit(

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -7,8 +7,17 @@ def process(client, edit, invitation):
     meta_invitation_id = domain.content['meta_invitation_id']['value']
     review_name = domain.content.get('review_name', {}).get('value')
     ethics_review_name = domain.content.get('ethics_review_name', {}).get('value')
+    source_submissions_query_mapping = domain.content.get('source_submissions_query_mapping', {}).get('value')
 
     submission = client.get_note(edit.note.id)
+
+    # get correct review invitation name
+    if source_submissions_query_mapping:
+        for invitation_name, query in source_submissions_query_mapping.items():
+            submission_field_name = query.keys()[0]
+
+            if submission.content.get(submission_field_name, {}).get('value', '') in query[submission_field_name]:
+                review_name = invitation_name 
 
     if submission.content['flagged_for_ethics_review']['value']:
 
@@ -32,6 +41,7 @@ def process(client, edit, invitation):
         if 'everyone' not in final_readers:
             final_readers.append(f'{venue_id}/{submission_name}{submission.number}/{ethics_reviewers_name}')
 
+        print('review_name:', review_name)
         paper_invitation_edit = client.post_invitation_edit(
                 invitations=f'{venue_id}/-/{review_name}',
                 readers=[venue_id],

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -14,7 +14,7 @@ def process(client, edit, invitation):
     # get correct review invitation name
     if source_submissions_query_mapping:
         for invitation_name, query in source_submissions_query_mapping.items():
-            submission_field_name = query.keys()[0]
+            submission_field_name = list(query.keys())[0]
 
             if submission.content.get(submission_field_name, {}).get('value', '') in query[submission_field_name]:
                 review_name = invitation_name 

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -67,9 +67,9 @@ def process(client, invitation):
             if source == 'flagged_for_ethics_review':
                 source_submissions = [s for s in source_submissions if s.content.get('flagged_for_ethics_review', {}).get('value', False)]
 
-            if content_query:
-                for key, value in content_query.items():
-                    source_submissions = [s for s in source_submissions if value in s.content.get(key, {}).get('value', '')]
+        if content_query:
+            for key, value in content_query.items():
+                source_submissions = [s for s in source_submissions if value in s.content.get(key, {}).get('value', '')]
 
         if reply_to == 'reviews':
             children_notes = [openreview.api.Note.from_json(reply) for s in source_submissions for reply in s.details['directReplies'] if f'{venue_id}/{submission_name}{s.number}/-/{review_name}' in reply['invitations']]

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -45,11 +45,11 @@ def process(client, invitation):
     def get_children_notes():
         source = invitation.content.get('source', {}).get('value', 'all_submissions') if invitation.content else False
         reply_to = invitation.content.get('reply_to', {}).get('value', 'forum') if invitation.content else False
-        content_query = invitation.content.get('content_query', {}).get('value') if invitation.content else ''
+        source_submissions_query = invitation.content.get('source_submissions_query', {}).get('value') if invitation.content else ''
 
         print('source', source)
         print('reply_to', reply_to)
-        print('content_query', content_query)
+        print('source_submissions_query', source_submissions_query)
         if source == 'accepted_submissions':
             source_submissions = client.get_all_notes(content={ 'venueid': venue_id }, sort='number:asc')
             if not source_submissions and decision_name:
@@ -67,8 +67,8 @@ def process(client, invitation):
             if source == 'flagged_for_ethics_review':
                 source_submissions = [s for s in source_submissions if s.content.get('flagged_for_ethics_review', {}).get('value', False)]
 
-        if content_query:
-            for key, value in content_query.items():
+        if source_submissions_query:
+            for key, value in source_submissions_query.items():
                 source_submissions = [s for s in source_submissions if value in s.content.get(key, {}).get('value', '')]
 
         if reply_to == 'reviews':

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -45,9 +45,11 @@ def process(client, invitation):
     def get_children_notes():
         source = invitation.content.get('source', {}).get('value', 'all_submissions') if invitation.content else False
         reply_to = invitation.content.get('reply_to', {}).get('value', 'forum') if invitation.content else False
+        content_query = invitation.content.get('content_query', {}).get('value') if invitation.content else ''
 
         print('source', source)
         print('reply_to', reply_to)
+        print('content_query', content_query)
         if source == 'accepted_submissions':
             source_submissions = client.get_all_notes(content={ 'venueid': venue_id }, sort='number:asc')
             if not source_submissions and decision_name:
@@ -64,6 +66,10 @@ def process(client, invitation):
 
             if source == 'flagged_for_ethics_review':
                 source_submissions = [s for s in source_submissions if s.content.get('flagged_for_ethics_review', {}).get('value', False)]
+
+            if content_query:
+                for key, value in content_query.items():
+                    source_submissions = [s for s in source_submissions if value in s.content.get(key, {}).get('value', '')]
 
         if reply_to == 'reviews':
             children_notes = [openreview.api.Note.from_json(reply) for s in source_submissions for reply in s.details['directReplies'] if f'{venue_id}/{submission_name}{s.number}/-/{review_name}' in reply['invitations']]

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -74,6 +74,7 @@ class Venue(object):
         self.allow_gurobi_solver = False
         self.submission_license = None
         self.use_publication_chairs = False
+        self.source_submissions_query_mapping = {}
 
     def get_id(self):
         return self.venue_id
@@ -543,7 +544,7 @@ class Venue(object):
 
         flag_invitation = self.invitation_builder.set_ethics_stage_invitation()
         self.invitation_builder.set_ethics_paper_groups_invitation()
-        self.invitation_builder.set_review_invitation()
+        self.invitation_builder.update_review_invitations()
         self.invitation_builder.set_ethics_review_invitation()
         if self.ethics_review_stage.enable_comments:
             self.invitation_builder.set_official_comment_invitation()

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -48,6 +48,12 @@ class VenueStages():
             'value-dict': {},
             'description': 'Override homepage defaults: title, subtitle, deadline, date, website, location. Valid JSON expected.'
         }
+        revision_content['source_submissions_query_mapping'] = {
+            'order': 23,
+            'value-dict': {},
+            'hidden': True,
+            'required': False
+        }
 
         with open(os.path.join(os.path.dirname(__file__), 'process/revision_pre_process.py')) as pre:
             pre_process_file_content = pre.read()

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -3486,9 +3486,9 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
                 )
             )
 
-        # assert number of Official_Review and Paper_Track_Review invitations has not changed after flagging papers for ethics reviews
+        # assert number of Official_Review and Position_Paper_Review invitations has not changed after flagging papers for ethics reviews
         assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Official_Review')) == 50
-        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Paper_Track_Review')) == 50
+        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Review')) == 50
 
     def test_comment_stage(self, openreview_client, helpers):
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -2394,7 +2394,7 @@ ICML 2023 Conference Program Chairs'''
                 }
             },
             remove_fields=['title', 'review'],
-            content_query={
+            source_submissions_query={
                 'position_paper_track': 'No'
             }
         )
@@ -2602,7 +2602,7 @@ ICML 2023 Conference Program Chairs'''
                 }
             },
             remove_fields=['title', 'review'],
-            content_query={
+            source_submissions_query={
                 'position_paper_track': 'No'
             }
         )
@@ -2625,7 +2625,7 @@ ICML 2023 Conference Program Chairs'''
             exp_date=review_exp_date,
             name='Position_Paper_Review',
             remove_fields=['title'],
-            content_query={
+            source_submissions_query={
                 'position_paper_track': 'Yes'
             }
         )
@@ -3929,7 +3929,7 @@ ICML 2023 Conference Program Chairs'''
                 }
             },
             remove_fields=['title', 'review'],
-            content_query={
+            source_submissions_query={
                 'position_paper_track': 'No'
             }
         )

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -380,9 +380,22 @@ class TestICMLConference():
                                 "input": "select"
                             }
                         }
+                    },
+                    "position_paper_track": {
+                        "order": 20,
+                        "description": "Is this a submission to the position paper track? See Call for Position Papers (https://icml.cc/Conferences/2024/CallForPositionPapers).",
+                        "value": {
+                            "param": {
+                                "type": "string",
+                                "enum": [
+                                    "Yes",
+                                    "No"
+                                ],
+                                "input": "radio"
+                            }
+                        }
                     }
                 }
-
             },
             forum=request_form.forum,
             invitation='openreview.net/Support/-/Request{}/Revision'.format(request_form.number),
@@ -658,7 +671,8 @@ reviewer6@gmail.com, Reviewer ICMLSix
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'supplementary_material': { 'value': '/attachment/' + 's' * 40 +'.zip'},
                     'financial_aid': { 'value': 'Yes' },
-                    'subject_areas': { 'value': [subject_areas[random.randint(0, 11)], subject_areas[random.randint(0, 11)]] }
+                    'subject_areas': { 'value': [subject_areas[random.randint(0, 11)], subject_areas[random.randint(0, 11)]] },
+                    'position_paper_track': { 'value': 'Yes' if i % 2 == 0 else 'No' }
                 }
             )
             if i == 1 or i == 101:
@@ -698,6 +712,7 @@ reviewer6@gmail.com, Reviewer ICMLSix
                     'supplementary_material': submission.content['supplementary_material'],
                     'financial_aid': submission.content['financial_aid'],
                     'subject_areas': submission.content['subject_areas'],
+                    'position_paper_track': submission.content['position_paper_track']
                 }
             ))
 
@@ -726,6 +741,7 @@ reviewer6@gmail.com, Reviewer ICMLSix
                     'supplementary_material': submission.content['supplementary_material'],
                     'financial_aid': submission.content['financial_aid'],
                     'subject_areas': submission.content['subject_areas'],
+                    'position_paper_track': submission.content['position_paper_track']
                 }
             ))
 
@@ -843,6 +859,20 @@ reviewer6@gmail.com, Reviewer ICMLSix
                                     'Representation: Other'
                                 ],
                                 "input": "select"
+                            }
+                        }
+                    },
+                    "position_paper_track": {
+                        "order": 20,
+                        "description": "Is this a submission to the position paper track? See Call for Position Papers (https://icml.cc/Conferences/2024/CallForPositionPapers).",
+                        "value": {
+                            "param": {
+                                "type": "string",
+                                "enum": [
+                                    "Yes",
+                                    "No"
+                                ],
+                                "input": "radio"
                             }
                         }
                     }
@@ -1038,6 +1068,7 @@ reviewer6@gmail.com, Reviewer ICMLSix
                     'supplementary_material': { 'value': { 'delete': True } },
                     'financial_aid': { 'value': submission.content['financial_aid']['value'] },
                     'subject_areas': { 'value': submission.content['subject_areas']['value'] },
+                    'position_paper_track': { 'value': submission.content['position_paper_track']['value'] }
                 }
             ))
 
@@ -2173,215 +2204,205 @@ ICML 2023 Conference Program Chairs'''
         now = datetime.datetime.utcnow()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
-        review_stage_note = openreview.Note(
-            content={
-                'review_start_date': start_date.strftime('%Y/%m/%d'),
-                'review_deadline': due_date.strftime('%Y/%m/%d'),
-                'make_reviews_public': 'No, reviews should NOT be revealed publicly when they are posted',
-                'release_reviews_to_authors': 'No, reviews should NOT be revealed when they are posted to the paper\'s authors',
-                'release_reviews_to_reviewers': 'Review should not be revealed to any reviewer, except to the author of the review',
-                'remove_review_form_options': 'title,review',
-                'email_program_chairs_about_reviews': 'No, do not email program chairs about received reviews',
-                'review_rating_field_name': 'rating',
-                'additional_review_form_options': {
-                    "summarry": {
-                        "order": 1,
-                        "description": "Briefly summarize the paper and its contributions. This is not the place to critique the paper; the authors should generally agree with a well-written summary.",
-                        "value": {
-                            "param": {
-                                "maxLength": 200000,
-                                "type": "string",
-                                "input": "textarea",
-                                "markdown": True
-                            }
-                        }
-                    },
-                    "strengths_and_weaknesses": {
-                        "order": 2,
-                        "description": "Please provide a thorough assessment of the strengths and weaknesses of the paper, touching on each of the following dimensions: originality, quality, clarity, and significance. We encourage people to be broad in their definitions of originality and significance. For example, originality may arise from creative combinations of existing ideas, application to a new domain, or removing restrictive assumptions from prior theoretical results. You can incorporate Markdown and Latex into your review. See https://openreview.net/faq.",
-                        "value": {
-                            "param": {
-                                "maxLength": 200000,
-                                "type": "string",
-                                "input": "textarea",
-                                "markdown": True
-                            }
-                        }
-                    },
-                    "questions": {
-                        "order": 3,
-                        "description": "Please list up and carefully describe any questions and suggestions for the authors. Think of the things where a response from the author can change your opinion, clarify a confusion or address a limitation. This can be very important for a productive rebuttal and discussion phase with the authors.",
-                        "value": {
-                            "param": {
-                                "maxLength": 200000,
-                                "type": "string",
-                                "input": "textarea",
-                                "markdown": True
-                            }
-                        }
-                    },
-                    "limitations": {
-                        "order": 4,
-                        "description": "Have the authors adequately addressed the limitations and potential negative societal impact of their work? If not, please include constructive suggestions for improvement. Authors should be rewarded rather than punished for being up front about the limitations of their work and any potential negative societal impact.",
-                        "value": {
-                            "param": {
-                                "maxLength": 200000,
-                                "type": "string",
-                                "input": "textarea",
-                                "markdown": True
-                            }
-                        }
-                    },
-                    "ethics_flag": {
-                        "order": 5,
-                        "description": "If there are ethical issues with this paper, please flag the paper for an ethics review. For guidance on when this is appropriate, please review the ethics guidelines (https://icml.cc/Conferences/2023/PublicationEthics).",
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": [
-                                    "Yes",
-                                    "No"
-                                ],
-                                "input": "radio"
-                            }
-                        }
-                    },
-                    "ethics_review_area": {
-                        "order": 6,
-                        "description": "If you flagged this paper for ethics review, what area of expertise would it be most useful for the ethics reviewer to have? Please click all that apply.",
-                        "value": {
-                            "param": {
-                                "type": "string[]",
-                                "enum": [
-                                    "Discrimination / Bias / Fairness Concerns",
-                                    "Inadequate Data and Algorithm Evaluation",
-                                    "Inappropriate Potential Applications & Impact  (e.g., human rights concerns)",
-                                    "Privacy and Security (e.g., consent)",
-                                    "Legal Compliance (e.g., GDPR, copyright, terms of use)",
-                                    "Research Integrity Issues (e.g., plagiarism)",
-                                    "Responsible Research Practice (e.g., IRB, documentation, research ethics)",
-                                    "I don't know"
-                                ],
-                                "input": "checkbox",
-                                "optional": True,
-                            }
-                        }
-                    },
-                    "soundness": {
-                        "order": 7,
-                        "description": "Please assign the paper a numerical rating on the following scale to indicate the soundness of the technical claims, experimental and research methodology and on whether the central claims of the paper are adequately supported with evidence.",
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": [
-                                    "4 excellent",
-                                    "3 good",
-                                    "2 fair",
-                                    "1 poor"
-                                ],
-                                "input": "radio"
-                            }
-                        }
-                    },
-                    "presentation": {
-                        "order": 8,
-                        "description": "Please assign the paper a numerical rating on the following scale to indicate the quality of the presentation. This should take into account the writing style and clarity, as well as contextualization relative to prior work.",
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": [
-                                    "4 excellent",
-                                    "3 good",
-                                    "2 fair",
-                                    "1 poor"
-                                ],
-                                "input": "radio"
-                            }
-                        }
-                    },
-                    "contribution": {
-                        "order": 9,
-                        "description": "Please assign the paper a numerical rating on the following scale to indicate the quality of the overall contribution this paper makes to the research area being studied. Are the questions being asked important? Does the paper bring a significant originality of ideas and/or execution? Are the results valuable to share with the broader ICML community?",
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": [
-                                    "4 excellent",
-                                    "3 good",
-                                    "2 fair",
-                                    "1 poor"
-                                ],
-                                "input": "radio"
-                            }
-                        }
-                    },
-                    "rating": {
-                        "order": 10,
-                        "description": "Please provide an \"overall score\" for this submission.",
-                        "value": {
-                            "param": {
-                                "type": 'integer',
-                                "enum": [
-                                    { 'value': 10, 'description': "10: Award quality: Technically flawless paper with groundbreaking impact, with exceptionally strong evaluation, reproducibility, and resources, and no unaddressed ethical considerations." },
-                                    { 'value': 9, 'description': "9: Very Strong Accept: Technically flawless paper with groundbreaking impact on at least one area of AI/ML and excellent impact on multiple areas of AI/ML, with flawless evaluation, resources, and reproducibility, and no unaddressed ethical considerations." },
-                                    { 'value': 8, 'description': "8: Strong Accept: Technically strong paper, with novel ideas, excellent impact on at least one area, or high-to-excellent impact on multiple areas, with excellent evaluation, resources, and reproducibility, and no unaddressed ethical considerations." },
-                                    { 'value': 7, 'description': "7: Accept: Technically solid paper, with high impact on at least one sub-area, or moderate-to-high impact on more than one areas, with good-to-excellent evaluation, resources, reproducibility, and no unaddressed ethical considerations." },
-                                    { 'value': 6, 'description': "6: Weak Accept: Technically solid, moderate-to-high impact paper, with no major concerns with respect to evaluation, resources, reproducibility, ethical considerations." },
-                                    { 'value': 5, 'description': "5: Borderline accept: Technically solid paper where reasons to accept outweigh reasons to reject, e.g., limited evaluation. Please use sparingly." },
-                                    { 'value': 4, 'description': "4: Borderline reject: Technically solid paper where reasons to reject, e.g., limited evaluation, outweigh reasons to accept, e.g., good evaluation. Please use sparingly." },
-                                    { 'value': 3, 'description': "3: Reject: For instance, a paper with technical flaws, weak evaluation, inadequate reproducibility and incompletely addressed ethical considerations." },
-                                    { 'value': 2, 'description': "2: Strong Reject: For instance, a paper with major technical flaws, and/or poor evaluation, limited impact, poor reproducibility and mostly unaddressed ethical considerations." },
-                                    { 'value': 1, 'description': "1: Very Strong Reject: For instance, a paper with trivial results or unaddressed ethical considerations" }
-                                ],
-                                "input": "radio"
 
-                            }
+        venue = openreview.helpers.get_conference(client, request_form.id, setup=False)
+        venue.review_stage = openreview.stages.ReviewStage(
+            start_date=start_date, 
+            due_date=due_date,
+            additional_fields={
+                "summarry": {
+                    "order": 1,
+                    "description": "Briefly summarize the paper and its contributions. This is not the place to critique the paper; the authors should generally agree with a well-written summary.",
+                    "value": {
+                        "param": {
+                            "maxLength": 200000,
+                            "type": "string",
+                            "input": "textarea",
+                            "markdown": True
                         }
-                    },
-                    "confidence": {
-                        "order": 11,
-                        "description": "Please provide a \"confidence score\" for your assessment of this submission to indicate how confident you are in your evaluation.",
-                        "value": {
-                            "param": {
-                                "type": 'integer',
-                                "enum": [
-                                   { 'value': 5, 'description': "5: You are absolutely certain about your assessment. You are very familiar with the related work and checked the math/other details carefully." },
-                                   { 'value': 4, 'description': "4: You are confident in your assessment, but not absolutely certain. It is unlikely, but not impossible, that you did not understand some parts of the submission or that you are unfamiliar with some pieces of related work." },
-                                   { 'value': 3, 'description': "3: You are fairly confident in your assessment. It is possible that you did not understand some parts of the submission or that you are unfamiliar with some pieces of related work. Math/other details were not carefully checked." },
-                                   { 'value': 2, 'description': "2: You are willing to defend your assessment, but it is quite likely that you did not understand the central parts of the submission or that you are unfamiliar with some pieces of related work. Math/other details were not carefully checked." },
-                                   { 'value': 1, 'description': "1: Your assessment is an educated guess. The submission is not in your area or the submission was difficult to understand. Math/other details were not carefully checked." }
-                                ],
-                                "input": "radio"
-                            }
+                    }
+                },
+                "strengths_and_weaknesses": {
+                    "order": 2,
+                    "description": "Please provide a thorough assessment of the strengths and weaknesses of the paper, touching on each of the following dimensions: originality, quality, clarity, and significance. We encourage people to be broad in their definitions of originality and significance. For example, originality may arise from creative combinations of existing ideas, application to a new domain, or removing restrictive assumptions from prior theoretical results. You can incorporate Markdown and Latex into your review. See https://openreview.net/faq.",
+                    "value": {
+                        "param": {
+                            "maxLength": 200000,
+                            "type": "string",
+                            "input": "textarea",
+                            "markdown": True
                         }
-                    },
-                    "code_of_conduct": {
-                        "description": "While performing my duties as a reviewer (including writing reviews and participating in discussions), I have and will continue to abide by the ICML code of conduct (https://icml.cc/public/CodeOfConduct).",
-                        "order": 12,
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": ["Yes"],
-                                "input": "checkbox"
-                            }
+                    }
+                },
+                "questions": {
+                    "order": 3,
+                    "description": "Please list up and carefully describe any questions and suggestions for the authors. Think of the things where a response from the author can change your opinion, clarify a confusion or address a limitation. This can be very important for a productive rebuttal and discussion phase with the authors.",
+                    "value": {
+                        "param": {
+                            "maxLength": 200000,
+                            "type": "string",
+                            "input": "textarea",
+                            "markdown": True
+                        }
+                    }
+                },
+                "limitations": {
+                    "order": 4,
+                    "description": "Have the authors adequately addressed the limitations and potential negative societal impact of their work? If not, please include constructive suggestions for improvement. Authors should be rewarded rather than punished for being up front about the limitations of their work and any potential negative societal impact.",
+                    "value": {
+                        "param": {
+                            "maxLength": 200000,
+                            "type": "string",
+                            "input": "textarea",
+                            "markdown": True
+                        }
+                    }
+                },
+                "ethics_flag": {
+                    "order": 5,
+                    "description": "If there are ethical issues with this paper, please flag the paper for an ethics review. For guidance on when this is appropriate, please review the ethics guidelines (https://icml.cc/Conferences/2023/PublicationEthics).",
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": [
+                                "Yes",
+                                "No"
+                            ],
+                            "input": "radio"
+                        }
+                    }
+                },
+                "ethics_review_area": {
+                    "order": 6,
+                    "description": "If you flagged this paper for ethics review, what area of expertise would it be most useful for the ethics reviewer to have? Please click all that apply.",
+                    "value": {
+                        "param": {
+                            "type": "string[]",
+                            "enum": [
+                                "Discrimination / Bias / Fairness Concerns",
+                                "Inadequate Data and Algorithm Evaluation",
+                                "Inappropriate Potential Applications & Impact  (e.g., human rights concerns)",
+                                "Privacy and Security (e.g., consent)",
+                                "Legal Compliance (e.g., GDPR, copyright, terms of use)",
+                                "Research Integrity Issues (e.g., plagiarism)",
+                                "Responsible Research Practice (e.g., IRB, documentation, research ethics)",
+                                "I don't know"
+                            ],
+                            "input": "checkbox",
+                            "optional": True,
+                        }
+                    }
+                },
+                "soundness": {
+                    "order": 7,
+                    "description": "Please assign the paper a numerical rating on the following scale to indicate the soundness of the technical claims, experimental and research methodology and on whether the central claims of the paper are adequately supported with evidence.",
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": [
+                                "4 excellent",
+                                "3 good",
+                                "2 fair",
+                                "1 poor"
+                            ],
+                            "input": "radio"
+                        }
+                    }
+                },
+                "presentation": {
+                    "order": 8,
+                    "description": "Please assign the paper a numerical rating on the following scale to indicate the quality of the presentation. This should take into account the writing style and clarity, as well as contextualization relative to prior work.",
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": [
+                                "4 excellent",
+                                "3 good",
+                                "2 fair",
+                                "1 poor"
+                            ],
+                            "input": "radio"
+                        }
+                    }
+                },
+                "contribution": {
+                    "order": 9,
+                    "description": "Please assign the paper a numerical rating on the following scale to indicate the quality of the overall contribution this paper makes to the research area being studied. Are the questions being asked important? Does the paper bring a significant originality of ideas and/or execution? Are the results valuable to share with the broader ICML community?",
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": [
+                                "4 excellent",
+                                "3 good",
+                                "2 fair",
+                                "1 poor"
+                            ],
+                            "input": "radio"
+                        }
+                    }
+                },
+                "rating": {
+                    "order": 10,
+                    "description": "Please provide an \"overall score\" for this submission.",
+                    "value": {
+                        "param": {
+                            "type": 'integer',
+                            "enum": [
+                                { 'value': 10, 'description': "10: Award quality: Technically flawless paper with groundbreaking impact, with exceptionally strong evaluation, reproducibility, and resources, and no unaddressed ethical considerations." },
+                                { 'value': 9, 'description': "9: Very Strong Accept: Technically flawless paper with groundbreaking impact on at least one area of AI/ML and excellent impact on multiple areas of AI/ML, with flawless evaluation, resources, and reproducibility, and no unaddressed ethical considerations." },
+                                { 'value': 8, 'description': "8: Strong Accept: Technically strong paper, with novel ideas, excellent impact on at least one area, or high-to-excellent impact on multiple areas, with excellent evaluation, resources, and reproducibility, and no unaddressed ethical considerations." },
+                                { 'value': 7, 'description': "7: Accept: Technically solid paper, with high impact on at least one sub-area, or moderate-to-high impact on more than one areas, with good-to-excellent evaluation, resources, reproducibility, and no unaddressed ethical considerations." },
+                                { 'value': 6, 'description': "6: Weak Accept: Technically solid, moderate-to-high impact paper, with no major concerns with respect to evaluation, resources, reproducibility, ethical considerations." },
+                                { 'value': 5, 'description': "5: Borderline accept: Technically solid paper where reasons to accept outweigh reasons to reject, e.g., limited evaluation. Please use sparingly." },
+                                { 'value': 4, 'description': "4: Borderline reject: Technically solid paper where reasons to reject, e.g., limited evaluation, outweigh reasons to accept, e.g., good evaluation. Please use sparingly." },
+                                { 'value': 3, 'description': "3: Reject: For instance, a paper with technical flaws, weak evaluation, inadequate reproducibility and incompletely addressed ethical considerations." },
+                                { 'value': 2, 'description': "2: Strong Reject: For instance, a paper with major technical flaws, and/or poor evaluation, limited impact, poor reproducibility and mostly unaddressed ethical considerations." },
+                                { 'value': 1, 'description': "1: Very Strong Reject: For instance, a paper with trivial results or unaddressed ethical considerations" }
+                            ],
+                            "input": "radio"
+
+                        }
+                    }
+                },
+                "confidence": {
+                    "order": 11,
+                    "description": "Please provide a \"confidence score\" for your assessment of this submission to indicate how confident you are in your evaluation.",
+                    "value": {
+                        "param": {
+                            "type": 'integer',
+                            "enum": [
+                                { 'value': 5, 'description': "5: You are absolutely certain about your assessment. You are very familiar with the related work and checked the math/other details carefully." },
+                                { 'value': 4, 'description': "4: You are confident in your assessment, but not absolutely certain. It is unlikely, but not impossible, that you did not understand some parts of the submission or that you are unfamiliar with some pieces of related work." },
+                                { 'value': 3, 'description': "3: You are fairly confident in your assessment. It is possible that you did not understand some parts of the submission or that you are unfamiliar with some pieces of related work. Math/other details were not carefully checked." },
+                                { 'value': 2, 'description': "2: You are willing to defend your assessment, but it is quite likely that you did not understand the central parts of the submission or that you are unfamiliar with some pieces of related work. Math/other details were not carefully checked." },
+                                { 'value': 1, 'description': "1: Your assessment is an educated guess. The submission is not in your area or the submission was difficult to understand. Math/other details were not carefully checked." }
+                            ],
+                            "input": "radio"
+                        }
+                    }
+                },
+                "code_of_conduct": {
+                    "description": "While performing my duties as a reviewer (including writing reviews and participating in discussions), I have and will continue to abide by the ICML code of conduct (https://icml.cc/public/CodeOfConduct).",
+                    "order": 12,
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": ["Yes"],
+                            "input": "checkbox"
                         }
                     }
                 }
             },
-            forum=request_form.forum,
-            invitation=f'openreview.net/Support/-/Request{request_form.number}/Review_Stage',
-            readers=['ICML.cc/2023/Conference/Program_Chairs', 'openreview.net/Support'],
-            replyto=request_form.forum,
-            referent=request_form.forum,
-            signatures=['~Program_ICMLChair1'],
-            writers=[]
+            content_query={
+                'position_paper_track': 'No'
+            }
         )
 
-        review_stage_note=pc_client.post_note(review_stage_note)
+        venue.create_review_stage()
 
-        helpers.await_queue()
+        helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Official_Review-0-1', count=1)
 
-        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Official_Review')) == 100
+        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Official_Review')) == 50
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Official_Review')
         assert 'summarry' in invitation.edit['note']['content']
         assert invitation.cdate < openreview.tools.datetime_millis(now)
@@ -2391,223 +2412,210 @@ ICML 2023 Conference Program Chairs'''
 
         review_exp_date = due_date + datetime.timedelta(days=2)
 
-        review_stage_note = openreview.Note(
-            content={
-                'review_start_date': start_date.strftime('%Y/%m/%d'),
-                'review_deadline': due_date.strftime('%Y/%m/%d'),
-                'review_expiration_date': review_exp_date.strftime('%Y/%m/%d'),
-                'make_reviews_public': 'No, reviews should NOT be revealed publicly when they are posted',
-                'release_reviews_to_authors': 'No, reviews should NOT be revealed when they are posted to the paper\'s authors',
-                'release_reviews_to_reviewers': 'Review should not be revealed to any reviewer, except to the author of the review',
-                'remove_review_form_options': 'title,review',
-                'email_program_chairs_about_reviews': 'No, do not email program chairs about received reviews',
-                'review_rating_field_name': 'rating',
-                'additional_review_form_options': {
-                    "summary": {
-                        "order": 1,
-                        "description": "Briefly summarize the paper and its contributions. This is not the place to critique the paper; the authors should generally agree with a well-written summary.",
-                        "value": {
-                            "param": {
-                                "maxLength": 200000,
-                                "type": "string",
-                                "input": "textarea",
-                                "markdown": True
-                            }
+        venue.review_stage = openreview.stages.ReviewStage(
+            start_date=start_date, 
+            due_date=due_date,
+            exp_date=review_exp_date,
+            additional_fields={
+                "summary": {
+                    "order": 1,
+                    "description": "Briefly summarize the paper and its contributions. This is not the place to critique the paper; the authors should generally agree with a well-written summary.",
+                    "value": {
+                        "param": {
+                            "maxLength": 200000,
+                            "type": "string",
+                            "input": "textarea",
+                            "markdown": True
                         }
-                    },
-                    "strengths_and_weaknesses": {
-                        "order": 2,
-                        "description": "Please provide a thorough assessment of the strengths and weaknesses of the paper, touching on each of the following dimensions: originality, quality, clarity, and significance. We encourage people to be broad in their definitions of originality and significance. For example, originality may arise from creative combinations of existing ideas, application to a new domain, or removing restrictive assumptions from prior theoretical results. You can incorporate Markdown and Latex into your review. See https://openreview.net/faq.",
-                        "value": {
-                            "param": {
-                                "maxLength": 200000,
-                                "type": "string",
-                                "input": "textarea",
-                                "markdown": True
-                            }
+                    }
+                },
+                "strengths_and_weaknesses": {
+                    "order": 2,
+                    "description": "Please provide a thorough assessment of the strengths and weaknesses of the paper, touching on each of the following dimensions: originality, quality, clarity, and significance. We encourage people to be broad in their definitions of originality and significance. For example, originality may arise from creative combinations of existing ideas, application to a new domain, or removing restrictive assumptions from prior theoretical results. You can incorporate Markdown and Latex into your review. See https://openreview.net/faq.",
+                    "value": {
+                        "param": {
+                            "maxLength": 200000,
+                            "type": "string",
+                            "input": "textarea",
+                            "markdown": True
                         }
-                    },
-                    "questions": {
-                        "order": 3,
-                        "description": "Please list up and carefully describe any questions and suggestions for the authors. Think of the things where a response from the author can change your opinion, clarify a confusion or address a limitation. This can be very important for a productive rebuttal and discussion phase with the authors.",
-                        "value": {
-                            "param": {
-                                "maxLength": 200000,
-                                "type": "string",
-                                "input": "textarea",
-                                "markdown": True
-                            }
+                    }
+                },
+                "questions": {
+                    "order": 3,
+                    "description": "Please list up and carefully describe any questions and suggestions for the authors. Think of the things where a response from the author can change your opinion, clarify a confusion or address a limitation. This can be very important for a productive rebuttal and discussion phase with the authors.",
+                    "value": {
+                        "param": {
+                            "maxLength": 200000,
+                            "type": "string",
+                            "input": "textarea",
+                            "markdown": True
                         }
-                    },
-                    "limitations": {
-                        "order": 4,
-                        "description": "Have the authors adequately addressed the limitations and potential negative societal impact of their work? If not, please include constructive suggestions for improvement. Authors should be rewarded rather than punished for being up front about the limitations of their work and any potential negative societal impact.",
-                        "value": {
-                            "param": {
-                                "maxLength": 200000,
-                                "type": "string",
-                                "input": "textarea",
-                                "markdown": True
-                            }
+                    }
+                },
+                "limitations": {
+                    "order": 4,
+                    "description": "Have the authors adequately addressed the limitations and potential negative societal impact of their work? If not, please include constructive suggestions for improvement. Authors should be rewarded rather than punished for being up front about the limitations of their work and any potential negative societal impact.",
+                    "value": {
+                        "param": {
+                            "maxLength": 200000,
+                            "type": "string",
+                            "input": "textarea",
+                            "markdown": True
                         }
-                    },
-                    "ethics_flag": {
-                        "order": 5,
-                        "description": "If there are ethical issues with this paper, please flag the paper for an ethics review. For guidance on when this is appropriate, please review the ethics guidelines (https://icml.cc/Conferences/2023/PublicationEthics).",
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": [
-                                    "Yes",
-                                    "No"
-                                ],
-                                "input": "radio"
-                            }
+                    }
+                },
+                "ethics_flag": {
+                    "order": 5,
+                    "description": "If there are ethical issues with this paper, please flag the paper for an ethics review. For guidance on when this is appropriate, please review the ethics guidelines (https://icml.cc/Conferences/2023/PublicationEthics).",
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": [
+                                "Yes",
+                                "No"
+                            ],
+                            "input": "radio"
                         }
-                    },
-                    "ethics_review_area": {
-                        "order": 6,
-                        "description": "If you flagged this paper for ethics review, what area of expertise would it be most useful for the ethics reviewer to have? Please click all that apply.",
-                        "value": {
-                            "param": {
-                                "type": "string[]",
-                                "enum": [
-                                    "Discrimination / Bias / Fairness Concerns",
-                                    "Inadequate Data and Algorithm Evaluation",
-                                    "Inappropriate Potential Applications & Impact  (e.g., human rights concerns)",
-                                    "Privacy and Security (e.g., consent)",
-                                    "Legal Compliance (e.g., GDPR, copyright, terms of use)",
-                                    "Research Integrity Issues (e.g., plagiarism)",
-                                    "Responsible Research Practice (e.g., IRB, documentation, research ethics)",
-                                    "I don't know"
-                                ],
-                                "input": "checkbox",
-                                "optional": True,
-                            }
+                    }
+                },
+                "ethics_review_area": {
+                    "order": 6,
+                    "description": "If you flagged this paper for ethics review, what area of expertise would it be most useful for the ethics reviewer to have? Please click all that apply.",
+                    "value": {
+                        "param": {
+                            "type": "string[]",
+                            "enum": [
+                                "Discrimination / Bias / Fairness Concerns",
+                                "Inadequate Data and Algorithm Evaluation",
+                                "Inappropriate Potential Applications & Impact  (e.g., human rights concerns)",
+                                "Privacy and Security (e.g., consent)",
+                                "Legal Compliance (e.g., GDPR, copyright, terms of use)",
+                                "Research Integrity Issues (e.g., plagiarism)",
+                                "Responsible Research Practice (e.g., IRB, documentation, research ethics)",
+                                "I don't know"
+                            ],
+                            "input": "checkbox",
+                            "optional": True,
                         }
-                    },
-                    "soundness": {
-                        "order": 7,
-                        "description": "Please assign the paper a numerical rating on the following scale to indicate the soundness of the technical claims, experimental and research methodology and on whether the central claims of the paper are adequately supported with evidence.",
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": [
-                                    "4 excellent",
-                                    "3 good",
-                                    "2 fair",
-                                    "1 poor"
-                                ],
-                                "input": "radio"
-                            }
+                    }
+                },
+                "soundness": {
+                    "order": 7,
+                    "description": "Please assign the paper a numerical rating on the following scale to indicate the soundness of the technical claims, experimental and research methodology and on whether the central claims of the paper are adequately supported with evidence.",
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": [
+                                "4 excellent",
+                                "3 good",
+                                "2 fair",
+                                "1 poor"
+                            ],
+                            "input": "radio"
                         }
-                    },
-                    "presentation": {
-                        "order": 8,
-                        "description": "Please assign the paper a numerical rating on the following scale to indicate the quality of the presentation. This should take into account the writing style and clarity, as well as contextualization relative to prior work.",
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": [
-                                    "4 excellent",
-                                    "3 good",
-                                    "2 fair",
-                                    "1 poor"
-                                ],
-                                "input": "radio"
-                            }
+                    }
+                },
+                "presentation": {
+                    "order": 8,
+                    "description": "Please assign the paper a numerical rating on the following scale to indicate the quality of the presentation. This should take into account the writing style and clarity, as well as contextualization relative to prior work.",
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": [
+                                "4 excellent",
+                                "3 good",
+                                "2 fair",
+                                "1 poor"
+                            ],
+                            "input": "radio"
                         }
-                    },
-                    "contribution": {
-                        "order": 9,
-                        "description": "Please assign the paper a numerical rating on the following scale to indicate the quality of the overall contribution this paper makes to the research area being studied. Are the questions being asked important? Does the paper bring a significant originality of ideas and/or execution? Are the results valuable to share with the broader ICML community?",
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": [
-                                    "4 excellent",
-                                    "3 good",
-                                    "2 fair",
-                                    "1 poor"
-                                ],
-                                "input": "radio"
-                            }
+                    }
+                },
+                "contribution": {
+                    "order": 9,
+                    "description": "Please assign the paper a numerical rating on the following scale to indicate the quality of the overall contribution this paper makes to the research area being studied. Are the questions being asked important? Does the paper bring a significant originality of ideas and/or execution? Are the results valuable to share with the broader ICML community?",
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": [
+                                "4 excellent",
+                                "3 good",
+                                "2 fair",
+                                "1 poor"
+                            ],
+                            "input": "radio"
                         }
-                    },
-                    "rating": {
-                        "order": 10,
-                        "description": "Please provide an \"overall score\" for this submission.",
-                        "value": {
-                            "param": {
-                                "type": 'integer',
-                                "enum": [
-                                    { 'value': 10, 'description': "10: Award quality: Technically flawless paper with groundbreaking impact, with exceptionally strong evaluation, reproducibility, and resources, and no unaddressed ethical considerations." },
-                                    { 'value': 9, 'description': "9: Very Strong Accept: Technically flawless paper with groundbreaking impact on at least one area of AI/ML and excellent impact on multiple areas of AI/ML, with flawless evaluation, resources, and reproducibility, and no unaddressed ethical considerations." },
-                                    { 'value': 8, 'description': "8: Strong Accept: Technically strong paper, with novel ideas, excellent impact on at least one area, or high-to-excellent impact on multiple areas, with excellent evaluation, resources, and reproducibility, and no unaddressed ethical considerations." },
-                                    { 'value': 7, 'description': "7: Accept: Technically solid paper, with high impact on at least one sub-area, or moderate-to-high impact on more than one areas, with good-to-excellent evaluation, resources, reproducibility, and no unaddressed ethical considerations." },
-                                    { 'value': 6, 'description': "6: Weak Accept: Technically solid, moderate-to-high impact paper, with no major concerns with respect to evaluation, resources, reproducibility, ethical considerations." },
-                                    { 'value': 5, 'description': "5: Borderline accept: Technically solid paper where reasons to accept outweigh reasons to reject, e.g., limited evaluation. Please use sparingly." },
-                                    { 'value': 4, 'description': "4: Borderline reject: Technically solid paper where reasons to reject, e.g., limited evaluation, outweigh reasons to accept, e.g., good evaluation. Please use sparingly." },
-                                    { 'value': 3, 'description': "3: Reject: For instance, a paper with technical flaws, weak evaluation, inadequate reproducibility and incompletely addressed ethical considerations." },
-                                    { 'value': 2, 'description': "2: Strong Reject: For instance, a paper with major technical flaws, and/or poor evaluation, limited impact, poor reproducibility and mostly unaddressed ethical considerations." },
-                                    { 'value': 1, 'description': "1: Very Strong Reject: For instance, a paper with trivial results or unaddressed ethical considerations" }
-                                ],
-                                "input": "radio"
+                    }
+                },
+                "rating": {
+                    "order": 10,
+                    "description": "Please provide an \"overall score\" for this submission.",
+                    "value": {
+                        "param": {
+                            "type": 'integer',
+                            "enum": [
+                                { 'value': 10, 'description': "10: Award quality: Technically flawless paper with groundbreaking impact, with exceptionally strong evaluation, reproducibility, and resources, and no unaddressed ethical considerations." },
+                                { 'value': 9, 'description': "9: Very Strong Accept: Technically flawless paper with groundbreaking impact on at least one area of AI/ML and excellent impact on multiple areas of AI/ML, with flawless evaluation, resources, and reproducibility, and no unaddressed ethical considerations." },
+                                { 'value': 8, 'description': "8: Strong Accept: Technically strong paper, with novel ideas, excellent impact on at least one area, or high-to-excellent impact on multiple areas, with excellent evaluation, resources, and reproducibility, and no unaddressed ethical considerations." },
+                                { 'value': 7, 'description': "7: Accept: Technically solid paper, with high impact on at least one sub-area, or moderate-to-high impact on more than one areas, with good-to-excellent evaluation, resources, reproducibility, and no unaddressed ethical considerations." },
+                                { 'value': 6, 'description': "6: Weak Accept: Technically solid, moderate-to-high impact paper, with no major concerns with respect to evaluation, resources, reproducibility, ethical considerations." },
+                                { 'value': 5, 'description': "5: Borderline accept: Technically solid paper where reasons to accept outweigh reasons to reject, e.g., limited evaluation. Please use sparingly." },
+                                { 'value': 4, 'description': "4: Borderline reject: Technically solid paper where reasons to reject, e.g., limited evaluation, outweigh reasons to accept, e.g., good evaluation. Please use sparingly." },
+                                { 'value': 3, 'description': "3: Reject: For instance, a paper with technical flaws, weak evaluation, inadequate reproducibility and incompletely addressed ethical considerations." },
+                                { 'value': 2, 'description': "2: Strong Reject: For instance, a paper with major technical flaws, and/or poor evaluation, limited impact, poor reproducibility and mostly unaddressed ethical considerations." },
+                                { 'value': 1, 'description': "1: Very Strong Reject: For instance, a paper with trivial results or unaddressed ethical considerations" }
+                            ],
+                            "input": "radio"
 
-                            }
                         }
-                    },
-                    "confidence": {
-                        "order": 11,
-                        "description": "Please provide a \"confidence score\" for your assessment of this submission to indicate how confident you are in your evaluation.",
-                        "value": {
-                            "param": {
-                                "type": 'integer',
-                                "enum": [
-                                   { 'value': 5, 'description': "5: You are absolutely certain about your assessment. You are very familiar with the related work and checked the math/other details carefully." },
-                                   { 'value': 4, 'description': "4: You are confident in your assessment, but not absolutely certain. It is unlikely, but not impossible, that you did not understand some parts of the submission or that you are unfamiliar with some pieces of related work." },
-                                   { 'value': 3, 'description': "3: You are fairly confident in your assessment. It is possible that you did not understand some parts of the submission or that you are unfamiliar with some pieces of related work. Math/other details were not carefully checked." },
-                                   { 'value': 2, 'description': "2: You are willing to defend your assessment, but it is quite likely that you did not understand the central parts of the submission or that you are unfamiliar with some pieces of related work. Math/other details were not carefully checked." },
-                                   { 'value': 1, 'description': "1: Your assessment is an educated guess. The submission is not in your area or the submission was difficult to understand. Math/other details were not carefully checked." }
-                                ],
-                                "input": "radio"
-                            }
+                    }
+                },
+                "confidence": {
+                    "order": 11,
+                    "description": "Please provide a \"confidence score\" for your assessment of this submission to indicate how confident you are in your evaluation.",
+                    "value": {
+                        "param": {
+                            "type": 'integer',
+                            "enum": [
+                                { 'value': 5, 'description': "5: You are absolutely certain about your assessment. You are very familiar with the related work and checked the math/other details carefully." },
+                                { 'value': 4, 'description': "4: You are confident in your assessment, but not absolutely certain. It is unlikely, but not impossible, that you did not understand some parts of the submission or that you are unfamiliar with some pieces of related work." },
+                                { 'value': 3, 'description': "3: You are fairly confident in your assessment. It is possible that you did not understand some parts of the submission or that you are unfamiliar with some pieces of related work. Math/other details were not carefully checked." },
+                                { 'value': 2, 'description': "2: You are willing to defend your assessment, but it is quite likely that you did not understand the central parts of the submission or that you are unfamiliar with some pieces of related work. Math/other details were not carefully checked." },
+                                { 'value': 1, 'description': "1: Your assessment is an educated guess. The submission is not in your area or the submission was difficult to understand. Math/other details were not carefully checked." }
+                            ],
+                            "input": "radio"
                         }
-                    },
-                    "code_of_conduct": {
-                        "description": "While performing my duties as a reviewer (including writing reviews and participating in discussions), I have and will continue to abide by the ICML code of conduct (https://icml.cc/public/CodeOfConduct).",
-                        "order": 12,
-                        "value": {
-                            "param": {
-                                "type": "string",
-                                "enum": ["Yes"],
-                                "input": "checkbox"
-                            }
+                    }
+                },
+                "code_of_conduct": {
+                    "description": "While performing my duties as a reviewer (including writing reviews and participating in discussions), I have and will continue to abide by the ICML code of conduct (https://icml.cc/public/CodeOfConduct).",
+                    "order": 12,
+                    "value": {
+                        "param": {
+                            "type": "string",
+                            "enum": ["Yes"],
+                            "input": "checkbox"
                         }
                     }
                 }
             },
-            forum=request_form.forum,
-            invitation=f'openreview.net/Support/-/Request{request_form.number}/Review_Stage',
-            readers=['ICML.cc/2023/Conference/Program_Chairs', 'openreview.net/Support'],
-            replyto=request_form.forum,
-            referent=request_form.forum,
-            signatures=['~Program_ICMLChair1'],
-            writers=[]
+            content_query={
+                'position_paper_track': 'No'
+            }
         )
 
-        review_stage_note=pc_client.post_note(review_stage_note)
+        venue.create_review_stage()
 
-        helpers.await_queue()
+        helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Official_Review-0-1', count=2)
 
-        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Official_Review')) == 100
+        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Official_Review')) == 50
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Official_Review')
         assert 'summarry' not in invitation.edit['note']['content']
         assert 'summary' in invitation.edit['note']['content']
         assert invitation.cdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
         # duedate + 2 days
-        exp_date = invitation.duedate + (2*24*60*60*1000)
-        assert invitation.expdate == exp_date
+        exp_date = invitation.duedate + (2*24*60)
 
         reviewer_client = openreview.api.OpenReviewClient(username='reviewer1@icml.cc', password=helpers.strong_password)
 


### PR DESCRIPTION
This PR adds two params to the Review Stage:
- `source_submissions_query`: the query by which to filter papers
- `child_invitations_name`: the name of the children invitations, since it can be different from the super invitation name

`invitation_edit_process.py` filters papers by source_submissions_query, and creates/updates official invitations only for these papers. 

Requires https://github.com/openreview/openreview-api/pull/362