### PR TITLE
TMLR: fix several issues

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -2328,6 +2328,8 @@ class Edit(object):
         invitation = None,
         nonreaders = None,
         cdate = None,
+        tcdate = None,
+        tmdate = None,
         ddate = None,
         tauthor = None,
         content = None):
@@ -2336,6 +2338,8 @@ class Edit(object):
         self.domain = domain
         self.invitations = invitations
         self.cdate = cdate
+        self.tcdate = tcdate
+        self.tmdate = tmdate
         self.ddate = ddate
         self.readers = readers
         self.nonreaders = nonreaders
@@ -2406,6 +2410,8 @@ class Edit(object):
             domain = e.get('domain'),
             invitations = e.get('invitations'),
             cdate = e.get('cdate'),
+            tcdate = e.get('tcdate'),
+            tmdate = e.get('tmdate'),
             ddate = e.get('ddate'),
             readers = e.get('readers'),
             nonreaders = e.get('nonreaders'),

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -322,7 +322,7 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
                                 signatories=[venue_id],
                                 members=[]
                                 )
-            with open(os.path.join(os.path.dirname(__file__), 'webfield/reviewersWebfield.js')) as f:
+            with open(os.path.join(os.path.dirname(__file__), 'webfield/archivedReviewersWebfield.js')) as f:
                 content = f.read()
                 content = content.replace("var VENUE_ID = '';", "var VENUE_ID = '" + venue_id + "';")
                 content = content.replace("var SHORT_PHRASE = '';", f'var SHORT_PHRASE = "{self.journal.short_name}";')

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3052,13 +3052,6 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     },                    
                     'readers': self.journal.get_under_review_submission_readers('${2/number}'),
                     'content': {
-                        'assigned_action_editor': {
-                            'value': {
-                                'param': {
-                                    'type': 'string'
-                                }
-                            }
-                        },
                         '_bibtex': {
                             'value': {
                                 'param': {
@@ -4491,21 +4484,17 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         )
 
         ## Change the edit readers
-        for edit in self.client.get_note_edits(note.id, invitation=revision_invitation_id, sort='tmdate:asc'):
-            edit.readers = self.journal.get_under_review_submission_readers(note.number)
-            edit.note.mdate = None
-            edit.note.cdate = None
-            edit.note.forum = None
-            self.client.post_edit(edit)
-
-        ## Change first edit readers
-        for edit in self.client.get_note_edits(note.id, invitation=self.journal.get_author_submission_id(), sort='tmdate:asc'):
-            edit.invitation = self.journal.get_meta_invitation_id()
-            edit.signatures = [self.journal.venue_id]
-            edit.readers = self.journal.get_under_review_submission_readers(note.number)
-            edit.note.mdate = None
-            edit.note.cdate = None
-            self.client.post_edit(edit)         
+        for edit in self.client.get_note_edits(note.id, sort='tmdate:asc'):
+            new_readers = self.journal.get_under_review_submission_readers(note.number)
+            if new_readers != edit.readers:
+                edit.readers = new_readers
+                edit.note.mdate = None
+                edit.note.cdate = None
+                edit.note.forum = None
+                if edit.invitation == self.journal.get_author_submission_id():
+                    edit.invitation = self.journal.get_meta_invitation_id()
+                    edit.signatures = [self.journal.venue_id]
+                self.client.post_edit(edit)
 
     def set_comment_invitation(self):
         venue_id = self.journal.venue_id

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -758,7 +758,10 @@ class Journal(object):
         if note.ddate:
             return
 
-        action = 'posted' if note.tcdate == note.tmdate else 'edited'
+        if note.id == forum.id:
+            action = 'posted' if edit.tcdate == edit.tmdate else 'edited'
+        else:
+            action = 'posted' if note.tcdate == note.tmdate else 'edited'
 
         readers = note.readers
         nonreaders = [edit.tauthor]

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -104,7 +104,10 @@ class Journal(object):
         return self.__get_group_id('Expert_Reviewers')
     
     def get_expert_reviewers_member_id(self):
-        return self.__get_invitation_id(name='Member', prefix=self.get_expert_reviewers_id())    
+        return self.__get_invitation_id(name='Member', prefix=self.get_expert_reviewers_id())
+
+    def get_archived_reviewers_member_id(self):
+        return self.__get_invitation_id(name='Member', prefix=self.get_reviewers_archived_id())        
 
     def get_solicit_reviewers_id(self, number=None, declined=False):
         group_id = self.__get_group_id(self.solicit_reviewers_name, number)

--- a/openreview/journal/process/ae_assignment_process.py
+++ b/openreview/journal/process/ae_assignment_process.py
@@ -71,21 +71,21 @@ def process_update(client, edge, invitation, existing_edge):
         journal.invitation_builder.expire_invitation(journal.get_ae_recommendation_id(number=note.number))
 
         ## add assigned_action_editor
-        content = {}
-        if note.content['venueid']['value'] == journal.under_review_venue_id:
-            content['assigned_action_editor'] = { 'value': edge.tail}
+        content = {
+            'assigned_action_editor': { 'value': edge.tail }
+        }
 
         if journal.assigning_AE_venue_id == note.content['venueid']['value']:
             content['venueid'] = { 'value': journal.assigned_AE_venue_id }
             content['venue'] = { 'value': f'{journal.short_name} Assigned AE' }
 
 
-        if content:
-            client.post_note_edit(invitation= journal.get_meta_invitation_id(),
-                                signatures=[journal.venue_id],
-                                note=openreview.api.Note(id=note.id,
-                                content = content 
-            ))
+        client.post_note_edit(invitation= journal.get_meta_invitation_id(),
+                            signatures=[journal.venue_id],
+                            readers=[journal.venue_id, journal.get_action_editors_id(number=note.number)],
+                            note=openreview.api.Note(id=note.id,
+                            content = content 
+        ))
 
         print('check if the EICs are authors of the submission')
         eics = client.get_group(journal.get_editors_in_chief_id()).members

--- a/openreview/journal/process/archived_reviewers_member_process.py
+++ b/openreview/journal/process/archived_reviewers_member_process.py
@@ -1,0 +1,17 @@
+def process(client, edit, invitation):
+
+    journal = openreview.journal.Journal()
+
+    members = edit.group.members.get('append', [])
+
+    print('Added archived reviewers', members)
+
+    for member in members:
+        print('Delete edges for member', member)
+        client.delete_edges(invitation=journal.get_reviewer_availability_id(), tail=member, soft_delete=True)
+        client.delete_edges(invitation=journal.get_reviewer_pending_review_id(), tail=member, soft_delete=True)
+        client.delete_edges(invitation=journal.get_reviewer_custom_max_papers_id(), tail=member, soft_delete=True)
+
+
+    print('Remove members from the reviewers group')
+    client.remove_members_from_group(journal.get_reviewers_id(), members)

--- a/openreview/journal/process/review_approval_process.py
+++ b/openreview/journal/process/review_approval_process.py
@@ -29,9 +29,6 @@ def process(client, edit, invitation):
                                 content={
                                     '_bibtex': {
                                         'value': journal.get_bibtex(submission, journal.under_review_venue_id)
-                                    },
-                                    'assigned_action_editor': {
-                                        'value': ', '.join(paper_action_editor_group.members)
                                     }
                                 }))
 

--- a/openreview/journal/process/review_reminder_with_no_ACK_process.py
+++ b/openreview/journal/process/review_reminder_with_no_ACK_process.py
@@ -31,7 +31,7 @@ def process(client, invitation):
                 subject=f'''[{journal.short_name}] Less than {journal.get_number_of_reviewers()} ACKs for the paper {submission.number}: {submission.content['title']['value']}''',
                 message=f'''Hi {{{{fullname}}}},
 
-This submissions has less than {journal.get_number_of_reviewers()} reviews and less than {journal.get_number_of_reviewers()} ACKs. 
+This submission has fewer than {journal.get_number_of_reviewers()} reviews and fewer than {journal.get_number_of_reviewers()} ACKs. 
 
 Task: {task}
 Submission: {submission.content['title']['value']}

--- a/openreview/journal/process/review_reminder_with_no_ACK_process.py
+++ b/openreview/journal/process/review_reminder_with_no_ACK_process.py
@@ -28,7 +28,7 @@ def process(client, invitation):
             client.post_message(
                 invitation=journal.get_meta_invitation_id(),
                 recipients=[journal.get_editors_in_chief_id()],
-                subject=f'''[{journal.short_name}] Less than {journal.get_number_of_reviewers()} ACKs for the paper {submission.number}: {submission.content['title']['value']}''',
+                subject=f'''[{journal.short_name}] Fewer than {journal.get_number_of_reviewers()} ACKs for the paper {submission.number}: {submission.content['title']['value']}''',
                 message=f'''Hi {{{{fullname}}}},
 
 This submission has fewer than {journal.get_number_of_reviewers()} reviews and fewer than {journal.get_number_of_reviewers()} ACKs. 

--- a/openreview/journal/process/review_reminder_with_no_ACK_process.py
+++ b/openreview/journal/process/review_reminder_with_no_ACK_process.py
@@ -1,0 +1,47 @@
+def process(client, invitation):
+
+    journal = openreview.journal.Journal()
+
+    submission = client.get_note(invitation.edit['note']['forum'])
+    assigned_action_editor = submission.content.get('assigned_action_editor', {}).get('value')
+    duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
+    now = datetime.datetime.utcnow()
+    task = invitation.pretty_id()
+
+    late_invitees = journal.get_late_invitees(invitation.id)
+
+    if len(late_invitees) == 0:
+      return
+
+    if days_late_map:
+        days_late = days_late_map.get(str(date_index), abs((now - duedate).days))
+    else:
+        days_late = abs((now - duedate).days)
+
+    reviews = client.get_notes(forum=submission.id, invitation=invitation.id)
+
+    if len(reviews) < journal.get_number_of_reviewers():
+        print(f'Not enough reviews ({len(reviews)}) for {submission.id}, check ACK count')
+        ACK_replies = [ r for r in client.get_notes(forum=submission.id) if 'Assignment/Acknowledgement' in r.invitations[0]]
+        if len(ACK_replies) < journal.get_number_of_reviewers():
+            print(f'Not enough ACKs ({len(ACK_replies)}) for {submission.id}, send reminders to EICs')
+            client.post_message(
+                invitation=journal.get_meta_invitation_id(),
+                recipients=[journal.get_editors_in_chief_id()],
+                subject=f'''[{journal.short_name}] Less than {journal.get_number_of_reviewers()} ACKs for the paper {submission.number}: {submission.content['title']['value']}''',
+                message=f'''Hi {{{{fullname}}}},
+
+This submissions has less than {journal.get_number_of_reviewers()} reviews and less than {journal.get_number_of_reviewers()} ACKs. 
+
+Task: {task}
+Submission: {submission.content['title']['value']}
+Number of days late: {days_late}
+Link: https://openreview.net/forum?id={submission.id}
+
+        ''',
+                replyTo=journal.contact_info, 
+                signature=journal.venue_id,
+                sender=journal.get_message_sender()
+            )      
+
+    

--- a/openreview/journal/process/reviewer_assignment_process.py
+++ b/openreview/journal/process/reviewer_assignment_process.py
@@ -86,7 +86,7 @@ def process_update(client, edge, invitation, existing_edge):
         if pending_review_edge:
             pending_review_edge.weight += 1
             client.post_edge(pending_review_edge)
-        else:
+        elif official_reviewer:
             client.post_edge(openreview.api.Edge(invitation = journal.get_reviewer_pending_review_id(),
                 signatures = [venue_id],
                 head = journal.get_reviewers_id(),

--- a/openreview/journal/process/submission_revision_process.py
+++ b/openreview/journal/process/submission_revision_process.py
@@ -7,6 +7,8 @@ def process(client, edit, invitation):
     paper_group_id=edit.invitation.split('/-/')[0]
     authors_group_id=f'{paper_group_id}/Authors'
 
+    journal.notify_readers(edit, content_fields=[])
+
     client.post_group_edit(
         invitation = journal.get_meta_invitation_id(),
         readers = [venue_id],

--- a/openreview/journal/webfield/actionEditorWebfield.js
+++ b/openreview/journal/webfield/actionEditorWebfield.js
@@ -385,6 +385,7 @@ var formatData = function(reviewersByNumber, invitations, submissions, invitatio
           noteId: submission.id,
           invitationId: Webfield2.utils.getInvitationId(VENUE_ID, submission.number, REVIEW_NAME, { submissionGroupName: SUBMISSION_GROUP_NAME })
         }),
+        paperNumber: number,
         anonymousGroupId: reviewer.anonymousGroupId
       };
     });

