### PR TITLE
Fix/meta review content query

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1083,7 +1083,7 @@ class MetaReviewStage(object):
         REVIEWERS_SUBMITTED = 2
         NO_REVIEWERS = 3
 
-    def __init__(self, name='Meta_Review', start_date = None, due_date = None, exp_date = None, public = False, release_to_authors = False, release_to_reviewers = Readers.NO_REVIEWERS, additional_fields = {}, remove_fields=[], process = None, recommendation_field_name = 'recommendation'):
+    def __init__(self, name='Meta_Review', start_date = None, due_date = None, exp_date = None, public = False, release_to_authors = False, release_to_reviewers = Readers.NO_REVIEWERS, additional_fields = {}, remove_fields=[], process = None, recommendation_field_name = 'recommendation', source_submissions_query = {}, child_invitations_name = 'Meta_Review'):
 
         self.start_date = start_date
         self.due_date = due_date
@@ -1096,6 +1096,8 @@ class MetaReviewStage(object):
         self.remove_fields = remove_fields
         self.process = None
         self.recommendation_field_name = recommendation_field_name
+        self.source_submissions_query = source_submissions_query
+        self.child_invitations_name = child_invitations_name
 
     def _get_reviewer_readers(self, conference, number):
         if self.release_to_reviewers is MetaReviewStage.Readers.REVIEWERS:

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -860,7 +860,7 @@ class InvitationBuilder(object):
                         'note': {
                             'id': {
                                 'param': {
-                                    'withInvitation': self.venue.get_invitation_id(meta_review_stage.name, '${6/content/noteNumber/value}'),
+                                    'withInvitation': self.venue.get_invitation_id(meta_review_stage.child_invitations_name, '${6/content/noteNumber/value}'),
                                     'optional': True
                                 }
                             },
@@ -962,7 +962,7 @@ class InvitationBuilder(object):
                     },
                     'replacement': True,
                     'invitation': {
-                        'id': self.venue.get_invitation_id(meta_review_stage.name + '_SAC_Revision', '${2/content/noteNumber/value}'),
+                        'id': self.venue.get_invitation_id(meta_review_stage.child_invitations_name + '_SAC_Revision', '${2/content/noteNumber/value}'),
                         'signatures': [ venue_id ],
                         'readers': ['everyone'],
                         'writers': [venue_id],
@@ -982,7 +982,7 @@ class InvitationBuilder(object):
                             'note': {
                                 'id': {
                                     'param': {
-                                        'withInvitation': self.venue.get_invitation_id(meta_review_stage.name, '${6/content/noteNumber/value}')
+                                        'withInvitation': self.venue.get_invitation_id(meta_review_stage.child_invitations_name, '${6/content/noteNumber/value}')
                                     }
                                 },
                                 'forum': '${4/content/noteId/value}',
@@ -995,6 +995,11 @@ class InvitationBuilder(object):
 
             if meta_review_expdate:
                 invitation.edit['invitation']['expdate'] = meta_review_expdate
+
+            if source_submissions_query:
+                invitation.content['source_submissions_query'] = {
+                    'value': source_submissions_query
+                }
 
             self.save_invitation(invitation, replacement=False)
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4497,7 +4497,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         venue.create_custom_stage()
 
-        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_Agreement')) == 1
+        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_Agreement')) == 2
 
         sac_client = openreview.api.OpenReviewClient(username = 'sac2@icml.cc', password=helpers.strong_password)
         submissions = sac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4343,12 +4343,17 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         venue.create_meta_review_stage()
         helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Meta_Review-0-1', count=1)
 
-        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review')) == 50
+        invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review')
+        assert len(invitations) == 50
+
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review')
+        assert invitation
+        assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
         assert 'suggestions' in invitation.edit['note']['content']
 
         invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_SAC_Revision')
         assert len(invitations) == 50
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review_SAC_Revision')
         assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
         # duedate + 2 days
@@ -4388,6 +4393,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review_SAC_Revision')
         assert len(invitations) == 50
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review_SAC_Revision')
         assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
         ac_client = openreview.api.OpenReviewClient(username='ac2@icml.cc', password=helpers.strong_password)

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4410,11 +4410,11 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         ac_client = openreview.api.OpenReviewClient(username='ac1@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
 
-        anon_groups = ac_client.get_groups(prefix='ICML.cc/2023/Conference/Submission2/Area_Chair_', signatory='~AC_ICMLOne1')
+        anon_groups = ac_client.get_groups(prefix='ICML.cc/2023/Conference/Submission4/Area_Chair_', signatory='~AC_ICMLOne1')
         anon_group_id = anon_groups[0].id
 
         meta_review_edit = ac_client.post_note_edit(
-            invitation='ICML.cc/2023/Conference/Submission2/-/Meta_Review',
+            invitation='ICML.cc/2023/Conference/Submission4/-/Meta_Review',
             signatures=[anon_group_id],
             note=openreview.api.Note(
                 content={
@@ -4446,7 +4446,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         )
 
         helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Position_Paper_Meta_Review-0-1', count=2)
-        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review')
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission4/-/Meta_Review')
         assert invitation.expdate == new_exp_date
 
     def test_meta_review_agreement(self, client, openreview_client, helpers, selenium, request_page):
@@ -4549,7 +4549,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         helpers.await_queue_edit(openreview_client, edit_id=meta_review_edit['id'])
 
-        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_Agreement')) == 2
+        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_Agreement')) == 3
 
         invitation_id = 'ICML.cc/2023/Conference/Submission2/Meta_Review1/-/Meta_Review_Agreement'
         sac_client = openreview.api.OpenReviewClient(username = 'sac1@gmail.com', password=helpers.strong_password)

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4347,13 +4347,13 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert len(invitations) == 50
         assert invitations[0].edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
-        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review')
-        assert invitation
-        assert 'suggestions' in invitation.edit['note']['content']
-
         invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_SAC_Revision')
         assert len(invitations) == 50
-        assert invitations[0].edit['note']['id']['param']['withInvitation'] == invitations[0].id
+
+        sac_revision_invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review_SAC_Revision')
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review')
+        assert sac_revision_invitation.edit['note']['id']['param']['withInvitation'] == invitation.id
+        assert 'suggestions' in invitation.edit['note']['content']
 
         # duedate + 2 days
         exp_date = invitation.duedate + (2*24*60*60*1000)
@@ -4385,14 +4385,14 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert len(invitations) == 50
         assert invitations[0].edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
-        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review')
-        assert invitation
-        assert 'metareview' in invitation.edit['note']['content']
-        assert 'suggestions' not in invitation.edit['note']['content']
-
         invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review_SAC_Revision')
         assert len(invitations) == 50
-        assert invitations[0].edit['note']['id']['param']['withInvitation'] == invitations[0].id
+
+        sac_revision_invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review_SAC_Revision')
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review')
+        assert sac_revision_invitation.edit['note']['id']['param']['withInvitation'] == invitation.id
+        assert 'metareview' in invitation.edit['note']['content']
+        assert 'suggestions' not in invitation.edit['note']['content']
 
         ac_client = openreview.api.OpenReviewClient(username='ac2@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4372,12 +4372,18 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         venue.create_meta_review_stage()
         helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Position_Paper_Meta_Review-0-1', count=1)
 
-        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review')) == 50
+        invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review')
+        assert len(invitations) == 50
+
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review')
         assert invitation
-        assert openreview_client.get_invitation('ICML.cc/2023/Conference/Submission4/-/Meta_Review')
+        assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
         assert 'metareview' in invitation.edit['note']['content']
         assert 'suggestions' not in invitation.edit['note']['content']
+
+        invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_SAC_Revision')
+        assert len(invitations) == 2
+        assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
         ac_client = openreview.api.OpenReviewClient(username='ac2@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4295,72 +4295,89 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         ]
 
     def test_meta_review_stage(self, client, openreview_client, helpers):
-
         pc_client=openreview.Client(username='pc@icml.cc', password=helpers.strong_password)
+        pc_client_v2=openreview.api.OpenReviewClient(username='pc@icml.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         now = datetime.datetime.utcnow()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         exp_date = due_date + datetime.timedelta(days=2)
-        pc_client.post_note(openreview.Note(
-            content={
-                'make_meta_reviews_public': 'No, meta reviews should NOT be revealed publicly when they are posted',
-                'meta_review_start_date': start_date.strftime('%Y/%m/%d'),
-                'meta_review_deadline': due_date.strftime('%Y/%m/%d'),
-                'meta_review_expiration_date': exp_date.strftime('%Y/%m/%d'),
-                'recommendation_options': 'Accept, Reject',
-                'release_meta_reviews_to_authors': 'No, meta reviews should NOT be revealed when they are posted to the paper\'s authors',
-                'release_meta_reviews_to_reviewers': 'Meta reviews should be immediately revealed to the paper\'s reviewers who have already submitted their review',
-                'additional_meta_review_form_options': {
-                    'recommendation': {
-                        'description': 'Please select a recommendation for the paper',
-                        'value': {
-                            'param': {
-                                'type': 'string',
-                                'enum': ['Accept', 'Reject'],
-                                'input': 'select'
-                            }
-                        },
-                        'order': 2
+
+        venue = openreview.helpers.get_conference(client, request_form.id, setup=False)
+        venue.meta_review_stage = openreview.stages.MetaReviewStage(
+            start_date=start_date,
+            due_date=due_date,
+            exp_date=exp_date,
+            additional_fields={
+                'recommendation': {
+                    'description': 'Please select a recommendation for the paper',
+                    'value': {
+                        'param': {
+                            'type': 'string',
+                            'enum': ['Accept', 'Reject'],
+                            'input': 'select'
+                        }
                     },
-                    'suggestions': {
-                        'description': 'Please provide suggestions on how to improve the paper',
-                        'value': {
-                            'param': {
-                                'type': 'string',
-                                'maxLength': 5000,
-                                'input': 'textarea',
-                                'optional': True,
-                                'deletable': True
-                            }
+                    'order': 2
+                },
+                'suggestions': {
+                    'description': 'Please provide suggestions on how to improve the paper',
+                    'value': {
+                        'param': {
+                            'type': 'string',
+                            'maxLength': 5000,
+                            'input': 'textarea',
+                            'optional': True,
+                            'deletable': True
                         }
                     }
-                },
-                'remove_meta_review_form_options': ['confidence']
+                }
             },
-            forum=request_form.forum,
-            invitation=f'openreview.net/Support/-/Request{request_form.number}/Meta_Review_Stage',
-            readers=['ICML.cc/2023/Conference/Program_Chairs', 'openreview.net/Support'],
-            replyto=request_form.forum,
-            referent=request_form.forum,
-            signatures=['~Program_ICMLChair1'],
-            writers=[]
-        ))
+            remove_fields=['confidence'],
+            source_submissions_query={
+                'position_paper_track': 'No'
+            }
+        )
 
+        venue.create_meta_review_stage()
+        helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Meta_Review-0-1', count=1)
 
-        helpers.await_queue()
-
+        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review')) == 50
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review')
+        assert 'suggestions' in invitation.edit['note']['content']
         # duedate + 2 days
         exp_date = invitation.duedate + (2*24*60*60*1000)
         assert invitation.expdate == exp_date
 
         assert openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review')
-        assert openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review')
+        assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/Submission2/-/Meta_Review')
         assert openreview_client.get_invitation('ICML.cc/2023/Conference/Submission3/-/Meta_Review')
-        assert openreview_client.get_invitation('ICML.cc/2023/Conference/Submission4/-/Meta_Review')
+        assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/Submission4/-/Meta_Review')
         assert openreview_client.get_invitation('ICML.cc/2023/Conference/Submission5/-/Meta_Review')
+
+        ## Create position paper meta reviews
+        venue = openreview.helpers.get_conference(client, request_form.id, setup=False)
+        venue.meta_review_stage = openreview.stages.MetaReviewStage(
+            start_date=start_date,
+            due_date=due_date,
+            exp_date=exp_date,
+            remove_fields=['confidence'],
+            name='Position_Paper_Meta_Review',
+            source_submissions_query={
+                'position_paper_track': 'Yes'
+            }
+        )
+
+        venue.create_meta_review_stage()
+        helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Position_Paper_Meta_Review-0-1', count=1)
+
+        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review')) == 50
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review')
+        assert invitation
+        assert openreview_client.get_invitation('ICML.cc/2023/Conference/Submission4/-/Meta_Review')
+        assert 'metareview' in invitation.edit['note']['content']
+        assert 'suggestions' not in invitation.edit['note']['content']
 
         ac_client = openreview.api.OpenReviewClient(username='ac2@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
@@ -4382,14 +4399,55 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         helpers.await_queue_edit(openreview_client, edit_id=meta_review_edit['id'])
 
         #try to delete AC assignment of paper with a submitted metareview
-        pc_client_v2=openreview.api.OpenReviewClient(username='pc@icml.cc', password=helpers.strong_password)
-
         assignment = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[0].id, tail='~AC_ICMLTwo1')[0]
         assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
         assignment.cdate = None
 
         with pytest.raises(openreview.OpenReviewException, match=r'Can not remove assignment, the user ~AC_ICMLTwo1 already posted a Meta Review.'):
             pc_client_v2.post_edge(assignment)
+
+        ## Post meta review to position paper
+        ac_client = openreview.api.OpenReviewClient(username='ac1@icml.cc', password=helpers.strong_password)
+        submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
+
+        anon_groups = ac_client.get_groups(prefix='ICML.cc/2023/Conference/Submission2/Area_Chair_', signatory='~AC_ICMLOne1')
+        anon_group_id = anon_groups[0].id
+
+        meta_review_edit = ac_client.post_note_edit(
+            invitation='ICML.cc/2023/Conference/Submission2/-/Meta_Review',
+            signatures=[anon_group_id],
+            note=openreview.api.Note(
+                content={
+                    'metareview': { 'value': 'This is a good paper' },
+                    'recommendation': { 'value': 'Accept (Oral)'}
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=meta_review_edit['id'])
+
+        ## Extend deadline using a meta invitation and propagate the change to all the children
+        new_due_date = openreview.tools.datetime_millis(now + datetime.timedelta(days=10))
+        new_exp_date = openreview.tools.datetime_millis(now + datetime.timedelta(days=15))
+        pc_client_v2.post_invitation_edit(
+            invitations='ICML.cc/2023/Conference/-/Edit',
+            readers=['ICML.cc/2023/Conference'],
+            writers=['ICML.cc/2023/Conference'],
+            signatures=['ICML.cc/2023/Conference'],
+            invitation=openreview.api.Invitation(
+                id='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review',
+                edit={
+                    'invitation': {
+                        'duedate': new_due_date,
+                        'expdate': new_exp_date
+                    }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Position_Paper_Meta_Review-0-1', count=2)
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review')
+        assert invitation.expdate == new_exp_date
 
     def test_meta_review_agreement(self, client, openreview_client, helpers, selenium, request_page):
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4346,6 +4346,11 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review')) == 50
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review')
         assert 'suggestions' in invitation.edit['note']['content']
+
+        invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_SAC_Revision')
+        assert len(invitations) == 50
+        assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
+
         # duedate + 2 days
         exp_date = invitation.duedate + (2*24*60*60*1000)
         assert invitation.expdate == exp_date
@@ -4381,8 +4386,8 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert 'metareview' in invitation.edit['note']['content']
         assert 'suggestions' not in invitation.edit['note']['content']
 
-        invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_SAC_Revision')
-        assert len(invitations) == 2
+        invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review_SAC_Revision')
+        assert len(invitations) == 50
         assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
         ac_client = openreview.api.OpenReviewClient(username='ac2@icml.cc', password=helpers.strong_password)

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4345,16 +4345,15 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review')
         assert len(invitations) == 50
+        assert invitations[0].edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review')
         assert invitation
-        assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
         assert 'suggestions' in invitation.edit['note']['content']
 
         invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Meta_Review_SAC_Revision')
         assert len(invitations) == 50
-        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Meta_Review_SAC_Revision')
-        assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
+        assert invitations[0].edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
         # duedate + 2 days
         exp_date = invitation.duedate + (2*24*60*60*1000)
@@ -4384,17 +4383,16 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review')
         assert len(invitations) == 50
+        assert invitations[0].edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review')
         assert invitation
-        assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
         assert 'metareview' in invitation.edit['note']['content']
         assert 'suggestions' not in invitation.edit['note']['content']
 
         invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Position_Paper_Meta_Review_SAC_Revision')
         assert len(invitations) == 50
-        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission2/-/Meta_Review_SAC_Revision')
-        assert invitation.edit['note']['id']['param']['withInvitation'] == invitations[0].id
+        assert invitations[0].edit['note']['id']['param']['withInvitation'] == invitations[0].id
 
         ac_client = openreview.api.OpenReviewClient(username='ac2@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4610,7 +4610,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
                 id=metareviews[0].id,
                 content={
                     'metareview': { 'value': 'I reverted the AC decision' },
-                    'recommendation': { 'value': 'Accept'}
+                    'recommendation': { 'value': 'Accept (Oral)'}
                 }
             )
         )


### PR DESCRIPTION
Adds support for multiple meta review forms by adding `source_submissions_query` and `child_invitations_name` to the meta review stage.