### PR TITLE
Fix/ Submission Revision Stage: do not add readers to any field

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2186,13 +2186,6 @@ class InvitationBuilder(object):
         only_accepted = revision_stage.only_accepted
         content = revision_stage.get_content(api_version='2', conference=self.venue)
 
-        hidden_field_names = self.venue.submission_stage.get_hidden_field_names()
-        for field in content:
-            if field in hidden_field_names:
-                content[field]['readers'] = [venue_id, self.venue.get_authors_id('${{4/id}/number}')]
-            if field not in hidden_field_names:
-                content[field]['readers'] = { 'delete': True }
-
         invitation = Invitation(id=revision_invitation_id,
             invitees=[venue_id],
             readers=[venue_id],

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2186,6 +2186,16 @@ class InvitationBuilder(object):
         only_accepted = revision_stage.only_accepted
         content = revision_stage.get_content(api_version='2', conference=self.venue)
 
+        hidden_field_names = self.venue.submission_stage.get_hidden_field_names()
+        existing_invitation = tools.get_invitation(self.client, revision_invitation_id)
+        invitation_content = existing_invitation.edit['invitation']['edit']['note']['content'] if existing_invitation else {}
+
+        for field in content:
+            if field in hidden_field_names:
+                content[field]['readers'] = [venue_id, self.venue.get_authors_id('${{4/id}/number}')]
+            if field not in hidden_field_names and invitation_content.get(field, {}).get('readers', []):
+                content[field]['readers'] = { 'delete': True }
+
         invitation = Invitation(id=revision_invitation_id,
             invitees=[venue_id],
             readers=[venue_id],

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2190,6 +2190,8 @@ class InvitationBuilder(object):
         for field in content:
             if field in hidden_field_names:
                 content[field]['readers'] = [venue_id, self.venue.get_authors_id('${{4/id}/number}')]
+            if field not in hidden_field_names:
+                content[field]['readers'] = { 'delete': True }
 
         invitation = Invitation(id=revision_invitation_id,
             invitees=[venue_id],

--- a/openreview/venue_request/process/bid_stage_pre_process.py
+++ b/openreview/venue_request/process/bid_stage_pre_process.py
@@ -6,4 +6,4 @@ def process(client, note, invitation):
         raise openreview.OpenReviewException('Papers should be visible to all program committee if bidding is enabled')
     
     if 'pdf' not in request_form.content.get('hide_fields', []):
-        raise openreview.OpenReviewException('The pdf field should be hidden during the bidding stage')
+        raise openreview.OpenReviewException('The pdf field should be hidden during the bidding stage. Please use the Post Submission button to hide pdfs.')

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -214,6 +214,12 @@ def process(client, note, invitation):
                 #update post submission hide_fields
                 submission_content = conference.submission_stage.get_content(api_version='2', conference=conference)
                 hide_fields = [key for key in submission_content.keys() if key not in ['title', 'authors', 'authorids', 'venue', 'venueid'] and 'delete' not in submission_content[key]]
+                second_deadline_fields = forum_note.content.get('second_deadline_additional_options', {})
+                if second_deadline_fields:
+                    fields = list(second_deadline_fields.keys())
+                    for field in fields:
+                        if field not in hide_fields and 'delete' not in second_deadline_fields[field]:
+                            hide_fields.append(field)
                 content = {
                     'submission_readers': {
                         'description': 'Please select who should have access to the submissions after the submission deadline. Note that program chairs and paper authors are always readers of submissions.',

--- a/openreview/venue_request/process/revision_pre_process.py
+++ b/openreview/venue_request/process/revision_pre_process.py
@@ -8,11 +8,3 @@ def process(client, note, invitation):
 
         if 'No' in note.content.get('desk_rejected_submissions_author_anonymity', ''):
             raise openreview.OpenReviewException('Author identities of desk-rejected submissions can only be anonymized for double-blind submissions')
-
-    if 'hide_fields' in note.content:
-        submission_fields = ['TLDR', 'abstract', 'keywords', 'pdf']
-        if 'Additional Submission Options' in note.content:
-            submission_fields.extend(list(note.content['Additional Submission Options'].keys()))
-        for field in note.content['hide_fields']:
-            if field not in submission_fields:
-                raise openreview.OpenReviewException('Invalid field to hide: ' + field)

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -25,12 +25,6 @@ class VenueStages():
             'value-dict': {},
             'description': 'Configure additional options in the submission form. Use lowercase for the field names and underscores to represent spaces. The UI will auto-format the names, for example: supplementary_material -> Supplementary Material. Valid JSON expected.'
         }
-        revision_content['hide_fields'] = {
-                'values-regex': '.*',
-                'required': False,
-                'description': 'Comma separated values of submission fields to be hidden, author names are already hidden. These fields will be hidden from all readers of the submissions, except for program chairs and paper authors. Write the field name exactly as it appears in the submission invitation. For reference, please see: https://docs.openreview.net/reference/default-forms/default-submission-form',
-                'order': 19
-        }
         revision_content['remove_submission_options'] = {
             'order': 20,
             'values-dropdown':  ['abstract','keywords', 'pdf', 'TL;DR'],

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -213,12 +213,28 @@ class TestARRVenueV2():
                 'homepage_override': { #TODO: Update
                     'location': 'Hawaii, USA',
                     'instructions': 'For author guidelines, please click [here](https://icml.cc/Conferences/2023/StyleAuthorInstructions)'
-                },
-                'hide_fields': hide_fields
+                }
             }
         ))
-
         helpers.await_queue_edit(client, invitation=f'openreview.net/Support/-/Request{request_form_note.number}/Revision')
+
+        # hide pdf
+        post_submission_note=pc_client.post_note(openreview.Note(
+            content= {
+                'force': 'Yes',
+                'hide_fields': hide_fields,
+                'submission_readers': 'Assigned program committee (assigned reviewers, assigned area chairs, assigned senior area chairs if applicable)'
+            },
+            forum=request_form_note.id,
+            invitation=f'openreview.net/Support/-/Request{request_form_note.number}/Post_Submission',
+            readers= ['aclweb.org/ACL/ARR/2023/August/Program_Chairs', 'openreview.net/Support'],
+            referent=request_form_note.id,
+            replyto=request_form_note.id,
+            signatures= ['~Program_ARRChair1'],
+            writers= [],
+        ))
+
+        helpers.await_queue()
 
         request_page(selenium, 'http://localhost:3030/group?id=aclweb.org/ACL/ARR/2023/August', pc_client.token, wait_for_element='header')
         header_div = selenium.find_element(By.ID, 'header')
@@ -455,8 +471,7 @@ class TestARRVenueV2():
                 'homepage_override': { #TODO: Update
                     'location': 'Hawaii, USA',
                     'instructions': 'For author guidelines, please click [here](https://icml.cc/Conferences/2023/StyleAuthorInstructions)'
-                },
-                'hide_fields': hide_fields
+                }
             }
         ))
 
