### PR TITLE
ARR: Fix ethics review tests

### DIFF
--- a/openreview/venue/process/submission_process.py
+++ b/openreview/venue/process/submission_process.py
@@ -79,9 +79,9 @@ To view your submission, click here: https://openreview.net/forum?id={note.forum
 
     for venue_invitation in invitation_invitations:
         print('processing invitation: ', venue_invitation.id)
-        accepted_only = ('accepted_submissions' == venue_invitation.content.get('source', {}).get('value', False)) if venue_invitation.content else False
+        all_submissions = ('all_submissions' == venue_invitation.content.get('source', {}).get('value', 'all_submissions')) if venue_invitation.content else False
         content_keys = venue_invitation.edit.get('content', {}).keys()
-        if not accepted_only and 'noteId' in content_keys and 'noteNumber' in content_keys and len(content_keys) == 2:
+        if all_submissions and 'noteId' in content_keys and 'noteNumber' in content_keys and len(content_keys) == 2:
             print('create invitation: ', venue_invitation.id)
             client.post_invitation_edit(invitations=venue_invitation.id,
                 content={

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -259,9 +259,9 @@ class TestARRVenueV2():
                     'ae_checklist_exp_date': (due_date).strftime('%Y/%m/%d %H:%M'),
                     'reviewer_checklist_due_date': (due_date).strftime('%Y/%m/%d %H:%M'),
                     'reviewer_checklist_exp_date': (due_date).strftime('%Y/%m/%d %H:%M'),
-                    'ethics_review_start_date': (now).strftime('%Y/%m/%d %H:%M'),
-                    'ethics_review_deadline': (now + datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M'),
-                    'ethics_review_expiration_date': (now + datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M'),
+                    'ethics_review_start_date': (due_date).strftime('%Y/%m/%d %H:%M'),
+                    'ethics_review_deadline': (due_date + datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M'),
+                    'ethics_review_expiration_date': (due_date + datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M'),
                     'emergency_reviewing_start_date': (due_date).strftime('%Y/%m/%d %H:%M'),
                     'emergency_reviewing_due_date': (due_date).strftime('%Y/%m/%d %H:%M'),
                     'emergency_reviewing_exp_date': (due_date).strftime('%Y/%m/%d %H:%M'),
@@ -3375,7 +3375,7 @@ class TestARRVenueV2():
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Desk_Reject_Verification').expdate < now()
 
         # Check that ethics reviewing is not available
-        with pytest.raises(openreview.OpenReviewException, match=r'The Invitation aclweb.org/ACL/ARR/2023/August/Submission4/-/Ethics_Review has expired'):
+        with pytest.raises(openreview.OpenReviewException, match=r'The Invitation aclweb.org/ACL/ARR/2023/August/Submission4/-/Ethics_Review was not found'):
             ethics_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Ethics_Review')
 
         # Edit with ethics flag and no violation field - check DSV flag is false and ethics flag exists and is True

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -259,9 +259,9 @@ class TestARRVenueV2():
                     'ae_checklist_exp_date': (due_date).strftime('%Y/%m/%d %H:%M'),
                     'reviewer_checklist_due_date': (due_date).strftime('%Y/%m/%d %H:%M'),
                     'reviewer_checklist_exp_date': (due_date).strftime('%Y/%m/%d %H:%M'),
-                    'ethics_review_start_date': (due_date).strftime('%Y/%m/%d %H:%M'),
-                    'ethics_review_deadline': (due_date + datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M'),
-                    'ethics_review_expiration_date': (due_date + datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M'),
+                    'ethics_review_start_date': (now).strftime('%Y/%m/%d %H:%M'),
+                    'ethics_review_deadline': (now + datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M'),
+                    'ethics_review_expiration_date': (now + datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M'),
                     'emergency_reviewing_start_date': (due_date).strftime('%Y/%m/%d %H:%M'),
                     'emergency_reviewing_due_date': (due_date).strftime('%Y/%m/%d %H:%M'),
                     'emergency_reviewing_exp_date': (due_date).strftime('%Y/%m/%d %H:%M'),
@@ -536,6 +536,9 @@ class TestARRVenueV2():
         ))
         
         helpers.await_queue_edit(client, invitation=f'openreview.net/Support/-/Request{request_form_note.number}/Ethics_Review_Stage')
+
+        ethics_review_invitations = openreview_client.get_all_invitations(invitation='aclweb.org/ACL/ARR/2023/August/-/Ethics_Review')
+        assert len(ethics_review_invitations) == 0
 
         venue = openreview.helpers.get_conference(client, request_form_note.id, 'openreview.net/Support')
         venue.create_ethics_review_stage()
@@ -3386,7 +3389,7 @@ class TestARRVenueV2():
         assert test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Desk_Reject_Verification').expdate < now()
 
-        helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/-/Ethics_Review_Flag', count=9   )
+        helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/-/Ethics_Review_Flag', count=9)
 
         # Post an ethics review
         ethics_anon_id = ethics_client.get_groups(prefix='aclweb.org/ACL/ARR/2023/August/Submission4/Ethics_Reviewer_', signatory='~EthicsReviewer_ARROne1')[0].id


### PR DESCRIPTION
This PR sets the ethics review stage to be active in the future instead of activating it as soon as the tests start. This fixes a bug where all submissions had an ethics review invitation created since the ethics review super invitation was active while the submission process functions ran.

Edited to add: I changed the test to start the ethics review stage from the beginning, to make sure no Ethics_Review invitatinos are created since no papers are flagged. 