### PR TITLE
ARR: Add checklist counter to submissions

### DIFF
--- a/openreview/arr/process/checklist_process.py
+++ b/openreview/arr/process/checklist_process.py
@@ -20,3 +20,48 @@ def process(client, edit, invitation):
         invitation,
         flagging_info
     )
+
+    domain = client.get_group(edit.domain)
+    venue_id = domain.id
+    meta_invitation_id = domain.content['meta_invitation_id']['value']
+    forum = client.get_note(id=edit.note.forum)
+
+    if invitation.id.endswith('Action_Editor_Checklist'):
+        client.post_note_edit(
+            invitation=meta_invitation_id,
+            readers=[venue_id],
+            writers=[venue_id],
+            signatures=[venue_id],
+            note=openreview.api.Note(
+                id=forum.id,
+                content={
+                    'number_of_action_editor_checklists': {
+                        'readers': [
+                            venue_id,
+                            f"{venue_id}/Submission{forum.number}/Senior_Area_Chairs"
+                        ],
+                        'value': forum.content.get('number_of_action_editor_checklists', {}).get('value', 0) + 1
+                    },
+                }
+            )
+        )
+    elif invitation.id.endswith('Reviewer_Checklist'):
+        client.post_note_edit(
+            invitation=meta_invitation_id,
+            readers=[venue_id],
+            writers=[venue_id],
+            signatures=[venue_id],
+            note=openreview.api.Note(
+                id=forum.id,
+                content={
+                    'number_of_reviewer_checklists': {
+                        'readers': [
+                            venue_id,
+                            f"{venue_id}/Submission{forum.number}/Senior_Area_Chairs",
+                            f"{venue_id}/Submission{forum.number}/Area_Chairs"
+                        ],
+                        'value': forum.content.get('number_of_reviewer_checklists', {}).get('value', 0) + 1
+                    },
+                }
+            )
+        )

--- a/openreview/arr/process/checklist_process.py
+++ b/openreview/arr/process/checklist_process.py
@@ -27,41 +27,82 @@ def process(client, edit, invitation):
     forum = client.get_note(id=edit.note.forum)
 
     if invitation.id.endswith('Action_Editor_Checklist'):
-        client.post_note_edit(
-            invitation=meta_invitation_id,
-            readers=[venue_id],
-            writers=[venue_id],
-            signatures=[venue_id],
-            note=openreview.api.Note(
-                id=forum.id,
-                content={
-                    'number_of_action_editor_checklists': {
-                        'readers': [
-                            venue_id,
-                            f"{venue_id}/Submission{forum.number}/Senior_Area_Chairs"
-                        ],
-                        'value': forum.content.get('number_of_action_editor_checklists', {}).get('value', 0) + 1
-                    },
-                }
+        if edit.note.ddate:
+            client.post_note_edit(
+                invitation=meta_invitation_id,
+                readers=[venue_id],
+                writers=[venue_id],
+                signatures=[venue_id],
+                note=openreview.api.Note(
+                    id=forum.id,
+                    content={
+                        'number_of_action_editor_checklists': {
+                            'readers': [
+                                venue_id,
+                                f"{venue_id}/Submission{forum.number}/Senior_Area_Chairs"
+                            ],
+                            'value': forum.content.get('number_of_action_editor_checklists', {}).get('value', 0) - 1
+                        },
+                    }
+                )
             )
-        )
+        else:
+            client.post_note_edit(
+                invitation=meta_invitation_id,
+                readers=[venue_id],
+                writers=[venue_id],
+                signatures=[venue_id],
+                note=openreview.api.Note(
+                    id=forum.id,
+                    content={
+                        'number_of_action_editor_checklists': {
+                            'readers': [
+                                venue_id,
+                                f"{venue_id}/Submission{forum.number}/Senior_Area_Chairs"
+                            ],
+                            'value': forum.content.get('number_of_action_editor_checklists', {}).get('value', 0) + 1
+                        },
+                    }
+                )
+            )
     elif invitation.id.endswith('Reviewer_Checklist'):
-        client.post_note_edit(
-            invitation=meta_invitation_id,
-            readers=[venue_id],
-            writers=[venue_id],
-            signatures=[venue_id],
-            note=openreview.api.Note(
-                id=forum.id,
-                content={
-                    'number_of_reviewer_checklists': {
-                        'readers': [
-                            venue_id,
-                            f"{venue_id}/Submission{forum.number}/Senior_Area_Chairs",
-                            f"{venue_id}/Submission{forum.number}/Area_Chairs"
-                        ],
-                        'value': forum.content.get('number_of_reviewer_checklists', {}).get('value', 0) + 1
-                    },
-                }
+        if edit.note.ddate:
+            client.post_note_edit(
+                invitation=meta_invitation_id,
+                readers=[venue_id],
+                writers=[venue_id],
+                signatures=[venue_id],
+                note=openreview.api.Note(
+                    id=forum.id,
+                    content={
+                        'number_of_reviewer_checklists': {
+                            'readers': [
+                                venue_id,
+                                f"{venue_id}/Submission{forum.number}/Senior_Area_Chairs",
+                                f"{venue_id}/Submission{forum.number}/Area_Chairs"
+                            ],
+                            'value': forum.content.get('number_of_reviewer_checklists', {}).get('value', 0) - 1
+                        },
+                    }
+                )
             )
-        )
+        else:
+            client.post_note_edit(
+                invitation=meta_invitation_id,
+                readers=[venue_id],
+                writers=[venue_id],
+                signatures=[venue_id],
+                note=openreview.api.Note(
+                    id=forum.id,
+                    content={
+                        'number_of_reviewer_checklists': {
+                            'readers': [
+                                venue_id,
+                                f"{venue_id}/Submission{forum.number}/Senior_Area_Chairs",
+                                f"{venue_id}/Submission{forum.number}/Area_Chairs"
+                            ],
+                            'value': forum.content.get('number_of_reviewer_checklists', {}).get('value', 0) + 1
+                        },
+                    }
+                )
+            )

--- a/openreview/arr/process/submission_process_extension.py
+++ b/openreview/arr/process/submission_process_extension.py
@@ -12,3 +12,30 @@
                     signatures=[venue_id]
                 )
             )