@@ -1196,8 +1211,7 @@ class TestARRVenueV2():
                 'homepage_override': { #TODO: Update
                     'location': 'Hawaii, USA',
                     'instructions': 'For author guidelines, please click [here](https://icml.cc/Conferences/2023/StyleAuthorInstructions)'
-                },
-                'hide_fields': hide_fields
+                }
             }
         ))
 
@@ -1664,8 +1678,7 @@ class TestARRVenueV2():
                 'homepage_override': { #TODO: Update
                     'location': 'Hawaii, USA',
                     'instructions': 'For author guidelines, please click [here](https://icml.cc/Conferences/2023/StyleAuthorInstructions)'
-                },
-                'hide_fields': hide_fields
+                }
             }
         ))
 
@@ -1804,8 +1817,7 @@ class TestARRVenueV2():
                 'homepage_override': { #TODO: Update
                     'location': 'Hawaii, USA',
                     'instructions': 'For author guidelines, please click [here](https://icml.cc/Conferences/2023/StyleAuthorInstructions)'
-                },
-                'hide_fields': hide_fields
+                }
             },
             forum=request_form.forum,
             invitation='openreview.net/Support/-/Request{}/Revision'.format(request_form.number),

--- a/tests/test_emnlp_conference.py
+++ b/tests/test_emnlp_conference.py
@@ -104,6 +104,12 @@ class TestEMNLPConference():
         assert 'second_deadline_additional_options' in revision.reply['content']
         assert 'second_deadline_remove_options' in revision.reply['content']
 
