### PR TITLE
Request form: remove support from signatures

### DIFF
--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -234,7 +234,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|{}'.format(self.venue_request.support_group.id)
+                    'values-regex': '~.*'
                 },
                 'content': review_stage_content
             }
@@ -316,7 +316,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|{}'.format(self.venue_request.support_group.id)
+                    'values-regex': '~.*'
                 },
                 'content': rebuttal_stage_content
             }
@@ -431,7 +431,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|{}'.format(self.venue_request.support_group.id)
+                    'values-regex': '~.*'
                 },
                 'content': ethics_review_stage_content
             }
@@ -512,7 +512,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|{}'.format(self.venue_request.support_group.id)
+                    'values-regex': '~.*'
                 },
                 'content': comment_stage_content
             }
@@ -609,7 +609,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|{}'.format(self.venue_request.support_group.id)
+                    'values-regex': '~.*'
                 },
                 'content': meta_review_stage_content
             }
@@ -687,7 +687,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|{}'.format(self.venue_request.support_group.id)
+                    'values-regex': '~.*'
                 },
                 'content': submission_revision_stage_content
             }
@@ -828,7 +828,7 @@ class VenueStages():
                             'values': [],
                         },
                         'signatures': {
-                            'values-regex': '~.*|{}'.format(self.venue_request.support_group.id)
+                            'values-regex': self.venue_request.support_group.id
                         },
                         'content': decisions_upload_status_content
                     }
@@ -853,7 +853,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|' + self.venue_request.support_group.id
+                    'values-regex': '~.*'
                 },
                 'content': decision_stage_content
             }
@@ -907,7 +907,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|' + self.venue_request.support_group.id
+                    'values-regex': '~.*'
                 },
                 'content': post_decision_content
             }
@@ -976,7 +976,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|' + self.venue_request.support_group.id
+                    'values-regex': '~.*'
                 },
                 'content': registration_content
             }
@@ -1044,7 +1044,7 @@ class VenueStages():
                     'values':[],
                 },
                 'signatures': {
-                    'values-regex': '~.*|' + self.venue_request.support_group.id
+                    'values-regex': '~.*'
                 },
                 'content': registration_content
             }
@@ -1491,7 +1491,7 @@ class VenueRequest():
                             ]
                         },
                         'signatures': {
-                            'values-regex': '~.*|' + self.support_group.id
+                            'values-regex': '~.*'
                         },
                         'content': self.request_content
                     }
@@ -1628,7 +1628,7 @@ class VenueRequest():
                         'values':[],
                     },
                     'signatures': {
-                        'values-regex': '~.*|{}'.format(self.support_group.id)
+                        'values-regex': '~.*'
                     },
                     'content': post_submission_content
                 }
@@ -1740,7 +1740,7 @@ If you would like to change your decision, please follow the link in the previou
                         'values':[],
                     },
                     'signatures': {
-                        'values-regex': '~.*|{}'.format(self.support_group.id)
+                        'values-regex': '~.*'
                     },
                     'content': recruitment_content
                 }
@@ -1806,7 +1806,7 @@ If you would like to change your decision, please follow the link in the previou
                         'values': [],
                     },
                     'signatures': {
-                        'values-regex': '~.*|{}'.format(self.support_group.id)
+                        'values-regex': self.support_group.id
                     },
                     'content': recruitment_status_content
                 }
@@ -1887,7 +1887,7 @@ If you would like to change your decision, please follow the link in the previou
                         'values':[],
                     },
                     'signatures': {
-                        'values-regex': '~.*|{}'.format(self.support_group.id)
+                        'values-regex': '~.*'
                     },
                     'content': remind_recruitment_content
                 }
@@ -1941,7 +1941,7 @@ If you would like to change your decision, please follow the link in the previou
                         'values': [],
                     },
                     'signatures': {
-                        'values-regex': '~.*|{}'.format(self.support_group.id)
+                        'values-regex': self.support_group.id
                     },
                     'content': remind_recruitment_status_content
                 }
@@ -2013,7 +2013,7 @@ If you would like to change your decision, please follow the link in the previou
                             'values':[],
                         },
                         'signatures': {
-                            'values-regex': '~.*|{}'.format(self.support_group.id)
+                            'values-regex': '~.*'
                         },
                         'content': matching_content
                     }
@@ -2072,7 +2072,7 @@ If you would like to change your decision, please follow the link in the previou
                         'values': [],
                     },
                     'signatures': {
-                        'values-regex': '~.*|{}'.format(self.support_group.id)
+                        'values-regex': self.support_group.id
                     },
                     'content': matching_status_content
                 }
@@ -2104,7 +2104,7 @@ If you would like to change your decision, please follow the link in the previou
                         ]
                     },
                     'signatures': {
-                        'values-regex': '~.*|' + self.support_group.id,
+                        'values-regex': self.support_group.id,
                         'description': 'How your identity will be displayed.'
                     },
                     'content': {


### PR DESCRIPTION
I removed support from all signatures except from comments, so we can keep signing comments using the support group instead of Super User. If this is not necessary, I can change it. 