### PR TITLE
ARR: Add quota to proposed assignments

### DIFF
--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -537,7 +537,7 @@ class ARR(object):
             replacement=False,
             invitation=openreview.api.Invitation(
                 id=self.venue.get_assignment_id(committee_id, deployed=False, invite=False),
-                preproces=self.invitation_builder.get_process_content('process/proposed_assignment_pre_process.js')
+                preprocess=self.invitation_builder.get_process_content('process/proposed_assignment_pre_process.js')
             )
         )
         return setup_value

--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -529,15 +529,16 @@ class ARR(object):
 
     def setup_committee_matching(self, committee_id=None, compute_affinity_scores=False, compute_conflicts=False, compute_conflicts_n_years=None, alternate_matching_group=None, submission_track=None):
         setup_value = self.venue.setup_committee_matching(committee_id, compute_affinity_scores, compute_conflicts, compute_conflicts_n_years, alternate_matching_group, submission_track)
-        invitation = self.client.get_invitation(self.venue.get_assignment_id(committee_id, deployed=False, invite=False))
-        invitation.preprocess = self.invitation_builder.get_process_content('process/proposed_assignment_pre_process.js')
         self.client.post_invitation_edit(
             invitations=self.venue.get_meta_invitation_id(),
             readers=[self.venue_id],
             writers=[self.venue_id],
             signatures=[self.venue_id],
             replacement=False,
-            invitation=invitation
+            invitation=openreview.api.Invitation(
+                id=self.venue.get_assignment_id(committee_id, deployed=False, invite=False),
+                preproces=self.invitation_builder.get_process_content('process/proposed_assignment_pre_process.js')
+            )
         )
         return setup_value
 

--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -528,7 +528,18 @@ class ARR(object):
         return self.venue.send_decision_notifications(decision_options,  messages)
 
     def setup_committee_matching(self, committee_id=None, compute_affinity_scores=False, compute_conflicts=False, compute_conflicts_n_years=None, alternate_matching_group=None, submission_track=None):
-        return self.venue.setup_committee_matching(committee_id, compute_affinity_scores, compute_conflicts, compute_conflicts_n_years, alternate_matching_group, submission_track)
+        setup_value = self.venue.setup_committee_matching(committee_id, compute_affinity_scores, compute_conflicts, compute_conflicts_n_years, alternate_matching_group, submission_track)
+        invitation = self.client.get_invitation(self.venue.get_assignment_id(committee_id, deployed=False, invite=False))
+        invitation.preprocess = self.invitation_builder.get_process_content('process/proposed_assignment_pre_process.js')
+        self.client.post_invitation_edit(
+            invitations=self.venue.get_meta_invitation_id(),
+            readers=[self.venue_id],
+            writers=[self.venue_id],
+            signatures=[self.venue_id],
+            replacement=False,
+            invitation=invitation
+        )
+        return setup_value
 
     def set_assignments(self, assignment_title, committee_id, enable_reviewer_reassignment=False, overwrite=False):
         return self.venue.set_assignments(assignment_title,  committee_id, enable_reviewer_reassignment, overwrite)

