### PR TITLE
Fix: Commitments: improve regex and preprocess

### DIFF
--- a/openreview/arr/process/submission_preprocess.py
+++ b/openreview/arr/process/submission_preprocess.py
@@ -9,7 +9,7 @@ def process(client, edit, invitation):
     authorids = edit.note.content.get('authorids').get('value')
 
     if paper_link:
-        paper_forum = paper_link.split('=')[-1]
+        paper_forum = paper_link.split('?id=')[-1]
         client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
 
         try:
@@ -28,6 +28,9 @@ def process(client, edit, invitation):
 
         if (arr_submission_v1 and 'aclweb.org/ACL/ARR' not in arr_submission_v1.invitation) or (arr_submission_v2 and not any('aclweb.org/ACL/ARR' in inv for inv in arr_submission_v2.invitations)):
             raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission')
+
+        if (arr_submission_v1 and arr_submission_v1.id != arr_submission_v1.forum) or (arr_submission_v2 and arr_submission_v2.id != arr_submission_v2.forum):
+            raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
 
     # If provided previous URL but left a reassignment request blank
     if paper_link and (not editor_reassignment_request or not reviewer_reassignment_request):

--- a/openreview/arr/process/submission_preprocess.py
+++ b/openreview/arr/process/submission_preprocess.py
@@ -9,6 +9,10 @@ def process(client, edit, invitation):
     authorids = edit.note.content.get('authorids').get('value')
 
     if paper_link:
+
+        if '&' in paper_link:
+            raise openreview.OpenReviewException('Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.')
+
         paper_forum = paper_link.split('?id=')[-1]
         client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
 
@@ -31,6 +35,9 @@ def process(client, edit, invitation):
 
         if (arr_submission_v1 and arr_submission_v1.id != arr_submission_v1.forum) or (arr_submission_v2 and arr_submission_v2.id != arr_submission_v2.forum):
             raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
+
+        if arr_submission_v1 and 'aclweb.org/ACL/ARR' in arr_submission_v1.invitation and not arr_submission_v1.invitation.endswith('Blind_Submission'):
+            raise openreview.OpenReviewException('Provided paper link does not point to a blind submission')
 
     # If provided previous URL but left a reassignment request blank
     if paper_link and (not editor_reassignment_request or not reviewer_reassignment_request):

--- a/openreview/arr/process/submission_preprocess.py
+++ b/openreview/arr/process/submission_preprocess.py
@@ -37,7 +37,7 @@ def process(client, edit, invitation):
             raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
 
         if arr_submission_v1 and 'aclweb.org/ACL/ARR' in arr_submission_v1.invitation and not arr_submission_v1.invitation.endswith('Blind_Submission'):
-            raise openreview.OpenReviewException('Provided paper link does not point to a blind submission')
+            raise openreview.OpenReviewException('Provided paper link does not point to a blind submission. Make sure you get the url to your submission from the browser')
 
     # If provided previous URL but left a reassignment request blank
     if paper_link and (not editor_reassignment_request or not reviewer_reassignment_request):

--- a/openreview/stages/arr_content.py
+++ b/openreview/stages/arr_content.py
@@ -207,7 +207,7 @@ arr_submission_content = {
                 'mismatchError': 'must be a valid link to an OpenReview submission: https://openreview.net/forum?id=...'
             }
         },
