### PR TITLE
Messages: Fix/add message sender

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1736,7 +1736,8 @@ class OpenReviewClient(object):
             json['ignoreGroups'] = ignoreRecipients
 
         if sender:
-            json['from'] = sender
+            json['fromName'] = sender.get('fromName')
+            json['fromEmail'] = sender.get('fromEmail')
 
         if replyTo:
             json['replyTo'] = replyTo

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -71,6 +71,7 @@ class GroupBuilder(object):
             'subtitle': { 'value': self.journal.short_name },
             'website': { 'value': self.journal.website },
             'contact': { 'value': self.journal.contact_info },
+            'message_sender': { 'value': self.venue.get_message_sender() },
             'submission_id': { 'value': self.journal.get_author_submission_id() },
             'under_review_venue_id': { 'value': self.journal.under_review_venue_id },
             'decision_pending_venue_id': { 'value': self.journal.decision_pending_venue_id },

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -71,7 +71,7 @@ class GroupBuilder(object):
             'subtitle': { 'value': self.journal.short_name },
             'website': { 'value': self.journal.website },
             'contact': { 'value': self.journal.contact_info },
-            'message_sender': { 'value': self.venue.get_message_sender() },
+            'message_sender': { 'value': self.journal.get_message_sender() },
             'submission_id': { 'value': self.journal.get_author_submission_id() },
             'under_review_venue_id': { 'value': self.journal.under_review_venue_id },
             'decision_pending_venue_id': { 'value': self.journal.decision_pending_venue_id },

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -69,6 +69,12 @@ class Journal(object):
         if number:
             return f'{group_id}/{self.submission_group_name}{number}/-/{name}'
         return f'{group_id}/-/{name}'
+    
+    def get_message_sender(self):
+        return {
+            'fromName': self.short_name,
+            'fromEmail': f'{self.short_name.replace(" ", "").lower()}-notifications@openreview.net'
+        }    
 
     def get_editors_in_chief_id(self):
         return f'{self.venue_id}/{self.editors_in_chief_name}'
@@ -779,7 +785,7 @@ To view the {lower_formatted_invitation}, click here: https://openreview.net/for
 Your {lower_formatted_invitation} on a submission has been {action}
 {content}
 '''
-            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=[edit.tauthor], subject=subject, message=message, replyTo=self.contact_info, signature=self.venue_id)
+            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=[edit.tauthor], subject=subject, message=message, replyTo=self.contact_info, signature=self.venue_id, sender=self.get_message_sender())
 
         ## Notify authors
         if is_public or self.get_authors_id(number=forum.number) in readers:
@@ -788,7 +794,7 @@ Your {lower_formatted_invitation} on a submission has been {action}
 {before_invitation} {lower_formatted_invitation} has been {action} on your submission.
 {content}
 '''
-            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=[self.get_authors_id(number=forum.number)], subject=subject, message=message, ignoreRecipients=nonreaders, replyTo=self.contact_info, signature=self.venue_id)
+            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=[self.get_authors_id(number=forum.number)], subject=subject, message=message, ignoreRecipients=nonreaders, replyTo=self.contact_info, signature=self.venue_id, sender=self.get_message_sender())
 
         ## Notify reviewers
         reviewer_recipients = []
@@ -805,7 +811,7 @@ Your {lower_formatted_invitation} on a submission has been {action}
 {before_invitation} {lower_formatted_invitation} has been {action} on a submission for which you are a reviewer.
 {content}
 '''
-            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=reviewer_recipients, subject=subject, message=message, ignoreRecipients=nonreaders, replyTo=self.contact_info, signature=self.venue_id)
+            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=reviewer_recipients, subject=subject, message=message, ignoreRecipients=nonreaders, replyTo=self.contact_info, signature=self.venue_id, sender=self.get_message_sender())
 
 
         ## Notify action editors
@@ -815,7 +821,7 @@ Your {lower_formatted_invitation} on a submission has been {action}
 {before_invitation} {lower_formatted_invitation} has been {action} on a submission for which you are an Action Editor.
 {content}
 '''
-            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=[self.get_action_editors_id(number=forum.number)], subject=subject, message=message, ignoreRecipients=nonreaders, replyTo=self.contact_info, signature=self.venue_id)
+            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=[self.get_action_editors_id(number=forum.number)], subject=subject, message=message, ignoreRecipients=nonreaders, replyTo=self.contact_info, signature=self.venue_id, sender=self.get_message_sender())
 
 
         if self.get_editors_in_chief_id() in readers and len(readers) == 2 and 'comment' in lower_formatted_invitation:
@@ -824,7 +830,7 @@ Your {lower_formatted_invitation} on a submission has been {action}
 {before_invitation} {lower_formatted_invitation} has been {action} on a submission for which you are serving as Editor-In-Chief.
 {content}
 '''
-            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=[self.get_editors_in_chief_id()], subject=subject, message=message, ignoreRecipients=nonreaders, replyTo=self.contact_info, signature=self.venue_id)
+            self.client.post_message(invitation=self.get_meta_invitation_id(), recipients=[self.get_editors_in_chief_id()], subject=subject, message=message, ignoreRecipients=nonreaders, replyTo=self.contact_info, signature=self.venue_id, sender=self.get_message_sender())
 
     def setup_note_invitations(self):
 
@@ -1145,7 +1151,8 @@ Your {lower_formatted_invitation} on a submission has been {action}
                                     subject=f'[{journal.short_name}] Suggest candidate Action Editor for your new {journal.short_name} submission',
                                     message=message,
                                     replyTo=journal.contact_info,
-                                    signature=journal.venue_id
+                                    signature=journal.venue_id,
+                                    sender=journal.get_message_sender()
                                 )
 
 
@@ -1657,7 +1664,7 @@ A conflict was detected between you and the submission authors and the assignmen
 If you have any questions, please contact us as info@openreview.net.
 
 OpenReview Team'''
-            response = client.post_message(subject, [edge.tail], message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id)
+            response = client.post_message(subject, [edge.tail], message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
 
             ## Send email to inviter
             subject=f"[{journal.short_name}] Conflict detected between reviewer {user_profile.get_preferred_name(pretty=True)} and paper {submission.number}: {submission.content['title']['value']}"
@@ -1669,7 +1676,7 @@ If you have any questions, please contact us as info@openreview.net.
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, edge.signatures, message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id)            
+            response = client.post_message(subject, edge.signatures, message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())            
         
         def mark_as_accepted(journal, edge, submission, user_profile):
 
@@ -1710,7 +1717,7 @@ If you would like to change your decision, please click the Decline link in the 
 OpenReview Team'''
 
                 ## - Send email
-                response = client.post_message(subject, [edge.tail], message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id)
+                response = client.post_message(subject, [edge.tail], message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
 
                 ## Send email to inviter
                 subject=f'[{short_phrase}] {reviewer_name} {user_profile.get_preferred_name(pretty=True)} signed up and is assigned to paper {submission.number}: {submission.content["title"]["value"]}'
@@ -1720,7 +1727,7 @@ The {reviewer_name} {user_profile.get_preferred_name(pretty=True)}({user_profile
 OpenReview Team'''
 
                 ## - Send email
-                response = client.post_message(subject, edge.signatures, message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id)            
+                response = client.post_message(subject, edge.signatures, message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())            
         
         journal_requests = client.get_all_notes(invitation=f'{support_group_id}/-/Journal_Request')
 

--- a/openreview/journal/process/action_editor_edge_reminder_process.py
+++ b/openreview/journal/process/action_editor_edge_reminder_process.py
@@ -34,7 +34,8 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
             replyTo=journal.contact_info,
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
     if date_index == 1 or date_index == 2:
@@ -61,5 +62,6 @@ Link: https://openreview.net/group?id={journal.get_action_editors_id()}#action-e
 OpenReview Team
 ''',
             replyTo=journal.contact_info,
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )

--- a/openreview/journal/process/action_editor_reminder_process.py
+++ b/openreview/journal/process/action_editor_reminder_process.py
@@ -37,7 +37,8 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
             replyTo=journal.contact_info,
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
     if date_index == 1 or date_index == 2:
@@ -61,7 +62,8 @@ Link: https://openreview.net/forum?id={submission.id}
 OpenReview Team
 ''',
             replyTo=journal.contact_info,
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )                    
 
 

