### PR TITLE
Fix/ Venue: check fields are in content before removing

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -519,8 +519,10 @@ class SubmissionRevisionStage():
                 'order':4
             }
         elif self.allow_author_reorder == AuthorReorder.DISALLOW_EDIT:
-            del content['authors']
-            del content['authorids']
+            if 'authors' in content:
+                del content['authors']
+            if 'authorids' in content:
+                del content['authorids']
 
         if conference:
             invitation_id = conference.get_invitation_id(self.name)

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -551,7 +551,7 @@ Best,
                         "order": 1
                     },
                 },
-                'submission_revision_remove_options': ['title', 'pdf', 'keywords']
+                'submission_revision_remove_options': ['title', 'pdf', 'keywords', 'authors', 'authorids']
             },
             forum=request_form.forum,
             invitation='openreview.net/Support/-/Request{}/Submission_Revision_Stage'.format(request_form.number),


### PR DESCRIPTION
The Submission Revision Stage would give an error if the PCs select `authors` and `authorids` in the remove options dropdown and also select `Do not allow any changes to author lists`.

Now that I think about it, it might be best to just remove `authors` and `authorids` from the remove options dropdown and control these two fields solely from the `submission_author_edition` field.  This might be less confusing to PCs. 

What do you think, @melisabok , @enrubio ?