### PR TITLE
Venue: Fix/ Revision stage after post decision

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -338,7 +338,7 @@ class SubmissionStage(object):
         return content
     
     def get_hidden_field_names(self):
-        return (['authors', 'authorids'] if self.double_blind else []) + self.hide_fields
+        return (['authors', 'authorids'] if self.double_blind and not self.author_names_revealed else []) + self.hide_fields
 
     def is_under_submission(self):
         return self.due_date is None or datetime.datetime.utcnow() < self.due_date

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -587,6 +587,33 @@ Best,
                         )
                         client.post_note(comment_note)
 
+            # update Submission_Revision_stage invitation
+            if forum_note.content.get('reveal_authors') == 'Reveal author identities of only accepted submissions to the public':
+                revision_stage_inv = openreview.tools.get_invitation(client, SUPPORT_GROUP + '/-/Request' + str(forum_note.number) + '/Submission_Revision_Stage')
+                if revision_stage_inv:
+                    content = revision_stage_inv.reply['content']
+                    content['accepted_submissions_only'] = {
+                        'description': 'At this point, revisions can only be enabled for accepted submissions. If you would like to enable revisions for rejected submissions as well, please contact us at info@openreview.net.',
+                        'value-radio': [
+                            'Enable revision for accepted submissions only',
+                        ],
+                        'default': 'Enable revision for accepted submissions only',
+                        'required': True,
+                        'order': 4
+                    }
+                    client.post_invitation(openreview.Invitation(
+                        id = SUPPORT_GROUP + '/-/Request' + str(forum_note.number) + '/Submission_Revision_Stage',
+                        super = SUPPORT_GROUP + '/-/Submission_Revision_Stage',
+                        invitees = [conference.get_program_chairs_id(), SUPPORT_GROUP],
+                        reply = {
+                            'forum': forum_note.id,
+                            'referent': forum_note.id,
+                            'readers' : revision_stage_inv.reply['readers'],
+                            'content': content
+                        },
+                        signatures = ['~Super_User1']
+                    ))
+
         elif invitation_type == 'Review_Rating_Stage':
 
             conference.create_custom_stage()

--- a/tests/test_iclr_conference_v2.py
+++ b/tests/test_iclr_conference_v2.py
@@ -493,4 +493,151 @@ class TestICLRConference():
                 "value": "ICLR.cc/2024/Conference/Submission1/Authors",
                 "optional": True
             }