--- a/openreview/journal/process/ae_assignment_process.py
+++ b/openreview/journal/process/ae_assignment_process.py
@@ -23,7 +23,7 @@ def process_update(client, edge, invitation, existing_edge):
             contact_info=journal.contact_info,
         )
 
-        client.post_message(subject, recipients, message, parentGroup=group.id, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id)
+        client.post_message(subject, recipients, message, parentGroup=group.id, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
 
         return client.remove_members_from_group(group.id, edge.tail)
 
@@ -46,7 +46,7 @@ def process_update(client, edge, invitation, existing_edge):
             number_of_reviewers=journal.get_number_of_reviewers(),
         )
 
-        client.post_message(subject, recipients, message, parentGroup=group.id, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id)
+        client.post_message(subject, recipients, message, parentGroup=group.id, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
 
         ## expire AE recommendation
         journal.invitation_builder.expire_invitation(journal.get_ae_recommendation_id(number=note.number))
@@ -82,7 +82,7 @@ def process_update(client, edge, invitation, existing_edge):
                     editors_in_chief_email=journal.get_editors_in_chief_email(),
                 )
 
-                client.post_message(subject, recipients, message, parentGroup=group.id, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id)
+                client.post_message(subject, recipients, message, parentGroup=group.id, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
                 return                                     
 
         return

--- a/openreview/journal/process/author_edge_reminder_process.py
+++ b/openreview/journal/process/author_edge_reminder_process.py
@@ -35,5 +35,6 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=assigned_action_editor if assigned_action_editor else journal.contact_info,
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )

--- a/openreview/journal/process/author_reminder_process.py
+++ b/openreview/journal/process/author_reminder_process.py
@@ -40,7 +40,8 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=assigned_action_editor if assigned_action_editor else journal.contact_info, 
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )
 
     ## send email to AE
@@ -70,7 +71,8 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
                 replyTo=journal.contact_info, 
-                signature=journal.venue_id
+                signature=journal.venue_id,
+                sender=journal.get_message_sender()
         )
 
     ## send email to EICs
@@ -94,7 +96,8 @@ Link: https://openreview.net/forum?id={submission.id}
 OpenReview Team
 ''',
                 replyTo=journal.contact_info, 
-                signature=journal.venue_id
+                signature=journal.venue_id,
+                sender=journal.get_message_sender()
         )        
 
     

--- a/openreview/journal/process/author_submission_process.py
+++ b/openreview/journal/process/author_submission_process.py
@@ -21,7 +21,8 @@ def process(client, edit, invitation):
                 submission_title=note.content['title']['value']
             ),
             replyTo=journal.contact_info, 
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
     if note.tcdate == note.tmdate and journal.should_eic_submission_notification():
@@ -35,5 +36,6 @@ def process(client, edit, invitation):
                 submission_id=note.id,
             ),
             replyTo=journal.contact_info, 
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )   

--- a/openreview/journal/process/camera_ready_revision_process.py
+++ b/openreview/journal/process/camera_ready_revision_process.py
@@ -42,5 +42,6 @@ def process(client, edit, invitation):
         subject=f'''[{journal.short_name}] Review camera ready version for {journal.short_name} paper {submission.number}: {submission.content['title']['value']}''',
         message=message,
         replyTo=journal.contact_info, 
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )

--- a/openreview/journal/process/camera_ready_verification_process.py
+++ b/openreview/journal/process/camera_ready_verification_process.py
@@ -66,5 +66,6 @@ We thank you again for your contribution to {journal.short_name} and congratulat
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=journal.contact_info, 
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )

--- a/openreview/journal/process/desk_rejection_approval_process.py
+++ b/openreview/journal/process/desk_rejection_approval_process.py
@@ -38,7 +38,8 @@ def process(client, edit, invitation):
             subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
             message=message,
             replyTo=journal.contact_info, 
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
         journal.invitation_builder.expire_paper_invitations(submission)

--- a/openreview/journal/process/desk_rejection_submission_process.py
+++ b/openreview/journal/process/desk_rejection_submission_process.py
@@ -28,7 +28,8 @@ def process(client, edit, invitation):
         subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
         message=message,
         replyTo=journal.contact_info, 
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )
 
     journal.invitation_builder.expire_paper_invitations(submission)     

--- a/openreview/journal/process/eic_reminder_process.py
+++ b/openreview/journal/process/eic_reminder_process.py
@@ -39,7 +39,8 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=journal.contact_info, 
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )
 
        

--- a/openreview/journal/process/official_recommendation_cdate_process.py
+++ b/openreview/journal/process/official_recommendation_cdate_process.py
@@ -26,7 +26,8 @@ def process(client, invitation):
         subject=f'''[{journal.short_name}] Submit official recommendation for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
         message=message,
         replyTo=assigned_action_editor.get_preferred_email(), 
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )
 
     ## send email to action editos
@@ -47,7 +48,8 @@ def process(client, invitation):
         subject=f'''[{journal.short_name}] Reviewers must submit official recommendation for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
         message=message,
         replyTo=journal.contact_info, 
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )
 
     print('Let EICs enable the review rating')
@@ -74,5 +76,6 @@ def process(client, invitation):
             subject=f'''[{journal.short_name}] Discussion period ended for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
             message=message,
             replyTo=assigned_action_editor.get_preferred_email(), 
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )

--- a/openreview/journal/process/official_recommendation_process.py
+++ b/openreview/journal/process/official_recommendation_process.py
@@ -41,7 +41,8 @@ def process(client, edit, invitation):
             subject=f'''[{journal.short_name}] Evaluate reviewers and submit decision for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
             message=message,
             replyTo=journal.contact_info, 
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
         journal.invitation_builder.expire_invitation(journal.get_review_rating_enabling_id(submission.number))

--- a/openreview/journal/process/official_recommendation_reminder_process.py
+++ b/openreview/journal/process/official_recommendation_reminder_process.py
@@ -33,5 +33,6 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=journal.contact_info, 
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )

--- a/openreview/journal/process/rejected_submission_process.py
+++ b/openreview/journal/process/rejected_submission_process.py
@@ -22,7 +22,8 @@ def process(client, edit, invitation):
         subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
         message=message,
         replyTo=journal.contact_info,
-        signature=venue_id
+        signature=venue_id,
+        sender=journal.get_message_sender()
     )
 
     journal.invitation_builder.expire_paper_invitations(submission)

--- a/openreview/journal/process/remind_ae_unavailable_process.py
+++ b/openreview/journal/process/remind_ae_unavailable_process.py
@@ -50,7 +50,7 @@ The {journal.short_name} Editors-in-Chief
             print(f"back to available: {edge.tail}")
             edge.label = 'Available'
             client.post_edge(edge)
-            client.post_message(available_subject, recipients, available_message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=journal.contact_info)
+            client.post_message(available_subject, recipients, available_message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
         elif edge.tmdate < reminder_period:
             print(f"check if we need to remind: {edge.tail}")
             profile = client.get_profile(edge.tail)
@@ -59,6 +59,6 @@ The {journal.short_name} Editors-in-Chief
                 print(f"already reminded: {edge.tail} on {messages[0]['cdate']}, no action needed")
             else:
                 print(f"remind: {edge.tail}")
-                client.post_message(reminder_subject, recipients, reminder_message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=journal.contact_info)
+                client.post_message(reminder_subject, recipients, reminder_message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
 
 

--- a/openreview/journal/process/remind_reviewer_unavailable_process.py
+++ b/openreview/journal/process/remind_reviewer_unavailable_process.py
@@ -32,7 +32,7 @@ The {journal.short_name} Editors-in-Chief
         if edge.tmdate < reminder_period:
             print(f"remind: {edge.tail}")
             recipients=[edge.tail]
-            client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=journal.contact_info)
+            client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
             ## update edge to reset the reminder counter
             client.post_edge(edge)
 

--- a/openreview/journal/process/retraction_approval_process.py
+++ b/openreview/journal/process/retraction_approval_process.py
@@ -37,5 +37,6 @@ To view our decision, follow this link: https://openreview.net/forum?id={edit.no
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=journal.contact_info,
-        signature=venue_id
+        signature=venue_id,
+        sender=journal.get_message_sender()
     )

--- a/openreview/journal/process/retraction_submission_process.py
+++ b/openreview/journal/process/retraction_submission_process.py
@@ -21,5 +21,6 @@ The authors of paper {submission.number}: {submission.content['title']['value']}
 OpenReview Team
 ''',
         replyTo=journal.contact_info,
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )

