### PR TITLE
Venue: support different committee role names

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -31,8 +31,11 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.use_publication_chairs = note.content.get('publication_chairs', 'No, our venue does not have Publication Chairs') == 'Yes, our venue has Publication Chairs'
         venue.automatic_reviewer_assignment = note.content.get('submission_reviewer_assignment', '') == 'Automatic'
         venue.senior_area_chair_roles = note.content.get('senior_area_chair_roles', ['Senior_Area_Chairs'])
+        venue.senior_area_chair_name = venue.senior_area_chair_roles[0]
         venue.area_chair_roles = note.content.get('area_chair_roles', ['Area_Chairs'])
+        venue.area_chairs_name = venue.area_chair_roles[0]
         venue.reviewer_roles = note.content.get('reviewer_roles', ['Reviewers'])
+        venue.reviewers_name = venue.reviewer_roles[0]
         venue.allow_gurobi_solver = venue_content.get('allow_gurobi_solver', {}).get('value', False)
         venue.submission_license = note.content.get('submission_license', ['CC BY 4.0'])
         set_homepage_options(note, venue)

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -31,11 +31,11 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.use_publication_chairs = note.content.get('publication_chairs', 'No, our venue does not have Publication Chairs') == 'Yes, our venue has Publication Chairs'
         venue.automatic_reviewer_assignment = note.content.get('submission_reviewer_assignment', '') == 'Automatic'
         venue.senior_area_chair_roles = note.content.get('senior_area_chair_roles', ['Senior_Area_Chairs'])
-        venue.senior_area_chairs_name = venue.senior_area_chair_roles[0] if len(venue.senior_area_chair_roles) == 1 else 'Senior_Area_Chairs' ## ask for this name in the request form?
+        venue.senior_area_chairs_name = venue.senior_area_chair_roles[0]
         venue.area_chair_roles = note.content.get('area_chair_roles', ['Area_Chairs'])
-        venue.area_chairs_name = venue.area_chair_roles[0] if len(venue.area_chair_roles) == 1 else 'Area_Chairs' ## ask for this name in the request form?
+        venue.area_chairs_name = venue.area_chair_roles[0]
         venue.reviewer_roles = note.content.get('reviewer_roles', ['Reviewers'])
-        venue.reviewers_name = venue.reviewer_roles[0] if len(venue.reviewer_roles) == 1 else 'Reviewers' ## ask for this name in the request form?
+        venue.reviewers_name = venue.reviewer_roles[0]
         venue.allow_gurobi_solver = venue_content.get('allow_gurobi_solver', {}).get('value', False)
         venue.submission_license = note.content.get('submission_license', ['CC BY 4.0'])
         set_homepage_options(note, venue)

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -31,7 +31,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.use_publication_chairs = note.content.get('publication_chairs', 'No, our venue does not have Publication Chairs') == 'Yes, our venue has Publication Chairs'
         venue.automatic_reviewer_assignment = note.content.get('submission_reviewer_assignment', '') == 'Automatic'
         venue.senior_area_chair_roles = note.content.get('senior_area_chair_roles', ['Senior_Area_Chairs'])
-        venue.senior_area_chair_name = venue.senior_area_chair_roles[0]
+        venue.senior_area_chairs_name = venue.senior_area_chair_roles[0]
         venue.area_chair_roles = note.content.get('area_chair_roles', ['Area_Chairs'])
         venue.area_chairs_name = venue.area_chair_roles[0]
         venue.reviewer_roles = note.content.get('reviewer_roles', ['Reviewers'])

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -31,11 +31,11 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.use_publication_chairs = note.content.get('publication_chairs', 'No, our venue does not have Publication Chairs') == 'Yes, our venue has Publication Chairs'
         venue.automatic_reviewer_assignment = note.content.get('submission_reviewer_assignment', '') == 'Automatic'
         venue.senior_area_chair_roles = note.content.get('senior_area_chair_roles', ['Senior_Area_Chairs'])
-        venue.senior_area_chairs_name = venue.senior_area_chair_roles[0]
+        venue.senior_area_chairs_name = venue.senior_area_chair_roles[0] if len(venue.senior_area_chair_roles) == 1 else 'Senior_Area_Chairs' ## ask for this name in the request form?
         venue.area_chair_roles = note.content.get('area_chair_roles', ['Area_Chairs'])
