### PR TITLE
Fix/retries and await

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -16,7 +16,7 @@ import os
 import re
 import time
 import jwt
-import traceback
+import json
 from ..openreview import Profile
 from ..openreview import OpenReviewException
 from .. import tools
@@ -31,7 +31,7 @@ class LogRetry(Retry):
         response_string = 'no response'
         if response:
             if 'application/json' in response.headers.get('Content-Type'):
-                response_string = response.json()
+                response_string = json.loads(response.data.decode('utf-8'))
             elif response.data:
                 response_string = response.data
             else:
@@ -1681,7 +1681,7 @@ class OpenReviewClient(object):
             delete_query['tail'] = tail
         if id: 
             delete_query['id'] = id
-            
+
         delete_query['waitToFinish'] = wait_to_finish
         delete_query['softDelete'] = soft_delete
 

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -102,7 +102,7 @@ class OpenReviewClient(object):
             'Accept': 'application/json'
         }
 
-        retry_strategy = LogRetry(total=3, backoff_factor=1, status_forcelist=[ 500, 502, 503, 504 ], respect_retry_after_header=False)
+        retry_strategy = LogRetry(total=3, backoff_factor=1, status_forcelist=[ 500, 502, 503, 504 ], respect_retry_after_header=True)
         self.session = requests.Session()
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount('https://', adapter)

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -56,10 +56,10 @@ class OpenReviewClient(object):
     :type expiresIn: number, optional
     """
     def __init__(self, baseurl = None, username = None, password = None, token= None, tokenExpiresIn=None):
-
-        self.baseurl = baseurl
-        if not self.baseurl:
-           self.baseurl = os.environ.get('OPENREVIEW_BASEURL', 'http://localhost:3001')
+        self.baseurl = baseurl if baseurl is not None else os.environ.get('OPENREVIEW_BASEURL', 'http://localhost:3001')
+        if 'https://api.openreview.net' in self.baseurl or 'https://devapi.openreview.net' in self.baseurl:
+            correct_baseurl = self.baseurl.replace('api', 'api2')
+            raise OpenReviewException(f'Please use "{correct_baseurl}" as the baseurl for the OpenReview API or use the old client openreview.Client')
         self.groups_url = self.baseurl + '/groups'
         self.login_url = self.baseurl + '/login'
         self.register_url = self.baseurl + '/register'

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -32,8 +32,8 @@ class LogRetry(Retry):
         if response:
             if 'application/json' in response.headers.get('Content-Type'):
                 response_string = response.json()
-            if response.text:
-                response_string = response.text
+            elif response.data:
+                response_string = response.data
             else:
                 response_string = response.reason
         print(f"Retrying request: {method} {url}, response: {response_string}, error: {error}")

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -45,10 +45,10 @@ class Client(object):
     :type expiresIn: number, optional
     """
     def __init__(self, baseurl = None, username = None, password = None, token= None, tokenExpiresIn=None):
-
-        self.baseurl = baseurl
-        if not self.baseurl:
-           self.baseurl = os.environ.get('OPENREVIEW_BASEURL', 'http://localhost:3000')
+        self.baseurl = baseurl if baseurl is not None else os.environ.get('OPENREVIEW_BASEURL', 'http://localhost:3000')
+        if 'https://api2.openreview.net' in self.baseurl or 'https://devapi2.openreview.net' in self.baseurl:
+            correct_baseurl = self.baseurl.replace('api2', 'api')
+            raise OpenReviewException(f'Please use "{correct_baseurl}" as the baseurl for the OpenReview API or use the new client openreview.api.OpenReviewClient')
         self.groups_url = self.baseurl + '/groups'
         self.login_url = self.baseurl + '/login'
         self.register_url = self.baseurl + '/register'

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -89,7 +89,7 @@ class Client(object):
             'Accept': 'application/json',
         }
 
-        retry_strategy = LogRetry(total=3, backoff_factor=0.1, status_forcelist=[ 500, 502, 503, 504 ], respect_retry_after_header=False)
+        retry_strategy = LogRetry(total=3, backoff_factor=0.1, status_forcelist=[ 500, 502, 503, 504 ], respect_retry_after_header=True)
         self.session = requests.Session()
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount('https://', adapter)

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -29,38 +29,6 @@ class TestEdges:
             )
         )
 