--- a/openreview/journal/process/review_process.py
+++ b/openreview/journal/process/review_process.py
@@ -75,7 +75,8 @@ def process(client, edit, invitation):
             subject=f'''[{journal.short_name}] Reviewer responses and discussion for your {journal.short_name} submission''',
             message=message,
             replyTo=assigned_action_editor.get_preferred_email(),
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
         ## Send email notifications to reviewers
@@ -99,7 +100,8 @@ def process(client, edit, invitation):
             subject=f'''[{journal.short_name}] Start of author discussion for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
             message=message,
             replyTo=assigned_action_editor.get_preferred_email(),
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
         ## Send email notifications to the action editor
@@ -122,7 +124,8 @@ def process(client, edit, invitation):
             subject=f'''[{journal.short_name}] Start of author discussion for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
             message=message,
             replyTo=journal.contact_info,
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
         assigned_reviewers = client.get_group(id=journal.get_reviewers_id(number=submission.number)).members
@@ -142,5 +145,6 @@ def process(client, edit, invitation):
                 subject=f'''[{journal.short_name}] Too many reviewers assigned to {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
                 message=message,
                 replyTo=journal.contact_info,
-                signature=journal.venue_id
+                signature=journal.venue_id,
+                sender=journal.get_message_sender()
             )            

--- a/openreview/journal/process/review_rating_enabling_process.py
+++ b/openreview/journal/process/review_rating_enabling_process.py
@@ -27,7 +27,8 @@ def process(client, edit, invitation):
         subject=f'''[{journal.short_name}] Evaluate reviewers and submit decision for {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
         message=message,
         replyTo=journal.contact_info,
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )
 
     journal.invitation_builder.expire_invitation(journal.get_review_rating_enabling_id(submission.number))    

--- a/openreview/journal/process/reviewer_assignment_acknowledgement_process.py
+++ b/openreview/journal/process/reviewer_assignment_acknowledgement_process.py
@@ -19,5 +19,5 @@ Assignment acknowledgement: {edit.note.content['assignment_acknowledgement']['va
 To view the acknowledgement, click here: https://openreview.net/forum?id={submission.id}&noteId={edit.note.id}
 '''
 
-    client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, ignoreRecipients=ignoreRecipients, replyTo=journal.contact_info)
+    client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, ignoreRecipients=ignoreRecipients, replyTo=journal.contact_info, sender=journal.get_message_sender())
 

--- a/openreview/journal/process/reviewer_assignment_process.py
+++ b/openreview/journal/process/reviewer_assignment_process.py
@@ -66,7 +66,7 @@ def process_update(client, edge, invitation, existing_edge):
             assigned_action_editor=assigned_action_editor.get_preferred_name(pretty=True)
         )
 
-        client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=assigned_action_editor.get_preferred_email())
+        client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=assigned_action_editor.get_preferred_email(), sender=journal.get_message_sender())
 
         if pending_review_edge and pending_review_edge.weight > 0:
             pending_review_edge.weight -= 1
@@ -130,7 +130,7 @@ def process_update(client, edge, invitation, existing_edge):
         )
 
         if official_reviewer:
-            client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, parentGroup=group.id, replyTo=assigned_action_editor.get_preferred_email())
+            client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, parentGroup=group.id, replyTo=assigned_action_editor.get_preferred_email(), sender=journal.get_message_sender())
 
     if responsiblity_invitation_edit is not None:
 
@@ -148,5 +148,5 @@ We thank you for your essential contribution to {journal.short_name}!
 
 The {journal.short_name} Editors-in-Chief
 '''
-        client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, ignoreRecipients=ignoreRecipients, parentGroup=group.id, replyTo=journal.contact_info)
+        client.post_message(subject, recipients, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, ignoreRecipients=ignoreRecipients, parentGroup=group.id, replyTo=journal.contact_info, sender=journal.get_message_sender())
 

--- a/openreview/journal/process/reviewer_assignment_recruitment_process.py
+++ b/openreview/journal/process/reviewer_assignment_recruitment_process.py
@@ -77,7 +77,7 @@ Confirmation of the assignment is pending until your profile is active and no co
 {decline_instructions}
 
 OpenReview Team'''
-            response = client.post_message(subject, [edge.tail], message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info)
+            response = client.post_message(subject, [edge.tail], message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
 
             ## Send email to inviter
             subject=f'[{short_phrase}] {committee_name} {preferred_name} accepted to review paper {submission.number}: {submission.content["title"]["value"]}, assignment pending'
@@ -89,7 +89,7 @@ Confirmation of the assignment is pending until the invited reviewer creates a p
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, edge.signatures, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info)
+            response = client.post_message(subject, edge.signatures, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
             return
 
         ## Check if there is already an accepted edge for that profile id
@@ -121,7 +121,7 @@ A conflict was detected between you and the submission authors and the assignmen
 If you have any questions, please contact us as info@openreview.net.
 
 OpenReview Team'''
-            response = client.post_message(subject, [edge.tail], message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info)
+            response = client.post_message(subject, [edge.tail], message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
 
             ## Send email to inviter
             subject=f'[{short_phrase}] Conflict detected between {committee_name} {preferred_name} and paper {submission.number}: {submission.content["title"]["value"]}'
@@ -133,7 +133,7 @@ If you have any questions, please contact us as info@openreview.net.
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, edge.signatures, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info)
+            response = client.post_message(subject, edge.signatures, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
             return
 
         edge.label=accepted_label
@@ -167,7 +167,7 @@ Thank you for accepting the invitation to review the paper number: {submission.n
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, [edge.tail], message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info)
+            response = client.post_message(subject, [edge.tail], message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
 
             ## Send email to inviter
             subject=f'[{short_phrase}] {committee_name} {preferred_name} accepted to review paper {submission.number}: {submission.content["title"]["value"]}'
@@ -177,7 +177,7 @@ The {committee_name} {preferred_name}({preferred_email}) that you invited to rev
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, edge.signatures, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info)
+            response = client.post_message(subject, edge.signatures, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
 
 
     elif (note.content['response']['value'] == 'No'):
@@ -208,7 +208,7 @@ You have declined the invitation to review the paper number: {submission.number}
 OpenReview Team'''
 
         ## - Send email
-        response = client.post_message(subject, [edge.tail], message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info)
+        response = client.post_message(subject, [edge.tail], message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
 
         ## Send email to inviter
         subject=f'[{short_phrase}] {committee_name} {preferred_name} declined to review paper {submission.number}: {submission.content["title"]["value"]}'
@@ -220,7 +220,7 @@ To read their response, please click here: https://openreview.net/forum?id={note
 OpenReview Team'''
 
         ## - Send email
-        response = client.post_message(subject, edge.signatures, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info)
+        response = client.post_message(subject, edge.signatures, message, invitation=journal.get_meta_invitation_id(), signature=venue_id, replyTo=journal.contact_info, sender=journal.get_message_sender())
 
     else:
         raise openreview.OpenReviewException(f"Invalid response: {note.content['response']['value']}")

--- a/openreview/journal/process/reviewer_invitation_assignment_process.py
+++ b/openreview/journal/process/reviewer_invitation_assignment_process.py
@@ -63,7 +63,7 @@ Thanks,
 
         
         ## - Send email
-        response = client.post_message(subject, [user_profile.id], message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=inviter_profile.get_preferred_name())
+        response = client.post_message(subject, [user_profile.id], message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=inviter_profile.get_preferred_name(), sender=journal.get_message_sender())
 
         ## - Update edge to INVITED_LABEL
         edge.label=invite_label

--- a/openreview/journal/process/reviewer_reminder_process.py
+++ b/openreview/journal/process/reviewer_reminder_process.py
@@ -42,7 +42,8 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=assigned_action_editor if assigned_action_editor else journal.contact_info,
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )
 
     ## send email to AE
@@ -72,7 +73,8 @@ We thank you for your cooperation.
 The {journal.short_name} Editors-in-Chief
 ''',
                 replyTo=journal.contact_info,
-                signature=journal.venue_id
+                signature=journal.venue_id,
+                sender=journal.get_message_sender()
         )
 
     ## send email to EICs
@@ -96,7 +98,8 @@ Link: https://openreview.net/forum?id={submission.id}
 OpenReview Team
 ''',
                 replyTo=journal.contact_info,
-                signature=journal.venue_id
+                signature=journal.venue_id,
+                sender=journal.get_message_sender()
         )        
 
     

--- a/openreview/journal/process/solicit_review_approval_process.py
+++ b/openreview/journal/process/solicit_review_approval_process.py
@@ -52,7 +52,8 @@ The {journal.short_name} Editors-in-Chief
 note: replies to this email will go to the AE, {assigned_action_editor.get_preferred_name(pretty=True)}.
 ''',
             replyTo=assigned_action_editor.get_preferred_email(),
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )
 
         return
@@ -74,5 +75,6 @@ Respectfully,
 The {journal.short_name} Editors-in-Chief
 ''',
             replyTo=journal.contact_info,
-            signature=journal.venue_id
+            signature=journal.venue_id,
+            sender=journal.get_message_sender()
         )

