### PR TITLE
Add license to revision invitation

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -481,7 +481,7 @@ class ExpertiseSelectionStage(object):
 
 class SubmissionRevisionStage():
 
-    def __init__(self, name='Revision', start_date=None, due_date=None, additional_fields={}, remove_fields=[], only_accepted=False, multiReply=None, allow_author_reorder=False):
+    def __init__(self, name='Revision', start_date=None, due_date=None, additional_fields={}, remove_fields=[], only_accepted=False, multiReply=None, allow_author_reorder=False, allow_license_edition=False):
         self.name = name
         self.start_date = start_date
         self.due_date = due_date
@@ -490,6 +490,7 @@ class SubmissionRevisionStage():
         self.only_accepted = only_accepted
         self.multiReply=multiReply
         self.allow_author_reorder=allow_author_reorder
+        self.allow_license_edition=allow_license_edition
 
     def get_content(self, api_version='2', conference=None):
         

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -387,6 +387,7 @@ class InvitationBuilder(object):
 
     def set_pc_submission_revision_invitation(self):
         venue_id = self.venue_id
+        submission_license = self.venue.submission_license
         submission_stage = self.venue.submission_stage
         cdate = tools.datetime_millis(submission_stage.exp_date) if submission_stage.exp_date else None
 
@@ -425,6 +426,20 @@ class InvitationBuilder(object):
             },
             process=self.get_process_content('process/pc_submission_revision_process.py')
         )
+
+        # Allow PCs to revise license
+        if submission_license:
+            if isinstance(submission_license, str):
+                submission_invitation.edit['note']['license'] = submission_license
+            elif len(submission_license) == 1:
+                submission_invitation.edit['note']['license'] = submission_license[0]
+            else:
+                license_options = [ { "value": license, "description": license } for license in submission_license ]
+                submission_invitation.edit['note']['license'] = {
+                    "param": {
+                        "enum": license_options
+                    }
+                }
 
         submission_invitation = self.save_invitation(submission_invitation, replacement=True)
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2498,6 +2498,7 @@ class InvitationBuilder(object):
     def set_submission_revision_invitation(self, submission_revision_stage=None):
 
         venue_id = self.venue_id
+        submission_license = self.venue.submission_license
         revision_stage = submission_revision_stage if submission_revision_stage else self.venue.submission_revision_stage
         revision_invitation_id = self.venue.get_invitation_id(revision_stage.name)
         revision_cdate = tools.datetime_millis(revision_stage.start_date if revision_stage.start_date else datetime.datetime.utcnow())
@@ -2603,6 +2604,20 @@ class InvitationBuilder(object):
 
         if revision_expdate:
             invitation.edit['invitation']['expdate'] = revision_expdate
+
+        # Allow license edition until full paper deadline
+        if submission_license and revision_stage.allow_license_edition:
+            if isinstance(submission_license, str):
+                invitation.edit['invitation']['edit']['note']['license'] = submission_license
+            elif len(submission_license) == 1:
+                invitation.edit['invitation']['edit']['note']['license'] = submission_license[0]
+            else:
+                license_options = [ { "value": license, "description": license } for license in submission_license ]
+                invitation.edit['invitation']['edit']['note']['license'] = {
+                    "param": {
+                        "enum": license_options
+                    }
+                }
 
         self.save_invitation(invitation, replacement=False)
         return invitation

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -483,7 +483,8 @@ class Venue(object):
                 remove_fields=stage.second_deadline_remove_fields if stage.second_deadline_remove_fields else stage.remove_fields,
                 only_accepted=False,
                 multiReply=True,
-                allow_author_reorder=stage.author_reorder_after_first_deadline
+                allow_author_reorder=stage.author_reorder_after_first_deadline,
+                allow_license_edition=True
             )
             self.invitation_builder.set_submission_revision_invitation(submission_revision_stage)
             self.invitation_builder.set_submission_deletion_invitation(submission_revision_stage)

--- a/tests/test_iclr_conference_v2.py
+++ b/tests/test_iclr_conference_v2.py
@@ -287,8 +287,8 @@ class TestICLRConference():
                 content = {
                     'title': { 'value': submission.content['title']['value'] + ' license revision' },
                     'abstract': submission.content['abstract'],
-                    'authorids': submission.content['authorids'],
-                    'authors': submission.content['authors'],
+                    'authorids': { 'value': submission.content['authorids']['value'] },
+                    'authors': { 'value': submission.content['authors']['value'] },
                     'keywords': submission.content['keywords'],
                     'pdf': submission.content['pdf'],
                 }
@@ -339,6 +339,7 @@ class TestICLRConference():
         helpers.await_queue_edit(openreview_client, 'ICLR.cc/2024/Conference/-/Withdrawal-0-1', count=2)
         helpers.await_queue_edit(openreview_client, 'ICLR.cc/2024/Conference/-/Desk_Rejection-0-1', count=2)
 
