### PR TITLE
Paper matching: Don't allow multiple setup matchings per group if process is ongoing

### DIFF
--- a/openreview/venue_request/process/matching_pre_process.py
+++ b/openreview/venue_request/process/matching_pre_process.py
@@ -2,3 +2,20 @@ def process(client, note, invitation):
 
     if 'Yes' in note.content['compute_affinity_scores'] and 'upload_affinity_scores' in note.content:
         raise openreview.OpenReviewException('Either upload your own affinity scores or select affinity scores computed by OpenReview')
+
+    matching_group = note.content['matching_group']
+    matching_notes = client.get_all_notes(invitation=invitation.id, sort='tmdate:desc')
+
+    if matching_notes:
+        latest_matching_note = None
+        for i, matching_note in enumerate(matching_notes):
+            if matching_note.content['matching_group'] == matching_group:
+                latest_matching_note = matching_notes[i]
+                break
+
+        if latest_matching_note:
+            status_inv = invitation.id.replace('Paper_Matching_Setup', 'Paper_Matching_Setup_Status')
+            status_note = client.get_all_notes(invitation=status_inv, replyto=latest_matching_note.id)
+
+            if not status_note:
+                raise openreview.OpenReviewException('Paper matching is already being run for this group. Please wait for a status reply in the forum.')

--- a/openreview/venue_request/process/matching_pre_process.py
+++ b/openreview/venue_request/process/matching_pre_process.py
@@ -9,18 +9,6 @@ def process(client, note, invitation):
     if compute_affinity_scores and 'upload_affinity_scores' in note.content:
         raise openreview.OpenReviewException('Either upload your own affinity scores or select affinity scores computed by OpenReview')
 
-    if forum_note.content.get('api_version', '1') == '2':
-        matching_group = note.content['matching_group']
-        senior_area_chairs_name = domain.get_content_value('senior_area_chairs_name')
-        if senior_area_chairs_name and matching_group.endswith(senior_area_chairs_name):
-            return
-
-        submission_venue_id = domain.get_content_value('submission_venue_id')
-        _, num_submissions = client_v2.get_notes(content={ 'venueid':submission_venue_id }, limit=1, with_count=True)
-        if compute_affinity_scores and num_submissions >= 2000:
-            raise openreview.OpenReviewException(f'Can not compute affinity scores for venues with 2000+ papers. Please contact us at info@openreview.net to compute your scores.')
-
-
     matching_group = note.content['matching_group']
     matching_notes = client.get_all_notes(invitation=invitation.id, sort='tmdate:desc')
     matching_group_notes = [matching_note for matching_note in matching_notes if matching_note.content['matching_group'] == matching_group]
@@ -29,3 +17,13 @@ def process(client, note, invitation):
         status_note = client.get_all_notes(invitation=invitation.id.replace('Paper_Matching_Setup', 'Paper_Matching_Setup_Status'), replyto=matching_group_notes[0].id)
         if not status_note:
             raise openreview.OpenReviewException('Paper matching is already being run for this group. Please wait for a status reply in the forum.')
+
+    if forum_note.content.get('api_version', '1') == '2':
+        senior_area_chairs_name = domain.get_content_value('senior_area_chairs_name')
+        if senior_area_chairs_name and matching_group.endswith(senior_area_chairs_name):
+            return
+
+        submission_venue_id = domain.get_content_value('submission_venue_id')
+        _, num_submissions = client_v2.get_notes(content={ 'venueid':submission_venue_id }, limit=1, with_count=True)
+        if compute_affinity_scores and num_submissions >= 2000:
+            raise openreview.OpenReviewException(f'Can not compute affinity scores for venues with 2000+ papers. Please contact us at info@openreview.net to compute your scores.')

--- a/openreview/venue_request/process/matching_pre_process.py
+++ b/openreview/venue_request/process/matching_pre_process.py
@@ -5,17 +5,9 @@ def process(client, note, invitation):
 
     matching_group = note.content['matching_group']
     matching_notes = client.get_all_notes(invitation=invitation.id, sort='tmdate:desc')
-
-    if matching_notes:
-        latest_matching_note = None
-        for i, matching_note in enumerate(matching_notes):
-            if matching_note.content['matching_group'] == matching_group:
-                latest_matching_note = matching_notes[i]
-                break
-
-        if latest_matching_note:
-            status_inv = invitation.id.replace('Paper_Matching_Setup', 'Paper_Matching_Setup_Status')
-            status_note = client.get_all_notes(invitation=status_inv, replyto=latest_matching_note.id)
-
-            if not status_note:
-                raise openreview.OpenReviewException('Paper matching is already being run for this group. Please wait for a status reply in the forum.')
+    matching_group_notes = [matching_note for matching_note in matching_notes if matching_note.content['matching_group'] == matching_group]
+    
+    if matching_group_notes:
+        status_note = client.get_all_notes(invitation=invitation.id.replace('Paper_Matching_Setup', 'Paper_Matching_Setup_Status'), replyto=matching_group_notes[0].id)
+        if not status_note:
+            raise openreview.OpenReviewException('Paper matching is already being run for this group. Please wait for a status reply in the forum.')

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -1184,7 +1184,31 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
             signatures=['~Program_ICMLChair1'],
             writers=[]
         ))
+
+        with pytest.raises(openreview.OpenReviewException, match=r'Paper matching is already being run for this group. Please wait for a status reply in the forum.'):
+            client.post_note(openreview.Note(
+                content={
+                    'title': 'Paper Matching Setup',
+                    'matching_group': 'ICML.cc/2023/Conference/Reviewers',
+                    'compute_conflicts': 'NeurIPS',
+                    'compute_conflicts_N_years': '3',
+                    'compute_affinity_scores': 'No',
+                    'upload_affinity_scores': affinity_scores_url
+                },
+                forum=request_form.id,
+                replyto=request_form.id,
+                invitation=f'openreview.net/Support/-/Request{request_form.number}/Paper_Matching_Setup',
+                readers=['ICML.cc/2023/Conference/Program_Chairs', 'openreview.net/Support'],
+                signatures=['~Program_ICMLChair1'],
+                writers=[]
+            ))
+
         helpers.await_queue()
+
+        # Only 1 reviewer matching note was posted
+        matching_notes = client.get_all_notes(invitation=f'openreview.net/Support/-/Request{request_form.number}/Paper_Matching_Setup')
+        rev_matching_notes = [note for note in matching_notes if note.content['matching_group'] == 'ICML.cc/2023/Conference/Reviewers']
+        assert len(rev_matching_notes) == 1
 
         assert openreview_client.get_invitation('ICML.cc/2023/Conference/Reviewers/-/Conflict')
 


### PR DESCRIPTION
- Fixes #2016

Tested in my local by running multiple paper matching setups in a large venue:
<img width="550" alt="paper-matching" src="https://github.com/openreview/openreview-py/assets/22416602/1ef2dc99-fb32-4054-8ad1-4caea4e4479b">