--- a/openreview/journal/process/solicit_review_process.py
+++ b/openreview/journal/process/solicit_review_process.py
@@ -33,5 +33,6 @@ We thank you for your contribution to {journal.short_name}!
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=journal.contact_info,
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )

--- a/openreview/journal/process/submission_decision_approval_process.py
+++ b/openreview/journal/process/submission_decision_approval_process.py
@@ -28,7 +28,8 @@ Your decision on submission {submission.number}: {submission.content['title']['v
 To know more about the decision, please follow this link: https://openreview.net/forum?id={submission.id}
 ''',
         replyTo=journal.contact_info,
-        signature=venue_id)
+        signature=venue_id,
+        sender=journal.get_message_sender())
 
     print('Check rejection')
     print(decision.content)
@@ -115,7 +116,8 @@ To know more about the decision, please follow this link: https://openreview.net
             subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
             message=message,
             replyTo=journal.contact_info,
-            signature=venue_id
+            signature=venue_id,
+            sender=journal.get_message_sender()
         )
         return
 
@@ -136,5 +138,6 @@ To know more about the decision, please follow this link: https://openreview.net
             subject=f'''[{journal.short_name}] Decision for your {journal.short_name} submission {submission.number}: {submission.content['title']['value']}''',
             message=message,
             replyTo=journal.contact_info,
-            signature=venue_id
+            signature=venue_id,
+            sender=journal.get_message_sender()
         )

--- a/openreview/journal/process/under_review_submission_process.py
+++ b/openreview/journal/process/under_review_submission_process.py
@@ -31,5 +31,6 @@ def process(client, edit, invitation):
         subject=f'''[{journal.short_name}] Perform reviewer assignments for {journal.short_name} submission {note.number}: {note.content['title']['value']}''',
         message=message,
         replyTo=journal.contact_info,
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )

--- a/openreview/journal/process/withdrawn_submission_process.py
+++ b/openreview/journal/process/withdrawn_submission_process.py
@@ -20,7 +20,8 @@ We thank you for your involvement with {journal.short_name}!
 The {journal.short_name} Editors-in-Chief
 ''',
         replyTo=journal.contact_info,
-        signature=journal.venue_id
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
     )
 
     print('Enable Author deanonymize')

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -154,6 +154,7 @@ class GroupBuilder(object):
             'subtitle': { 'value': self.venue.short_name if self.venue.short_name else '' },
             'website': { 'value': self.venue.website if self.venue.website else '' },
             'contact': { 'value': self.venue.contact if self.venue.contact else '' },
+            'message_sender': { 'value': self.venue.get_message_sender() },
             'location': { 'value': self.venue.location if self.venue.location else '' },
             'instructions': { 'value': self.venue.instructions if self.venue.instructions else '' },
             'start_date': { 'value': self.venue.start_date if self.venue.start_date else '' },

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -3615,6 +3615,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         invitation_id = self.venue.get_invitation_id(f'{self.venue.submission_stage.name}_Message', prefix=self.venue.get_reviewers_id())
         cdate=tools.datetime_millis(self.venue.submission_stage.second_due_date_exp_date if self.venue.submission_stage.second_due_date_exp_date else self.venue.submission_stage.exp_date)
+        venue_sender = self.venue.get_message_sender()
 
         committee = [venue_id]
         committee_signatures = [venue_id, self.venue.get_program_chairs_id()]
@@ -3670,7 +3671,9 @@ class InvitationBuilder(object):
                         'groups': { 'param': { 'inGroup': self.venue.get_reviewers_id('${3/content/noteNumber/value}') } },
                         'parentGroup': { 'param': { 'const': self.venue.get_reviewers_id('${3/content/noteNumber/value}') } },
                         'ignoreGroups': { 'param': { 'regex': r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})', 'optional': True } },
-                        'signature': { 'param': { 'enum': committee_signatures } }
+                        'signature': { 'param': { 'enum': committee_signatures } },
+                        'fromName': venue_sender['fromName'],
+                        'fromEmail': venue_sender['fromEmail']
                     }
                 }
 
@@ -3692,7 +3695,9 @@ class InvitationBuilder(object):
                 'groups': { 'param': { 'inGroup': self.venue.get_reviewers_id() } },
                 'parentGroup': { 'param': { 'const': self.venue.get_reviewers_id() } },
                 'ignoreGroups': { 'param': { 'regex': r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})', 'optional': True } },
-                'signature': { 'param': { 'enum': [venue_id, self.venue.get_program_chairs_id()] } }
+                'signature': { 'param': { 'enum': [venue_id, self.venue.get_program_chairs_id()] } },
+                'fromName': venue_sender['fromName'],
+                'fromEmail': venue_sender['fromEmail']
             }
         )
 
@@ -3711,7 +3716,9 @@ class InvitationBuilder(object):
                     'groups': { 'param': { 'inGroup': self.venue.get_area_chairs_id() } },
                     'parentGroup': { 'param': { 'const': self.venue.get_area_chairs_id() } },
                     'ignoreGroups': { 'param': { 'regex': r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})', 'optional': True } },
-                    'signature': { 'param': { 'enum': [venue_id, self.venue.get_program_chairs_id(), '~.*'] } } 
+                    'signature': { 'param': { 'enum': [venue_id, self.venue.get_program_chairs_id(), '~.*'] } },
+                    'fromName': venue_sender['fromName'],
+                    'fromEmail': venue_sender['fromEmail']
                 }
             )
 

--- a/openreview/venue/process/assignment_post_process.py
+++ b/openreview/venue/process/assignment_post_process.py
@@ -11,6 +11,7 @@ def process_update(client, edge, invitation, existing_edge):
     reviewers_id = invitation.content['reviewers_id']['value']
     sync_sac_id = invitation.content.get('sync_sac_id',{}).get('value')
     sac_assignment_id = invitation.content.get('sac_assignment_id',{}).get('value')
+    sender = domain.content.get('message_sender').get('value')
     pretty_name = openreview.tools.pretty_id(reviewers_name)
     pretty_name = pretty_name[:-1] if pretty_name.endswith('s') else pretty_name
 
@@ -62,4 +63,4 @@ Thank you,
 
 {signature}'''
 
-        client.post_message(subject, recipients, message, invitation=meta_invitation_id, signature=venue_id, parentGroup=group.id, replyTo=contact)
+        client.post_message(subject, recipients, message, invitation=meta_invitation_id, signature=venue_id, parentGroup=group.id, replyTo=contact, sender=sender)

--- a/openreview/venue/process/comment_process.py
+++ b/openreview/venue/process/comment_process.py
@@ -10,6 +10,8 @@ def process(client, edit, invitation):
     reviewers_name = domain.get_content_value('reviewers_name')
     reviewers_anon_name = domain.get_content_value('reviewers_anon_name')
     reviewers_submitted_name = domain.get_content_value('reviewers_submitted_name')
+    sender = domain.get_content_value('message_sender')
+
 
     submission = client.get_note(edit.note.forum)
     comment = client.get_note(edit.note.id)
@@ -44,7 +46,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             ignoreRecipients = ignore_groups,
             subject=f'''[{short_name}] {pretty_signature} commented on a paper. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''{pretty_signature} commented on a paper for which you are serving as Program Chair.{content}''',
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
 
     senior_area_chairs_name = domain.get_content_value('senior_area_chairs_name')
@@ -59,7 +62,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             subject=f'''[{short_name}] {pretty_signature} commented on a paper in your area. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''{pretty_signature} commented on a paper for which you are serving as Senior Area Chair.{content}''',
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
 
     area_chairs_name = domain.get_content_value('area_chairs_name')
@@ -73,7 +77,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             subject=f'''[{short_name}] {pretty_signature} commented on a paper in your area. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''{pretty_signature} commented on a paper for which you are serving as Area Chair.{content}''',
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
 
     paper_reviewers_id = f'{paper_group_id}/{reviewers_name}'
@@ -88,7 +93,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
     elif paper_reviewers_submitted_group and paper_reviewers_submitted_id in comment.readers:
         client.post_message(
@@ -98,7 +104,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
     else:
         anon_reviewers = [reader for reader in comment.readers if reader.find(reviewers_anon_name) >=0]
@@ -111,7 +118,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
                 subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
                 message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
                 replyTo=contact,
-                signature=venue_id
+                signature=venue_id,
+                sender=sender
             )
 
     #send email to author of comment
@@ -121,7 +129,8 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
         subject=f'''[{short_name}] Your comment was received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
         message=f'''Your comment was received on a submission to {short_name}.{content}''',
         replyTo=contact,