-        ]                             
+        ]
+
+    def test_camera_ready_revision_stage(self, client, openreview_client, helpers):
+
+        pc_client=openreview.Client(username='pc@iclr.cc', password=helpers.strong_password)
+        request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+
+        decisions = ['Accept (Oral)', 'Accept (Poster)', 'Reject']
+        comment = {
+            'Accept (Oral)': 'Congratulations on your acceptance.',
+            'Accept (Poster)': 'Congratulations on your acceptance.',
+            'Reject': 'We regret to inform you...'
+        }
+
+        submissions = openreview_client.get_notes(invitation='ICLR.cc/2024/Conference/-/Submission', sort='number:asc')
+
+        with open(os.path.join(os.path.dirname(__file__), 'data/ICML_decisions.csv'), 'w') as file_handle:
+            writer = csv.writer(file_handle)
+            writer.writerow([submissions[0].number, 'Accept (Oral)', comment["Accept (Oral)"]])
+            writer.writerow([submissions[1].number, 'Accept (Poster)', comment["Accept (Poster)"]])
+            writer.writerow([submissions[2].number, 'Reject', comment["Reject"]])
+            for submission in submissions[3:]:
+                decision = random.choice(decisions)
+                writer.writerow([submission.number, decision, comment[decision]])
+
+        decision_stage_invitation = f'openreview.net/Support/-/Request{request_form.number}/Decision_Stage'
+        url = pc_client.put_attachment(os.path.join(os.path.dirname(__file__), 'data/ICML_decisions.csv'),
+                                         decision_stage_invitation, 'decisions_file')
+
+        ## enable decision stage
+        now = datetime.datetime.utcnow()
+        end_date = now + datetime.timedelta(days=3)
+        decision_stage_note = pc_client.post_note(openreview.Note(
+            content={
+                'decision_deadline': end_date.strftime('%Y/%m/%d'),
+                'make_decisions_public': "No, decisions should NOT be revealed publicly when they are posted",
+                'release_decisions_to_authors': 'Yes, decisions should be revealed when they are posted to the paper\'s authors',
+                'release_decisions_to_reviewers': 'Yes, decisions should be immediately revealed to the paper\'s reviewers',
+                'release_decisions_to_area_chairs': 'Yes, decisions should be immediately revealed to the paper\'s area chairs',
+                'decisions_file': url
+            },
+            forum=request_form.forum,
+            invitation=f'openreview.net/Support/-/Request{request_form.number}/Decision_Stage',
+            readers=['ICLR.cc/2024/Conference/Program_Chairs', 'openreview.net/Support'],
+            replyto=request_form.forum,
+            referent=request_form.forum,
+            signatures=['~Program_ICLRChair1'],
+            writers=[]
+        ))
+
+        helpers.await_queue()
+
+        invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Post_Decision_Stage')
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        client.post_invitation(invitation)
+
+        # post a post decision stage note
+        short_name = 'ICLR 2024'
+        post_decision_stage_note = pc_client.post_note(openreview.Note(
+            content={
+                'reveal_authors': 'Reveal author identities of only accepted submissions to the public',
+                'submission_readers': 'Everyone (submissions are public)',
+                'home_page_tab_names': {
+                    'Accept (Oral)': 'Accept (Oral)',
+                    'Accept (Poster)': 'Accept (Poster)',
+                    'Reject': 'Submitted'
+                },
+                'send_decision_notifications': 'No, I will send the emails to the authors',
+                'accept_(oral)_email_content': f'''Dear {{{{fullname}}}},
+
+Thank you for submitting your paper, {{{{submission_title}}}}, to {short_name}. We are delighted to inform you that your submission has been accepted. Congratulations!
+You can find the final reviews for your paper on the submission page in OpenReview at: {{{{forum_url}}}}
+
+Best,
+{short_name} Program Chairs
+''',
+                'accept_(poster)_email_content': f'''Dear {{{{fullname}}}},
+
+Thank you for submitting your paper, {{{{submission_title}}}}, to {short_name}. We are delighted to inform you that your submission has been accepted. Congratulations!
+You can find the final reviews for your paper on the submission page in OpenReview at: {{{{forum_url}}}}
+
+Best,
+{short_name} Program Chairs
+''',
+                'reject_email_content': f'''Dear {{{{fullname}}}},
+
+Thank you for submitting your paper, {{{{submission_title}}}}, to {short_name}. We regret to inform you that your submission was not accepted.
+You can find the final reviews for your paper on the submission page in OpenReview at: {{{{forum_url}}}}
+
+Best,
+{short_name} Program Chairs
+'''
+            },
+            forum=request_form.forum,
+            invitation=f'openreview.net/Support/-/Request{request_form.number}/Post_Decision_Stage',
+            readers=['ICLR.cc/2024/Conference/Program_Chairs', 'openreview.net/Support'],
+            replyto=request_form.forum,
+            referent=request_form.forum,
+            signatures=['~Program_ICLRChair1'],
+            writers=[]
+        ))
+        assert post_decision_stage_note
+        helpers.await_queue()
+
+        # Post revision stage note
+        now = datetime.datetime.utcnow()
+        start_date = now - datetime.timedelta(days=2)
+        due_date = now + datetime.timedelta(days=5)
+        revision_stage_note = pc_client.post_note(openreview.Note(
+            content={
+                'submission_revision_name': 'Camera_Ready_Revision',
+                'submission_revision_start_date': start_date.strftime('%Y/%m/%d'),
+                'submission_revision_deadline': due_date.strftime('%Y/%m/%d'),
+                'accepted_submissions_only': 'Enable revision for accepted submissions only',
+                'submission_author_edition': 'Allow reorder of existing authors only',
+                'submission_revision_additional_options': {
+                    "submission_type": {
+                        "value": {
+                            "param": {
+                                "type": "string",
+                                "enum": [
+                                    "Regular Long Paper",
+                                    "Regular Short Paper"
+                                ],
+                                "input": "select"
+                            }
+                        },
+                        "description": "Please enter the category under which the submission should be reviewed. This cannot be changed after the abstract submission deadline.",
+                        "order": 20
+                    }
+                },
+                'submission_revision_remove_options': ['keywords']
+            },
+            forum=request_form.forum,
+            invitation=f'openreview.net/Support/-/Request{request_form.number}/Submission_Revision_Stage',
+            readers=['ICLR.cc/2024/Conference/Program_Chairs', 'openreview.net/Support'],
+            referent=request_form.forum,
+            replyto=request_form.forum,
+            signatures=['~Program_ICLRChair1'],
+            writers=[]
+        ))
+        assert revision_stage_note
+        helpers.await_queue()
+
+        invitation = openreview_client.get_invitation('ICLR.cc/2024/Conference/Submission1/-/Camera_Ready_Revision')
+        assert invitation
+        assert 'authorids' in invitation.edit['note']['content']
+        assert 'readers' not in invitation.edit['note']['content']['authorids']

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -3200,12 +3200,12 @@ Best,
         now = datetime.datetime.utcnow()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=5)