+        # check Post_Submission hide_fields has all default fields
+        post_submission_invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form_note.number}/Post_Submission')
+        assert post_submission_invitation
+        assert 'values-dropdown' in post_submission_invitation.reply['content']['hide_fields']
+        assert ['keywords', 'TLDR', 'abstract', 'pdf'] == post_submission_invitation.reply['content']['hide_fields']['values-dropdown']
+
         pc_client.post_note(openreview.Note(
             invitation=f'openreview.net/Support/-/Request{request_form_note.number}/Revision',
             forum=request_form_note.id,
@@ -210,6 +216,12 @@ class TestEMNLPConference():
         assert 'optional' not in revision_invitation.edit['invitation']['edit']['note']['content']['supplementary_materials']['value']['param']
         assert 'TLDR' not in revision_invitation.edit['invitation']['edit']['note']['content']
         assert 'ddate' not in revision_invitation.edit['invitation']['edit']['note']
+
+        # check Post_Submission hide_fields has all fields in second_deadline_additional_options as well
+        post_submission_invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form_note.number}/Post_Submission')
+        assert post_submission_invitation
+        assert 'values-dropdown' in post_submission_invitation.reply['content']['hide_fields']
+        assert ['keywords', 'abstract', 'supplementary_materials', 'pdf', 'submission_type'] == post_submission_invitation.reply['content']['hide_fields']['values-dropdown']
 
     def test_submit_papers(self, test_client, client, openreview_client, helpers):
 

--- a/tests/test_emnlp_conference.py
+++ b/tests/test_emnlp_conference.py
@@ -313,8 +313,7 @@ class TestEMNLPConference():
                         "description": "Each submission can optionally be accompanied by a single .tgz or .zip archive containing software, and/or a single .tgz or .zip archive containing data. EMNLP 2023 encourages the submission of these supplementary materials to improve the reproducibility of results and to enable authors to provide additional information that does not fit in the paper. All supplementary materials must be properly anonymized.",
                         "order": 9
                     }
-                },
-                'hide_fields': ['pdf']
+                }
             },
             forum=request_form.forum,
             invitation='openreview.net/Support/-/Request{}/Revision'.format(request_form.number),
@@ -346,26 +345,6 @@ class TestEMNLPConference():
             'EMNLP/2023/Conference/Reviewers',
             'EMNLP/2023/Conference/Submission5/Authors'
         ]
-
-        submission = submissions[2]
-        revision_note = test_client.post_note_edit(invitation='EMNLP/2023/Conference/Submission3/-/Revision',
-            signatures=['EMNLP/2023/Conference/Submission3/Authors'],
-            note=openreview.api.Note(
-                content={
-                    'title': submission.content['title'],
-                    'abstract': submission.content['abstract'],
-                    'authorids': submission.content['authorids'],
-                    'authors': submission.content['authors'],
-                    'keywords': submission.content['keywords'],
-                    'pdf': { 'value':  '/attachment/' + 's' * 40 +'.pdf' },
-                    'submission_type': { 'value': 'Regular Long Paper'},
-                    'supplementary_materials': { 'value':  '/attachment/' + 's' * 40 +'.zip' },
-                }
-            ))
-        helpers.await_queue_edit(openreview_client, edit_id=revision_note['id'])
-
-        submission = openreview_client.get_note(submission.id)
-        assert 'readers' in submission.content['pdf']
 
         authors_group = openreview_client.get_group('EMNLP/2023/Conference/Authors')
         assert 'EMNLP/2023/Conference/Submission5/Authors' in authors_group.members