-        signature=venue_id
+        signature=venue_id,
+        sender=sender
     )
 
     #send email to paper authors
@@ -134,5 +143,6 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             subject=f'''[{short_name}] {pretty_signature} commented on your submission. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''{pretty_signature} commented on your submission.{content}''',
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )

--- a/openreview/venue/process/custom_stage_process.py
+++ b/openreview/venue/process/custom_stage_process.py
@@ -12,6 +12,7 @@ def process(client, edit, invitation):
     email_sacs = meta_invitation.content['email_sacs']['value']
     notify_readers = meta_invitation.content['notify_readers']['value']
     email_template = meta_invitation.content['email_template']['value']
+    sender = domain.get_content_value('message_sender')
 
     submission = client.get_note(edit.note.forum)
     note = client.get_note(edit.note.id)
@@ -45,6 +46,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[program_chairs_id],
             ignoreRecipients = ignore_groups,
             subject=f'''[{short_name}] A {invitation_name} has been received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
@@ -58,6 +60,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
     client.post_message(
         invitation=meta_invitation_id,
         signature=venue_id,
+        sender=sender,
         recipients=[edit.tauthor],
         replyTo=contact,
         subject=f'''[{short_name}] Your {invitation_name} has been received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
@@ -75,6 +78,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_senior_area_chairs_id],
             ignoreRecipients = ignore_groups,
             replyTo=contact,
@@ -92,6 +96,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_area_chairs_id],
             ignoreRecipients = ignore_groups,
             replyTo=contact,
@@ -111,6 +116,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_reviewers_id],
             ignoreRecipients=ignore_groups,
             replyTo=contact,
@@ -124,6 +130,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_reviewers_submitted_id],
             ignoreRecipients=ignore_groups,
             replyTo=contact,
@@ -141,6 +148,7 @@ To view the {invitation_name}, click here: https://openreview.net/forum?id={subm
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=submission.content['authorids']['value'],
             ignoreRecipients=ignore_groups,
             replyTo=contact,

--- a/openreview/venue/process/decision_process.py
+++ b/openreview/venue/process/decision_process.py
@@ -7,7 +7,8 @@ def process(client, edit, invitation):
     contact = domain.get_content_value('contact')
     authors_name = domain.get_content_value('authors_name')
     submission_name = domain.get_content_value('submission_name')    
-    authors_accepted_id = domain.get_content_value('authors_accepted_id')    
+    authors_accepted_id = domain.get_content_value('authors_accepted_id') 
+    sender = domain.get_content_value('message_sender')   
 
     submission = client.get_note(edit.note.forum)
     decision = client.get_note(edit.note.id)
@@ -25,7 +26,8 @@ def process(client, edit, invitation):
             subject=f'''[{short_name}] Decision {action} your submission - Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
             message=f'''To view the decision, click here: https://openreview.net/forum?id={submission.id}&noteId={decision.id}''',
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
 
     if (authors_accepted_id):      

--- a/openreview/venue/process/desk_rejected_submission_process.py
+++ b/openreview/venue/process/desk_rejected_submission_process.py
@@ -13,6 +13,7 @@ def process(client, edit, invitation):
     authors_name = domain.content['authors_name']['value']
     desk_rejection_email_pcs = domain.content.get('desk_rejection_email_pcs', {}).get('value')
     program_chairs_id = domain.content['program_chairs_id']['value']
+    sender = domain.get_content_value('message_sender')
 
     submission = client.get_note(edit.note.id)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'
@@ -65,4 +66,4 @@ def process(client, edit, invitation):
 For more information, click here https://openreview.net/forum?id={submission.id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, ignoreRecipients=ignoreRecipients, replyTo=contact)
+    client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, ignoreRecipients=ignoreRecipients, replyTo=contact, sender=sender)

--- a/openreview/venue/process/desk_rejection_reversion_submission_process.py
+++ b/openreview/venue/process/desk_rejection_reversion_submission_process.py
@@ -10,6 +10,7 @@ def process(client, edit, invitation):
     desk_reject_committee = domain.content['desk_reject_committee']['value']
     submission_name = domain.content['submission_name']['value']
     authors_name = domain.content['authors_name']['value']
+    sender = domain.get_content_value('message_sender')
 
     now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
     submission = client.get_note(edit.note.forum)
@@ -48,7 +49,7 @@ def process(client, edit, invitation):
 For more information, click here https://openreview.net/forum?id={submission.id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, replyTo=contact)
+    client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
 
     print(f'Add {paper_group_id}/{authors_name} to {venue_id}/{authors_name}')
     client.add_members_to_group(f'{venue_id}/{authors_name}', f'{paper_group_id}/{authors_name}')

--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -4,6 +4,7 @@ def process_update(client, edge, invitation, existing_edge):
     meta_invitation_id = domain.content['meta_invitation_id']['value']
     short_phrase = domain.content['subtitle']['value']
     contact = domain.content['contact']['value']
+    sender = domain.get_content_value('message_sender')
     recruitment_invitation_id = invitation.content['recruitment_invitation_id']['value']
     committee_invited_id = invitation.content['committee_invited_id']['value']
     invite_label = invitation.content['invite_label']['value']
@@ -94,7 +95,7 @@ Thanks,
             client.add_members_to_group(committee_invited_id, [user_profile.id])
 
         ## - Send email
-        response = client.post_message(subject, [user_profile.id], message, invitation=meta_invitation_id, signature=domain.id, parentGroup=committee_invited_id, replyTo=contact)
+        response = client.post_message(subject, [user_profile.id], message, invitation=meta_invitation_id, signature=domain.id, parentGroup=committee_invited_id, replyTo=contact, sender=sender)
 
         ## - Update edge to INVITED_LABEL
         edge.label=invited_label
@@ -150,4 +151,4 @@ Thanks,
 {inviter_id}
 {inviter_preferred_name} ({edge.tauthor})'''
 
-        response = client.post_message(subject, [user_profile.id], message, invitation=meta_invitation_id, signature=domain.id, replyTo=contact)
+        response = client.post_message(subject, [user_profile.id], message, invitation=meta_invitation_id, signature=domain.id, replyTo=contact, sender=sender)

--- a/openreview/venue/process/paper_recruitment_process.py
+++ b/openreview/venue/process/paper_recruitment_process.py
@@ -22,6 +22,8 @@ def process(client, edit, invitation):
     external_paper_committee_id = invitation.content['external_paper_committee_id']['value']
     conflict_policy = domain.content.get('reviewers_conflict_policy', {}).get('value', 'Default')
     conflict_n_years = domain.content.get('reviewers_conflict_n_years', {}).get('value')
+    contact = domain.content['contact']['value']
+    sender = domain.get_content_value('message_sender')
 
     note = edit.note
 
@@ -81,7 +83,7 @@ Confirmation of the assignment is pending until your profile is active and no co
 {decline_instructions}
 
 OpenReview Team'''
-            response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id)
+            response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
 
             ## Send email to inviter
             subject=f'[{short_phrase}] {committee_name} {preferred_name} accepted to review paper {submission.number}, assignment pending'