-        venue.area_chairs_name = venue.area_chair_roles[0]
+        venue.area_chairs_name = venue.area_chair_roles[0] if len(venue.area_chair_roles) == 1 else 'Area_Chairs' ## ask for this name in the request form?
         venue.reviewer_roles = note.content.get('reviewer_roles', ['Reviewers'])
-        venue.reviewers_name = venue.reviewer_roles[0]
+        venue.reviewers_name = venue.reviewer_roles[0] if len(venue.reviewer_roles) == 1 else 'Reviewers' ## ask for this name in the request form?
         venue.allow_gurobi_solver = venue_content.get('allow_gurobi_solver', {}).get('value', False)
         venue.submission_license = note.content.get('submission_license', ['CC BY 4.0'])
         set_homepage_options(note, venue)

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -1011,7 +1011,7 @@ class InvitationBuilder(object):
         invitation_content = {
             'hash_seed': { 'value': '1234', 'readers': [ venue.venue_id ]},
             'venue_id': { 'value': self.venue_id },
-            'committee_name': { 'value': committee_name.replace('_', ' ')[:-1] },
+            'committee_name': { 'value': venue.get_committee_name(committee_name, pretty=True) },
             'committee_id': { 'value': venue.get_committee_id(committee_name) },
             'committee_invited_id': { 'value': venue.get_committee_id_invited(committee_name) },
             'committee_declined_id': { 'value': venue.get_committee_id_declined(committee_name) },

--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -1119,7 +1119,8 @@ class Matching(object):
             'committee_invited_id': { 'value': venue.get_committee_id(name=invited_committee_name + '/Invited') },
             'paper_reviewer_invited_id': { 'value': venue.get_committee_id(name=invited_committee_name + '/Invited', number='{number}') if assignment_title else ''},
             'hash_seed': { 'value': hash_seed, 'readers': [ venue.venue_id ]},
-            'email_template': { 'value': email_template if email_template else ''}
+            'email_template': { 'value': email_template if email_template else ''},
+            'is_reviewer': { 'value': True if (self.match_group.id.split('/')[-1] in venue.reviewer_roles) else False },
         }
 
         # set invite assignment invitation

--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -11,7 +11,7 @@ def process_update(client, edge, invitation, existing_edge):
     assignment_invitation_id = invitation.content['assignment_invitation_id']['value']
     paper_reviewer_invited_id = invitation.content['paper_reviewer_invited_id']['value']
     email_template = invitation.content['email_template']['value']
-    is_reviewer = 'Reviewers' in assignment_invitation_id
+    is_reviewer = assignment_invitation_id.start_with(f"{domain.content['reviewers_id']['value']}/-/")
     action_string = 'to review' if is_reviewer else 'to serve as area chair for'
     print(edge.id)
 

--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -8,10 +8,9 @@ def process_update(client, edge, invitation, existing_edge):
     invite_label = invitation.content['invite_label']['value']
     invited_label = invitation.content['invited_label']['value']
     hash_seed = invitation.content['hash_seed']['value']
-    assignment_invitation_id = invitation.content['assignment_invitation_id']['value']
     paper_reviewer_invited_id = invitation.content['paper_reviewer_invited_id']['value']
     email_template = invitation.content['email_template']['value']
-    is_reviewer = assignment_invitation_id.startswith(f"{domain.content['reviewers_id']['value']}/-/")
+    is_reviewer = invitation.content['is_reviewer']['value']
     action_string = 'to review' if is_reviewer else 'to serve as area chair for'
     print(edge.id)
 

--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -11,7 +11,7 @@ def process_update(client, edge, invitation, existing_edge):
     assignment_invitation_id = invitation.content['assignment_invitation_id']['value']
     paper_reviewer_invited_id = invitation.content['paper_reviewer_invited_id']['value']
     email_template = invitation.content['email_template']['value']