@@ -574,8 +553,7 @@ Please note that responding to this email will direct your reply to pc@emnlp.org
                         "description": "Each submission can optionally be accompanied by a single .tgz or .zip archive containing software, and/or a single .tgz or .zip archive containing data. EMNLP 2023 encourages the submission of these supplementary materials to improve the reproducibility of results and to enable authors to provide additional information that does not fit in the paper. All supplementary materials must be properly anonymized.",
                         "order": 9
                     }            
-                }, 
-                'hide_fields': ['pdf']
+                }
             },
             forum=request_form.forum,
             invitation='openreview.net/Support/-/Request{}/Revision'.format(request_form.number),
@@ -587,15 +565,6 @@ Please note that responding to this email will direct your reply to pc@emnlp.org
         ))
 
         helpers.await_queue()
-
-        #assert 'pdf' is hidden in revision invitations
-        revision_invitation = openreview_client.get_invitation('EMNLP/2023/Conference/-/Revision')
-        assert 'readers' in revision_invitation.edit['invitation']['edit']['note']['content']['pdf']
-
-        submissions = openreview_client.get_notes(content={'venueid':'EMNLP/2023/Conference/Submission'}, sort='number:asc')
-        assert len(submissions) == 5
-
-        assert 'readers' in submissions[0].content['pdf']
 
         # assert Deletion invitations are expired
         invitations = openreview_client.get_invitations(invitation='EMNLP/2023/Conference/-/Deletion')
@@ -965,36 +934,6 @@ url={https://openreview.net/forum?id='''
                 f"EMNLP/2023/Conference/Submission{submission.number}/Reviewers",
                 f"EMNLP/2023/Conference/Submission{submission.number}/Authors"
             ]
-
-        #assert pdf is not hidden
-        assert 'readers' not in submissions[0].content['pdf']
-
-        #enable revisions for submissions using the default /Revision invitation
-        revision_due_date = datetime.datetime.utcnow() + datetime.timedelta(days=10)
-        revision_stage_note = pc_client.post_note(openreview.Note(
-            content={
-                'submission_revision_name': 'Revision',
-                'submission_revision_deadline': revision_due_date.strftime('%Y/%m/%d'),
-                'accepted_submissions_only': 'Enable revision for all submissions',
-                'submission_author_edition': 'Do not allow any changes to author lists',
-                'submission_revision_remove_options': ['title', 'authors', 'authorids', 'abstract', 'keywords', 'supplementary_materials']
-            },
-            forum=request_form.forum,
-            invitation='openreview.net/Support/-/Request{}/Submission_Revision_Stage'.format(request_form.number),
-            readers=['{}/Program_Chairs'.format('EMNLP/2023/Conference'), 'openreview.net/Support'],
-            referent=request_form.forum,
-            replyto=request_form.forum,
-            signatures=['~Program_EMNLPChair1'],
-            writers=[]
-        ))
-        assert revision_stage_note
-
-        helpers.await_queue()
-        helpers.await_queue_edit(openreview_client, 'EMNLP/2023/Conference/-/Revision-0-1', count=5)
-
-        revision_invitations = openreview_client.get_all_invitations(invitation='EMNLP/2023/Conference/-/Revision')
-        assert len(revision_invitations) == 3
-        assert 'readers' not in revision_invitations[0].edit['note']['content']['pdf']
 
     def test_enable_ethics_reviewers(self, client, openreview_client, helpers):
 

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -881,8 +881,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
                 'Location': 'Virtual',
                 'submission_reviewer_assignment': 'Automatic',
                 'How did you hear about us?': 'ML conferences',
-                'Expected Submissions': '100',
-                'hide_fields': ['keywords', 'financial_support']
+                'Expected Submissions': '100'
             },
             forum=request_form.forum,
             invitation='openreview.net/Support/-/Request{}/Revision'.format(request_form.number),
@@ -892,16 +891,28 @@ Please note that responding to this email will direct your reply to pc@neurips.c
             signatures=['~Program_NeurIPSChair1'],
             writers=[]
         )