@@ -93,7 +95,7 @@ Confirmation of the assignment is pending until the invited reviewer creates a p
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, edge.signatures, message, invitation=meta_invitation_id, signature=venue_id)
+            response = client.post_message(subject, edge.signatures, message, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
             return
 
         ## Check if there is already an accepted edge for that profile id
@@ -125,7 +127,7 @@ A conflict was detected between you and the submission authors and the assignmen
 If you have any questions, please contact us as info@openreview.net.
 
 OpenReview Team'''
-            response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id)
+            response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
 
             ## Send email to inviter
             subject=f'[{short_phrase}] Conflict detected between {committee_name} {preferred_name} and paper {submission.number}'
@@ -137,7 +139,7 @@ If you have any questions, please contact us as info@openreview.net.
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, edge.signatures, message, invitation=meta_invitation_id, signature=venue_id)
+            response = client.post_message(subject, edge.signatures, message, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
             return
 
         edge.label=accepted_label
@@ -189,7 +191,7 @@ Thank you for accepting the invitation to review the paper number: {submission.n
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id)
+            response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
 
             ## Send email to inviter
             subject=f'[{short_phrase}] {committee_name} {preferred_name} accepted to review paper {submission.number}'
@@ -199,7 +201,7 @@ The {committee_name} {preferred_name}({preferred_email}) that you invited to rev
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, edge.signatures, message, invitation=meta_invitation_id, signature=venue_id)
+            response = client.post_message(subject, edge.signatures, message, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
 
 
     elif (note.content['response']['value'] == 'No'):
@@ -236,7 +238,7 @@ You have declined the invitation to review the paper number: {submission.number}
 OpenReview Team'''
 
         ## - Send email
-        response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id)
+        response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
 
         ## Send email to inviter
         subject=f'[{short_phrase}] {committee_name} {preferred_name} declined to review paper {submission.number}'
@@ -248,7 +250,7 @@ To read their response, please click here: https://openreview.net/forum?id={note
 OpenReview Team'''
 
         ## - Send email
-        response = client.post_message(subject, edge.signatures, message, invitation=meta_invitation_id, signature=venue_id)
+        response = client.post_message(subject, edge.signatures, message, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
 
     else:
         raise openreview.OpenReviewException(f"Invalid response: {note.content['response']['value']}")

--- a/openreview/venue/process/pc_submission_revision_process.py
+++ b/openreview/venue/process/pc_submission_revision_process.py
@@ -7,6 +7,7 @@ def process(client, edit, invitation):
     contact = domain.content['contact']['value']
     authors_name = domain.content['authors_name']['value']
     submission_name = domain.content['submission_name']['value']
+    sender = domain.get_content_value('message_sender')
 
     submission = client.get_note(edit.note.id)
 
@@ -28,7 +29,8 @@ To view your submission, click here: https://openreview.net/forum?id={submission
         recipients=submission.content['authorids']['value'],
         message=message,
         replyTo=contact,
-        signature=venue_id
+        signature=venue_id,
+        sender=sender
     )
 
     if 'authorids' in submission.content:

--- a/openreview/venue/process/recruitment_process.py
+++ b/openreview/venue/process/recruitment_process.py
@@ -5,6 +5,7 @@ def process(client, edit, invitation):
     meta_invitation_id = domain.content['meta_invitation_id']['value']
     short_phrase = domain.content['subtitle']['value']
     contact = domain.content['contact']['value']
+    sender = domain.get_content_value('message_sender')
     committee_name = invitation.content['committee_name']['value']
     committee_invited_id = invitation.content['committee_invited_id']['value']
     committee_id = invitation.content['committee_id']['value']
@@ -40,7 +41,7 @@ def process(client, edit, invitation):
 
                 subject = f'[{short_phrase}] {committee_name} Invitation not accepted'
                 message = f'''It seems like you already accepted an invitation to serve as a {overlap_committee_name} for {short_phrase}. If you would like to change your decision and serve as a {committee_name}, please decline the invitation to be {overlap_committee_name} and then accept the invitation to be {committee_name}.'''
-                client.post_message(subject, [user], message, invitation=meta_invitation_id, signature=domain.id, replyTo=contact)
+                client.post_message(subject, [user], message, invitation=meta_invitation_id, signature=domain.id, replyTo=contact, sender=sender)
                 return
 
             client.remove_members_from_group(committee_declined_id, members_to_remove)
@@ -57,7 +58,7 @@ The {short_phrase} program chairs will be contacting you with more information r
 
 If you would like to change your decision, please follow the link in the previous invitation email and click on the "Decline" button.'''
 
-            client.post_message(subject, [user], message, invitation=meta_invitation_id, signature=domain.id, parentGroup=committee_id, replyTo=contact)
+            client.post_message(subject, [user], message, invitation=meta_invitation_id, signature=domain.id, parentGroup=committee_id, replyTo=contact, sender=sender)
             return
 
         if (response == 'No'):
@@ -69,7 +70,7 @@ If you would like to change your decision, please follow the link in the previou
 
 If you would like to change your decision, please follow the link in the previous invitation email and click on the "Accept" button.'''
 
-            client.post_message(subject, [user], message, invitation=meta_invitation_id, signature=domain.id, parentGroup=committee_declined_id, replyTo=contact)
+            client.post_message(subject, [user], message, invitation=meta_invitation_id, signature=domain.id, parentGroup=committee_declined_id, replyTo=contact, sender=sender)
 
         else:
             raise openreview.OpenReviewException('Invalid response')

--- a/openreview/venue/process/review_process.py
+++ b/openreview/venue/process/review_process.py
@@ -12,6 +12,7 @@ def process(client, edit, invitation):
     senior_area_chairs_name = domain.get_content_value('senior_area_chairs_name')
     reviewers_submitted_name = domain.get_content_value('reviewers_submitted_name')
     review_name = domain.get_content_value('review_name')
+    sender = domain.get_content_value('message_sender')
 
     submission = client.get_note(edit.note.forum)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'
@@ -61,6 +62,7 @@ def process(client, edit, invitation):
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[domain.get_content_value('program_chairs_id')],
             ignoreRecipients=ignore_groups,
             subject=f'''[{short_name}] A {review_name} has been received on Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