-        revision_stage_note = test_client.post_note(openreview.Note(
+        revision_stage_note = openreview.Note(
             content={
                 'submission_revision_name': 'Camera_Ready_Revision',
                 'submission_revision_start_date': start_date.strftime('%Y/%m/%d'),
                 'submission_revision_deadline': due_date.strftime('%Y/%m/%d'),
-                'accepted_submissions_only': 'Enable revision for accepted submissions only',
+                'accepted_submissions_only': 'Enable revision for all submissions',
                 'submission_author_edition': 'Allow reorder of existing authors only',
                 'submission_revision_additional_options': {
                     "submission_type": {
@@ -3232,7 +3232,14 @@ Best,
             replyto=venue['request_form_note'].forum,
             signatures=['~SomeFirstName_User1'],
             writers=[]
-        ))
+        )
+
+        with pytest.raises(openreview.OpenReviewException, match=r'The value Enable revision for all submissions in field accepted_submissions_only does not match the invitation definition'):
+            test_client.post_note(revision_stage_note)
+
+        revision_stage_note.content['accepted_submissions_only'] = 'Enable revision for accepted submissions only'
+        test_client.post_note(revision_stage_note)
+
         assert revision_stage_note
 
         helpers.await_queue()
@@ -3357,7 +3364,7 @@ Best,
                 'submission_revision_name':'Supplementary Material',
                 'submission_revision_start_date': start_date.strftime('%Y/%m/%d'),
                 'submission_revision_deadline': due_date.strftime('%Y/%m/%d'),
-                'accepted_submissions_only': 'Enable revision for all submissions',
+                'accepted_submissions_only': 'Enable revision for accepted submissions only',
                 'submission_author_edition': 'Allow addition and removal of authors',
                 'submission_revision_remove_options': ['title','authors', 'authorids','abstract','keywords', 'TLDR'],
                 'submission_revision_additional_options': {
@@ -3388,22 +3395,12 @@ Best,
         submissions = openreview_client.get_notes(invitation='V2.cc/2030/Conference/-/Submission', sort='number')
         assert submissions and len(submissions) == 3
 
+        invitations = openreview_client.get_invitations(invitation = 'V2.cc/2030/Conference/-/Supplementary_Material')
+        assert len(invitations) == 1
         revision_invitation = openreview.tools.get_invitation(openreview_client, 'V2.cc/2030/Conference/Submission1/-/Supplementary_Material')
         assert revision_invitation
         assert revision_invitation.edit['readers'] == ['everyone']
         revision_invitation = openreview.tools.get_invitation(openreview_client, 'V2.cc/2030/Conference/Submission2/-/Supplementary_Material')
-        assert revision_invitation.edit['readers'] == ['V2.cc/2030/Conference',
-            'V2.cc/2030/Conference/Submission2/Senior_Area_Chairs',
-            'V2.cc/2030/Conference/Submission2/Area_Chairs',
-            'V2.cc/2030/Conference/Submission2/Reviewers',
-            'V2.cc/2030/Conference/Submission2/Authors']
+        assert not revision_invitation
         revision_invitation = openreview.tools.get_invitation(openreview_client, 'V2.cc/2030/Conference/Submission3/-/Supplementary_Material')
-        assert revision_invitation
-        assert revision_invitation.edit['readers'] == ['V2.cc/2030/Conference',
-            'V2.cc/2030/Conference/Submission3/Senior_Area_Chairs',
-            'V2.cc/2030/Conference/Submission3/Area_Chairs',
-            'V2.cc/2030/Conference/Submission3/Reviewers',
-            'V2.cc/2030/Conference/Submission3/Authors']
-
-        assert all(x not in revision_invitation.edit['note']['content'] for x in ['title','authors', 'authorids','abstract','keywords', 'TLDR'])
-        assert 'supplementary_material' in revision_invitation.edit['note']['content']
+        assert not revision_invitation


### PR DESCRIPTION
ICLR papers were being anonymized by camera ready revisions. Now, after the post decision stage is run, if only author names of accepted papers were released, then revisions are only allowed for accepted submissions. 