-
-        with pytest.raises(openreview.OpenReviewException, match=r'Invalid field to hide: financial_support'):
-            pc_client.post_note(venue_revision_note)
-
-        venue_revision_note.content['hide_fields'] = ['keywords']
         pc_client.post_note(venue_revision_note)
 
         helpers.await_queue()
         helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Conference/-/Post_Submission-0-0')
         helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Conference/-/Revision-0-0')
+
+        post_submission_note=pc_client.post_note(openreview.Note(
+            content= {
+                'force': 'Yes',
+                'hide_fields': ['keywords'],
+                'submission_readers': 'Program chairs and paper authors only'
+            },
+            forum= request_form.id,
+            invitation= f'openreview.net/Support/-/Request{request_form.number}/Post_Submission',
+            readers= ['NeurIPS.cc/2023/Conference/Program_Chairs', 'openreview.net/Support'],
+            referent= request_form.id,
+            replyto= request_form.id,
+            signatures= ['~Program_NeurIPSChair1'],
+            writers= [],
+        ))
+
+        helpers.await_queue()
 
         notes = test_client.get_notes(content= { 'venueid': 'NeurIPS.cc/2023/Conference/Submission' }, sort='number:desc')
         assert len(notes) == 5
@@ -912,16 +923,16 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Conference/Submission5/-/Revision')
         assert revision_inv
         assert ['NeurIPS.cc/2023/Conference', 'NeurIPS.cc/2023/Conference/Submission5/Authors'] == revision_inv.readers
-        assert 'readers' in revision_inv.edit['note']['content']['authors']
-        assert  revision_inv.edit['note']['content']['authors']['readers'] == [
-            "NeurIPS.cc/2023/Conference",
-            "NeurIPS.cc/2023/Conference/Submission5/Authors"
-        ]
-        assert 'readers' in revision_inv.edit['note']['content']['authorids']
-        assert  revision_inv.edit['note']['content']['authorids']['readers'] == [
-            "NeurIPS.cc/2023/Conference",
-            "NeurIPS.cc/2023/Conference/Submission5/Authors"
-        ]
+        # assert 'readers' in revision_inv.edit['note']['content']['authors']
+        # assert  revision_inv.edit['note']['content']['authors']['readers'] == [
+        #     "NeurIPS.cc/2023/Conference",
+        #     "NeurIPS.cc/2023/Conference/Submission5/Authors"
+        # ]
+        # assert 'readers' in revision_inv.edit['note']['content']['authorids']
+        # assert  revision_inv.edit['note']['content']['authorids']['readers'] == [
+        #     "NeurIPS.cc/2023/Conference",
+        #     "NeurIPS.cc/2023/Conference/Submission5/Authors"
+        # ]
 
         post_submission =  openreview_client.get_invitation('NeurIPS.cc/2023/Conference/-/Post_Submission')
         assert 'authors' in post_submission.edit['note']['content']
@@ -992,15 +1003,20 @@ Please note that responding to this email will direct your reply to pc@neurips.c
             ))
         helpers.await_queue_edit(openreview_client, edit_id=revision_note['id'])
 