@@ -73,6 +75,7 @@ def process(client, edit, invitation):
     client.post_message(
         invitation=meta_invitation_id,
         signature=venue_id,
+        sender=sender,
         recipients=review.signatures,
         replyTo=contact,
         subject=f'''[{short_name}] Your {review_name} has been received on your assigned Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
@@ -89,6 +92,7 @@ Paper title: {submission.content['title']['value']}
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_area_chairs_id],
             ignoreRecipients=ignore_groups,
             replyTo=contact,
@@ -108,6 +112,7 @@ Paper title: {submission.content['title']['value']}
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_reviewers_id],
             ignoreRecipients=ignore_groups,
             replyTo=contact,
@@ -125,6 +130,7 @@ Paper title: {submission.content['title']['value']}
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_reviewers_submitted_id],
             ignoreRecipients=ignore_groups,
             replyTo=contact,
@@ -144,6 +150,7 @@ Paper title: {submission.content['title']['value']}
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_authors_id],
             ignoreRecipients=ignore_groups,
             replyTo=contact,

--- a/openreview/venue/process/review_rebuttal_process.py
+++ b/openreview/venue/process/review_rebuttal_process.py
@@ -8,6 +8,7 @@ def process(client, edit, invitation):
     submission_name = domain.get_content_value('submission_name')
     program_chairs_id = domain.get_content_value('program_chairs_id')
     email_pcs = domain.get_content_value('rebuttal_email_pcs')
+    sender = domain.get_content_value('message_sender')
     
     submission = client.get_note(edit.note.forum)
     rebuttal = client.get_note(edit.note.id)
@@ -36,7 +37,8 @@ Title: {submission.content['title']['value']}
         subject=f'''[{short_name}] Your author rebuttal was {action} on Submission Number: {submission.number}, Submission Title: "{submission.content['title']['value']}"''',
         message=author_message,
         replyTo=contact,
-        signature=venue_id
+        signature=venue_id,
+        sender=sender
     )
 
     #send email to paper authors
@@ -47,13 +49,15 @@ Title: {submission.content['title']['value']}
         subject=f'''[{short_name}] An author rebuttal was {action} on Submission Number: {submission.number}, Submission Title: "{submission.content['title']['value']}"''',
         message=author_message,
         replyTo=contact,
-        signature=venue_id
+        signature=venue_id,
+        sender=sender
     )
 
     if email_pcs:
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=program_chairs_id,
             ignoreRecipients=ignore_groups,
             subject=f'''[{short_name}] An author rebuttal was {action} on Submission Number: {submission.number}, Submission Title: "{submission.content['title']['value']}"''',
@@ -73,6 +77,7 @@ Title: {submission.content['title']['value']}
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,
+            sender=sender,
             recipients=[paper_area_chairs_id],
             ignoreRecipients=ignore_groups,
             replyTo=contact,
@@ -108,7 +113,8 @@ Title: {submission.content['title']['value']}
             subject=reviewer_subject,
             message=reviewer_message,
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
     elif paper_reviewers_submitted_id in rebuttal.readers:
         client.post_message(
@@ -118,7 +124,8 @@ Title: {submission.content['title']['value']}
             subject=reviewer_subject,
             message=reviewer_message,
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
 
     

--- a/openreview/venue/process/simple_paper_recruitment_process.py
+++ b/openreview/venue/process/simple_paper_recruitment_process.py
@@ -6,6 +6,7 @@ def process(client, edit, invitation):
     venue_id = domain.id
     meta_invitation_id = domain.content['meta_invitation_id']['value']
     short_phrase = domain.content['subtitle']['value']
+    sender = domain.get_content_value('message_sender')
     submission_name = domain.content['submission_name']['value']
     committee_name = invitation.content['committee_name']['value']
     edge_readers = invitation.content['edge_readers']['value']
@@ -103,7 +104,7 @@ If you would like to change your decision, please click the Decline link in the 
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id)
+            response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id, sender=sender)
 
             ## If reviewer recruitment then send email to the assigned AC
             if is_reviewer:
@@ -113,7 +114,7 @@ The {committee_name} {preferred_name}({preferred_email}) that was invited {actio
 
 OpenReview Team'''
 
-                client.post_message(subject, [f'{venue_id}/Submission{submission.number}/Area_Chairs'], message, invitation=meta_invitation_id, signature=venue_id)
+                client.post_message(subject, [f'{venue_id}/Submission{submission.number}/Area_Chairs'], message, invitation=meta_invitation_id, signature=venue_id, sender=sender)
             return
 
     elif (note.content['response']['value'] == 'No'):
@@ -140,7 +141,7 @@ If you would like to change your decision, please click the Accept link in the p
 OpenReview Team'''
 
         ## - Send email
-        response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id)
+        response = client.post_message(subject, [edge.tail], message, invitation=meta_invitation_id, signature=venue_id, sender=sender)
 
         if is_reviewer:
             subject=f'[{short_phrase}] {committee_name} {preferred_name} declined {action_string} paper {submission.number}'
@@ -151,7 +152,7 @@ Please go to the Area Chair console: https://openreview.net/group?id={venue_id}/
 
 OpenReview Team'''
 
-            client.post_message(subject, [f'{venue_id}/Submission{submission.number}/Area_Chairs'], message, invitation=meta_invitation_id, signature=venue_id)
+            client.post_message(subject, [f'{venue_id}/Submission{submission.number}/Area_Chairs'], message, invitation=meta_invitation_id, signature=venue_id, sender=sender)
         return
 
     else:

--- a/openreview/venue/process/submission_deletion_process.py
+++ b/openreview/venue/process/submission_deletion_process.py
@@ -8,6 +8,7 @@ def process(client, edit, invitation):
     short_phrase = domain.content['subtitle']['value']
     contact = domain.content['contact']['value']
     meta_invitation_id = domain.content['meta_invitation_id']['value']
+    sender = domain.get_content_value('message_sender')
 
     note = client.get_note(edit.note.id)
     action = 'deleted' if note.ddate else 'restored'
@@ -43,7 +44,8 @@ Title: {note.content['title']['value']}{note_abstract}
             subject=author_subject,
             message=author_message,
             recipients=[edit.tauthor],
-            replyTo=contact
+            replyTo=contact,
+            sender=sender
         )
 
     # send co-author emails
@@ -56,5 +58,6 @@ Title: {note.content['title']['value']}{note_abstract}
             message=author_message,
             recipients=note.content['authorids']['value'],
             ignoreRecipients=[edit.tauthor],
-            replyTo=contact
+            replyTo=contact,
+            sender=sender
         )

--- a/openreview/venue/process/submission_process.py
+++ b/openreview/venue/process/submission_process.py
@@ -11,6 +11,7 @@ def process(client, edit, invitation):
     submission_email = domain.content['submission_email_template']['value']
     email_pcs = domain.content['submission_email_pcs']['value']
     program_chairs_id = domain.content['program_chairs_id']['value']
+    sender = domain.get_content_value('message_sender')
 
     note = client.get_note(edit.note.id)
 
@@ -125,7 +126,8 @@ To view your submission, click here: https://openreview.net/forum?id={note.forum
             message=author_message,
             recipients=[edit.tauthor],
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
 
     # send co-author emails
@@ -138,7 +140,8 @@ To view your submission, click here: https://openreview.net/forum?id={note.forum
             recipients=note.content['authorids']['value'],
             ignoreRecipients=[edit.tauthor],
             replyTo=contact,
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )
 
     if email_pcs:
@@ -152,5 +155,6 @@ Title: {note.content['title']['value']} {note_abstract}
 
 To view the submission, click here: https://openreview.net/forum?id={note.forum}''',
             recipients=[program_chairs_id],
-            signature=venue_id
+            signature=venue_id,
+            sender=sender
         )

--- a/openreview/venue/process/submission_revision_process.py
+++ b/openreview/venue/process/submission_revision_process.py
@@ -7,6 +7,7 @@ def process(client, edit, invitation):
     contact = domain.content['contact']['value']
     authors_name = domain.content['authors_name']['value']
     submission_name = domain.content['submission_name']['value']
+    sender = domain.get_content_value('message_sender')
 
     submission = client.get_note(edit.note.id)
 
@@ -28,7 +29,8 @@ To view your submission, click here: https://openreview.net/forum?id={submission
         recipients=submission.content['authorids']['value'],
         message=message,
         replyTo=contact,
-        signature=venue_id
+        signature=venue_id,
+        sender=sender
     )
 
     if 'authorids' in submission.content:

--- a/openreview/venue/process/withdrawal_reversion_submission_process.py
+++ b/openreview/venue/process/withdrawal_reversion_submission_process.py
@@ -9,7 +9,8 @@ def process(client, edit, invitation):
     withdraw_expiration_id = domain.content['withdraw_expiration_id']['value']
     withdraw_committee = domain.content['withdraw_committee']['value']
     submission_name = domain.content['submission_name']['value']
-    authors_name = domain.content['authors_name']['value'] 
+    authors_name = domain.content['authors_name']['value']
+    sender = domain.get_content_value('message_sender')
 
     now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
     submission = client.get_note(edit.note.forum)
@@ -48,7 +49,7 @@ def process(client, edit, invitation):
 For more information, click here https://openreview.net/forum?id={submission.id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, replyTo=contact)
+    client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, replyTo=contact, sender=sender)
 
     print(f'Add {paper_group_id}/{authors_name} to {venue_id}/{authors_name}')
     client.add_members_to_group(f'{venue_id}/{authors_name}', f'{paper_group_id}/{authors_name}')

--- a/openreview/venue/process/withdrawn_submission_process.py
+++ b/openreview/venue/process/withdrawn_submission_process.py
@@ -13,6 +13,7 @@ def process(client, edit, invitation):
     authors_name = domain.content['authors_name']['value']
     withdrawal_email_pcs = domain.content.get('withdrawal_email_pcs', {}).get('value')
     program_chairs_id = domain.content['program_chairs_id']['value']
+    sender = domain.get_content_value('message_sender')
 
     submission = client.get_note(edit.note.id)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'    
@@ -62,4 +63,4 @@ def process(client, edit, invitation):
 For more information, click here https://openreview.net/forum?id={submission.id}&noteId={withdrawal_notes[0].id}
 '''
 
-    client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, ignoreRecipients=ignoreRecipients, replyTo=contact)
+    client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, ignoreRecipients=ignoreRecipients, replyTo=contact, sender=sender)

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -83,6 +83,12 @@ class Venue(object):
     def get_short_name(self):
         return self.short_name
     
+    def get_message_sender(self):
+        return {
+            'fromName': self.short_name,
+            'fromEmail': f'{self.short_name.replace(" ", "").lower()}-notifications@openreview.net'
+        }
+    
     def get_edges_archive_date(self):
         archive_date = datetime.datetime.utcnow()
         if self.date:
@@ -809,7 +815,14 @@ Total Errors: {len(errors)}
                 message = messages[decision_note['content']['decision']['value']]
                 final_message = message.replace("{{submission_title}}", note.content['title']['value'])
                 final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={note.id}')
-                self.client.post_message(subject, recipients=[self.get_authors_id(note.number)], message=final_message, parentGroup=self.get_authors_id(), replyTo=self.contact, invitation=self.get_meta_invitation_id(), signature=self.venue_id)
+                self.client.post_message(subject, 
+                                         recipients=[self.get_authors_id(note.number)], 
+                                         message=final_message, 
+                                         parentGroup=self.get_authors_id(), 
+                                         replyTo=self.contact, 
+                                         invitation=self.get_meta_invitation_id(), 
+                                         signature=self.venue_id,
+                                         sender=self.get_message_sender())
 
         tools.concurrent_requests(send_notification, paper_notes)
 
@@ -988,7 +1001,7 @@ A conflict was detected between you and the submission authors and the assignmen
 If you have any questions, please contact us as info@openreview.net.
 
 OpenReview Team'''