-        "description": "If this is a resubmission, provide the URL of your previous submission to ACL Rolling Review (this URL will look like https://openreview.net/forum?id=<some string>).",
+        "description": "If this is a resubmission, provide the URL of your previous submission to ACL Rolling Review (this URL will look like https://openreview.net/forum?id=<some string>). Make sure to only add the paper id and not other parameters after &.",
         "order": 14
     },
     "response_PDF": {

--- a/openreview/stages/arr_content.py
+++ b/openreview/stages/arr_content.py
@@ -201,9 +201,10 @@ arr_submission_content = {
     "previous_URL": {
         "value": {
             "param": {
-                "regex": ".{1,500}",
+                "regex": 'https:\/\/openreview\.net\/forum\?id=.*',
                 "optional": True,
-                "type": "string"
+                "type": "string",
+                'mismatchError': 'must be a valid link to an OpenReview submission: https://openreview.net/forum?id=...'
             }
         },
         "description": "If this is a resubmission, provide the URL of your previous submission to ACL Rolling Review (this URL will look like https://openreview.net/forum?id=<some string>).",

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -302,7 +302,7 @@ class SubmissionStage(object):
                         'param': {
                             'type': 'string',
                             'regex': 'https:\/\/openreview\.net\/forum\?id=.*',
-                            'mismatchError': 'must be a valid link to an OpenrReview submission: https://openreview.net/forum?id=...'
+                            'mismatchError': 'must be a valid link to an OpenReview submission: https://openreview.net/forum?id=...'
                         }
                     },
                     'description': 'Please provide the link to your ARR submission. The link should have the following format: https://openreview.net/forum?id=<PAPER_ID>" where <PAPER_ID> is the paper ID of your ARR submission.',

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -300,7 +300,7 @@ class SubmissionStage(object):
                     'value': {
                         'param': {
                             'type': 'string',
-                            'regex': '(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)',
+                            'regex': 'https:\/\/openreview\.net\/forum\?id=.*',
                             'mismatchError': 'must be a valid link to an OpenrReview submission: https://openreview.net/forum?id=...'
                         }
                     },

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -305,7 +305,7 @@ class SubmissionStage(object):
                             'mismatchError': 'must be a valid link to an OpenReview submission: https://openreview.net/forum?id=...'
                         }
                     },
-                    'description': 'Please provide the link to your ARR submission. The link should have the following format: https://openreview.net/forum?id=<PAPER_ID>" where <PAPER_ID> is the paper ID of your ARR submission.',
+                    'description': 'Please provide the link to your ARR submission. The link should have the following format: https://openreview.net/forum?id=<PAPER_ID> where <PAPER_ID> is the paper ID of your ARR submission. Make sure to only add the paper id and not other parameters after &.',
                     'order': 8
                 }
 

--- a/openreview/venue/process/submission_commitments_preprocess.py
+++ b/openreview/venue/process/submission_commitments_preprocess.py
@@ -3,14 +3,29 @@ def process(client, edit, invitation):
     paper_link = edit.note.content['paper_link']['value']
     paper_forum = paper_link.split('?id=')[-1]
 
+    if '&' in paper_link:
+        raise openreview.OpenReviewException('Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.')
+
+    client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
+
     try:
-        client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
-        arr_submission = client_v1.get_note(paper_forum)
-    except openreview.OpenReviewException as e:
+        arr_submission_v1 = client_v1.get_note(paper_forum)
+    except:
+        arr_submission_v1 = None
+
+    try:
+        arr_submission_v2 = client.get_note(paper_forum)
+    except:
+        arr_submission_v2 = None
+
+    if not arr_submission_v1 and not arr_submission_v2:
         raise openreview.OpenReviewException('Provided paper link does not correspond to a submission in OpenReview')
 
-    if 'aclweb.org/ACL/ARR' not in arr_submission.invitation:
+    if (arr_submission_v1 and 'aclweb.org/ACL/ARR' not in arr_submission_v1.invitation) or (arr_submission_v2 and not any('aclweb.org/ACL/ARR' in inv for inv in arr_submission_v2.invitations)):
         raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission')
 
-    if arr_submission.id != arr_submission.forum:
-        raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
+    if (arr_submission_v1 and arr_submission_v1.id != arr_submission_v1.forum) or (arr_submission_v2 and arr_submission_v2.id != arr_submission_v2.forum):
+            raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
+
+    if arr_submission_v1 and 'aclweb.org/ACL/ARR' in arr_submission_v1.invitation and not arr_submission_v1.invitation.endswith('Blind_Submission'):
+        raise openreview.OpenReviewException('Provided paper link does not point to a blind submission')

--- a/openreview/venue/process/submission_commitments_preprocess.py
+++ b/openreview/venue/process/submission_commitments_preprocess.py
@@ -1,7 +1,7 @@
 def process(client, edit, invitation):
 
     paper_link = edit.note.content['paper_link']['value']
-    paper_forum = paper_link.split('?id=')[-1].split('&')[0]
+    paper_forum = paper_link.split('?id=')[-1]
 
     try:
         client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