-        note_edits = openreview_client.get_note_edits(invitation='NeurIPS.cc/2023/Conference/Submission2/-/Revision')
-        assert len(note_edits) == 1
-        assert 'readers' in note_edits[0].note.content['authors']
-        assert  note_edits[0].note.content['authors']['readers'] == [
+        note = openreview_client.get_note(revision_note['note']['id'])
+        assert note
+        assert 'readers' in note.content['authors']
+        assert  note.content['authors']['readers'] == [
         "NeurIPS.cc/2023/Conference",
         "NeurIPS.cc/2023/Conference/Submission2/Authors"
         ]
-        assert 'readers' in note_edits[0].note.content['authors']
-        assert  note_edits[0].note.content['authors']['readers'] == [
+        assert 'readers' in note.content['authors']
+        assert  note.content['authors']['readers'] == [
+        "NeurIPS.cc/2023/Conference",
+        "NeurIPS.cc/2023/Conference/Submission2/Authors"
+        ]
+        assert 'readers' in note.content['keywords']
+        assert  note.content['keywords']['readers'] == [
         "NeurIPS.cc/2023/Conference",
         "NeurIPS.cc/2023/Conference/Submission2/Authors"
         ]

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -923,16 +923,16 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Conference/Submission5/-/Revision')
         assert revision_inv
         assert ['NeurIPS.cc/2023/Conference', 'NeurIPS.cc/2023/Conference/Submission5/Authors'] == revision_inv.readers
-        # assert 'readers' in revision_inv.edit['note']['content']['authors']
-        # assert  revision_inv.edit['note']['content']['authors']['readers'] == [
-        #     "NeurIPS.cc/2023/Conference",
-        #     "NeurIPS.cc/2023/Conference/Submission5/Authors"
-        # ]
-        # assert 'readers' in revision_inv.edit['note']['content']['authorids']
-        # assert  revision_inv.edit['note']['content']['authorids']['readers'] == [
-        #     "NeurIPS.cc/2023/Conference",
-        #     "NeurIPS.cc/2023/Conference/Submission5/Authors"
-        # ]
+        assert 'readers' in revision_inv.edit['note']['content']['authors']
+        assert  revision_inv.edit['note']['content']['authors']['readers'] == [
+            "NeurIPS.cc/2023/Conference",
+            "NeurIPS.cc/2023/Conference/Submission5/Authors"
+        ]
+        assert 'readers' in revision_inv.edit['note']['content']['authorids']
+        assert  revision_inv.edit['note']['content']['authorids']['readers'] == [
+            "NeurIPS.cc/2023/Conference",
+            "NeurIPS.cc/2023/Conference/Submission5/Authors"
+        ]
 
         post_submission =  openreview_client.get_invitation('NeurIPS.cc/2023/Conference/-/Post_Submission')
         assert 'authors' in post_submission.edit['note']['content']

--- a/tests/test_neurips_track_conference.py
+++ b/tests/test_neurips_track_conference.py
@@ -146,6 +146,22 @@ class TestNeurIPSTrackConference():
                 signatures=['~SomeFirstName_User1'],
                 note=note)            
 
+        post_submission_note=pc_client.post_note(openreview.Note(
+            content= {
+                'force': 'Yes',
+                'hide_fields': ['keywords'],
+                'submission_readers': 'Program chairs and paper authors only'
+            },
+            forum= request_form.id,
+            invitation= f'openreview.net/Support/-/Request{request_form.number}/Post_Submission',
+            readers= ['NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Program_Chairs', 'openreview.net/Support'],
+            referent= request_form.id,
+            replyto= request_form.id,
+            signatures= ['~Program_NeurIPSChair1'],
+            writers= [],
+        ))
+
+        helpers.await_queue()
 
         ## finish submission deadline
         now = datetime.datetime.utcnow()
@@ -169,7 +185,6 @@ class TestNeurIPSTrackConference():
                 'submission_reviewer_assignment': 'Automatic',
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
-                'hide_fields': ['keywords'],
                 'submission_deadline_author_reorder': 'No'
             },
             forum=request_form.forum,

--- a/tests/test_sac_paper_matching.py
+++ b/tests/test_sac_paper_matching.py
@@ -125,8 +125,7 @@ class TestSACAssignments():
                 'submission_reviewer_assignment': 'Automatic',
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '50',
-                'use_recruitment_template': 'Yes',
-                'hide_fields': ['pdf']
+                'use_recruitment_template': 'Yes'
             },
             forum=request_form.forum,
             invitation='openreview.net/Support/-/Request{}/Revision'.format(request_form.number),
@@ -135,6 +134,24 @@ class TestSACAssignments():
             replyto=request_form.forum,
             signatures=['~Program_MatchingChair1'],
             writers=[]
+        ))
+
+        helpers.await_queue()
+
+        # hide pdf for bidding
+        post_submission_note=pc_client.post_note(openreview.Note(
+            content= {
+                'force': 'Yes',
+                'hide_fields': ['pdf'],
+                'submission_readers': 'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)'
+            },
+            forum= request_form.id,
+            invitation= f'openreview.net/Support/-/Request{request_form.number}/Post_Submission',
+            readers= ['TSACM/2024/Conference/Program_Chairs', 'openreview.net/Support'],
+            referent= request_form.id,
+            replyto= request_form.id,
+            signatures= ['~Program_MatchingChair1'],
+            writers= [],
         ))
 
         helpers.await_queue()

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -922,7 +922,7 @@ class TestVenueRequest():
 
         helpers.await_queue()        
 
