### PR TITLE
Journal: parametrize the number of reviewers

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -24,7 +24,7 @@ class InvitationBuilder(object):
 
         self.author_edge_reminder_process = {
             'dates': ["#{4/duedate} + " + str(day), "#{4/duedate} + " + str(week)],
-            'script': self.get_process_content('process/author_edge_reminder_process.py')
+            'script': self.get_super_dateprocess_content('author_edge_reminder_script', self.journal.get_meta_invitation_id(), { 0: '1', 1: 'one week' })
         }
 
         self.author_reminder_process = {
@@ -54,7 +54,7 @@ class InvitationBuilder(object):
 
         self.ae_edge_reminder_process = {
             'dates': ["#{4/duedate} + " + str(day), "#{4/duedate} + " + str(week), "#{4/duedate} + " + str(one_month)],
-            'script': self.get_process_content('process/action_editor_edge_reminder_process.py')
+            'script': self.get_super_dateprocess_content('ae_edge_reminder_script', self.journal.get_meta_invitation_id(), { 0: '1', 1: 'one week', 2: 'one month' })
         }
 
     def set_invitations(self, assignment_delay):
@@ -244,6 +244,12 @@ class InvitationBuilder(object):
                     },
                     'author_reminder_script': {
                         'value': self.get_process_content('process/author_reminder_process.py')
+                    },
+                    'ae_edge_reminder_script': {
+                        'value': self.get_process_content('process/action_editor_edge_reminder_process.py')
+                    },
+                    'author_edge_reminder_script': {
+                        'value': self.get_process_content('process/author_edge_reminder_process.py')
                     }
                 },
                 edit=True

--- a/openreview/journal/process/action_editor_edge_reminder_process.py
+++ b/openreview/journal/process/action_editor_edge_reminder_process.py
@@ -9,7 +9,7 @@ def process(client, invitation):
 
     edges = client.get_edges(invitation=journal.get_reviewer_assignment_id(), head=submission.id)
 
-    if len(edges) >= 3:
+    if len(edges) >= journal.get_number_of_reviewers():
       return
 
     if date_index == 0 or date_index == 1:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='openreview-py',
 
-    version='1.36.0',
+    version='1.36.1',
 
     description='OpenReview API Python client library',
     url='https://github.com/openreview/openreview-py',


### PR DESCRIPTION
move all the reminder scripts to the meta invitation so it is easy to edit for all the existing invitations.

Issue found in one of the venues where the number of reviewers is 2 and AEs were getting reminders the assignment task wasn't complete.