### PR TITLE
Invitation builder: parametrize the process file in the stage class

### DIFF
--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -360,23 +360,10 @@ class ARR(object):
 
     def create_review_stage(self):
         self.venue.review_stage = self.review_stage
-        stage_value = self.venue.create_review_stage()
-        invitation = self.client.get_invitation(self.get_invitation_id(self.review_stage.name))
-        invitation.content = {
-            'review_process_script': {
-                'value': self.invitation_builder.get_process_content('process/review_process.py')
-            }
-        }
-        invitation.edit['invitation']['preprocess'] = self.invitation_builder.get_process_content('process/review_preprocess.py')
-        self.client.post_invitation_edit(
-            invitations=self.venue.get_meta_invitation_id(),
-            readers=[self.venue_id],
-            writers=[self.venue_id],
-            signatures=[self.venue_id],
-            replacement=False,
-            invitation=invitation
-        )
-        return stage_value
+        self.venue.review_stage.process_path = '../arr/process/review_process.py'
+        self.venue.review_stage.preprocess_path = '../arr/process/review_preprocess.py'
+
+        return self.venue.create_review_stage()
 
     def create_review_rebuttal_stage(self):
         self.venue.review_rebuttal_stage = None
@@ -384,23 +371,10 @@ class ARR(object):
 
     def create_meta_review_stage(self):
         self.venue.meta_review_stage = self.meta_review_stage
-        stage_value = self.venue.create_meta_review_stage()
-        invitation = self.client.get_invitation(self.get_invitation_id(self.meta_review_stage.name))
-        invitation.content = {
-            'meta_review_process_script': {
-                'value': self.invitation_builder.get_process_content('process/metareview_process.py')
-            }
-        }
-        invitation.edit['invitation']['preprocess'] = self.invitation_builder.get_process_content('process/review_preprocess.py')
-        self.client.post_invitation_edit(
-            invitations=self.venue.get_meta_invitation_id(),
-            readers=[self.venue_id],
-            writers=[self.venue_id],
-            signatures=[self.venue_id],
-            replacement=False,
-            invitation=invitation
-        )
-        return stage_value
+        self.venue.meta_review_stage.process_path = '../arr/process/metareview_process.py'
+        self.venue.meta_review_stage.preprocess_path = '../arr/process/review_preprocess.py'
+
+        return self.venue.create_meta_review_stage()
 
     def create_registration_stages(self):
         self.venue.registration_stages = self.registration_stages
@@ -433,18 +407,9 @@ class ARR(object):
 
     def create_ethics_review_stage(self):
         self.venue.ethics_review_stage = self.ethics_review_stage
-        stage_value = self.venue.create_ethics_review_stage()
-        invitation = self.client.get_invitation(f"{self.venue_id}/-/{self.ethics_review_stage.name}_Flag")
-        invitation.process = self.invitation_builder.get_process_content('process/ethics_flag_process.py')
-        self.client.post_invitation_edit(
-            invitations=self.venue.get_meta_invitation_id(),
-            readers=[self.venue_id],
-            writers=[self.venue_id],
-            signatures=[self.venue_id],
-            replacement=False,
-            invitation=invitation
-        )
-        return stage_value
+        self.venue.ethics_review_stage.flag_process_path = '../arr/process/ethics_flag_process.py'
+        
+        return self.venue.create_ethics_review_stage()
 
     def update_conflict_policies(self, committee_id, compute_conflicts, compute_conflicts_n_years):
         return self.venue.update_conflict_policies(committee_id,  compute_conflicts,  compute_conflicts_n_years)

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -889,7 +889,7 @@ class ReviewInvitation(openreview.Invitation):
             if field in content:
                 del content[field]
 
-        process_file = review_stage.process_path if review_stage.process_path else os.path.join(os.path.dirname(__file__), 'templates/reviewProcess.js')
+        process_file = os.path.join(os.path.dirname(__file__), 'templates/reviewProcess.js')
         with open(process_file) as f:
             file_content = f.read()
 

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -580,6 +580,8 @@ class ReviewStage(object):
         self.process_path = process_path
         self.source_submissions_query = source_submissions_query
         self.child_invitations_name = child_invitations_name
+        self.process_path = 'process/review_process.py'
+        self.preprocess_path = None
 
     def _get_reviewer_readers(self, conference, number, review_signature=None):
         if self.release_to_reviewers is ReviewStage.Readers.REVIEWERS:
