### PR TITLE
Fix/ DBLP import - Add logging when html does not exist

### DIFF
--- a/openreview/profile/process/dblp_abstract_process.js
+++ b/openreview/profile/process/dblp_abstract_process.js
@@ -11,6 +11,8 @@ async function process(client, edit, invitation) {
     console.log('abstract: ' + abstract);
     console.log('pdf: ' + extractionResult.pdf);
     console.log('error: ' + extractionResult.error);
+  } else {
+    console.log('html field is empty');
   }
 
   if (!abstract) return

--- a/openreview/profile/process/dblp_record_process.js
+++ b/openreview/profile/process/dblp_record_process.js
@@ -24,6 +24,8 @@ async function process(client, edit, invitation) {
       if (pdf) {
         note.content.pdf = { value: pdf };
       }
+    } else {
+      console.log('html field is empty');
     }
   } catch (error) {
     console.log('error: ' + JSON.stringify(error.toJson()));


### PR DESCRIPTION
currently the process function log is empty when there's no html field in dblp xml
which makes it looks like an error.

this pr should add a log when html does not exist