### PR TITLE
Fix/Invalid regex in html field of direct upload

### DIFF
--- a/openreview/profile/management.py
+++ b/openreview/profile/management.py
@@ -670,7 +670,7 @@ class ProfileManagement():
                                 'value': {
                                     'param': {
                                         'type': 'string',
-                                        'regex': '"(http|https):\\/\\/.+"',
+                                        'regex': '(http|https):\/\/.+',
                                         'optional': True
                                     }
                                 }

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -425,7 +425,8 @@ class TestProfileManagement():
                     'abstract': { 'value': 'Paper abstract 1' },
                     'authors': { 'value': ['John Alternate Last', 'Test Client'] },
                     'authorids': { 'value': ['~John_Alternate_Last1', 'test@mail.com'] },
-                    'venue': { 'value': 'Arxiv' }
+                    'venue': { 'value': 'Arxiv' },
+                    'html': { 'value': 'https://arxiv.org/abs/test' }
                 },
                 license = 'CC BY-SA 4.0'
         ))


### PR DESCRIPTION
the regex in html field of direct upload invitation is invalid when it's moved to v2.
this pr should fix this issue and add html in one of the test