### PR TITLE
Fix/ Assignment configuration: add default if no scores were computed

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -1228,9 +1228,17 @@ class InvitationBuilder(object):
 
             configuration_invitation = tools.get_invitation(self.client, f'{match_group_id}/-/Assignment_Configuration')
             if configuration_invitation:
-                scores_spec = configuration_invitation.edit['note']['content']['scores_specification']
-                if bid_invitation.id not in scores_spec['value']['param']['default']:
-                    scores_spec['value']['param']['default'][bid_invitation.id] = bid_score_spec
+                updated_config = False
+                scores_spec_param = configuration_invitation.edit['note']['content']['scores_specification']['value']['param']
+                if 'default' in scores_spec_param and bid_invitation.id not in scores_spec_param:
+                    scores_spec_param['default'][bid_invitation.id] = bid_score_spec
+                    updated_config = True
+                elif 'default' not in scores_spec_param:
+                    scores_spec_param['default'] = {
+                        bid_invitation.id: bid_score_spec
+                    }
+                    updated_config = True
+                if updated_config:
                     self.client.post_invitation_edit(invitations=venue.get_meta_invitation_id(),
                         signatures=[venue_id],
                         invitation=openreview.api.Invitation(
@@ -1238,7 +1246,11 @@ class InvitationBuilder(object):
                             edit={
                                 'note': {
                                     'content': {
-                                        'scores_specification': scores_spec
+                                        'scores_specification': {
+                                            'value': {
+                                                'param': scores_spec_param
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/tests/test_sac_paper_matching.py
+++ b/tests/test_sac_paper_matching.py
@@ -194,6 +194,37 @@ class TestSACAssignments():
             ['~SAC_MatchingOne1', '~SAC_MatchingTwo1', '~SAC_MatchingThree1']
         )
 
+        ## setup matching to assign SAC to papers to create Assignment_Configuration, do not compute affinity scores
+        matching_setup_note = client.post_note(openreview.Note(
+            content={
+                'title': 'Paper Matching Setup',
+                'matching_group': 'TSACM/2024/Conference/Senior_Area_Chairs',
+                'compute_conflicts': 'Default',
+                'compute_affinity_scores': 'No'
+
+            },
+            forum=request_form.id,
+            replyto=request_form.id,
+            invitation=f'openreview.net/Support/-/Request{request_form.number}/Paper_Matching_Setup',
+            readers=['TSACM/2024/Conference/Program_Chairs', 'openreview.net/Support'],
+            signatures=['~Program_MatchingChair1'],
+            writers=[]
+        ))
+
+        helpers.await_queue()
+
+        comment_invitation_id = f'openreview.net/Support/-/Request{request_form.number}/Paper_Matching_Setup_Status'
+        matching_status = client.get_notes(invitation=comment_invitation_id, replyto=matching_setup_note.id, forum=request_form.forum, sort='tmdate')[0]
+        assert matching_status
+        assert matching_status.content['comment'] == '''Affinity scores and/or conflicts were successfully computed. To run the matcher, click on the 'Senior Area Chairs Paper Assignment' link in the PC console: https://openreview.net/group?id=TSACM/2024/Conference/Program_Chairs
+
+Please refer to the documentation for instructions on how to run the matcher: https://docs.openreview.net/how-to-guides/paper-matching-and-assignment/how-to-do-automatic-assignments'''
+
+        assignment_config_inv = pc_client_v2.get_invitation('TSACM/2024/Conference/Senior_Area_Chairs/-/Assignment_Configuration')
+        assert assignment_config_inv
+        assert 'scores_specification' in assignment_config_inv.edit['note']['content']
+        assert 'default' not in assignment_config_inv.edit['note']['content']['scores_specification']['value']['param']
+
         with open(os.path.join(os.path.dirname(__file__), 'data/sac_scores_matching.csv'), 'w') as file_handle:
             writer = csv.writer(file_handle)
             for submission in submissions:


### PR DESCRIPTION
This was an issue seen when a PC tried to run the Bid Stage before computing scores for reviewers: https://openreview.net/forum?id=UcboZez8Z8&noteId=VQEB5nVJder

The assignment configuration invitation existed, but there was no default because no scores invitation had been created. 