--- a/openreview/journal/webfield/archivedReviewersWebfield.js
+++ b/openreview/journal/webfield/archivedReviewersWebfield.js
@@ -1,0 +1,174 @@
+// webfield_template
+// Remove line above if you don't want this page to be overwriten
+
+// ------------------------------------
+// Author Console Webfield
+// ------------------------------------
+
+// Constants
+var VENUE_ID = '';
+var SHORT_PHRASE = '';
+var WEBSITE = '';
+var SUBMISSION_ID = '';
+var HEADER = {
+  title: SHORT_PHRASE + ' Reviewer Console',
+  instructions: 'Visit the <a href="https://' + WEBSITE + '" target="_blank" rel="nofollow"> ' + SHORT_PHRASE + ' website</a> for the reviewer guidelines.'
+};
+var REVIEWERS_NAME = '';
+var REVIEW_NAME = 'Review';
+var ACTION_EDITORS_NAME = '';
+var OFFICIAL_RECOMMENDATION_NAME = 'Official_Recommendation';
+var DECISION_NAME = 'Decision';
+var SUBMISSION_GROUP_NAME = 'Paper';
+var REVIEWERS_ID = VENUE_ID + '/' + REVIEWERS_NAME;
+var REVIEWERS_CUSTOM_MAX_PAPERS_NAME = 'Custom_Max_Papers';
+var REVIEWERS_AVAILABILITY_NAME = 'Assignment_Availability';
+var REVIEWERS_EXPERTISE_SELECTION_ID = REVIEWERS_ID + '/-/Expertise_Selection';
+var referrerUrl = encodeURIComponent('[Reviewer Console](/group?id=' + VENUE_ID + '/' + REVIEWERS_NAME + '#assigned-papers)');
+
+
+function main() {
+
+  Webfield2.ui.setup('#group-container', VENUE_ID, {
+    title: HEADER.title,
+    instructions: HEADER.instructions,
+    tabs: ['Assigned Papers', 'Reviewer Tasks'],
+    referrer: args && args.referrer
+  })
+
+  loadData()
+  .then(formatData)
+  .then(renderData)
+  .then(Webfield2.ui.done)
+  .fail(Webfield2.ui.errorMessage);
+}
+
+// Load makes all the API calls needed to get the data to render the page
+var loadData = function() {
+
+  return Webfield2.api.getGroupsByNumber(VENUE_ID, REVIEWERS_NAME, { assigned: true })
+  .then(function(assignedGroups) {
+    return $.when(
+      assignedGroups,
+      Webfield2.api.getGroupsByNumber(VENUE_ID, ACTION_EDITORS_NAME),
+      Webfield2.api.getAssignedInvitations(VENUE_ID, REVIEWERS_NAME, { numbers: Object.keys(assignedGroups), submissionGroupName: SUBMISSION_GROUP_NAME }),
+      Webfield2.api.getAllSubmissions(SUBMISSION_ID, { numbers: Object.keys(assignedGroups), domain: VENUE_ID})
+    );
+  })
+}
+
+var formatData = function(assignedGroups, actionEditorsByNumber, invitations, submissions) {
+
+  //build the rows
+  var rows = [];
+
+  submissions.forEach(function(submission) {
+
+    var number = submission.number;
+    var formattedSubmission = {
+      id: submission.id,
+      forum: submission.forum,
+      number: number,
+      cdate: submission.cdate,
+      mdate: submission.mdate,
+      tcdate: submission.tcdate,
+      tmdate: submission.tmdate,
+      showDates: true,
+      content: Object.keys(submission.content).reduce(function(content, currentValue) {
+        content[currentValue] = submission.content[currentValue].value;
+        return content;
+      }, {}),
+      referrerUrl: referrerUrl
+    };
+    var assignedReviewers = assignedGroups[number];
+    var assignedGroup = assignedReviewers.find(function(group) { return group.id ==  user.profile.id && group.anonId;  });
+    var reviewInvitationId = VENUE_ID + '/Paper' + number + '/-/' + REVIEW_NAME;
+    var review = assignedGroup ? submission.details.replies.find(function(reply) {
+      return reply.invitations.indexOf(reviewInvitationId) >= 0 && reply.signatures[0] == (VENUE_ID + '/' + SUBMISSION_GROUP_NAME + number + '/Reviewer_' + assignedGroup.anonId);
+    }) : null;
+    var recommendations = Webfield2.utils.getRepliesfromSubmission(VENUE_ID, submission, OFFICIAL_RECOMMENDATION_NAME, { submissionGroupName: SUBMISSION_GROUP_NAME });
+    var recommendationByReviewer = {};
+    recommendations.forEach(function(recommendation) {
+      recommendationByReviewer[recommendation.signatures[0]] = recommendation;
+    });
+    var decisions =  Webfield2.utils.getRepliesfromSubmission(VENUE_ID, submission, DECISION_NAME, { submissionGroupName: SUBMISSION_GROUP_NAME });
+    var decision = decisions.length && decisions[0];
+    var reviewInvitation = invitations.find(function(invitation) { return invitation.id == reviewInvitationId; })
+
+    rows.push({
+      submissionNumber: { number: number},
+      submission: formattedSubmission,
+      reviewStatus: {
+        invitationUrl: reviewInvitation && '/forum?id=' + submission.forum + '&noteId=' + submission.forum + '&invitationId=' + reviewInvitation.id + '&referrer=' + referrerUrl,
+        review: review,
+        recommendation: review ? recommendationByReviewer[review.signatures[0]] : null,
+        editUrl: review && ('/forum?id=' + submission.forum + '&noteId=' + review.id + '&referrer=' + referrerUrl)
+      },
+      actionEditorData: {
+        recommendation: decision && decision.content.recommendation.value,
+        url: decision ? ('/forum?id=' + submission.id + '&noteId=' + decision.id + '&referrer=' + referrerUrl) : null
+      }
+    })
+  })
+
+  return venueStatusData = {
+    invitations: invitations,
+    rows: rows
+  };
+
+}
+
+var renderData = function(venueStatusData) {
+
+  Webfield2.ui.renderTasks('#reviewer-tasks', venueStatusData.invitations, { referrer: encodeURIComponent('[Reviewer Console](/group?id=' + VENUE_ID + '/' + REVIEWERS_NAME + '#reviewer-tasks)') + '&t=' + Date.now()});
+
+  Webfield2.ui.renderTable('#assigned-papers', venueStatusData.rows, {
+    headings: ['#', 'Paper Summary', 'Your Review', 'Decision Status'],
+    renders: [
+      function(data) {
+        return '<strong class="note-number">' + data.number + '</strong>';
+      },
+      Handlebars.templates.noteSummary,
+      function(data) {
+        if (data.review) {
+          var recommendationHtml = '';
+          if (data.recommendation) {
+            recommendationHtml = '<h4>Recommendation:</h4>' +
+            '<p>' + (data.recommendation.content.decision_recommendation?.value  || 'Yes' )+ '</p>' +
+            '<h4>Certifications:</h4>' +
+            '<p>' + ((data.recommendation.content.certification_recommendations && data.recommendation.content.certification_recommendations.value.join(', ')) || '') + '</p>';
+          }
+          return '<div>' +
+          recommendationHtml +
+          '<p>' +
+            '<a href="' + data.editUrl + '" target="_blank">Read ' + REVIEW_NAME+ '</a>' +
+          '</p>' +
+          '</div>';
+        } else if (data.invitationUrl) {
+          return '<h4><a href="' + data.invitationUrl + '" target="_blank">Submit ' + REVIEW_NAME + '</a></h4>'
+        }
+        return '<div></div>'
+      },
+      function(data) {
+        if (data.recommendation) {
+          return '<div>' +
+          '<h4>Action Editor Decision:</h4>' +
+          '<p>' +
+            '<strong>' + data.recommendation + '</strong>' +
+          '</p>' +
+          '<p>' +
+            '<a href="' + data.url + '" target="_blank">Read</a>' +
+          '</p>' +
+          '</div>'
+        }
+        return '<div><h4><strong>No Recommendation</strong></h4></div>'
+      }
+    ],
+    extraClasses: 'console-table'
+  })
+
+}
+
+
+// Go!
+main();