@@ -9,5 +9,8 @@ def process(client, edit, invitation):
     except openreview.OpenReviewException as e:
         raise openreview.OpenReviewException('Provided paper link does not correspond to a submission in OpenReview')
 
-    if 'aclweb.org/ACL/ARR' not in arr_submission.invitation or arr_submission.id != arr_submission.forum:
+    if 'aclweb.org/ACL/ARR' not in arr_submission.invitation:
         raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission')
+
+    if arr_submission.id != arr_submission.forum:
+        raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')

--- a/openreview/venue/process/submission_commitments_preprocess.py
+++ b/openreview/venue/process/submission_commitments_preprocess.py
@@ -1,7 +1,7 @@
 def process(client, edit, invitation):
 
     paper_link = edit.note.content['paper_link']['value']
-    paper_forum = paper_link.split('=')[-1]
+    paper_forum = paper_link.split('?id=')[-1].split('&')[0]
 
     try:
         client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)

--- a/openreview/venue/process/submission_commitments_preprocess.py
+++ b/openreview/venue/process/submission_commitments_preprocess.py
@@ -28,4 +28,4 @@ def process(client, edit, invitation):
             raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
 
     if arr_submission_v1 and 'aclweb.org/ACL/ARR' in arr_submission_v1.invitation and not arr_submission_v1.invitation.endswith('Blind_Submission'):
-        raise openreview.OpenReviewException('Provided paper link does not point to a blind submission')
+        raise openreview.OpenReviewException('Provided paper link does not point to a blind submission. Make sure you get the url to your submission from the browser')

--- a/openreview/venue/process/submission_commitments_preprocess.py
+++ b/openreview/venue/process/submission_commitments_preprocess.py
@@ -9,5 +9,5 @@ def process(client, edit, invitation):
     except openreview.OpenReviewException as e:
         raise openreview.OpenReviewException('Provided paper link does not correspond to a submission in OpenReview')
 
-    if 'aclweb.org/ACL/ARR' not in arr_submission.invitation:
+    if 'aclweb.org/ACL/ARR' not in arr_submission.invitation or arr_submission.id != arr_submission.forum:
         raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission')

--- a/tests/test_acl_commitment_v2.py
+++ b/tests/test_acl_commitment_v2.py
@@ -186,7 +186,7 @@ class TestACLCommitment():
                     }
                 ))
 
-        with pytest.raises(openreview.OpenReviewException, match=r'Provided paper link does not correspond to a submission in OpenReview'):
+        with pytest.raises(openreview.OpenReviewException, match=r'Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.'):
             test_client.post_note_edit(invitation='aclweb.org/ACL/2024/Conference/-/Submission',
                     signatures=['~SomeFirstName_User1'],
                     note=openreview.api.Note(
@@ -200,7 +200,7 @@ class TestACLCommitment():
                     }
                 ))
 
-        with pytest.raises(openreview.OpenReviewException, match=r'Provided paper link does not correspond to a submission in OpenReview'):
+        with pytest.raises(openreview.OpenReviewException, match=r'Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.'):
             test_client.post_note_edit(invitation='aclweb.org/ACL/2024/Conference/-/Submission',
                     signatures=['~SomeFirstName_User1'],
                     note=openreview.api.Note(

--- a/tests/test_acl_commitment_v2.py
+++ b/tests/test_acl_commitment_v2.py
@@ -172,7 +172,7 @@ class TestACLCommitment():
 
         test_client = openreview.api.OpenReviewClient(username='test@mail.com', password=helpers.strong_password)
 
-        with pytest.raises(openreview.OpenReviewException, match=r'paper_link value must be a valid link to an OpenReview submission: https://openreview.net/forum?id=...'):
+        with pytest.raises(openreview.OpenReviewException, match=r'paper_link value must be a valid link to an OpenReview submission'):
             test_client.post_note_edit(invitation='aclweb.org/ACL/2024/Conference/-/Submission',
                     signatures=['~SomeFirstName_User1'],
                     note=openreview.api.Note(

--- a/tests/test_acl_commitment_v2.py
+++ b/tests/test_acl_commitment_v2.py
@@ -119,7 +119,7 @@ class TestACLCommitment():
                         'value': {
                         'param': {
                             'type': 'string',
-                            'regex': '(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)',
+                            'regex': 'https:\/\/openreview\.net\/forum\?id=.*',
                             'mismatchError': 'must be a valid link to an OpenrReview submission: https://openreview.net/forum?id=...'
                         }
                     },

--- a/tests/test_acl_commitment_v2.py
+++ b/tests/test_acl_commitment_v2.py
@@ -120,7 +120,7 @@ class TestACLCommitment():
                         'param': {
                             'type': 'string',
                             'regex': 'https:\/\/openreview\.net\/forum\?id=.*',
-                            'mismatchError': 'must be a valid link to an OpenrReview submission: https://openreview.net/forum?id=...'
+                            'mismatchError': 'must be a valid link to an OpenReview submission: https://openreview.net/forum?id=...'
                         }
                     },
                         'description': 'This is a different description.',
@@ -145,7 +145,7 @@ class TestACLCommitment():
                         "order": 8
                     }
                 },
-                'remove_submission_options': ['TL;DR']
+                'remove_submission_options': ['TL;DR', 'pdf']
             }
         ))
         helpers.await_queue()