-    is_reviewer = assignment_invitation_id.start_with(f"{domain.content['reviewers_id']['value']}/-/")
+    is_reviewer = assignment_invitation_id.startswith(f"{domain.content['reviewers_id']['value']}/-/")
     action_string = 'to review' if is_reviewer else 'to serve as area chair for'
     print(edge.id)
 

--- a/openreview/venue/recruitment.py
+++ b/openreview/venue/recruitment.py
@@ -51,9 +51,6 @@ class Recruitment(object):
 
         invitation = venue.invitation_builder.set_recruitment_invitation(committee_name, options)
         
-        role = committee_name.replace('_', ' ')
-        role = role[:-1] if role.endswith('s') else role
-        
         invitation_id = invitation.id
         hash_seed = invitation.content['hash_seed']['value']
 

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -235,8 +235,7 @@ class Venue(object):
 
     def get_reviewers_name(self, pretty=True):
         if pretty:
-            name=self.reviewers_name.replace('_', ' ')
-            return name[:-1] if name.endswith('s') else name
+            return self.get_committee_name(self.reviewers_name, pretty)
         return self.reviewers_name
     
     def get_anon_committee_name(self, name):
@@ -248,8 +247,7 @@ class Venue(object):
 
     def get_ethics_reviewers_name(self, pretty=True):
         if pretty:
-            name=self.ethics_reviewers_name.replace('_', ' ')
-            return name[:-1] if name.endswith('s') else name
+            return self.get_committee_name(self.ethics_reviewers_name, pretty)
         return self.ethics_reviewers_name
 
     def anon_ethics_reviewers_name(self, pretty=True):
@@ -257,8 +255,7 @@ class Venue(object):
 
     def get_area_chairs_name(self, pretty=True):
         if pretty:
-            name=self.area_chairs_name.replace('_', ' ')
-            return name[:-1] if name.endswith('s') else name
+            return self.get_committee_name(self.area_chairs_name, pretty)
         return self.area_chairs_name
 
     def get_anon_area_chairs_name(self, pretty=True):

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -32,13 +32,13 @@ class Venue(object):
         self.date = 'TBD'
         self.id = venue_id # get compatibility with conference
         self.program_chairs_name = 'Program_Chairs'
-        self.reviewers_name = 'Reviewers'
         self.reviewer_roles = ['Reviewers']
+        self.reviewers_name = self.reviewer_roles[0]
         self.area_chair_roles = ['Area_Chairs']
+        self.area_chairs_name = self.area_chair_roles[0]
         self.senior_area_chair_roles = ['Senior_Area_Chairs']        
-        self.area_chairs_name = 'Area_Chairs'
+        self.senior_area_chairs_name = self.senior_area_chair_roles[0]
         self.secondary_area_chairs_name = 'Secondary_Area_Chairs'
-        self.senior_area_chairs_name = 'Senior_Area_Chairs'
         self.ethics_chairs_name = 'Ethics_Chairs'
         self.ethics_reviewers_name = 'Ethics_Reviewers'
         self.authors_name = 'Authors'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='openreview-py',
 
-    version='1.38.0',
+    version='1.39.0',
 
     description='OpenReview API Python client library',
     url='https://github.com/openreview/openreview-py',

