### PR TITLE
Fix/ ARR Ethics_Reviewers Invite_Assignment

### DIFF
--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -447,7 +447,7 @@ class GroupBuilder(object):
                             readers=[venue_id, ethics_chairs_id],
                             writers=[venue_id],
                             signatures=[venue_id],
-                            signatories=[venue_id],
+                            signatories=[venue_id, ethics_chairs_id],
                             members=[]
                         )
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -3266,26 +3266,8 @@ class InvitationBuilder(object):
         process_content = self.get_process_content(process_file)
         preprocess_content = self.get_process_content('process/paper_recruitment_pre_process.js')
 
-        edge_readers = []
-        edge_writers = []
-        if committee_id.endswith(venue.area_chairs_name):
-            if venue.use_senior_area_chairs:
-                edge_readers.append(venue.get_senior_area_chairs_id(number='{number}'))
-                edge_writers.append(venue.get_senior_area_chairs_id(number='{number}'))
-
-        if committee_id.endswith(venue.reviewers_name):
-            if venue.use_senior_area_chairs:
-                edge_readers.append(venue.get_senior_area_chairs_id(number='{number}'))
-                edge_writers.append(venue.get_senior_area_chairs_id(number='{number}'))
-
-            if venue.use_area_chairs:
-                edge_readers.append(venue.get_area_chairs_id(number='{number}'))
-                edge_writers.append(venue.get_area_chairs_id(number='{number}'))
-
         invitation_content = {
             'committee_name': { 'value':  venue.get_committee_name(committee_id, pretty=True) },
-            'edge_readers': { 'value': edge_readers },
-            'edge_writers': { 'value': edge_writers },
             'hash_seed': { 'value': hash_seed, 'readers': [ venue.venue_id ]},
             'committee_id': { 'value': committee_id },
             'committee_invited_id': { 'value': venue.get_committee_id(name=invited_committee_name + '/Invited') if invited_committee_name else ''},

--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -1138,6 +1138,7 @@ class Matching(object):
             'hash_seed': { 'value': hash_seed, 'readers': [ venue.venue_id ]},
             'email_template': { 'value': email_template if email_template else ''},
             'is_reviewer': { 'value': True if (self.match_group.id.split('/')[-1] in venue.reviewer_roles) else False },
+            'is_ethics_reviewer': { 'value': True if self.match_group.id == venue.get_ethics_reviewers_id() else False }
         }
 
         # set invite assignment invitation

--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -13,7 +13,10 @@ def process_update(client, edge, invitation, existing_edge):
     paper_reviewer_invited_id = invitation.content['paper_reviewer_invited_id']['value']
     email_template = invitation.content['email_template']['value']
     is_reviewer = invitation.content['is_reviewer']['value']
+    is_ethics_reviewer = invitation.content.get('is_ethics_reviewer',{}).get('value', False)
     action_string = 'to review' if is_reviewer else 'to serve as area chair for'
+    if is_ethics_reviewer:
+        action_string = 'to serve as ethics reviewer for'
     print(edge.id)
 
     if edge.ddate is None and edge.label == invite_label and not existing_edge:

--- a/openreview/venue/process/paper_recruitment_process.py
+++ b/openreview/venue/process/paper_recruitment_process.py
@@ -8,8 +8,6 @@ def process(client, edit, invitation):
     short_phrase = domain.content['subtitle']['value']
     submission_name = domain.content['submission_name']['value']
     committee_name = invitation.content['committee_name']['value']
-    edge_readers = invitation.content['edge_readers']['value']
-    edge_writers = invitation.content['edge_writers']['value']
     hash_seed = invitation.content['hash_seed']['value']
     committee_id = invitation.content['committee_id']['value']
     invite_assignment_invitation_id = invitation.content['invite_assignment_invitation_id']['value']
@@ -150,19 +148,17 @@ OpenReview Team'''
 
         if not assignment_edges:
             print('post assignment edge')
-            readers=[r.replace('{number}', str(submission.number)) for r in edge_readers]
-            writers=[r.replace('{number}', str(submission.number)) for r in edge_writers]
-            client.post_edge(openreview.Edge(
+            client.post_edge(openreview.api.Edge(
                 invitation=assignment_invitation_id,
                 head=edge.head,
                 tail=edge.tail,
                 label=assignment_title,
                 weight = 1,
-                readers=[venue_id] + readers + [edge.tail],
+                readers=None,
                 nonreaders=[
                     f'{venue_id}/{submission_name}{submission.number}/Authors'
                 ],
-                writers=[venue_id] + writers,
+                writers=None,
                 signatures=[venue_id]
             ))
 

--- a/openreview/venue/process/simple_paper_recruitment_process.py
+++ b/openreview/venue/process/simple_paper_recruitment_process.py
@@ -9,8 +9,6 @@ def process(client, edit, invitation):
     sender = domain.get_content_value('message_sender')
     submission_name = domain.content['submission_name']['value']
     committee_name = invitation.content['committee_name']['value']
-    edge_readers = invitation.content['edge_readers']['value']
-    edge_writers = invitation.content['edge_writers']['value']
     hash_seed = invitation.content['hash_seed']['value']
     committee_id = invitation.content['committee_id']['value']
     invite_assignment_invitation_id = invitation.content['invite_assignment_invitation_id']['value']
@@ -76,18 +74,16 @@ def process(client, edit, invitation):
 
         if not assignment_edges:
             print('post assignment edge')
-            readers=[r.replace('{number}', str(submission.number)) for r in edge_readers]
-            writers=[r.replace('{number}', str(submission.number)) for r in edge_writers]
-            client.post_edge(openreview.Edge(
+            client.post_edge(openreview.api.Edge(
                 invitation=assignment_invitation_id,
                 head=edge.head,
                 tail=edge.tail,
                 weigth = 1,
-                readers=[venue_id] + readers + [edge.tail],
+                readers=None,
                 nonreaders=[
                     f'{venue_id}/{submission_name}{submission.number}/Authors'
                 ],
-                writers=[venue_id] + writers,
+                writers=None,
                 signatures=[venue_id]
             ))
 


### PR DESCRIPTION
Changes:
- add `is_ethics_reviewer` variable to invite assignment invitation so emails are sent with proper committee name
- add ethics chairs as signatures of the `Ethics_Chairs` group so they can sign `Invite_Assignment` edges
- remove `edge_readers` and `edge_writers` and pass None for these two fields (use openreview.api.Edge instead of openreview.Edge)