@@ -696,6 +698,9 @@ class EthicsReviewStage(object):
         self.remove_fields = remove_fields
         self.submission_numbers = submission_numbers
         self.enable_comments = enable_comments
+        self.process_path = 'process/ethics_review_process.py'
+        self.flag_process_path = 'process/ethics_flag_process.py'
+        self.preprocess_path = None        
 
     def get_readers(self, conference, number, ethics_review_signature=None):
 
@@ -1096,6 +1101,8 @@ class MetaReviewStage(object):
         self.remove_fields = remove_fields
         self.process = None
         self.recommendation_field_name = recommendation_field_name
+        self.process_path = 'process/metareview_process.py'
+        self.preprocess_path = None        
 
     def _get_reviewer_readers(self, conference, number):
         if self.release_to_reviewers is MetaReviewStage.Readers.REVIEWERS:

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -557,7 +557,6 @@ class ReviewStage(object):
         remove_fields = [],
         rating_field_name = 'rating',
         confidence_field_name = 'confidence',
-        process_path = None,
         source_submissions_query = {},
         child_invitations_name = 'Official_Review'
     ):
@@ -577,7 +576,6 @@ class ReviewStage(object):
         self.remove_fields = remove_fields
         self.rating_field_name = rating_field_name
         self.confidence_field_name = confidence_field_name
-        self.process_path = process_path
         self.source_submissions_query = source_submissions_query
         self.child_invitations_name = child_invitations_name
         self.process_path = 'process/review_process.py'

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -444,11 +444,7 @@ class InvitationBuilder(object):
                 'dates': ["#{4/edit/invitation/cdate}", self.update_date_string],
                 'script': self.invitation_edit_process              
             }],
-            content={
-                'review_process_script': {
-                    'value': self.get_process_content('process/review_process.py')
-                }
-            },
+            content={},
             edit={
                 'signatures': [venue_id],
                 'readers': [venue_id],
@@ -478,15 +474,6 @@ class InvitationBuilder(object):
                     'invitees': [venue_id, self.venue.get_reviewers_id(number='${3/content/noteNumber/value}')],
                     'maxReplies': 1,
                     'cdate': review_cdate,
-                    'process': '''def process(client, edit, invitation):
-    meta_invitation = client.get_invitation(invitation.invitations[0])
-    script = meta_invitation.content['review_process_script']['value']
-    funcs = {
-        'openreview': openreview
-    }
-    exec(script, funcs)
-    funcs['process'](client, edit, invitation)
-''',
                     'edit': {
                         'signatures': { 
                             'param': { 
@@ -523,6 +510,34 @@ class InvitationBuilder(object):
 
             }
         )
+
+        if review_stage.process_path:
+            invitation.content['review_process_script'] = {
+               'value': self.get_process_content(review_stage.process_path)
+            }
+            invitation.edit['invitation']['process'] = '''def process(client, edit, invitation):
+    meta_invitation = client.get_invitation(invitation.invitations[0])
+    script = meta_invitation.content['review_process_script']['value']
+    funcs = {
+        'openreview': openreview
+    }
+    exec(script, funcs)
+    funcs['process'](client, edit, invitation)
+'''
+        
+        if review_stage.preprocess_path:
+            invitation.content['review_preprocess_script'] = {
+                'value': self.get_process_content(review_stage.preprocess_path)
+            }
+            invitation.edit['invitation']['preprocess'] = '''def process(client, edit, invitation):
+    meta_invitation = client.get_invitation(invitation.invitations[0])
+    script = meta_invitation.content['review_preprocess_script']['value']
+    funcs = {
+        'openreview': openreview
+    }
+    exec(script, funcs)
+    funcs['process'](client, edit, invitation)
+'''           
 
         if review_duedate:
             invitation.edit['invitation']['duedate'] = review_duedate
@@ -787,11 +802,7 @@ class InvitationBuilder(object):
                 'dates': ["#{4/edit/invitation/cdate}", self.update_date_string],
                 'script': self.invitation_edit_process              
             }],