--- a/tests/test_aaai_conference.py
+++ b/tests/test_aaai_conference.py
@@ -1,0 +1,271 @@
+import time
+import openreview
+import pytest
+import datetime
+import re
+import random
+import os
+import csv
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import NoSuchElementException
+from openreview import ProfileManagement
+
+class TestAAAIConference():
+
+
+    @pytest.fixture(scope="class")
+    def profile_management(self, openreview_client):
+        profile_management = ProfileManagement(openreview_client, 'openreview.net')
+        profile_management.setup()
+        return profile_management
+
+
+    def test_create_conference(self, client, openreview_client, helpers, profile_management):
+
+        now = datetime.datetime.utcnow()
+        due_date = now + datetime.timedelta(days=3)
+
+        # Post the request form note
+        helpers.create_user('pc@aaai.org', 'Program', 'AAAIChair')
+        pc_client = openreview.Client(username='pc@aaai.org', password=helpers.strong_password)
+
+
+        helpers.create_user('ac1@aaai.org', 'AC', 'AAAIOne')
+        helpers.create_user('ac2@aaai.org', 'AC', 'AAAITwo')
+        helpers.create_user('senior_program_committee1@aaai.org', 'Senior Program Committee', 'AAAIOne')
+        helpers.create_user('senior_program_committee2@aaai.org', 'Senior Program Committee', 'AAAITwo')
+        helpers.create_user('program_committee1@aaai.org', 'Program Committee', 'AAAIOne')
+        helpers.create_user('program_committee2@aaai.org', 'Program Committee', 'AAAITwo')
+        helpers.create_user('program_committee3@aaai.org', 'Program Committee', 'AAAIThree')
+
+        request_form_note = pc_client.post_note(openreview.Note(
+            invitation='openreview.net/Support/-/Request_Form',
+            signatures=['~Program_AAAIChair1'],
+            readers=[
+                'openreview.net/Support',
+                '~Program_AAAIChair1'
+            ],
+            writers=[],
+            content={
+                'title': 'The 39th Annual AAAI Conference on Artificial Intelligence',
+                'Official Venue Name': 'The 39th Annual AAAI Conference on Artificial Intelligence',
+                'Abbreviated Venue Name': 'AAAI 2025',
+                'Official Website URL': 'https://aaai.org/conference/aaai-25/',
+                'program_chair_emails': ['pc@aaai.org'],
+                'contact_email': 'pc@aaai.org',
+                'publication_chairs':'No, our venue does not have Publication Chairs',
+                'Area Chairs (Metareviewers)': 'Yes, our venue has Area Chairs',
+                'senior_area_chairs': 'Yes, our venue has Senior Area Chairs',
+                'senior_area_chairs_assignment': 'Area Chairs',
+                'ethics_chairs_and_reviewers': 'No, our venue does not have Ethics Chairs and Reviewers',
+                'Venue Start Date': '2025/07/01',
+                'Submission Deadline': due_date.strftime('%Y/%m/%d'),
+                'Location': 'Philadelphia, PA',
+                'submission_reviewer_assignment': 'Automatic',
+                'Author and Reviewer Anonymity': 'Double-blind',
+                'reviewer_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair'],
+                'area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair', 'Assigned Reviewers'],
+                'senior_area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair'],
+                'submission_readers': 'Program chairs and paper authors only',
+                'How did you hear about us?': 'ML conferences',
+                'Expected Submissions': '10000',
+                'use_recruitment_template': 'Yes',
+                'api_version': '2',
+                'submission_license': ['CC BY 4.0']
+            }))
+
+        helpers.await_queue()
+
+        # Use super user to update the roles
+        request_form_note.content['reviewer_roles'] = ['Program_Committee']
+        request_form_note.content['area_chair_roles'] = ['Senior_Program_Committee']
+        request_form_note.content['senior_area_chair_roles'] = ['Area_Chairs']
+        client.post_note(request_form_note)
+
+        helpers.await_queue()
+
+        # Post a deploy note
+        client.post_note(openreview.Note(
+            content={'venue_id': 'AAAI.org/2025/Conference'},
+            forum=request_form_note.forum,
+            invitation='openreview.net/Support/-/Request{}/Deploy'.format(request_form_note.number),
+            readers=['openreview.net/Support'],
+            referent=request_form_note.forum,
+            replyto=request_form_note.forum,
+            signatures=['openreview.net/Support'],
+            writers=['openreview.net/Support']
+        ))
+
+        helpers.await_queue()
+
+        assert openreview_client.get_group('AAAI.org/2025/Conference')
+        assert openreview_client.get_group('AAAI.org/2025/Conference/Area_Chairs')
+        assert openreview_client.get_group('AAAI.org/2025/Conference/Senior_Program_Committee')
+        assert openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee')
+        assert openreview_client.get_group('AAAI.org/2025/Conference/Authors')
+
+        submission_invitation = openreview_client.get_invitation('AAAI.org/2025/Conference/-/Submission')
+        assert submission_invitation
+        assert submission_invitation.duedate
+
+        assert openreview_client.get_invitation('AAAI.org/2025/Conference/Program_Committee/-/Expertise_Selection')
+        assert openreview_client.get_invitation('AAAI.org/2025/Conference/Senior_Program_Committee/-/Expertise_Selection')
+        assert openreview_client.get_invitation('AAAI.org/2025/Conference/Area_Chairs/-/Expertise_Selection')
+
+
+    def test_sac_recruitment(self, client, openreview_client, helpers, request_page, selenium):
+
+        pc_client=openreview.Client(username='pc@aaai.org', password=helpers.strong_password)
+        request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+
+        reviewer_details = '''ac1@aaai.org, AC AAAIOne\nac2@aaai.org, AC AAAITwo'''
+        pc_client.post_note(openreview.Note(
+            content={
+                'title': 'Recruitment',
+                'invitee_role': 'Area_Chairs',
+                'invitee_details': reviewer_details,
+                'invitation_email_subject': '[AAAI 2025] Invitation to serve as {{invitee_role}}',
+                'invitation_email_content': 'Dear {{fullname}},\n\nYou have been nominated by the program chair committee of AAAI to serve as {{invitee_role}}.\n\n{{invitation_url}}\n\nCheers!\n\nProgram Chairs'
+            },
+            forum=request_form.forum,
+            replyto=request_form.forum,
+            invitation='openreview.net/Support/-/Request{}/Recruitment'.format(request_form.number),
+            readers=['AAAI.org/2025/Conference/Program_Chairs', 'openreview.net/Support'],
+            signatures=['~Program_AAAIChair1'],
+            writers=[]
+        ))
+
+        helpers.await_queue()
+
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Area_Chairs').members) == 0
+        group = openreview_client.get_group('AAAI.org/2025/Conference/Area_Chairs/Invited')
+        assert len(group.members) == 2
+        assert group.readers == ['AAAI.org/2025/Conference', 'AAAI.org/2025/Conference/Area_Chairs/Invited']
+
+        messages = openreview_client.get_messages(subject = '[AAAI 2025] Invitation to serve as Area Chair')
+        assert len(messages) == 2
+
+        for message in messages:
+            text = message['content']['text']
+
+            invitation_url = re.search('https://.*\n', text).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+            helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
+
+        helpers.await_queue_edit(openreview_client, invitation='AAAI.org/2025/Conference/Area_Chairs/-/Recruitment', count=2)
+
+        messages = client.get_messages(subject='[AAAI 2025] Area Chair Invitation accepted')
+        assert len(messages) == 2
+
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Area_Chairs').members) == 2
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Area_Chairs/Invited').members) == 2
+
+    def test_ac_recruitment(self, client, openreview_client, helpers, request_page, selenium):
+
+        pc_client=openreview.Client(username='pc@aaai.org', password=helpers.strong_password)
+        request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+
+        reviewer_details = '''senior_program_committee1@aaai.org, Senior Program Committee AAAIOne\nsenior_program_committee2@aaai.org, Senior Program Committee AAAITwo'''
+        pc_client.post_note(openreview.Note(
+            content={
+                'title': 'Recruitment',
+                'invitee_role': 'Senior_Program_Committee',
+                'invitee_details': reviewer_details,
+                'invitation_email_subject': '[AAAI 2025] Invitation to serve as {{invitee_role}}',
+                'invitation_email_content': 'Dear {{fullname}},\n\nYou have been nominated by the program chair committee of AAAI to serve as {{invitee_role}}.\n\n{{invitation_url}}\n\nCheers!\n\nProgram Chairs'
+            },
+            forum=request_form.forum,
+            replyto=request_form.forum,
+            invitation='openreview.net/Support/-/Request{}/Recruitment'.format(request_form.number),
+            readers=['AAAI.org/2025/Conference/Program_Chairs', 'openreview.net/Support'],
+            signatures=['~Program_AAAIChair1'],
+            writers=[]
+        ))
+
+        helpers.await_queue()
+
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Senior_Program_Committee').members) == 0
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Senior_Program_Committee/Invited').members) == 2
+
+        messages = openreview_client.get_messages(subject = '[AAAI 2025] Invitation to serve as Senior Program Committee')
+        assert len(messages) == 2
+
+        for message in messages:
+            text = message['content']['text']
+
+            invitation_url = re.search('https://.*\n', text).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+            helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
+
+        helpers.await_queue_edit(openreview_client, invitation='AAAI.org/2025/Conference/Senior_Program_Committee/-/Recruitment', count=2)
+
+        messages = client.get_messages(subject='[AAAI 2025] Senior Program Committee Invitation accepted')
+        assert len(messages) == 2
+
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Senior_Program_Committee').members) == 2
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Senior_Program_Committee/Invited').members) == 2
+
+    def test_reviewer_recruitment(self, client, openreview_client, helpers, request_page, selenium):
+
+        pc_client=openreview.Client(username='pc@aaai.org', password=helpers.strong_password)
+        request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+
+        reviewer_details = '''program_committee1@aaai.org, Program Committee AAAIOne
+program_committee2@aaai.org, Program Committee AAAITwo
+program_committee3@aaai.org, Program Committee AAAIThree
+program_committee4@yahoo.com, Program Committee AAAIFour
+'''
+        pc_client.post_note(openreview.Note(
+            content={
+                'title': 'Recruitment',
+                'invitee_role': 'Program_Committee',
+                'invitee_details': reviewer_details,
+                'invitee_reduced_load': ["1", "2", "3"],
+                'invitation_email_subject': '[AAAI 2025] Invitation to serve as {{invitee_role}}',
+                'invitation_email_content': 'Dear {{fullname}},\n\nYou have been nominated by the program chair committee of AAAI to serve as {{invitee_role}}.\n\n{{invitation_url}}\n\nCheers!\n\nProgram Chairs'
+            },
+            forum=request_form.forum,
+            replyto=request_form.forum,
+            invitation='openreview.net/Support/-/Request{}/Recruitment'.format(request_form.number),
+            readers=['AAAI.org/2025/Conference/Program_Chairs', 'openreview.net/Support'],
+            signatures=['~Program_AAAIChair1'],
+            writers=[]
+        ))
+
+        helpers.await_queue()
+
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee').members) == 0
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee/Invited').members) == 4
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee/Declined').members) == 0
+
+        messages = openreview_client.get_messages(subject = '[AAAI 2025] Invitation to serve as Program Committee')
+        assert len(messages) == 4
+
+        for message in messages:
+            text = message['content']['text']
+
+            invitation_url = re.search('https://.*\n', text).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+            helpers.respond_invitation(selenium, request_page, invitation_url, accept=True, quota=3)
+
+        helpers.await_queue_edit(openreview_client, invitation='AAAI.org/2025/Conference/Program_Committee/-/Recruitment', count=8)
+
+        messages = client.get_messages(subject='[AAAI 2025] Program Committee Invitation accepted with reduced load')
+        assert len(messages) == 4
+
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee').members) == 4
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee/Invited').members) == 4
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee/Declined').members) == 0
+
+        messages = openreview_client.get_messages(to = 'program_committee4@yahoo.com', subject = '[AAAI 2025] Invitation to serve as Program Committee')
+        invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+        helpers.respond_invitation(selenium, request_page, invitation_url, accept=False)
+
+        helpers.await_queue_edit(openreview_client, invitation='AAAI.org/2025/Conference/Program_Committee/-/Recruitment', count=9)
+
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee').members) == 3
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee/Invited').members) == 4
+        assert len(openreview_client.get_group('AAAI.org/2025/Conference/Program_Committee/Declined').members) == 1
+
+        reviewer_client = openreview.api.OpenReviewClient(username='program_committee1@aaai.org', password=helpers.strong_password)
+
+        request_page(selenium, "http://localhost:3030/group?id=AAAI.org/2025/Conference/Program_Committee", reviewer_client.token, wait_for_element='header')
+        header = selenium.find_element(By.ID, 'header')
+        assert 'You have agreed to review up to 1 papers' in header.text


### PR DESCRIPTION
- committee names are set by the first element of the roles array.

This PR verifies:

- Committee groups are created:

AAAI.org/2025/Conference/Area_Chairs
AAAI.org/2025/Conference/Senior_Program_Commmittee
AAAI.org/2025/Conference/Program_Committee

and the recruitment invitations are created correctly.

We will keep testing this in another PR. 