-        # builder.set_conference_id('NIPS.cc/2020/Workshop/MLITS')
-        # builder.set_submission_stage(public=True)
-        # conference = builder.get_result()
-
-        # # Edge invitation
-        # inv1 = openreview.Invitation(id=conference.id + '/-/affinity', signatures=['~Super_User1'], reply={
-        #     'readers': {
-        #         'values': ['everyone']
-        #     },
-        #     'writers': {
-        #         'values': [conference.id]
-        #     },
-        #     'signatures': {
-        #         'values': ['~Super_User1']
-        #     },
-        #     'content': {
-        #         'head': {
-        #             'type': 'Note'
-        #         },
-        #         'tail': {
-        #             'type': 'Profile',
-        #         },
-        #         'label': {
-        #             'value-radio': ['Very High', 'High', 'Neutral', 'Low', 'Very Low']
-        #         },
-        #         'weight': {
-        #             'value-regex': r'[0-9]+\.[0-9]'
-        #         }
-        #     }
-        # })
-        # inv1 = client.post_invitation(inv1)
-
         note_edit = openreview_client.post_note_edit(
             'openreview.net/-/Edit',
             ['~Super_User1'],
@@ -81,21 +49,6 @@ class TestEdges:
         )
 
         note_id = note_edit['note']['id']
-
-        # Sample note
-        # note = openreview.Note(invitation = conference.get_submission_id(),
-        #     readers = [conference.id],
-        #     writers = [conference.id],
-        #     signatures = ['~SomeFirstName_User1'],
-        #     content = {
-        #         'title': 'Paper title',
-        #         'abstract': 'This is an abstract',
-        #         'authorids': ['test@mail.com'],
-        #         'authors': ['SomeFirstName User'],
-        #         'pdf': '/pdf/22234qweoiuweroi22234qweoiuweroi12345678.pdf'
-        #     }
-        # )
-        # note = test_client.post_note(note)
 
         # Edges
         edges = []
@@ -154,7 +107,4 @@ class TestEdges:
 
         openreview_client.delete_edges(invitation='openreview.net/-/Affinity', wait_to_finish=True)
         edges_count_after = openreview_client.get_edges_count(invitation='openreview.net/-/Affinity')
-        assert edges_count_after == 0
-    
-    
-        
+        assert edges_count_after == 0    

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -1,117 +1,159 @@
 import openreview
+import openreview.api
 import openreview.tools
 import time
 
 class TestEdges:
 
