### PR TITLE
Fix/ Review Revision: add replysignatures as invitation signature

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2682,6 +2682,7 @@ class InvitationBuilder(object):
         custom_stage_source = custom_stage.get_source_submissions()
         custom_stage_reply_type = custom_stage.get_reply_type()
         note_writers = None
+        all_signatures = custom_stage.get_signatures(self.venue, '${7/content/noteNumber/value}')
 
         if custom_stage_reply_type == 'reply':
             paper_invitation_id = self.venue.get_invitation_id(name=custom_stage.name, number='${2/content/noteNumber/value}')
@@ -2732,9 +2733,10 @@ class InvitationBuilder(object):
                 reply_to = None
                 edit_readers = [venue_id, '${2/signatures}']
                 note_readers = None
-                invitees = ['${3/content/replytoSignatures/value}']
+                invitees = [venue_id, '${3/content/replytoSignatures/value}']
                 noninvitees = []
                 note_nonreaders = []
+                all_signatures = ['${7/content/replytoSignatures/value}']
 
         invitation_content = {
             'source': { 'value': custom_stage_source },
@@ -2800,7 +2802,7 @@ class InvitationBuilder(object):
                     'edit': {
                         'signatures': {
                             'param': {
-                                'items': [ { 'prefix': s, 'optional': True } if '.*' in s else { 'value': s, 'optional': True } for s in custom_stage.get_signatures(self.venue, '${7/content/noteNumber/value}')]
+                                'items': [ { 'prefix': s, 'optional': True } if '.*' in s else { 'value': s, 'optional': True } for s in all_signatures]
                             }
                         },
                         'readers': edit_readers,

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -1884,8 +1884,15 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         anon_group_id = anon_groups[0].id
 
         invitation = openreview_client.get_invitation('V2.cc/2030/Conference/Submission1/Official_Review1/-/Review_Revision')
-        assert invitation and anon_group_id in invitation.invitees
+        assert invitation and invitation.invitees == ['V2.cc/2030/Conference', anon_group_id]
         assert 'readers' in invitation.edit['note']['content']['final_review_rating']
+        assert invitation.edit['signatures']['param']['items'][0] == {
+            'value': anon_group_id,
+            'optional': True
+        }
+
+        helpers.create_user('tom_venue@mail.com', 'ProgramChair', 'Venue')
+        pc_client = openreview.api.OpenReviewClient(username='tom_venue@mail.com', password=helpers.strong_password)
 
         review = reviewer_client.get_notes(invitation='V2.cc/2030/Conference/Submission1/-/Official_Review', sort='number:asc')[0]
         assert review.readers == ['V2.cc/2030/Conference/Program_Chairs',
@@ -1898,7 +1905,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert invitation.edit['note']['forum'] == review.forum
         assert invitation.edit['note']['id'] == review.id
 
-        review_revision = reviewer_client.post_note_edit(
+        review_revision = pc_client.post_note_edit(
             invitation='V2.cc/2030/Conference/Submission1/Official_Review1/-/Review_Revision',
             signatures=[anon_group_id],
             note=Note(
@@ -2562,7 +2569,6 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert submissions and len(submissions) == 3
         submission = submissions[0]
 
-        helpers.create_user('tom_venue@mail.com', 'ProgramChair', 'Venue')
         pc_client = openreview.api.OpenReviewClient(username='tom_venue@mail.com', password=helpers.strong_password)
 
         # Assert that PC does not have access to the Decision invitation


### PR DESCRIPTION
Fixes #2150

- Adds venue id as invitee of review revision invitations
- Adds the replySignatures as the signatures, so PCs should sign with the anonid instead of with the PC group