### PR TITLE
Invitation edit process: propagate writers to the replied notes

### DIFF
--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -117,12 +117,16 @@ def process(client, invitation):
             updated_note = openreview.api.Note(
                 id = note.id
             )
+            final_invitation_writers = list(dict.fromkeys([note.signatures[0] if 'signatures' in r else r for r in paper_invitation.edit['note'].get('writers', [])]))
+            
             if final_invitation_readers and note.readers != final_invitation_readers:
                 updated_note.readers = final_invitation_readers
                 updated_note.nonreaders = paper_invitation.edit['note'].get('nonreaders')
+            if final_invitation_writers and note.writers != final_invitation_writers:
+                updated_note.writers = final_invitation_writers
             if updated_content:
                 updated_note.content = updated_content
-            if updated_note.content or updated_note.readers:
+            if updated_note.content or updated_note.readers or updated_note.writers:
                 client.post_note_edit(
                     invitation = meta_invitation_id,
                     readers = edit_readers,

--- a/tests/test_single_blind_conference_v2.py
+++ b/tests/test_single_blind_conference_v2.py
@@ -310,6 +310,34 @@ class TestSingleBlindVenueV2():
             ))
         helpers.await_queue_edit(openreview_client, edit_id=decision_note['id'])
 
+        ## Try to add the ACs as writers of the decision notes
+        openreview_client.post_invitation_edit(
+            invitations='V2.cc/2050/Conference_Single_Blind/-/Edit',
+            signatures=['V2.cc/2050/Conference_Single_Blind'],
+            invitation=openreview.api.Invitation(
+                id='V2.cc/2050/Conference_Single_Blind/-/Decision',
+                edit = {
+                    'invitation': {
+                        'edit': {
+                            'writers': ['V2.cc/2050/Conference_Single_Blind', 'V2.cc/2050/Conference_Single_Blind/Submission${4/content/noteNumber/value}/Area_Chairs'],
+                            'note': {
+                                'writers': ['V2.cc/2050/Conference_Single_Blind', 'V2.cc/2050/Conference_Single_Blind/Submission${5/content/noteNumber/value}/Area_Chairs', '${3/signatures}']
+                            }
+                        }
+                    }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id='V2.cc/2050/Conference_Single_Blind/-/Decision-0-1', count=2)
+
+        invitation = openreview_client.get_invitation('V2.cc/2050/Conference_Single_Blind/Submission1/-/Decision')
+        assert 'V2.cc/2050/Conference_Single_Blind/Submission1/Area_Chairs' in invitation.edit['writers']
+        assert 'V2.cc/2050/Conference_Single_Blind/Submission1/Area_Chairs' in invitation.edit['note']['writers']
+
+        decision_note = openreview_client.get_notes(invitation='V2.cc/2050/Conference_Single_Blind/Submission1/-/Decision')[0]
+        assert decision_note.writers == ['V2.cc/2050/Conference_Single_Blind', 'V2.cc/2050/Conference_Single_Blind/Submission1/Area_Chairs', 'V2.cc/2050/Conference_Single_Blind/Program_Chairs'] 
+
         invitation = client.get_invitation('{}/-/Request{}/Post_Decision_Stage'.format(venue['support_group_id'], venue['request_form_note'].number))
         invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
         client.post_invitation(invitation)


### PR DESCRIPTION
If invitation writers change then propagate them to the replied notes.