--- a/tests/test_dmlr_journal.py
+++ b/tests/test_dmlr_journal.py
@@ -386,7 +386,7 @@ Please note that responding to this email will direct your reply to dmlr@jmlr.or
 
         note = andrew_client.get_note(note_id_1)
         assert note
-        assert note.invitations == ['DMLR/-/Submission', 'DMLR/-/Under_Review']
+        assert note.invitations == ['DMLR/-/Submission', 'DMLR/-/Edit', 'DMLR/-/Under_Review']
         assert note.readers == ['DMLR', 'DMLR/Action_Editors', 'DMLR/Paper1/Reviewers', 'DMLR/Paper1/Authors']
         assert note.writers == ['DMLR', 'DMLR/Paper1/Authors']
         assert note.signatures == ['DMLR/Paper1/Authors']
@@ -417,7 +417,7 @@ note={Under review}
         assert "DMLR/Paper1/-/Moderation" not in [i.id for i in invitations]
 
         edits = openreview_client.get_note_edits(note.id)
-        assert len(edits) == 2
+        assert len(edits) == 3
         for edit in edits:
             assert edit.readers == ['DMLR', 'DMLR/Action_Editors', 'DMLR/Paper1/Reviewers', 'DMLR/Paper1/Authors']
 
@@ -740,7 +740,7 @@ Please note that responding to this email will direct your reply to andrew@dmlrz
         assert note.forum == note_id_1
         assert note.replyto is None
         assert note.pdate