-            response = client.post_message(subject, [edge.tail], message, invitation=venue_group.content['meta_invitation_id']['value'], signature=venue_group.id)
+            response = client.post_message(subject, [edge.tail], message, invitation=venue_group.content['meta_invitation_id']['value'], signature=venue_group.id, replyTo=venue_group.content['contact']['value'], sender=venue_group.content['message_sender']['value'])
 
             ## Send email to inviter
             subject=f"[{venue_group.content['subtitle']['value']}] Conflict detected between reviewer {user_profile.get_preferred_name(pretty=True)} and paper {submission.number}"
@@ -1000,7 +1013,7 @@ If you have any questions, please contact us as info@openreview.net.
 OpenReview Team'''
 
             ## - Send email
-            response = client.post_message(subject, edge.signatures, message, invitation=venue_group.content['meta_invitation_id']['value'], signature=venue_group.id)            
+            response = client.post_message(subject, edge.signatures, message, invitation=venue_group.content['meta_invitation_id']['value'], signature=venue_group.id, replyTo=venue_group.content['contact']['value'], sender=venue_group.content['message_sender']['value'])            
         
         def mark_as_accepted(venue_group, edge, submission, user_profile, invite_assignment_invitation):
 
@@ -1056,7 +1069,7 @@ If you would like to change your decision, please click the Decline link in the 
 OpenReview Team'''
 
                 ## - Send email
-                response = client.post_message(subject, [edge.tail], message, invitation=venue_group.content['meta_invitation_id']['value'], signature=venue_group.id)
+                response = client.post_message(subject, [edge.tail], message, invitation=venue_group.content['meta_invitation_id']['value'], signature=venue_group.id, replyTo=venue_group.content['contact']['value'], sender=venue_group.content['message_sender']['value'])
 
                 ## Send email to inviter
                 subject=f'[{short_phrase}] {reviewer_name} {user_profile.get_preferred_name(pretty=True)} signed up and is assigned to paper {submission.number}'
@@ -1066,7 +1079,7 @@ The {reviewer_name} {user_profile.get_preferred_name(pretty=True)}({user_profile
 OpenReview Team'''
 
                 ## - Send email
-                response = client.post_message(subject, edge.signatures, message, invitation=venue_group.content['meta_invitation_id']['value'], signature=venue_group.id)            
+                response = client.post_message(subject, edge.signatures, message, invitation=venue_group.content['meta_invitation_id']['value'], signature=venue_group.id, replyTo=venue_group.content['contact']['value'], sender=venue_group.content['message_sender']['value'])            
         
         active_venues = client.get_group('active_venues').members
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -1756,7 +1756,10 @@ Confirmation of the assignment is pending until your profile is active and no co
 
 If you would like to change your decision, please follow the link in the previous invitation email and click on the "Decline" button.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         messages = openreview_client.get_messages(to='ac1@icml.cc', subject='[ICML 2023] Reviewer melisa@icml.cc accepted to review paper 1, assignment pending')
         assert messages and len(messages) == 1
@@ -1765,7 +1768,10 @@ The Reviewer melisa@icml.cc that you invited to review paper 1 has accepted the 
 
 Confirmation of the assignment is pending until the invited reviewer creates a profile in OpenReview and no conflicts of interest are detected.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         # try to remove Invite_Assignment edge with label == 'Pending Sign Up'
         with pytest.raises(openreview.OpenReviewException, match=r'Cannot cancel the invitation since it has status: "Pending Sign Up"'):
@@ -1801,14 +1807,20 @@ The ICML 2023 program chairs will be contacting you with more information regard
 
 If you would like to change your decision, please click the Decline link in the previous invitation email.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         messages = openreview_client.get_messages(to='ac1@icml.cc', subject='[ICML 2023] Reviewer Melisa ICML signed up and is assigned to paper 1')
         assert messages and len(messages) == 1
         assert messages[0]['content']['text'] == '''Hi AC ICMLOne,
 The Reviewer Melisa ICML(melisa@icml.cc) that you invited to review paper 1 has accepted the invitation, signed up and is now assigned to the paper 1.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         assert openreview_client.get_groups('ICML.cc/2023/Conference/Submission1/External_Reviewers', member='melisa@icml.cc')
         assert openreview_client.get_groups('ICML.cc/2023/Conference/External_Reviewers', member='melisa@icml.cc')
@@ -1980,7 +1992,10 @@ Confirmation of the assignment is pending until your profile is active and no co
 
 If you would like to change your decision, please follow the link in the previous invitation email and click on the "Decline" button.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         messages = openreview_client.get_messages(to='ac2@icml.cc', subject='[ICML 2023] Reviewer carlos@icml.cc accepted to review paper 1, assignment pending')
         assert messages and len(messages) == 1
@@ -1989,7 +2004,10 @@ The Reviewer carlos@icml.cc that you invited to review paper 1 has accepted the 
 
 Confirmation of the assignment is pending until the invited reviewer creates a profile in OpenReview and no conflicts of interest are detected.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         ## External reviewer creates a profile and accepts the invitation again
         helpers.create_user('carlos@icml.cc', 'Carlos', 'ICML', institution='amazon.com')
@@ -2016,7 +2034,10 @@ A conflict was detected between you and the submission authors and the assignmen
 
 If you have any questions, please contact us as info@openreview.net.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         messages = openreview_client.get_messages(to='ac2@icml.cc', subject='[ICML 2023] Conflict detected between reviewer Carlos ICML and paper 1')
         assert messages and len(messages) == 1
@@ -2025,7 +2046,10 @@ A conflict was detected between Carlos ICML(carlos@icml.cc) and the paper 1 and 
 
 If you have any questions, please contact us as info@openreview.net.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         assert not openreview_client.get_groups('ICML.cc/2023/Conference/Emergency_Reviewers', member='carlos@icml.cc')
         assert not openreview_client.get_groups('ICML.cc/2023/Conference/Reviewers', member='carlos@icml.cc')
@@ -2074,14 +2098,20 @@ Please go to the ICML 2023 Reviewers Console and check your pending tasks: https
 
 If you would like to change your decision, please click the Decline link in the previous invitation email.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         messages = openreview_client.get_messages(to='ac2@icml.cc', subject='[ICML 2023] Reviewer Celeste ICML signed up and is assigned to paper 1')
         assert messages and len(messages) == 1
         assert messages[0]['content']['text'] == '''Hi AC ICMLTwo,
 The Reviewer Celeste ICML(celeste@icml.cc) that you invited to review paper 1 has accepted the invitation, signed up and is now assigned to the paper 1.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@icml.cc.
+'''
 
         assignment_edge = pc_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Assignment', head=submissions[0].id, tail='~Celeste_ICML1')[0]
         helpers.await_queue_edit(openreview_client, edit_id=assignment_edge.id)

--- a/tests/test_venue_with_tracks.py
+++ b/tests/test_venue_with_tracks.py
@@ -1020,4 +1020,7 @@ Please go to the TheWebConf24 Reviewers Console and check your pending tasks: ht
 
 If you would like to change your decision, please click the Decline link in the previous invitation email.
 
-OpenReview Team'''
+OpenReview Team
+
+Please note that responding to this email will direct your reply to pc@webconf.org.
+'''


### PR DESCRIPTION
Add `fromName` and `fromEmail` to all the messages sent by the Venue and Journal workflows.

The values would be: "ICML 2023" and "icml2023-notifcations@openreview.net".

This way users can see their email notifications split by conference and complain with the PCs if they receive too many emails.