+
+    client.post_note_edit(
+        invitation=meta_invitation_id,
+        readers=[venue_id],
+        writers=[venue_id],
+        signatures=[venue_id],
+        note=openreview.api.Note(
+            id=note.id,
+            content={
+                'number_of_reviewer_checklists': {
+                    'readers': [
+                        venue_id,
+                        f"{venue_id}/Submission{note.number}/Senior_Area_Chairs",
+                        f"{venue_id}/Submission{note.number}/Area_Chairs"
+                    ],
+                    'value': 0
+                },
+                'number_of_action_editor_checklists': {
+                    'readers': [
+                        venue_id,
+                        f"{venue_id}/Submission{note.number}/Senior_Area_Chairs"
+                    ],
+                    'value': 0
+                },
+            }
+        )
+    )

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -1788,6 +1788,10 @@ class TestARRVenueV2():
                     f'aclweb.org/ACL/ARR/2023/August/Submission{submission.number}/-/Blind_Submission_License_Agreement'
                 ).duedate == None
 
+            # Add check for counters
+            assert submission.content['number_of_reviewer_checklists']['value'] == 0
+            assert submission.content['number_of_action_editor_checklists']['value'] == 0
+
     def test_post_submission(self, client, openreview_client, helpers, test_client, request_page, selenium):
 
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password=helpers.strong_password)
@@ -2889,10 +2893,13 @@ class TestARRVenueV2():
         edit, test_submission = post_checklist(user_client, checklist_inv, user)
         assert 'flagged_for_ethics_review' not in test_submission.content
         assert 'flagged_for_desk_reject_verification' not in test_submission.content
+        assert test_submission.content['number_of_reviewer_checklists']['value'] == 1
         _, test_submission = post_checklist(user_client, checklist_inv, user, ddate=now(), existing_note=edit['note'])
+        assert test_submission.content['number_of_reviewer_checklists']['value'] == 0
 
         # Post checklist with no ethics flag and a violation field - check for DSV flag
         edit, test_submission = post_checklist(user_client, checklist_inv, user, tested_field=violation_fields[0])
+        assert test_submission.content['number_of_reviewer_checklists']['value'] == 1
         assert 'flagged_for_ethics_review' not in test_submission.content
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert test_submission.content['flagged_for_desk_reject_verification']['value']
@@ -2952,10 +2959,13 @@ class TestARRVenueV2():
         edit, test_submission = post_checklist(user_client, checklist_inv, user)
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert not test_submission.content['flagged_for_ethics_review']['value']
+        assert test_submission.content['number_of_action_editor_checklists']['value'] == 1
         _, test_submission = post_checklist(user_client, checklist_inv, user, ddate=now(), existing_note=edit['note'])
+        assert test_submission.content['number_of_action_editor_checklists']['value'] == 0
 
         # Post checklist with no ethics flag and a violation field - check for DSV flag
         edit, test_submission = post_checklist(user_client, checklist_inv, user, tested_field=violation_fields[2])
+        assert test_submission.content['number_of_action_editor_checklists']['value'] == 1
         assert test_submission.content['flagged_for_desk_reject_verification']['value']
         assert not test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission2/-/Desk_Reject_Verification').expdate > now()


### PR DESCRIPTION
This PR initializes action editor and reviewer checklist counters when the submission is made and updates this counter whenever checklists are posted or deleted. This is to be used for query searches in the consoles