@@ -166,4 +166,22 @@ class TestACLCommitment():
         venue.invitation_builder.expire_invitation('aclweb.org/ACL/2024/Conference/Reviewers/-/Submission_Group')        
         venue.invitation_builder.expire_invitation('aclweb.org/ACL/2024/Conference/-/Post_Submission')
         venue.invitation_builder.expire_invitation('aclweb.org/ACL/2024/Conference/-/Desk_Rejection')                
-        venue.invitation_builder.expire_invitation('aclweb.org/ACL/2024/Conference/-/Withdrawal')                            
+        venue.invitation_builder.expire_invitation('aclweb.org/ACL/2024/Conference/-/Withdrawal')     
+
+    def test_submit_papers(self, test_client, client, openreview_client, helpers):
+
+        test_client = openreview.api.OpenReviewClient(username='test@mail.com', password=helpers.strong_password)
+
+        with pytest.raises(openreview.OpenReviewException, match=r'paper_link value must be a valid link to an OpenReview submission: https://openreview.net/forum?id=...'):
+            test_client.post_note_edit(invitation='aclweb.org/ACL/2024/Conference/-/Submission',
+                    signatures=['~SomeFirstName_User1'],
+                    note=openreview.api.Note(
+                    content = {
+                        'title': { 'value': 'Commitment Paper' },
+                        'abstract': { 'value': 'This is a test abstract' },
+                        'authorids': { 'value': ['test@mail.com'] },
+                        'authors': { 'value': ['SomeFirstName User'] },
+                        'keywords': { 'value': ['machine learning'] },
+                        'paper_link': { 'value': 'https://openreview.net/pdf?id=1234' }
+                    }
+                ))                    

--- a/tests/test_acl_commitment_v2.py
+++ b/tests/test_acl_commitment_v2.py
@@ -184,4 +184,32 @@ class TestACLCommitment():
                         'keywords': { 'value': ['machine learning'] },
                         'paper_link': { 'value': 'https://openreview.net/pdf?id=1234' }
                     }