--- a/openreview/arr/process/proposed_assignment_pre_process.js
+++ b/openreview/arr/process/proposed_assignment_pre_process.js
@@ -1,0 +1,46 @@
+async function process(client, edge, invitation) {
+  client.throwErrors = true
+
+  const committeeName = invitation.content.committee_name?.value;
+  const { groups } = await client.getGroups({ id: invitation.domain });
+  const domain = groups[0];
+
+  const customMaxPapersId = domain.content[committeeName.toLowerCase() + '_custom_max_papers_id']?.value;
+
+  if (edge.ddate) {
+    return
+  }
+
+  if (edge.tcdate !== edge.tmdate) {
+    return
+  }
+
+  if (!customMaxPapersId) {
+    return
+  }
+
+  const [res1, res2, res3] = await Promise.all([
+    client.getEdges({ invitation: customMaxPapersId, tail: edge.tail }),
+    client.getEdges({ invitation: edge.invitation, label: edge.label, tail: edge.tail }),
+    client.getEdges({ invitation: edge.invitation, label: edge.label, head: edge.head })
+  ])
+  let customMaxPapers = (res1.count > 0 && res1.edges[0].weight) || 0;
+  const assignmentEdges = res2.edges;
+  const submissionEdges = res3.edges;
+
+  if (!customMaxPapers) {
+    const { invitations } = await client.getInvitations({ id: customMaxPapersId });
+    customMaxPapers = invitations[0].edge.weight.param.default;
+  }
+
+  if (assignmentEdges.length >= customMaxPapers) {
+    const { profiles } = await client.getProfiles({ id: edge.tail });
+    const profile = profiles[0];
+    return Promise.reject(new OpenReviewError({ name: 'Error', message: `Max Papers allowed reached for ${Tools.getPreferredName(profile)}` }));
+  }
+
+  if ((submissionEdges.length + 1) > 3 && committeeName.includes('Reviewers')) {
+    return Promise.reject(new OpenReviewError({ name: 'Error', message: `You cannot assign more than 3 reviewers to this paper` }));
+  }
+
+}

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3026,8 +3026,8 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
 
         # Revert the data to preserve the rest of the tests
         now = datetime.datetime.utcnow()
-        rev_2_edge.ddate = now
-        rev_3_edge.ddate = now
+        rev_2_edge.ddate = openreview.tools.datetime_millis(now)
+        rev_3_edge.ddate = openreview.tools.datetime_millis(now)
         openreview_client.post_edge(
             rev_2_edge
         )

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3031,7 +3031,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         openreview_client.post_edge(
             rev_2_edge
         )
-        openreview_client.delete_edge(
+        openreview_client.post_edge(
             rev_3_edge
         )
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -2996,6 +2996,45 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             label = 'reviewer-assignments'
         ))
 
+        rev_2_edge = openreview_client.post_edge(openreview.api.Edge(
+            invitation = 'aclweb.org/ACL/ARR/2023/August/Reviewers/-/Proposed_Assignment',
+            head = submissions[0].id,
+            tail = '~Reviewer_ARRTwo1',
+            signatures = ['aclweb.org/ACL/ARR/2023/August/Program_Chairs'],
+            weight = 1,
+            label = 'reviewer-assignments'
+        ))
+
+        rev_3_edge = openreview_client.post_edge(openreview.api.Edge(
+            invitation = 'aclweb.org/ACL/ARR/2023/August/Reviewers/-/Proposed_Assignment',
+            head = submissions[0].id,
+            tail = '~Reviewer_ARRThree1',
+            signatures = ['aclweb.org/ACL/ARR/2023/August/Program_Chairs'],
+            weight = 1,
+            label = 'reviewer-assignments'
+        ))
+
+        with pytest.raises(openreview.OpenReviewException, match=r'You cannot assign more than 3 reviewers to this paper'):
+            openreview_client.post_edge(openreview.api.Edge(
+                invitation = 'aclweb.org/ACL/ARR/2023/August/Reviewers/-/Proposed_Assignment',
+                head = submissions[0].id,
+                tail = '~Reviewer_ARRFive1',
+                signatures = ['aclweb.org/ACL/ARR/2023/August/Program_Chairs'],
+                weight = 1,
+                label = 'reviewer-assignments'
+            ))
+
+        # Revert the data to preserve the rest of the tests
+        now = datetime.datetime.utcnow()
+        rev_2_edge.ddate = now
+        rev_3_edge.ddate = now
+        openreview_client.post_edge(
+            rev_2_edge
+        )
+        openreview_client.delete_edge(
+            rev_3_edge
+        )
+
         august_venue.set_assignments(assignment_title='reviewer-assignments', committee_id='aclweb.org/ACL/ARR/2023/August/Reviewers')
 
         pc_client.post_note(


### PR DESCRIPTION
This PR adds an additional edges call `client.getEdges({ invitation: edge.invitation, label: edge.label, head: edge.head })` and uses this to prevent more than 3 reviewers from being assigned in the proposed assignments