+        # Author can't revise license after paper deadline
         with pytest.raises(openreview.OpenReviewException, match=r'The Invitation ICLR.cc/2024/Conference/Submission1/-/Revision has expired'):
             revision_note = author_client.post_note_edit(
                 invitation = f'ICLR.cc/2024/Conference/Submission{submission.number}/-/Revision',
@@ -348,8 +349,8 @@ class TestICLRConference():
                     content = {
                         'title': submission.content['title'],
                         'abstract': submission.content['abstract'],
-                        'authorids': submission.content['authorids'],
-                        'authors': submission.content['authors'],
+                        'authorids': { 'value': submission.content['authorids']['value'] },
+                        'authors': { 'value': submission.content['authors']['value'] },
                         'keywords': submission.content['keywords'],
                         'pdf': submission.content['pdf'],
                     }
@@ -365,8 +366,8 @@ class TestICLRConference():
                 content = {
                     'title': submission.content['title'],
                     'abstract': submission.content['abstract'],
-                    'authorids': submission.content['authorids'],
-                    'authors': submission.content['authors'],
+                    'authorids': { 'value': submission.content['authorids']['value'] },
+                    'authors': { 'value': submission.content['authors']['value'] },
                     'keywords': submission.content['keywords'],
                     'pdf': submission.content['pdf'],
                 }

--- a/tests/test_iclr_conference_v2.py
+++ b/tests/test_iclr_conference_v2.py
@@ -42,6 +42,7 @@ class TestICLRConference():
         helpers.create_user('reviewer5@gmail.com', 'Reviewer', 'ICLRFive')
         helpers.create_user('reviewer6@gmail.com', 'Reviewer', 'ICLRSix')
         helpers.create_user('reviewerethics@gmail.com', 'Reviewer', 'ICLRSeven')
+        helpers.create_user('peter@mail.com', 'Peter', 'SomeLastName') # Author
 
         request_form_note = pc_client.post_note(openreview.Note(
             invitation='openreview.net/Support/-/Request_Form',
@@ -269,11 +270,33 @@ class TestICLRConference():
         assert submission_invitation.expdate < openreview.tools.datetime_millis(now)
 
         submissions = pc_client_v2.get_notes(invitation='ICLR.cc/2024/Conference/-/Submission', sort='number:asc')
+        submission = submissions[0]
         assert len(submissions) == 11
-        assert submissions[0].license == 'CC BY-SA 4.0'
-        assert submissions[0].readers == ['everyone']
-        assert '_bibtex' in submissions[0].content
-        assert 'author={Anonymous}' in submissions[0].content['_bibtex']['value']
+        assert submission.license == 'CC BY-SA 4.0'
+        assert submission.readers == ['everyone']
+        assert '_bibtex' in submission.content
+        assert 'author={Anonymous}' in submission.content['_bibtex']['value']
+
+        # Author revises submission license
+        author_client = openreview.api.OpenReviewClient(username='peter@mail.com', password=helpers.strong_password)
+        revision_note = author_client.post_note_edit(
+            invitation = f'ICLR.cc/2024/Conference/Submission{submission.number}/-/Revision',
+            signatures = [f'ICLR.cc/2024/Conference/Submission{submission.number}/Authors'],
+            note = openreview.api.Note(
+                license = 'CC0 1.0',
+                content = {
+                    'title': { 'value': submission.content['title']['value'] + ' license revision' },
+                    'abstract': submission.content['abstract'],
+                    'authorids': submission.content['authorids'],
+                    'authors': submission.content['authors'],
+                    'keywords': submission.content['keywords'],
+                    'pdf': submission.content['pdf'],
+                }
+            ))
+        helpers.await_queue_edit(openreview_client, edit_id=revision_note['id'])
+
+        submission = pc_client_v2.get_notes(invitation='ICLR.cc/2024/Conference/-/Submission', sort='number:asc')[0]
+        assert submission.license == 'CC0 1.0'
         
         # Assert that activation date of matching invitation == abstract deadline
         matching_invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Paper_Matching_Setup')
@@ -316,7 +339,43 @@ class TestICLRConference():
         helpers.await_queue_edit(openreview_client, 'ICLR.cc/2024/Conference/-/Withdrawal-0-1', count=2)
         helpers.await_queue_edit(openreview_client, 'ICLR.cc/2024/Conference/-/Desk_Rejection-0-1', count=2)
 
-        client.get_group('ICLR.cc/2024/Conference/Submission1/Reviewers')    
+        with pytest.raises(openreview.OpenReviewException, match=r'The Invitation ICLR.cc/2024/Conference/Submission1/-/Revision has expired'):
+            revision_note = author_client.post_note_edit(
+                invitation = f'ICLR.cc/2024/Conference/Submission{submission.number}/-/Revision',
+                signatures = [f'ICLR.cc/2024/Conference/Submission{submission.number}/Authors'],
+                note = openreview.api.Note(
+                    license = 'CC BY 4.0',
+                    content = {
+                        'title': submission.content['title'],
+                        'abstract': submission.content['abstract'],
+                        'authorids': submission.content['authorids'],
+                        'authors': submission.content['authors'],
+                        'keywords': submission.content['keywords'],
+                        'pdf': submission.content['pdf'],
+                    }
+                ))
+
+        # PC revises submission license
+        pc_revision = pc_client_v2.post_note_edit(
+            invitation='ICLR.cc/2024/Conference/-/PC_Revision',
+            signatures=['ICLR.cc/2024/Conference/Program_Chairs'],
+            note=openreview.api.Note(
+                id = submission.id,
+                license = 'CC BY 4.0',
+                content = {
+                    'title': submission.content['title'],
+                    'abstract': submission.content['abstract'],
+                    'authorids': submission.content['authorids'],
+                    'authors': submission.content['authors'],
+                    'keywords': submission.content['keywords'],
+                    'pdf': submission.content['pdf'],
+                }
+            ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=pc_revision['id'])
+
+        submission = pc_client_v2.get_notes(invitation='ICLR.cc/2024/Conference/-/Submission', sort='number:asc')[0]
+        assert submission.license == 'CC BY 4.0'
 
     def test_review_stage(self, client, openreview_client, helpers, test_client):
 


### PR DESCRIPTION
This allows authors to revise the submission license until the paper deadline and allows PCs to use PC revision to edit license.