-                ))                    
+                ))
+
+        with pytest.raises(openreview.OpenReviewException, match=r'Provided paper link does not correspond to a submission in OpenReview'):
+            test_client.post_note_edit(invitation='aclweb.org/ACL/2024/Conference/-/Submission',
+                    signatures=['~SomeFirstName_User1'],
+                    note=openreview.api.Note(
+                    content = {
+                        'title': { 'value': 'Commitment Paper' },
+                        'abstract': { 'value': 'This is a test abstract' },
+                        'authorids': { 'value': ['test@mail.com'] },
+                        'authors': { 'value': ['SomeFirstName User'] },
+                        'keywords': { 'value': ['machine learning'] },
+                        'paper_link': { 'value': 'https://openreview.net/forum?id=1234&replyto=4567' }
+                    }
+                ))
+
+        with pytest.raises(openreview.OpenReviewException, match=r'Provided paper link does not correspond to a submission in OpenReview'):
+            test_client.post_note_edit(invitation='aclweb.org/ACL/2024/Conference/-/Submission',
+                    signatures=['~SomeFirstName_User1'],
+                    note=openreview.api.Note(
+                    content = {
+                        'title': { 'value': 'Commitment Paper' },
+                        'abstract': { 'value': 'This is a test abstract' },
+                        'authorids': { 'value': ['test@mail.com'] },
+                        'authors': { 'value': ['SomeFirstName User'] },
+                        'keywords': { 'value': ['machine learning'] },
+                        'paper_link': { 'value': 'https://openreview.net/forum?id=1234&referrer=[Author%20Console](/group?id=aclweb.org/ACL/2024/Conference/Authors)' }
+                    }
+                ))

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -1069,7 +1069,7 @@ class TestARRVenueV2():
         note = openreview.api.Note(
             content = {
                     **generic_note_content,
-                    'previous_URL': { 'value': f"http://localhost:3030/forum?id={allowed_note['note']['id']}" },
+                    'previous_URL': { 'value': f"https://openreview.net/forum?id={allowed_note['note']['id']}" },
                     'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
                     'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
                     'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' }
@@ -1082,8 +1082,47 @@ class TestARRVenueV2():
         
         helpers.await_queue_edit(openreview_client, edit_id=allowed_note_second['id'])
 
-        # Not allowed: submission with invalid previous URL
+        with pytest.raises(openreview.OpenReviewException, match=r'previous_URL value must be a valid link to an OpenReview submission'):
+            test_client.post_note_edit(invitation='aclweb.org/ACL/ARR/2023/June/-/Submission',
+                    signatures=['~SomeFirstName_User1'],
+                    note=openreview.api.Note(
+                    content = {
+                        **generic_note_content,
+                        'previous_URL': { 'value': 'https://openreview.net/pdf?id=1234' },
+                        'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
+                        'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
+                        'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' }
+                    }
+                ))
+        
         with pytest.raises(openreview.OpenReviewException, match=r'Provided paper link does not correspond to a submission in OpenReview'):
