### PR TITLE
Fix/ Venue: replace note readers

### DIFF
--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -108,6 +108,8 @@ def process(client, invitation):
         for note in notes:
             final_invitation_readers = list(dict.fromkeys([note.signatures[0] if 'signatures' in r else r for r in invitation_readers]))
             edit_readers = list(dict.fromkeys([note.signatures[0] if 'signatures' in r else r for r in paper_invitation.edit.get('readers',[])]))
+            if '${2/note/readers}' in edit_readers:
+                edit_readers = final_invitation_readers
             updated_content = updated_content_readers(note, paper_invitation)
             updated_note = openreview.api.Note(
                 id = note.id

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4040,6 +4040,10 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
             'ICML.cc/2023/Conference/Submission2/Authors',
             reviews[0].signatures[0]
         ]
+        edits = openreview_client.get_note_edits(note_id=reviews[0].id)
+        for edit in edits:
+            assert edit.readers == edit.note.readers
+            assert '${2/note/readers}' not in edit.readers
 
         now = datetime.datetime.utcnow()
         start_date = now - datetime.timedelta(days=2)


### PR DESCRIPTION
If the edit copies the readers from note.readers, replace this value in `invitation_edit_process.py`