-        assert note.invitations == ['DMLR/-/Submission', 'DMLR/-/Under_Review', 'DMLR/-/Edit', 'DMLR/-/Accepted']
+        assert note.invitations == ['DMLR/-/Submission', 'DMLR/-/Edit', 'DMLR/-/Under_Review', 'DMLR/-/Accepted']
         assert note.readers == ['everyone']
         assert note.writers == ['DMLR']
         assert note.signatures == ['DMLR/Paper1/Authors']

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -4605,7 +4605,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         helpers.await_queue_edit(openreview_client, edit_id=under_review_note['id'])
 
-        edits = openreview_client.get_note_edits(note_id_11, sort='tmdate:desc')
+        edits = openreview_client.get_note_edits(note_id_11, sort='tcdate:desc')
         assert len(edits) == 3
         assert edits[0].invitation == 'TMLR/-/Under_Review'
         helpers.await_queue_edit(openreview_client, edit_id=edits[0].id)

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1601,7 +1601,7 @@ The TMLR Editors-in-Chief
 Please note that responding to this email will direct your reply to tmlr@jmlr.org.
 '''        
 
-        messages = journal.client.get_messages(subject = '[TMLR] Less than 3 ACKs for the paper 1: Paper title UPDATED')
+        messages = journal.client.get_messages(subject = '[TMLR] Fewer than 3 ACKs for the paper 1: Paper title UPDATED')
         assert len(messages) == 2
 
         ## Check review reminders

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -652,6 +652,10 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         ae_group = raia_client.get_group(f'{venue_id}/Paper1/Action_Editors')
         assert ae_group.members == ['~Joelle_Pineau1']
 
+        note = joelle_client.get_note(note_id_1)
+        assert note
+        assert note.content['assigned_action_editor']['value'] == '~Joelle_Pineau1'        
+
         messages = journal.client.get_messages(to = 'joelle@mailseven.com', subject = '[TMLR] Assignment to new TMLR submission 1: Paper title UPDATED')
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi Joelle Pineau,
@@ -721,7 +725,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         note = joelle_client.get_note(note_id_1)
         assert note
         assert note.odate
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Under_Review']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Edit', 'TMLR/-/Under_Review']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper1/Authors']
         assert note.signatures == ['TMLR/Paper1/Authors']
@@ -905,7 +909,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         note = joelle_client.get_note(note_id_2)
         assert note
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Desk_Rejected']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Edit', 'TMLR/-/Desk_Rejected']
         assert note.readers == ['TMLR', 'TMLR/Paper2/Action_Editors', 'TMLR/Paper2/Authors']
         assert note.writers == ['TMLR', 'TMLR/Paper2/Action_Editors']
         assert note.signatures == ['TMLR/Paper2/Authors']
@@ -2429,7 +2433,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert note
         assert note.forum == note_id_1
         assert note.replyto is None
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Under_Review', 'TMLR/-/Edit', 'TMLR/Paper1/-/Camera_Ready_Revision']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Edit', 'TMLR/-/Under_Review', 'TMLR/Paper1/-/Camera_Ready_Revision']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper1/Authors']
         assert note.signatures == ['TMLR/Paper1/Authors']
@@ -2551,7 +2555,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert note.forum == note_id_1
         assert note.replyto is None
         assert note.pdate
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Under_Review', 'TMLR/-/Edit', 'TMLR/Paper1/-/Camera_Ready_Revision', 'TMLR/-/Accepted']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Edit', 'TMLR/-/Under_Review', 'TMLR/Paper1/-/Camera_Ready_Revision', 'TMLR/-/Accepted']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR']
         assert note.signatures == ['TMLR/Paper1/Authors']
@@ -2614,7 +2618,7 @@ note={Featured Certification, Reproducibility Certification, Expert Certificatio
         assert note
         assert note.forum == note_id_1
         assert note.replyto is None
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Under_Review', 'TMLR/-/Edit', 'TMLR/Paper1/-/Camera_Ready_Revision', 'TMLR/-/Accepted', 'TMLR/Paper1/-/EIC_Revision']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Edit', 'TMLR/-/Under_Review', 'TMLR/Paper1/-/Camera_Ready_Revision', 'TMLR/-/Accepted', 'TMLR/Paper1/-/EIC_Revision']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR']
         assert note.signatures == ['TMLR/Paper1/Authors']
@@ -2699,7 +2703,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert note
         assert note.forum == note_id_1
         assert note.replyto is None
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Under_Review', 'TMLR/-/Edit', 'TMLR/Paper1/-/Camera_Ready_Revision', 'TMLR/-/Accepted', 'TMLR/Paper1/-/EIC_Revision', 'TMLR/-/Retracted']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/Paper1/-/Revision', 'TMLR/-/Edit', 'TMLR/-/Under_Review', 'TMLR/Paper1/-/Camera_Ready_Revision', 'TMLR/-/Accepted', 'TMLR/Paper1/-/EIC_Revision', 'TMLR/-/Retracted']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR']
         assert note.signatures == ['TMLR/Paper1/Authors']
@@ -3259,7 +3263,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert note
         assert note.forum == note_id_4
         assert note.replyto is None
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Under_Review', 'TMLR/-/Edit', 'TMLR/-/Rejected']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Edit', 'TMLR/-/Under_Review', 'TMLR/-/Rejected']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper4/Authors']
         assert note.signatures == ['TMLR/Paper4/Authors']
@@ -3291,7 +3295,7 @@ note={Rejected}
         assert note
         assert note.forum == note_id_4
         assert note.replyto is None
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Under_Review', 'TMLR/-/Edit', 'TMLR/-/Rejected', 'TMLR/-/Authors_Release']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Edit', 'TMLR/-/Under_Review', 'TMLR/-/Rejected', 'TMLR/-/Authors_Release']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper4/Authors']
         assert note.signatures == ['TMLR/Paper4/Authors']
@@ -3951,7 +3955,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         note = test_client.get_note(note_id_6)
         assert note
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Under_Review', 'TMLR/-/Withdrawn']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Edit', 'TMLR/-/Under_Review', 'TMLR/-/Withdrawn']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper6/Authors']
         assert note.signatures == ['TMLR/Paper6/Authors']
@@ -3990,7 +3994,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert note
         assert note.forum == note_id_6
         assert note.replyto is None
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Under_Review', 'TMLR/-/Withdrawn', 'TMLR/-/Authors_Release']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Edit', 'TMLR/-/Under_Review', 'TMLR/-/Withdrawn', 'TMLR/-/Authors_Release']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper6/Authors']
         assert note.signatures == ['TMLR/Paper6/Authors']
@@ -4578,8 +4582,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         helpers.await_queue_edit(openreview_client, edit_id=under_review_note['id'])
 
-        edits = openreview_client.get_note_edits(note_id_11)
-        assert len(edits) == 2
+        edits = openreview_client.get_note_edits(note_id_11, sort='tmdate:desc')
+        assert len(edits) == 3
         assert edits[0].invitation == 'TMLR/-/Under_Review'
         helpers.await_queue_edit(openreview_client, edit_id=edits[0].id)
               
@@ -4668,7 +4672,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         note = joelle_client.get_note(note_id_12)
         assert note
         assert note.odate
-        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Under_Review']
+        assert note.invitations == ['TMLR/-/Submission', 'TMLR/-/Edit', 'TMLR/-/Under_Review']
         assert note.readers == ['everyone']
         assert note.writers == ['TMLR', 'TMLR/Paper12/Authors']
         assert note.signatures == ['TMLR/Paper12/Authors']

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -541,6 +541,9 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             ))
         helpers.await_queue_edit(openreview_client, edit_id=updated_submission_note_1['id'])
 
+        messages = openreview_client.get_messages(subject='[TMLR] Revision posted on submission 1: Paper title UPDATED')
+        assert len(messages) == 3
+
         note = openreview_client.get_note(note_id_1)
         assert note
         assert note.number == 1
@@ -804,6 +807,9 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         note = openreview_client.get_note(note_id_1)
         assert note
         assert note.number == 1
+
+        messages = openreview_client.get_messages(subject='[TMLR] Revision posted on submission 1: Paper title UPDATED')
+        assert len(messages) == 7        
 
         ## Check active invitations
         invitations = joelle_client.get_invitations(replyForum=note_id_1)
@@ -1932,7 +1938,24 @@ The TMLR Editors-in-Chief
 
 Please note that responding to this email will direct your reply to tmlr@jmlr.org.
 '''