-        with pytest.raises(openreview.OpenReviewException, match=r'The pdf field should be hidden during the bidding stage'):
+        with pytest.raises(openreview.OpenReviewException, match=r'The pdf field should be hidden during the bidding stage. Please use the Post Submission button to hide pdfs.'):
     
             bid_stage_note = test_client.post_note(openreview.Note(
                 content={

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -398,8 +398,7 @@ class TestVenueRequest():
                 'contact_email': venue['request_form_note'].content['contact_email'],
                 'publication_chairs':'No, our venue does not have Publication Chairs',
                 'email_pcs_for_new_submissions': 'Yes, email PCs for every new submission.',
-                'submission_email': 'Your submission to {{Abbreviated_Venue_Name}} has been {{action}}.\n\nSubmission Number: {{note_number}} \n\nTitle: {{note_title}} {{note_abstract}} \n\nTo view your submission, click here: https://openreview.net/forum?id={{note_forum}} \n\nIf you have any questions, please contact the PCs at test@mail.com',
-                'hide_fields': ['pdf']
+                'submission_email': 'Your submission to {{Abbreviated_Venue_Name}} has been {{action}}.\n\nSubmission Number: {{note_number}} \n\nTitle: {{note_title}} {{note_abstract}} \n\nTo view your submission, click here: https://openreview.net/forum?id={{note_forum}} \n\nIf you have any questions, please contact the PCs at test@mail.com'
             },
             forum=venue['request_form_note'].forum,
             invitation='{}/-/Request{}/Revision'.format(venue['support_group_id'], venue['request_form_note'].number),
@@ -423,6 +422,24 @@ class TestVenueRequest():
         title_tag = header_div.find_element(By.TAG_NAME, 'h1')
         assert title_tag
         assert title_tag.text == '{} Updated'.format(venue['request_form_note'].content['title'])
+
+        # hide pdf
+        post_submission_note=test_client.post_note(openreview.Note(
+            content= {
+                'force': 'Yes',
+                'hide_fields': ['pdf'],
+                'submission_readers': 'All program committee (all reviewers, all area chairs, all senior area chairs if applicable)'
+            },
+            forum=venue['request_form_note'].forum,
+            invitation='{}/-/Request{}/Post_Submission'.format(venue['support_group_id'], venue['request_form_note'].number),
+            readers= ['{}/Program_Chairs'.format(venue['venue_id']), venue['support_group_id']],
+            referent=venue['request_form_note'].forum,
+            replyto=venue['request_form_note'].forum,
+            signatures= ['~SomeFirstName_User1'],
+            writers= [],
+        ))
+
+        helpers.await_queue()
 
     def test_venue_recruitment_email_error(self, client, test_client, selenium, request_page, venue, helpers):
 


### PR DESCRIPTION
This PR removes `hide_fields` from the Revision invitation and allows to hide fields only using the Post_Submission. 

This PR also adds all possible content fields to the `hide_fields` dropdown (we were not adding the `second_deadline_additional_options`)

~This issue has happened twice, once to MIDL and once to AutoML.~
~I believe what happened was both venues had an abstract deadline, which created the `/Revision` invitations. At some~ ~point, the pdf was hidden for all submissions. Then the Post Submission was used to unhide the pdfs. Later on, they re-~ ~run the Revision stage to allow authors to revise their papers, but they used the default name `/Revision`. Since pdfs were~ ~hidden in these invitations, pdfs started being hidden after authors edited their submission.~

~This PR checks if the field is in `hide_fields` and if it isn't, it removes the readers.~

~**Edit: I have now also noticed that if we used `replacement=True` when posting revision invitations, we would not have~ ~this issue. I am unsure why we sometimes use `replacement=True` and sometimes we use `replacement=False`**~