-            content = {
-                'meta_review_process_script': {
-                    'value': self.get_process_content('process/metareview_process.py')
-                }
-            },
+            content = {},
             edit={
                 'signatures': [venue_id],
                 'readers': [venue_id],
@@ -822,15 +833,6 @@ class InvitationBuilder(object):
                     'noninvitees': [self.venue.get_authors_id(number='${3/content/noteNumber/value}')] + ([self.venue.get_secondary_area_chairs_id('${3/content/noteNumber/value}')] if self.venue.use_secondary_area_chairs else []),
                     'maxReplies': 1,
                     'cdate': meta_review_cdate,
-                    'process': '''def process(client, edit, invitation):
-    meta_invitation = client.get_invitation(invitation.invitations[0])
-    script = meta_invitation.content['meta_review_process_script']['value']
-    funcs = {
-        'openreview': openreview
-    }
-    exec(script, funcs)
-    funcs['process'](client, edit, invitation)
-''',
                     'edit': {
                         'signatures': { 
                             'param': { 
@@ -866,6 +868,34 @@ class InvitationBuilder(object):
                 }
             }
         )
+
+        if meta_review_stage.process_path:
+            invitation.content['metareview_process_script'] = {
+               'value': self.get_process_content(meta_review_stage.process_path)
+            }
+            invitation.edit['invitation']['process'] = '''def process(client, edit, invitation):
+    meta_invitation = client.get_invitation(invitation.invitations[0])
+    script = meta_invitation.content['metareview_process_script']['value']
+    funcs = {
+        'openreview': openreview
+    }
+    exec(script, funcs)
+    funcs['process'](client, edit, invitation)
+'''
+        
+        if meta_review_stage.preprocess_path:
+            invitation.content['metareview_preprocess_script'] = {
+                'value': self.get_process_content(meta_review_stage.preprocess_path)
+            }
+            invitation.edit['invitation']['preprocess'] = '''def process(client, edit, invitation):
+    meta_invitation = client.get_invitation(invitation.invitations[0])
+    script = meta_invitation.content['metareview_preprocess_script']['value']
+    funcs = {
+        'openreview': openreview
+    }
+    exec(script, funcs)
+    funcs['process'](client, edit, invitation)
+'''           
 
         if meta_review_duedate:
             invitation.edit['invitation']['duedate'] = meta_review_duedate
@@ -3154,9 +3184,6 @@ class InvitationBuilder(object):
             content={
                 'source': {
                     'value': 'flagged_for_ethics_review'
-                },
-                'ethics_review_process_script': {
-                    'value': self.get_process_content('process/ethics_review_process.py')
                 }
             },
             edit={
@@ -3188,15 +3215,6 @@ class InvitationBuilder(object):
                     'invitees': [venue_id, self.venue.get_ethics_reviewers_id(number='${3/content/noteNumber/value}')],
                     'maxReplies': 1,
                     'cdate': ethics_review_cdate,
-                    'process': '''def process(client, edit, invitation):
-    meta_invitation = client.get_invitation(invitation.invitations[0])
-    script = meta_invitation.content['ethics_review_process_script']['value']
-    funcs = {
-        'openreview': openreview
-    }
-    exec(script, funcs)
-    funcs['process'](client, edit, invitation)
-''',
                     'edit': {
                         'signatures': { 
                             'param': { 
@@ -3233,6 +3251,34 @@ class InvitationBuilder(object):
 
             }
         )
+
+        if ethics_review_stage.process_path:
+            invitation.content['ethics_review_process_script'] = {
+               'value': self.get_process_content(ethics_review_stage.process_path)
+            }
+            invitation.edit['invitation']['process'] = '''def process(client, edit, invitation):
+    meta_invitation = client.get_invitation(invitation.invitations[0])
+    script = meta_invitation.content['ethics_review_process_script']['value']
+    funcs = {
+        'openreview': openreview
+    }
+    exec(script, funcs)
+    funcs['process'](client, edit, invitation)
+'''
+        
+        if ethics_review_stage.preprocess_path:
+            invitation.content['ethics_review_preprocess_script'] = {
+                'value': self.get_process_content(ethics_review_stage.preprocess_path)
+            }
+            invitation.edit['invitation']['preprocess'] = '''def process(client, edit, invitation):
+    meta_invitation = client.get_invitation(invitation.invitations[0])
+    script = meta_invitation.content['ethics_review_preprocess_script']['value']
+    funcs = {
+        'openreview': openreview
+    }
+    exec(script, funcs)
+    funcs['process'](client, edit, invitation)
+'''        
 
         if ethics_review_duedate:
             invitation.edit['invitation']['duedate'] = ethics_review_duedate
@@ -3308,9 +3354,11 @@ class InvitationBuilder(object):
                         }
                     }
                 }