+        
+        ## Update submission 1 again
+        updated_submission_note_1 = test_client.post_note_edit(invitation='TMLR/Paper1/-/Revision',
+            signatures=['TMLR/Paper1/Authors'],
+            note=Note(
+                content={
+                    'title': { 'value': 'Paper title UPDATED' },
+                    'supplementary_material': { 'value': '/attachment/' + 'z' * 40 +'.zip'},
+                    'competing_interests': { 'value': 'None beyond the authors normal conflict of interests VERSION 3'},
+                    'human_subjects_reporting': { 'value': 'Not applicable'},
+                    'pdf': { 'value': '/pdf/22234qweoiuweroi22234qweoiuweroi12345678.pdf' },
+                    'submission_length': { 'value': 'Regular submission (no more than 12 pages of main content)'}
+                }
+            ))
+        helpers.await_queue_edit(openreview_client, edit_id=updated_submission_note_1['id'])
 
+        messages = openreview_client.get_messages(subject='[TMLR] Revision posted on submission 1: Paper title UPDATED')
+        assert len(messages) == 15        
 
         ## Edit a review and don't release the review again
         review_note = david_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Review',

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1601,6 +1601,8 @@ The TMLR Editors-in-Chief
 Please note that responding to this email will direct your reply to tmlr@jmlr.org.
 '''        
 
+        helpers.await_queue_edit(openreview_client, 'TMLR/Paper1/-/Review-1-0')
+        
         messages = journal.client.get_messages(subject = '[TMLR] Fewer than 3 ACKs for the paper 1: Paper title UPDATED')
         assert len(messages) == 2
 

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1601,6 +1601,8 @@ The TMLR Editors-in-Chief
 Please note that responding to this email will direct your reply to tmlr@jmlr.org.
 '''        
 
