### PR TITLE
revert change and throw abstract errors

### DIFF
--- a/openreview/profile/process/dblp_abstract_process.js
+++ b/openreview/profile/process/dblp_abstract_process.js
@@ -5,16 +5,12 @@ async function process(client, edit, invitation) {
   const html = result.notes?.[0]?.content?.html?.value
 
   let abstract = null
-  try {
-    if (html) {
-      const extractionResult = await Tools.extractAbstract(html).then(result => result.json());
-      abstract = extractionResult.abstract
-      console.log('abstract: ' + abstract);
-      console.log('pdf: ' + extractionResult.pdf);
-      console.log('error: ' + extractionResult.error);
-    }
-  } catch (error) {
-    console.log('server error: ' + error);
+  if (html) {
+    const extractionResult = await Tools.extractAbstract(html).then(result => result.json());
+    abstract = extractionResult.abstract
+    console.log('abstract: ' + abstract);
+    console.log('pdf: ' + extractionResult.pdf);
+    console.log('error: ' + extractionResult.error);
   }
 
   if (!abstract) return

--- a/openreview/profile/process/dblp_record_process.js
+++ b/openreview/profile/process/dblp_record_process.js
@@ -10,6 +10,7 @@ async function process(client, edit, invitation) {
   }
 
   const html = note.content.html?.value;
+  let abstractError = false;
 
   try {
     if (html) {
@@ -26,13 +27,18 @@ async function process(client, edit, invitation) {
     }
   } catch (error) {
     console.log('error: ' + error);
+    abstractError = error;
   }
-
-
 
   await client.postNoteEdit({
     invitation: 'DBLP.org/-/Edit',
     signatures: ['DBLP.org/Uploader'],
+    readers: ['everyone'],
+    writers: ['DBLP.org'],
     note: note
   });
+
+  if (abstractError) {
+    throw abstractError;
+  }
 }


### PR DESCRIPTION
Reverts openreview/openreview-py#2032

Otherwise PCs can not see messages sent.

Once we use invitations to send messages we won't have the performance issue. 