-    def test_save_bulk (self, client, test_client):
-        builder = openreview.conference.ConferenceBuilder(client, support_user='openreview.net/Support')
-        assert builder, 'builder is None'
-
-        builder.set_conference_id('NIPS.cc/2020/Workshop/MLITS')
-        builder.set_submission_stage(public=True)
-        conference = builder.get_result()
-
-        # Edge invitation
-        inv1 = openreview.Invitation(id=conference.id + '/-/affinity', signatures=['~Super_User1'], reply={
-            'readers': {
-                'values': ['everyone']
-            },
-            'writers': {
-                'values': [conference.id]
-            },
-            'signatures': {
-                'values': ['~Super_User1']
-            },
-            'content': {
-                'head': {
-                    'type': 'Note'
-                },
-                'tail': {
-                    'type': 'Profile',
-                },
-                'label': {
-                    'value-radio': ['Very High', 'High', 'Neutral', 'Low', 'Very Low']
-                },
-                'weight': {
-                    'value-regex': r'[0-9]+\.[0-9]'
+    def test_save_bulk (self, openreview_client, test_client):
+        openreview_client.post_invitation_edit(
+            'openreview.net/-/Edit',
+            readers=['everyone'],
+            writers=['~Super_User1'],
+            signatures=['~Super_User1'],
+            invitation=openreview.api.Invitation(
+                id='openreview.net/-/Affinity',
+                writers=['~Super_User1'],
+                signatures=['~Super_User1'],
+                invitees=['~Super_User1'],
+                readers=['everyone'],
+                edge={
+                    'signatures': { 'param': { 'regex': '.*' } },
+                    'readers': { 'param': { 'regex': '.*' } },
+                    'writers': { 'param': { 'regex': '.*' } },
+                    'head': { 'param': { 'type': 'note' } },
+                    'tail': { 'param': { 'type': 'profile' } },
+                    'label': { 'param': { 'enum': ['Very High', 'High', 'Neutral', 'Low', 'Very Low'] } },
+                    'weight': { 'param': { 'enum': [5, 10] } }
                 }
-            }
-        })
-        inv1 = client.post_invitation(inv1)
+            )
+        )
+
+        # builder.set_conference_id('NIPS.cc/2020/Workshop/MLITS')
+        # builder.set_submission_stage(public=True)
+        # conference = builder.get_result()
+
+        # # Edge invitation
+        # inv1 = openreview.Invitation(id=conference.id + '/-/affinity', signatures=['~Super_User1'], reply={
+        #     'readers': {
+        #         'values': ['everyone']
+        #     },
+        #     'writers': {
+        #         'values': [conference.id]
+        #     },
+        #     'signatures': {
+        #         'values': ['~Super_User1']
+        #     },
+        #     'content': {
+        #         'head': {
+        #             'type': 'Note'
+        #         },
+        #         'tail': {
+        #             'type': 'Profile',
+        #         },
+        #         'label': {
+        #             'value-radio': ['Very High', 'High', 'Neutral', 'Low', 'Very Low']
+        #         },
+        #         'weight': {
+        #             'value-regex': r'[0-9]+\.[0-9]'
+        #         }
+        #     }
+        # })
+        # inv1 = client.post_invitation(inv1)
+
+        note_edit = openreview_client.post_note_edit(
+            'openreview.net/-/Edit',
+            ['~Super_User1'],
+            readers=['everyone'],
+            writers=['~Super_User1'],
+            note=openreview.api.Note(
+                readers=['everyone'],
+                writers=['~Super_User1'],
+                signatures=['~Super_User1'],
+                content={
+                    'title': { 'value': 'Paper title' },
+                    'abstract': { 'value': 'This is an abstract' },
+                    'authorids': { 'value': ['test@mail.com'] },
+                    'authors': { 'value': ['SomeFirstName User'] },
+                    'pdf': { 'value': '/pdf/22234qweoiuweroi22234qweoiuweroi12345678.pdf' },
+                }
+            )
+        )
+
+        note_id = note_edit['note']['id']
 
         # Sample note
-        note = openreview.Note(invitation = conference.get_submission_id(),
-            readers = [conference.id],
-            writers = [conference.id],
-            signatures = ['~SomeFirstName_User1'],
-            content = {
-                'title': 'Paper title',
-                'abstract': 'This is an abstract',
-                'authorids': ['test@mail.com'],
-                'authors': ['SomeFirstName User'],
-                'pdf': '/pdf/22234qweoiuweroi22234qweoiuweroi12345678.pdf'
-            }
-        )
-        note = test_client.post_note(note)
+        # note = openreview.Note(invitation = conference.get_submission_id(),
+        #     readers = [conference.id],
+        #     writers = [conference.id],
+        #     signatures = ['~SomeFirstName_User1'],
+        #     content = {
+        #         'title': 'Paper title',
+        #         'abstract': 'This is an abstract',
+        #         'authorids': ['test@mail.com'],
+        #         'authors': ['SomeFirstName User'],
+        #         'pdf': '/pdf/22234qweoiuweroi22234qweoiuweroi12345678.pdf'
+        #     }
+        # )
+        # note = test_client.post_note(note)
 
         # Edges
         edges = []
         for _ in range(1000):
-            edge1 = openreview.Edge(head=note.id, tail='~Super_User1', label='High', weight='0.5',
-                invitation=inv1.id, readers=['everyone'], writers=[conference.id],
+            edge1 = openreview.Edge(head=note_id, tail='~Super_User1', label='High', weight=5,
+                invitation='openreview.net/-/Affinity', readers=['everyone'], writers=['~Super_User1'],
                 signatures=['~Super_User1'])
 
-            edge2 = openreview.Edge(head=note.id, tail='~Super_User1', label='Very High', weight='1.0',
-                invitation=inv1.id, readers=['everyone'], writers=[conference.id],
+            edge2 = openreview.Edge(head=note_id, tail='~Super_User1', label='Very High', weight=10,
+                invitation='openreview.net/-/Affinity', readers=['everyone'], writers=['~Super_User1'],
                 signatures=['~Super_User1'])
 
             edges.extend([edge1, edge2])
 
-        openreview.tools.post_bulk_edges(client, edges)
-        posted_edges = list(openreview.tools.iterget_edges(client, invitation=inv1.id, tail='~Super_User1'))
+        openreview.tools.post_bulk_edges(openreview_client, edges)
+        posted_edges = list(openreview.tools.iterget_edges(openreview_client, invitation='openreview.net/-/Affinity', tail='~Super_User1'))
         assert len(edges) == len(posted_edges)
     
-    def test_rename_edges(self, client, helpers):
-        guest = openreview.Client()
+    def test_rename_edges(self, client, openreview_client, helpers):
+        guest = openreview.api.OpenReviewClient()
         to_profile = guest.register_user(email = 'nadia@mail.com', fullname = 'Nadia L', password = helpers.strong_password)
         assert to_profile
         assert to_profile['id'] == '~Nadia_L1'
-        super_user_edges = list(openreview.tools.iterget_edges(client, tail="~Super_User1"))
-        client.rename_edges('~Super_User1', '~Nadia_L1')
-        nadias_edges = list(openreview.tools.iterget_edges(client, tail="~Nadia_L1"))
+        super_user_edges = list(openreview.tools.iterget_edges(openreview_client, tail="~Super_User1"))
+        openreview_client.rename_edges('~Super_User1', '~Nadia_L1')
+        nadias_edges = list(openreview.tools.iterget_edges(openreview_client, tail="~Nadia_L1"))
         super_edges_ids = [edge.id for edge in super_user_edges]
         nadia_edges_ids = [edge.id for edge in nadias_edges]
         for edge in super_edges_ids:
             assert edge in nadia_edges_ids
         assert len(super_user_edges)==len(nadias_edges)
-        super_user_edges = list(openreview.tools.iterget_edges(client, tail="~Super_User1"))
+        super_user_edges = list(openreview.tools.iterget_edges(openreview_client, tail="~Super_User1"))
         assert len(super_user_edges) == 0
-        client.rename_edges('~Nadia_L1','~Super_User1')
+        openreview_client.rename_edges('~Nadia_L1','~Super_User1')
         
-    def test_get_edges(self, client):
-        invitation_id = 'NIPS.cc/2020/Workshop/MLITS/-/affinity'
-        all_edges = client.get_edges(invitation=invitation_id, tail='~Super_User1')
+    def test_get_edges(self, client, openreview_client):
+        invitation_id = 'openreview.net/-/Affinity'
+        all_edges = openreview_client.get_edges(invitation=invitation_id, tail='~Super_User1')
         assert len(all_edges) == 1000
-        some_edges = client.get_edges(invitation=invitation_id, tail='~Super_User1', limit=500)
+        some_edges = openreview_client.get_edges(invitation=invitation_id, tail='~Super_User1', limit=500)
         assert len(some_edges) == 500
-        super_user_edges = client.get_edges(tail='~Super_User1')
+        super_user_edges = openreview_client.get_edges(tail='~Super_User1')
         assert len(super_user_edges) == 1000
 
-    def test_get_edges_count(self, client):
-        invitation_id = 'NIPS.cc/2020/Workshop/MLITS/-/affinity'
-        count = client.get_edges_count(invitation=invitation_id)
+    def test_get_edges_count(self, client, openreview_client):
+        invitation_id = 'openreview.net/-/Affinity'
+        count = openreview_client.get_edges_count(invitation=invitation_id)
         assert count == 2000
     
-    def test_delete_edges(self, client):
-        edges_count_before = client.get_edges_count(invitation='NIPS.cc/2020/Workshop/MLITS/-/affinity', label='High')
+    def test_delete_edges(self, client, openreview_client):
+        edges_count_before = openreview_client.get_edges_count(invitation='openreview.net/-/Affinity', label='High')
         assert edges_count_before == 1000
-        client.delete_edges(invitation='NIPS.cc/2020/Workshop/MLITS/-/affinity', label='High', wait_to_finish=True)
-        edges_count_after = client.get_edges_count(invitation='NIPS.cc/2020/Workshop/MLITS/-/affinity', label='High')
+        openreview_client.delete_edges(invitation='openreview.net/-/Affinity', label='High', wait_to_finish=True)
+        edges_count_after = openreview_client.get_edges_count(invitation='openreview.net/-/Affinity', label='High')
         assert edges_count_after == 0
 
-        client.delete_edges(invitation='NIPS.cc/2020/Workshop/MLITS/-/affinity', wait_to_finish=True)
-        edges_count_after = client.get_edges_count(invitation='NIPS.cc/2020/Workshop/MLITS/-/affinity')
+        openreview_client.delete_edges(invitation='openreview.net/-/Affinity', wait_to_finish=True)
+        edges_count_after = openreview_client.get_edges_count(invitation='openreview.net/-/Affinity')
         assert edges_count_after == 0
     
     


### PR DESCRIPTION
This PR fixes how retries are made in openreview-py and how the error is read.
I also migrated the test_edges file to use API 2. However, I could not make the polling strategy work because the count that I was getting was cached, so the polling timed out every time.