### PR TITLE
Fix/ethics review settings

### DIFF
--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -941,8 +941,11 @@ class ARRWorkflow(object):
                         'release_ethics_reviews_to_reviewers': 'Ethics reviews should be immediately revealed to the paper\'s reviewers and ethics reviewers',
                         'additional_ethics_review_form_options': arr_ethics_review_content,
                         'remove_ethics_review_form_options': 'ethics_review',
+                        'release_submissions_to_ethics_chairs': 'Yes, release flagged submissions to the ethics chairs.',
                         "release_submissions_to_ethics_reviewers": "We confirm we want to release the submissions and reviews to the ethics reviewers",
                         'enable_comments_for_ethics_reviewers': 'Yes, enable commenting for ethics reviewers.',
+                        'compute_affinity_scores': 'No'
+
                     },
                     'forum': request_form_id,
                     'invitation': '{}/-/Request{}/Ethics_Review_Stage'.format(support_user, request_form.number),

--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -1536,7 +1536,7 @@ def flag_submission(
         subject = f'[{short_name}] A submission has been flagged for ethics reviewing'
         message = '''Paper {} has been flagged for ethics review.
 
-        To view the submission, click here: https://openreview.net/forum?id={}'''.format(forum.number, forum.id)
+To view the submission, click here: https://openreview.net/forum?id={}'''.format(forum.number, forum.id)
         client.post_message(
             recipients=[domain.content['ethics_chairs_id']['value']],
             ignoreRecipients=[edit.tauthor],

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -678,6 +678,8 @@ def get_ethics_review_stage(request_forum):
     if request_forum.content.get('ethics_review_submissions'):
         flagged_submissions = [int(number) for number in request_forum.content['ethics_review_submissions'].split(',')]
 
+    compute_affinity_scores = None if request_forum.content.get('compute_affinity_scores') == 'No' else request_forum.content.get('compute_affinity_scores')
+
     return openreview.stages.EthicsReviewStage(
         start_date = review_start_date,
         due_date = review_due_date,
@@ -688,7 +690,9 @@ def get_ethics_review_stage(request_forum):
         additional_fields = review_form_additional_options,
         remove_fields = review_form_remove_options,
         submission_numbers = flagged_submissions,
-        enable_comments = (request_forum.content.get('enable_comments_for_ethics_reviewers', '').startswith('Yes'))
+        enable_comments = (request_forum.content.get('enable_comments_for_ethics_reviewers', '').startswith('Yes')),
+        release_to_chairs = (request_forum.content.get('release_submissions_to_ethics_chairs', '').startswith('Yes')),
+        compute_affinity_scores = compute_affinity_scores
     )
 
 def get_meta_review_stage(request_forum):

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -678,7 +678,7 @@ def get_ethics_review_stage(request_forum):
     if request_forum.content.get('ethics_review_submissions'):
         flagged_submissions = [int(number) for number in request_forum.content['ethics_review_submissions'].split(',')]
 
-    compute_affinity_scores = None if request_forum.content.get('compute_affinity_scores') == 'No' else request_forum.content.get('compute_affinity_scores')
+    compute_affinity_scores = False if request_forum.content.get('compute_affinity_scores', 'No') == 'No' else request_forum.content.get('compute_affinity_scores')
 
     return openreview.stages.EthicsReviewStage(
         start_date = review_start_date,

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -684,7 +684,9 @@ class EthicsReviewStage(object):
         additional_fields = {},
         remove_fields = [],
         submission_numbers = [],
-        enable_comments = False
+        enable_comments = False,
+        release_to_chairs = False,
+        compute_affinity_scores = None
     ):
 
         self.start_date = start_date
@@ -700,7 +702,9 @@ class EthicsReviewStage(object):
         self.enable_comments = enable_comments
         self.process_path = 'process/ethics_review_process.py'
         self.flag_process_path = 'process/ethics_flag_process.py'
-        self.preprocess_path = None        
+        self.preprocess_path = None
+        self.release_to_chairs = release_to_chairs
+        self.compute_affinity_scores = compute_affinity_scores     
 
     def get_readers(self, conference, number, ethics_review_signature=None):
 

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -257,7 +257,8 @@ class GroupBuilder(object):
             content['ethics_chairs_name'] = { 'value': self.venue.ethics_chairs_name }
             content['ethics_reviewers_name'] = { 'value': self.venue.ethics_reviewers_name }
             content['ethics_review_name'] = { 'value': self.venue.ethics_review_stage.name }
-            content['anon_ethics_reviewer_name'] = { 'value': self.venue.anon_ethics_reviewers_name()}
+            content['anon_ethics_reviewer_name'] = { 'value': self.venue.anon_ethics_reviewers_name() }
+            content['release_to_chairs'] = { 'value': self.venue.ethics_review_stage.release_to_chairs }
 
         if venue_group.content.get('enable_reviewers_reassignment'):
             content['enable_reviewers_reassignment'] = venue_group.content.get('enable_reviewers_reassignment')

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -3743,18 +3743,6 @@ class InvitationBuilder(object):
         if ethics_review_stage.flag_process_path:
             ethics_stage_invitation.process = self.get_process_content(ethics_review_stage.flag_process_path)
 
-        if 'everyone' not in self.venue.submission_stage.get_readers(self.venue, '${{2/id}/number}'):
-            readers_to_append = [self.venue.get_ethics_reviewers_id('${{3/id}/number}')]
-            if ethics_review_stage.release_to_chairs:
-                readers_to_append.append(self.venue.get_ethics_chairs_id())
-            ethics_stage_invitation.edit['note']['readers'] = {
-                'param': {
-                    'const': {
-                        'append': readers_to_append
-                    }
-                }
-            }
-
         self.save_invitation(ethics_stage_invitation, replacement=False)
         return ethics_stage_invitation
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -1426,7 +1426,7 @@ class InvitationBuilder(object):
                 }
             invitation.edit['invitation']['edit']['note']['readers'] = comment_readers
 
-            invitation.edit['invitation']['invitees'].append(self.venue.get_ethics_reviewers_id('${3/content/noteNumber/value}'))
+            invitation.edit['invitation']['invitees'].extend([self.venue.get_ethics_reviewers_id('${3/content/noteNumber/value}'), self.venue.get_ethics_chairs_id()])
             invitation.edit['invitation']['edit']['signatures']['param']['items'].append({ 'prefix': self.venue.get_ethics_reviewers_id('${7/content/noteNumber/value}', anon=True), 'optional': True })
             invitation.edit['invitation']['edit']['signatures']['param']['items'].append({ 'value': self.venue.get_ethics_chairs_id(), 'optional': True })
 
@@ -3744,10 +3744,13 @@ class InvitationBuilder(object):
             ethics_stage_invitation.process = self.get_process_content(ethics_review_stage.flag_process_path)
 
         if 'everyone' not in self.venue.submission_stage.get_readers(self.venue, '${{2/id}/number}'):
+            readers_to_append = [self.venue.get_ethics_reviewers_id('${{3/id}/number}')]
+            if ethics_review_stage.release_to_chairs:
+                readers_to_append.append(self.venue.get_ethics_chairs_id())
             ethics_stage_invitation.edit['note']['readers'] = {
                 'param': {
                     'const': {
-                        'append': [self.venue.get_ethics_reviewers_id('${{3/id}/number}')]
+                        'append': readers_to_append
                     }
                 }
             }

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -63,7 +63,8 @@ def process(client, edit, invitation):
                         final_readers.remove('{signatures}')
                     if 'everyone' not in final_readers:
                         final_readers.append(f'{venue_id}/{submission_name}{submission.number}/{ethics_reviewers_name}')
-                        final_readers.append(ethics_chairs_id)
+                        if release_to_ethics_chairs:
+                            final_readers.append(ethics_chairs_id)
 
                     print('review_name:', review_name)
                     paper_invitation_edit = client.post_invitation_edit(

--- a/openreview/venue/process/ethics_review_process.py
+++ b/openreview/venue/process/ethics_review_process.py
@@ -8,6 +8,10 @@ def process(client, edit, invitation):
     authors_name = domain.get_content_value('authors_name')
     submission_name = domain.get_content_value('submission_name')
     ethics_reviewers_name = domain.get_content_value('ethics_reviewers_name')
+    sender = domain.get_content_value('message_sender')
+    contact = domain.get_content_value('contact')
+    short_name = domain.get_content_value('subtitle')
+    ethics_review_name = domain.get_content_value('ethics_review_name')
 
     submission = client.get_note(edit.note.forum)
     paper_group_id = f'{venue_id}/{submission_name}{submission.number}'
@@ -38,4 +42,47 @@ def process(client, edit, invitation):
         )
 
     create_group(paper_reviewers_submitted_id, [ethics_review.signatures[0]])
+
+    capital_ethics_review_name = ethics_review_name.replace('_', ' ')
+    ethics_review_name = capital_ethics_review_name.lower()
+
+    ignore_groups = ethics_review.nonreaders if ethics_review.nonreaders else []
+    ignore_groups.append(edit.tauthor)  
+
+    content = f'To view the {ethics_review_name}, click here: https://openreview.net/forum?id={submission.id}&noteId={edit.note.id}'
+
+    # email tauthor
+    client.post_message(
+        invitation=meta_invitation_id,
+        signature=venue_id,
+        sender=sender,
+        recipients=ethics_review.signatures,
+        replyTo=contact,
+        subject=f'''[{short_name}] Your {ethics_review_name} has been received on your assigned Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
+        message=f''''We have received an ethics review on a submission to {short_name}.
+
+Paper number: {submission.number}
+
+Paper title: {submission.content['title']['value']}        
         
+{content}
+''')
+    
+    # email ethics chairs
+    client.post_message(
+            invitation=meta_invitation_id,
+            signature=venue_id,
+            sender=sender,
+            recipients=[ethics_chairs_id],
+            ignoreRecipients=ignore_groups,
+            replyTo=contact,
+            subject=f'''[{short_name}] {capital_ethics_review_name} posted to your assigned Paper number: {submission.number}, Paper title: "{submission.content['title']['value']}"''',
+            message=f''''A submission to {short_name}, for which you are an official ethics chair, has received an ethics review.
+
+Paper number: {submission.number}
+
+Paper title: {submission.content['title']['value']}
+
+{content}
+'''
+        )

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -13,6 +13,7 @@ def process(client, invitation):
     meta_review_name = domain.content.get('meta_review_name', {}).get('value')
     ethics_chairs_id = domain.content.get('ethics_chairs_id', {}).get('value')
     ethics_reviewers_name = domain.content.get('ethics_reviewers_name', {}).get('value')
+    release_to_ethics_chairs = domain.get_content_value('release_to_chairs')
 
     now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
     cdate = invitation.edit['invitation']['cdate'] if 'cdate' in invitation.edit['invitation'] else invitation.cdate
@@ -164,7 +165,8 @@ def process(client, invitation):
             if note.content.get('flagged_for_ethics_review', {}).get('value', False):
                 if 'everyone' not in final_readers or invitation.content.get('reader_selection',{}).get('value'):
                     final_readers.append(f'{venue_id}/{submission_name}{note.number}/{ethics_reviewers_name}')
-                    final_readers.append(ethics_chairs_id)
+                    if release_to_ethics_chairs:
+                        final_readers.append(ethics_chairs_id)
             content['noteReaders'] = { 'value': final_readers }
 
         paper_invitation_edit = client.post_invitation_edit(invitations=invitation.id,

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -164,6 +164,7 @@ def process(client, invitation):
             if note.content.get('flagged_for_ethics_review', {}).get('value', False):
                 if 'everyone' not in final_readers or invitation.content.get('reader_selection',{}).get('value'):
                     final_readers.append(f'{venue_id}/{submission_name}{note.number}/{ethics_reviewers_name}')
+                    final_readers.append(ethics_chairs_id)
             content['noteReaders'] = { 'value': final_readers }
 
         paper_invitation_edit = client.post_invitation_edit(invitations=invitation.id,

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -572,7 +572,7 @@ class Venue(object):
         tools.replace_members_with_ids(self.client, ethics_chairs_group)
         group = tools.get_group(self.client, id=self.get_ethics_reviewers_id())
         if group and len(group.members) > 0:
-            self.setup_committee_matching(group.id, compute_affinity_scores=False, compute_conflicts=True)
+            self.setup_committee_matching(group.id, compute_affinity_scores=self.ethics_review_stage.compute_affinity_scores, compute_conflicts=True)
             self.invitation_builder.set_assignment_invitation(group.id)
 
         flagged_submission_numbers = self.ethics_review_stage.submission_numbers

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -394,21 +394,36 @@ class VenueStages():
                 'required': False,
                 'description': 'Comma separated list of fields (recommendation, ethics_review) that you want removed from the review form.'
             },
+            "release_submissions_to_ethics_chairs": {
+                "description": "Do you want to release flagged submissions to the ethics chairs? All flagged submissions will be released to ethics chairs, despite any conflicts between ethics chairs and flagged submissions.",
+                "order": 9,
+                'value-radio': [
+                    'Yes, release flagged submissions to the ethics chairs.',
+                    'No, do not release flagged submissions to the ethics chairs.'
+                ],
+                "default": "No, do not release flagged submissions to the ethics chairs"
+            },
             "release_submissions_to_ethics_reviewers": {
                 "description": "Confirm that you want to release the submissions to the ethics reviewers if they are no currently released.",
-                "order": 9,
+                "order": 10,
                 "value-checkbox": "We confirm we want to release the submissions and reviews to the ethics reviewers",
                 "required": True
             },
+            "compute_affinity_scores": {
+                "order": 11,
+                'description': 'Please select whether you would like affinity scores for ethics reviewers to be computed and uploaded automatically. Select the model you want to use to compute the affinity scores or "No" if you don\'t want to compute affinity scores. The model "specter2+scincl" has the best performance, refer to our expertise repository for more information on the models: https://github.com/openreview/openreview-expertise.',
+                'value-radio': ['specter+mfr', 'specter2', 'scincl', 'specter2+scincl','No'],
+                "default": "No"
+            },
             'enable_comments_for_ethics_reviewers': {
-                'description': 'Should ethics reviewers be able to post comments? Note you can control the comment stage deadline as well who else can post comments by using the Comment Stage button.',
+                'description': 'Should ethics reviewers be able to post comments? Note you can control the comment stage deadline as well who else can post comments by using the Comment Stage button. Enabling comments for ethics reviewers will also enable them for ethics chairs.',
                 'value-radio': [
                     'Yes, enable commenting for ethics reviewers.',
                     'No, do not enable commenting for ethics reviewers.'
                 ],
                 'required': False,
                 'default': 'No, do not enable commenting for ethics reviewers.',
-                'order': 10
+                'order': 12
             }
         }
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -2927,6 +2927,8 @@ class TestARRVenueV2():
         assert test_submission.content['number_of_reviewer_checklists']['value'] == 1
         _, test_submission = post_checklist(user_client, checklist_inv, user, ddate=now(), existing_note=edit['note'])
         assert test_submission.content['number_of_reviewer_checklists']['value'] == 0
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Post checklist with no ethics flag and a violation field - check for DSV flag
         edit, test_submission = post_checklist(user_client, checklist_inv, user, tested_field=violation_fields[0])
@@ -2935,6 +2937,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert test_submission.content['flagged_for_desk_reject_verification']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission2/-/Desk_Reject_Verification').expdate > now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Delete checklist - check DSV flag is False, invitation is expired
         _, test_submission = post_checklist(user_client, checklist_inv, user, ddate=now(), existing_note=edit['note'])
@@ -2942,6 +2946,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission2/-/Desk_Reject_Verification').expdate < now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Re-post with no ethics flag and a violation field - check DSV flag is True
         violation_edit, test_submission = post_checklist(user_client, checklist_inv, user, tested_field=violation_fields[1])
@@ -2949,6 +2955,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert test_submission.content['flagged_for_desk_reject_verification']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission2/-/Desk_Reject_Verification').expdate > now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Edit with no ethics flag and no violation field - check DSV flag is False
         violation_edit['note']['content'][violation_fields[1]]['value'] = 'Yes'
@@ -3207,13 +3215,14 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' not in test_submission.content
         _, test_submission = post_official_review(user_client, review_inv, user, ddate=now(), existing_note=edit['note'])
 
-
         # Post checklist with no ethics flag and a violation field - check for DSV flag
         edit, test_submission = post_official_review(user_client, review_inv, user, tested_field=violation_fields[0])
         assert 'flagged_for_ethics_review' not in test_submission.content
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert test_submission.content['flagged_for_desk_reject_verification']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission3/-/Desk_Reject_Verification').expdate > now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Delete checklist - check DSV flag is False, invitation is expired
         _, test_submission = post_official_review(user_client, review_inv, user, ddate=now(), existing_note=edit['note'])
@@ -3221,6 +3230,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission3/-/Desk_Reject_Verification').expdate < now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Re-post with no ethics flag and a violation field - check DSV flag is True
         violation_edit, test_submission = post_official_review(user_client, review_inv, user, tested_field=violation_fields[0])
@@ -3228,6 +3239,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert test_submission.content['flagged_for_desk_reject_verification']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission3/-/Desk_Reject_Verification').expdate > now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Edit with no ethics flag and no violation field - check DSV flag is False
         violation_edit['note']['content'][violation_fields[0]]['value'] = 'No'
@@ -3236,6 +3249,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission3/-/Desk_Reject_Verification').expdate < now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Edit with ethics flag and no violation field - check DSV flag is false and ethics flag exists and is True
         _, test_submission = post_official_review(user_client, review_inv, user, tested_field='needs_ethics_review', existing_note=violation_edit['note'])
@@ -3244,6 +3259,8 @@ class TestARRVenueV2():
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission3/-/Desk_Reject_Verification').expdate < now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' in test_submission.readers
 
         # Delete checklist - check both flags False
         _, test_submission = post_official_review(user_client, review_inv, user, ddate=now(), existing_note=violation_edit['note'])
@@ -3251,6 +3268,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert not test_submission.content['flagged_for_ethics_review']['value']
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Re-post with no flag - check both flags false
         reviewer_edit, test_submission = post_official_review(user_client, review_inv, user)
@@ -3259,6 +3278,8 @@ class TestARRVenueV2():
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert not test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission3/-/Desk_Reject_Verification').expdate < now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Make reviews public
         pc_client.post_note(
@@ -3573,13 +3594,16 @@ class TestARRVenueV2():
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Desk_Reject_Verification').expdate < now()
+        comment_inv = openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Official_Comment')
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' in comment_inv.invitees
+        assert 'aclweb.org/ACL/ARR/2023/August/Submission4/Ethics_Reviewers' in comment_inv.readers
 
         helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/-/Ethics_Review_Flag', count=9)
 
         # Post an ethics review
         ethics_anon_id = ethics_client.get_groups(prefix='aclweb.org/ACL/ARR/2023/August/Submission4/Ethics_Reviewer_', signatory='~EthicsReviewer_ARROne1')[0].id
         assert ethics_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Ethics_Review')
-        ethics_client.post_note_edit(
+        ethics_review_edit = ethics_client.post_note_edit(
             invitation='aclweb.org/ACL/ARR/2023/August/Submission4/-/Ethics_Review',
             signatures=[ethics_anon_id],
             note=openreview.api.Note(
@@ -3590,6 +3614,12 @@ class TestARRVenueV2():
                 }
             )
         )
+        helpers.await_queue_edit(openreview_client, edit_id=ethics_review_edit['id'])
+        messages = openreview_client.get_messages(to='ec1@aclrollingreview.com', subject='[ARR - August 2023] Ethics Review posted to your assigned Paper number: 4, Paper title: "Paper title 4"')
+        assert messages and len(messages) == 1
+
+        messages = openreview_client.get_messages(to='reviewerethics@aclrollingreview.com', subject='[ARR - August 2023] Your ethics review has been received on your assigned Paper number: 4, Paper title: "Paper title 4"')
+        assert messages and len(messages) == 1
 
         # Delete checklist - check both flags False
         _, test_submission = post_meta_review(user_client, review_inv, user, ddate=now(), existing_note=violation_edit['note'])

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -2981,8 +2981,9 @@ class TestARRVenueV2():
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission2/-/Desk_Reject_Verification').expdate < now()
-        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' in test_submission.readers
-        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' in test_submission.readers
+        assert test_submission.readers == ['everyone']
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Delete checklist - check both flags False
         _, test_submission = post_checklist(user_client, checklist_inv, user, ddate=now(), existing_note=violation_edit['note'])
@@ -3602,7 +3603,7 @@ class TestARRVenueV2():
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Desk_Reject_Verification').expdate < now()
         comment_inv = openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission4/-/Official_Comment')
         assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' in comment_inv.invitees
-        assert 'aclweb.org/ACL/ARR/2023/August/Submission4/Ethics_Reviewers' in comment_inv.readers
+        assert 'aclweb.org/ACL/ARR/2023/August/Submission4/Ethics_Reviewers' in comment_inv.invitees
 
         helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/-/Ethics_Review_Flag', count=9)
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -573,7 +573,9 @@ class TestARRVenueV2():
                         }
                     }
                 },
-                'release_submissions_to_ethics_reviewers': 'We confirm we want to release the submissions and reviews to the ethics reviewers'
+                'release_submissions_to_ethics_reviewers': 'We confirm we want to release the submissions and reviews to the ethics reviewers',
+                'release_submissions_to_ethics_chairs': 'Yes, release flagged submissions to the ethics chairs.',
+                'compute_affinity_scores': 'No'
             },
             forum=request_form_note.forum,
             referent=request_form_note.forum,
@@ -2955,6 +2957,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission2/-/Desk_Reject_Verification').expdate < now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Edit with ethics flag and no violation field - check DSV flag is false and ethics flag exists and is True
         _, test_submission = post_checklist(user_client, checklist_inv, user, tested_field='need_ethics_review', existing_note=violation_edit['note'])
@@ -2963,6 +2967,8 @@ class TestARRVenueV2():
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission2/-/Desk_Reject_Verification').expdate < now()
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' in test_submission.readers
 
         # Delete checklist - check both flags False
         _, test_submission = post_checklist(user_client, checklist_inv, user, ddate=now(), existing_note=violation_edit['note'])
@@ -2970,6 +2976,8 @@ class TestARRVenueV2():
         assert 'flagged_for_desk_reject_verification' in test_submission.content
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert not test_submission.content['flagged_for_ethics_review']['value']
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Re-post with no flag - check both flags false
         reviewer_edit, test_submission = post_checklist(user_client, checklist_inv, user)
@@ -2978,7 +2986,8 @@ class TestARRVenueV2():
         assert not test_submission.content['flagged_for_desk_reject_verification']['value']
         assert not test_submission.content['flagged_for_ethics_review']['value']
         assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Submission2/-/Desk_Reject_Verification').expdate < now()
-
+        assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers
+        assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' not in test_submission.readers
 
         # Test checklists for AEs
         checklist_inv = test_data_templates[venue.get_area_chairs_id()]['checklist_invitation']

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -3373,7 +3373,6 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
                 'ICML.cc/2023/Conference/Submission1/Senior_Area_Chairs',
                 'ICML.cc/2023/Conference/Submission1/Area_Chairs',
                 'ICML.cc/2023/Conference/Submission1/Ethics_Reviewers',
-                'ICML.cc/2023/Conference/Ethics_Chairs',
                 review.signatures[0]
             ]
 
@@ -3485,7 +3484,6 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
                 'ICML.cc/2023/Conference/Submission1/Senior_Area_Chairs',
                 'ICML.cc/2023/Conference/Submission1/Area_Chairs',
                 'ICML.cc/2023/Conference/Submission1/Ethics_Reviewers',
-                'ICML.cc/2023/Conference/Ethics_Chairs',
                 review.signatures[0]
             ]
 
@@ -3526,7 +3524,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         invitations = openreview_client.get_all_invitations(invitation='ICML.cc/2023/Conference/-/Official_Comment')
         assert len(invitations) == 100
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Official_Comment')
-        assert invitation.invitees == ['ICML.cc/2023/Conference', 'openreview.net/Support', 'ICML.cc/2023/Conference/Submission1/Ethics_Reviewers']
+        assert invitation.invitees == ['ICML.cc/2023/Conference', 'openreview.net/Support', 'ICML.cc/2023/Conference/Submission1/Ethics_Reviewers', 'ICML.cc/2023/Conference/Ethics_Chairs']
 
         # post ethics review
         openreview_client.add_members_to_group('ICML.cc/2023/Conference/Submission5/Ethics_Reviewers', '~Reviewer_ICMLOne1')

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -3373,6 +3373,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
                 'ICML.cc/2023/Conference/Submission1/Senior_Area_Chairs',
                 'ICML.cc/2023/Conference/Submission1/Area_Chairs',
                 'ICML.cc/2023/Conference/Submission1/Ethics_Reviewers',
+                'ICML.cc/2023/Conference/Ethics_Chairs',
                 review.signatures[0]
             ]
 
@@ -3484,6 +3485,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
                 'ICML.cc/2023/Conference/Submission1/Senior_Area_Chairs',
                 'ICML.cc/2023/Conference/Submission1/Area_Chairs',
                 'ICML.cc/2023/Conference/Submission1/Ethics_Reviewers',
+                'ICML.cc/2023/Conference/Ethics_Chairs',
                 review.signatures[0]
             ]
 


### PR DESCRIPTION
The following issues are fixed here:
- add ethics chairs as readers of flagged submissions (since we are using append in the invitation, we add them even if the paper is public. Perhaps we should do this in the process function so we can check this?)
- send an email to ethics chair and to the writer of the ethics review when a ethics review is posted
- adds ethics chairs as invitees of official comment invitations (and removes them if the papers is unflagged)

Fixes:  #2164 and items (2) and (3) of #2126