+        messages = journal.client.get_messages(subject = '[TMLR] Less than 3 ACKs for the paper 1: Paper title UPDATED')
+        assert len(messages) == 2
 
         ## Check review reminders
         raia_client.post_invitation_edit(
@@ -3128,12 +3130,12 @@ Please note that responding to this email will direct your reply to joelle@mails
 
         ## Check pending review edges
         edges = joelle_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews')
-        assert edges == 6
+        assert edges == 5
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Carlos_Mondragon1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Javier_Burroni1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Hugo_Larochelle1')[0].weight == 1
-        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Peter_Snow1')[0].weight == 1
+        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Antony_Bal1')[0].weight == 0
 
         invitation = raia_client.get_invitation(f'{venue_id}/Paper4/-/Official_Recommendation')
         #assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
@@ -3354,13 +3356,12 @@ note={Rejected}
 
         ## Check pending review edges
         edges_count = joelle_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews')
-        assert edges_count == 6
+        assert edges_count == 5
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Carlos_Mondragon1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Javier_Burroni1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Antony_Bal1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Hugo_Larochelle1')[0].weight == 0
-        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Peter_Snow1')[0].weight == 0
 
     def test_eic_submission(self, journal, openreview_client, test_client, helpers):
 
@@ -4310,36 +4311,36 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         ## Check pending review edges
         edges = joelle_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews')
-        assert edges == 6
+        assert edges == 5
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Carlos_Mondragon1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Javier_Burroni1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1')[0].weight == 2
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Hugo_Larochelle1')[0].weight == 0
-        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Peter_Snow1')[0].weight == 2
+        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Antony_Bal1')[0].weight == 0
 
         note = openreview_client.get_note(note_id_7)
         journal.invitation_builder.expire_paper_invitations(note)
 
         ## Check pending review edges
         edges = joelle_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews')
-        assert edges == 6
+        assert edges == 5
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Carlos_Mondragon1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Javier_Burroni1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1')[0].weight == 1
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Hugo_Larochelle1')[0].weight == 0
-        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Peter_Snow1')[0].weight == 1
+        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Antony_Bal1')[0].weight == 0
 
         note = openreview_client.get_note(note_id_8)
         journal.invitation_builder.expire_paper_invitations(note)
 
         ## Check pending review edges
         edges = joelle_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews')
-        assert edges == 6
+        assert edges == 5
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Carlos_Mondragon1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Javier_Burroni1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Hugo_Larochelle1')[0].weight == 0
-        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Peter_Snow1')[0].weight == 0
+        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Antony_Bal1')[0].weight == 0
 
         # Assign another Action Editor and the submission should be updated
         current_assignment = raia_client.get_edges(invitation='TMLR/Action_Editors/-/Assignment', head=note_id_8)[0]
@@ -4519,12 +4520,12 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         ## Check pending review edges
         edges = joelle_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews')
-        assert edges == 6
+        assert edges == 5
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Carlos_Mondragon1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Javier_Burroni1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1')[0].weight == 1
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Hugo_Larochelle1')[0].weight == 0
-        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Peter_Snow1')[0].weight == 0
+        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Antony_Bal1')[0].weight == 0
 
 
         note = openreview_client.get_note(note_id_10)
@@ -4532,12 +4533,12 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         ## Check pending review edges
         edges = joelle_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews')
-        assert edges == 6
+        assert edges == 5
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Carlos_Mondragon1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Javier_Burroni1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1')[0].weight == 0
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Hugo_Larochelle1')[0].weight == 0
-        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Peter_Snow1')[0].weight == 0
+        assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Antony_Bal1')[0].weight == 0
 
 
     def test_submission_with_many_authors(self, journal, openreview_client, test_client, helpers):
@@ -4843,8 +4844,27 @@ note={Under review}
             tail='~David_Belanger1',
             label='Unavailable'
         ))        
