### PR TITLE
Fix/ AC console - add reviewerName and anonReviewerName

### DIFF
--- a/openreview/venue/webfield/areachairsWebfield.js
+++ b/openreview/venue/webfield/areachairsWebfield.js
@@ -58,6 +58,8 @@ return {
     metaReviewRecommendationName: domain.content.meta_review_recommendation?.value || 'recommendation',
     shortPhrase: domain.content.subtitle?.value,
     enableQuerySearch: true,
-    emailReplyTo: domain.content.contact?.value
+    emailReplyTo: domain.content.contact?.value,
+    reviewerName: domain.content.reviewers_name?.value,
+    anonReviewerName: domain.content.reviewers_anon_name?.value
   }
 }


### PR DESCRIPTION
currently ac console reply on default value set in component for reviewerName and anonReviewerName to work
the default values are removed in https://github.com/openreview/openreview-web/pull/1924

so add these two configs in the template