### PR TITLE
Fix/ Venue: add ethics chairs as readers of ethics reviewers groups

### DIFF
--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -414,10 +414,11 @@ class GroupBuilder(object):
     def create_ethics_reviewers_group(self):
         venue_id = self.venue.id
         ethics_reviewers_id = self.venue.get_ethics_reviewers_id()
+        ethics_chairs_id = self.venue.get_ethics_chairs_id()
         ethics_reviewers_group = openreview.tools.get_group(self.client, ethics_reviewers_id)
         if not ethics_reviewers_group:
             ethics_reviewers_group = Group(id=ethics_reviewers_id,
-                            readers=[venue_id, ethics_reviewers_id],
+                            readers=[venue_id, ethics_reviewers_id, ethics_chairs_id],
                             writers=[venue_id],
                             signatures=[venue_id],
                             signatories=[venue_id],
@@ -508,10 +509,13 @@ class GroupBuilder(object):
                             members=[]
                             ))
 
+        invited_group_readers = [venue_id, committee_invited_id]
+        if committee_name == self.venue.ethics_reviewers_name:
+            invited_group_readers.append(self.venue.get_ethics_chairs_id())
         committee_invited_group = tools.get_group(self.client, committee_invited_id)
         if not committee_invited_group:
             committee_invited_group=self.post_group(Group(id=committee_invited_id,
-                            readers=[venue_id, committee_invited_id],
+                            readers=invited_group_readers,
                             writers=[venue_id, pc_group_id],
                             signatures=[venue_id],
                             signatories=[venue_id, committee_invited_id],

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -444,7 +444,9 @@ class TestICMLConference():
         helpers.await_queue()
 
         assert len(openreview_client.get_group('ICML.cc/2023/Conference/Senior_Area_Chairs').members) == 0
-        assert len(openreview_client.get_group('ICML.cc/2023/Conference/Senior_Area_Chairs/Invited').members) == 2
+        group = openreview_client.get_group('ICML.cc/2023/Conference/Senior_Area_Chairs/Invited')
+        assert len(group.members) == 2
+        assert group.readers == ['ICML.cc/2023/Conference', 'ICML.cc/2023/Conference/Senior_Area_Chairs/Invited']
 
         messages = openreview_client.get_messages(subject = '[ICML 2023] Invitation to serve as Senior Area Chair')
         assert len(messages) == 2
@@ -3195,12 +3197,15 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert recruitment_note
         helpers.await_queue()        
               
-        assert openreview_client.get_group('ICML.cc/2023/Conference/Ethics_Reviewers')
+        group = openreview_client.get_group('ICML.cc/2023/Conference/Ethics_Reviewers')
+        assert group
+        assert 'ICML.cc/2023/Conference/Ethics_Chairs' in group.readers
         assert openreview_client.get_group('ICML.cc/2023/Conference/Ethics_Reviewers/Declined')
         group = openreview_client.get_group('ICML.cc/2023/Conference/Ethics_Reviewers/Invited')
         assert group
         assert len(group.members) == 1
         assert 'reviewerethics@yahoo.com' in group.members
+        assert 'ICML.cc/2023/Conference/Ethics_Chairs' in group.readers
 
         messages = openreview_client.get_messages(to='reviewerethics@yahoo.com', subject='[ICML 2023] Invitation to serve as Ethics Reviewer')
         assert messages and len(messages) == 1


### PR DESCRIPTION
Ethics Chairs should be readers of the `Ethics_Reviewers` and `Ethics_Reviewers/Invited` groups in order for the Ethics Chair console overview to show the correct count for recruitment:

![Screen Shot 2024-04-03 at 2 58 55 PM](https://github.com/openreview/openreview-py/assets/32438984/a6fea2ac-f6e7-4ce1-a79c-9cfef20efbd4)
