### PR TITLE
Revert "Update venue.py"

### DIFF
--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -808,7 +808,7 @@ Total Errors: {len(errors)}
                 message = messages[decision_note['content']['decision']['value']]
                 final_message = message.replace("{{submission_title}}", note.content['title']['value'])
                 final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={note.id}')
-                self.client.post_message(subject, recipients=[self.get_authors_id(note.number)], message=final_message, replyTo=self.contact)
+                self.client.post_message(subject, recipients=[self.get_authors_id(note.number)], message=final_message, parentGroup=self.get_authors_id(), replyTo=self.contact)
 
         tools.concurrent_requests(send_notification, paper_notes)
 


### PR DESCRIPTION
Reverts openreview/openreview-py#2032

Otherwise PCs can not see messages sent.

Once we use invitations to send messages we won't have the performance issue. 