-            },
-            process=self.get_process_content('process/ethics_flag_process.py')
+            }
         )
+
+        if ethics_review_stage.flag_process_path:
+            ethics_stage_invitation.process = self.get_process_content(ethics_review_stage.flag_process_path)
 
         if 'everyone' not in self.venue.submission_stage.get_readers(self.venue, '${{2/id}/number}'):
             ethics_stage_invitation.edit['note']['readers'] = {

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -537,6 +537,10 @@ class TestARRVenueV2():
         
         helpers.await_queue_edit(client, invitation=f'openreview.net/Support/-/Request{request_form_note.number}/Ethics_Review_Stage')
 
+        flag_invitation = openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/-/Ethics_Review_Flag')
+        assert flag_invitation.process
+        assert 'official_review_name, ae_checklist_name, reviewer_checklist_name' in flag_invitation.process
+
         venue = openreview.helpers.get_conference(client, request_form_note.id, 'openreview.net/Support')
         venue.create_ethics_review_stage()
 
@@ -2936,6 +2940,13 @@ class TestARRVenueV2():
         default_fields['needs_ethics_review'] = False
         test_submission = submissions[2]
 
+        review_invitation = openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission3/-/Official_Review')
+        assert review_invitation.preprocess
+        assert review_invitation.process
+        super_invitation = openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/-/Official_Review')
+        assert 'Knowledge_of_or_educated_guess_at_author_identity' in super_invitation.content['review_process_script']['value']
+        assert 'You have indicated that this submission needs an ethics review. Please enter a brief justification for your flagging' in super_invitation.content['review_preprocess_script']['value']
+
         openreview_client.add_members_to_group(venue.get_reviewers_id(number=3), ['~Reviewer_ARROne1'])
 
         reviewer_client = openreview.api.OpenReviewClient(username = 'reviewer1@aclrollingreview.com', password=helpers.strong_password)
@@ -3098,7 +3109,7 @@ class TestARRVenueV2():
         time.sleep(5)
 
         helpers.await_queue_edit(openreview_client, 'aclweb.org/ACL/ARR/2023/August/-/Release_Official_Reviews-0-1', count=1)
-        helpers.await_queue_edit(openreview_client, 'aclweb.org/ACL/ARR/2023/August/-/Official_Review-0-1', count=4)
+        helpers.await_queue_edit(openreview_client, 'aclweb.org/ACL/ARR/2023/August/-/Official_Review-0-1', count=2)
 
         review = openreview_client.get_note(reviewer_edit['note']['id'])
         assert 'aclweb.org/ACL/ARR/2023/August/Submission3/Authors' in review.readers
@@ -3261,6 +3272,13 @@ class TestARRVenueV2():
         default_fields['needs_ethics_review'] = False
         test_submission = submissions[3]
 
+        review_invitation = openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Meta_Review')
+        assert review_invitation.preprocess
+        assert review_invitation.process
+        super_invitation = openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/-/Meta_Review')
+        assert 'violation_fields' in super_invitation.content['metareview_process_script']['value']
+        assert 'You have indicated that this submission needs an ethics review. Please enter a brief justification for your flagging' in super_invitation.content['metareview_preprocess_script']['value']
+
         openreview_client.add_members_to_group(venue.get_area_chairs_id(number=4), ['~AC_ARROne1'])
         openreview_client.add_members_to_group(venue.get_ethics_reviewers_id(number=4), ['~EthicsReviewer_ARROne1'])
 
@@ -3386,7 +3404,7 @@ class TestARRVenueV2():
         assert test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Desk_Reject_Verification').expdate < now()
 
-        helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/-/Ethics_Review_Flag', count=9   )
+        helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/-/Ethics_Review_Flag', count=9)
 
         # Post an ethics review
         ethics_anon_id = ethics_client.get_groups(prefix='aclweb.org/ACL/ARR/2023/August/Submission4/Ethics_Reviewer_', signatory='~EthicsReviewer_ARROne1')[0].id


### PR DESCRIPTION
In order for the ARR values to use a different version of the process functions, we will place the path of these files in each stage class. 

The ARR class can override the paths and use a different file. 

This avoids updating the invitation twice and running the date process function more than once. 