-        raia_client.remove_members_from_group(raia_client.get_group('TMLR/Reviewers'), '~David_Belanger1')
-        raia_client.add_members_to_group(raia_client.get_group('TMLR/Reviewers/Archived'), '~David_Belanger1')
+        #raia_client.remove_members_from_group(raia_client.get_group('TMLR/Reviewers'), '~David_Belanger1')
+        #raia_client.add_members_to_group(raia_client.get_group('TMLR/Reviewers/Archived'), '~David_Belanger1')
+
+        edit_group = raia_client.post_group_edit(
+            invitation='TMLR/Reviewers/Archived/-/Member',
+            signatures=['TMLR'],
+            group=openreview.api.Group(
+                members={
+                    'append': ['~David_Belanger1']
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=edit_group['id'])        
+
+        assert '~David_Belanger1' in openreview_client.get_group('TMLR/Reviewers/Archived').members
+        assert '~David_Belanger1' not in openreview_client.get_group('TMLR/Reviewers').members
+        assert openreview_client.get_edges_count(invitation='TMLR/Reviewers/-/Assignment_Availability', tail='~David_Belanger1') == 0
+        assert openreview_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1') == 0
+        assert openreview_client.get_edges_count(invitation='TMLR/Reviewers/-/Custom_Max_Papers', tail='~David_Belanger1') == 0
+
 
         ## Carlos Mondragon
         paper_assignment_edge = joelle_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Assignment',
@@ -4891,6 +4911,8 @@ note={Under review}
         )
 
         helpers.await_queue_edit(openreview_client, edit_id=david_review_note['id'])
+
+        assert openreview_client.get_edges_count(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~David_Belanger1') == 0
 
         carlos_anon_groups=carlos_client.get_groups(prefix=f'{venue_id}/Paper13/Reviewer_.*', signatory='~Carlos_Mondragon1')
         assert len(carlos_anon_groups) == 1

--- a/tests/test_melba_journal.py
+++ b/tests/test_melba_journal.py
@@ -270,7 +270,7 @@ Please note that responding to this email will direct your reply to editors@melb
 
         note = aasa_client.get_note(note_id_1)
         assert note
-        assert note.invitations == ['MELBA/-/Submission', 'MELBA/-/Under_Review']
+        assert note.invitations == ['MELBA/-/Submission', 'MELBA/-/Edit', 'MELBA/-/Under_Review']
 
         edits = openreview_client.get_note_edits(note.id, invitation='MELBA/-/Under_Review')
         helpers.await_queue_edit(openreview_client, edit_id=edits[0].id)        

--- a/tests/test_tacl_journal.py
+++ b/tests/test_tacl_journal.py
@@ -209,7 +209,7 @@ Please note that responding to this email will direct your reply to tacl@venue.o
 
         note = graham_client.get_note(note_id_1)
         assert note
-        assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Under_Review']
+        assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Edit', 'TACL/-/Under_Review']
         assert note.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert note.writers == ['TACL', 'TACL/Paper1/Authors']
         assert note.signatures == ['TACL/Paper1/Authors']
@@ -240,7 +240,7 @@ note={Under review}
         assert "TACL/Paper1/-/Moderation" not in [i.id for i in invitations]
 
         edits = openreview_client.get_note_edits(note.id)
-        assert len(edits) == 3
+        assert len(edits) == 4
         for edit in edits:
             assert edit.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
 
@@ -605,7 +605,7 @@ Please note that responding to this email will direct your reply to graham@mails
         assert note
         assert note.forum == note_id_1
         assert note.replyto is None
-        assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Under_Review', 'TACL/-/Edit', 'TACL/Paper1/-/Camera_Ready_Revision']
+        assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Edit', 'TACL/-/Under_Review', 'TACL/Paper1/-/Camera_Ready_Revision']
         assert note.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert note.writers == ['TACL', 'TACL/Paper1/Authors']
         assert note.signatures == ['TACL/Paper1/Authors']
@@ -636,7 +636,7 @@ Please note that responding to this email will direct your reply to graham@mails
         assert note
         assert note.forum == note_id_1
         assert note.replyto is None
-        assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Under_Review', 'TACL/-/Edit', 'TACL/Paper1/-/Camera_Ready_Revision', 'TACL/-/Accepted']
+        assert note.invitations == ['TACL/-/Submission', 'TACL/Paper1/-/Revision', 'TACL/-/Edit', 'TACL/-/Under_Review', 'TACL/Paper1/-/Camera_Ready_Revision', 'TACL/-/Accepted']
         assert note.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
         assert note.writers == ['TACL']
         assert note.signatures == ['TACL/Paper1/Authors']
@@ -660,7 +660,7 @@ note={Featured Certification, Reproducibility Certification}
 }'''
 
         edits = openreview_client.get_note_edits(note.id)
-        assert len(edits) == 6
+        assert len(edits) == 7
         for edit in edits:
             assert edit.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper1/Reviewers', 'TACL/Paper1/Authors']
 
@@ -728,7 +728,7 @@ note={Featured Certification, Reproducibility Certification}
 
         note = test_client.get_note(note_id_2)
         assert note
-        assert note.invitations == ['TACL/-/Submission', 'TACL/-/Under_Review', 'TACL/-/Withdrawn']
+        assert note.invitations == ['TACL/-/Submission', 'TACL/-/Edit', 'TACL/-/Under_Review', 'TACL/-/Withdrawn']
         assert note.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper2/Reviewers', 'TACL/Paper2/Authors']
         assert note.writers == ['TACL', 'TACL/Paper2/Authors']
         assert note.signatures == ['TACL/Paper2/Authors']
@@ -748,7 +748,7 @@ note={Withdrawn}
         helpers.await_queue_edit(openreview_client, invitation='TACL/-/Withdrawn')
 
         edits = openreview_client.get_note_edits(note.id)
-        assert len(edits) == 3
+        assert len(edits) == 4
         for edit in edits:
             assert edit.readers == ['TACL', 'TACL/Action_Editors', 'TACL/Paper2/Reviewers', 'TACL/Paper2/Authors']
 


### PR DESCRIPTION
- pass paper number so reminders can be sent
- customize reviewers archived console so they can not change the quota, availability or expertise
- use a group invitation to add members to the archive group so edges are deleted: assignment availability, pending reviews and custom max papers
- compute pending review count for official reviewers only
- send reminders to the EICs when a paper is late 2 weeks and it has less than 3 reviews and less than 3 ACKs.
- show assigned AE as soon as the AE is assigned and don't wait until the paper is under review
- notify the AE and reviewers when a new paper revision is posted

it depends on https://github.com/openreview/openreview-web/pull/1999