+            test_client.post_note_edit(invitation='aclweb.org/ACL/ARR/2023/June/-/Submission',
+                    signatures=['~SomeFirstName_User1'],
+                    note=openreview.api.Note(
+                    content = {
+                        **generic_note_content,
+                        'previous_URL': { 'value': 'https://openreview.net/forum?id=1234&replyto=4567' },
+                        'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
+                        'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
+                        'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' }
+                    }
+                ))
+
+        with pytest.raises(openreview.OpenReviewException, match=r'Provided paper link does not correspond to a submission in OpenReview'):
+            test_client.post_note_edit(invitation='aclweb.org/ACL/ARR/2023/June/-/Submission',
+                    signatures=['~SomeFirstName_User1'],
+                    note=openreview.api.Note(
+                    content = {
+                        **generic_note_content,
+                        'previous_URL': { 'value': 'https://openreview.net/forum?id=1234&referrer=[Author%20Console](/group?id=aclweb.org/ACL/ARR/2023/June)' },
+                        'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
+                        'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
+                        'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' }
+                    }
+                ))
+
+        # Not allowed: submission with invalid previous URL
+        with pytest.raises(openreview.OpenReviewException, match=r'previous_URL value must be a valid link to an OpenReview submission'):
             test_client.post_note_edit(invitation='aclweb.org/ACL/ARR/2023/June/-/Submission',
                 signatures=['~SomeFirstName_User1'],
                 note=openreview.api.Note(
@@ -1144,7 +1183,7 @@ class TestARRVenueV2():
                 note=openreview.api.Note(
                 content = {
                     **generic_note_content,
-                    'previous_URL': { 'value': f"http://localhost:3030/forum?id={allowed_note['note']['id']}" },
+                    'previous_URL': { 'value': f"https://openreview.net/forum?id={allowed_note['note']['id']}" },
                     'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' },
                 }
             )
@@ -1157,7 +1196,7 @@ class TestARRVenueV2():
                 note=openreview.api.Note(
                 content = {
                     **generic_note_content,
-                    'previous_URL': { 'value': f"http://localhost:3030/forum?id={allowed_note['note']['id']}" },
+                    'previous_URL': { 'value': f"https://openreview.net/forum?id={allowed_note['note']['id']}" },
                     'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
                     'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' },
                 }
@@ -1171,7 +1210,7 @@ class TestARRVenueV2():
                 note=openreview.api.Note(
                 content = {
                     **generic_note_content,
-                    'previous_URL': { 'value': f"http://localhost:3030/forum?id={allowed_note['note']['id']}" },
+                    'previous_URL': { 'value': f"https://openreview.net/forum?id={allowed_note['note']['id']}" },
                     'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
                     'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' },
                 }
@@ -1188,7 +1227,7 @@ class TestARRVenueV2():
                 note=openreview.api.Note(
                 content = {
                     **case_content,
-                    'previous_URL': { 'value': f"http://localhost:3030/forum?id={allowed_note['note']['id']}" },
+                    'previous_URL': { 'value': f"https://openreview.net/forum?id={allowed_note['note']['id']}" },
                     'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
                     'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
                     'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' },
@@ -1714,7 +1753,7 @@ class TestARRVenueV2():
                     'languages_studied': { 'value': 'A language' },
                     'reassignment_request_action_editor': { 'value': 'This is not a resubmission' },
                     'reassignment_request_reviewers': { 'value': 'This is not a resubmission' },
-                    'previous_URL': { 'value': f'http://localhost:3030/forum?id={june_submission.id}' },
+                    'previous_URL': { 'value': f'https://openreview.net/forum?id={june_submission.id}' },
                     'response_PDF': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
                     'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
@@ -2518,7 +2557,7 @@ class TestARRVenueV2():
             note=openreview.api.Note(
                 id=submissions[1].id,
                 content={
-                    'previous_URL': {'value': f'http://localhost:3030/forum?id={june_submissions[1].id}'},
+                    'previous_URL': {'value': f'https://openreview.net/forum?id={june_submissions[1].id}'},
                     'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
                     'reassignment_request_reviewers': { 'value': 'No, I want the same set of reviewers from our previous submission and understand that new reviewers may be assigned if any of the previous ones are unavailable' },
                 }
@@ -2532,7 +2571,7 @@ class TestARRVenueV2():
             note=openreview.api.Note(
                 id=submissions[2].id,
                 content={
-                    'previous_URL': {'value': f'http://localhost:3030/forum?id={june_submissions[2].id}'},
+                    'previous_URL': {'value': f'https://openreview.net/forum?id={june_submissions[2].id}'},
                     'reassignment_request_action_editor': {'value': 'Yes, I want a different action editor for our submission' },
                     'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
                 }

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -1095,7 +1095,7 @@ class TestARRVenueV2():
                     }
                 ))
         
-        with pytest.raises(openreview.OpenReviewException, match=r'Provided paper link does not correspond to a submission in OpenReview'):
+        with pytest.raises(openreview.OpenReviewException, match=r'Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.'):
             test_client.post_note_edit(invitation='aclweb.org/ACL/ARR/2023/June/-/Submission',
                     signatures=['~SomeFirstName_User1'],
                     note=openreview.api.Note(
@@ -1108,13 +1108,13 @@ class TestARRVenueV2():
                     }
                 ))
 
-        with pytest.raises(openreview.OpenReviewException, match=r'Provided paper link does not correspond to a submission in OpenReview'):
+        with pytest.raises(openreview.OpenReviewException, match=r'Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.'):
             test_client.post_note_edit(invitation='aclweb.org/ACL/ARR/2023/June/-/Submission',
                     signatures=['~SomeFirstName_User1'],
                     note=openreview.api.Note(
                     content = {
                         **generic_note_content,
-                        'previous_URL': { 'value': 'https://openreview.net/forum?id=1234&referrer=[Author%20Console](/group?id=aclweb.org/ACL/ARR/2023/June)' },
+                        'previous_URL': { 'value': f'https://openreview.net/forum?id=1234&referrer=[Author%20Console](/group?id=aclweb.org/ACL/ARR/2023/June)' },
                         'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
                         'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
                         'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' }


### PR DESCRIPTION
Fixes #2136 

I tried multiple regexes to make sure authors don't add `&noteId=xxx` after the forum id, but none seemed to work. Instead, I take care of this in the preprocess. 