### PR TITLE
Fix/ Second deadline revision: change revision name to avoid overwriting it

### DIFF
--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -489,7 +489,7 @@ class Venue(object):
 
         if self.submission_stage.second_due_date:
             stage = self.submission_stage
-            submission_revision_stage = openreview.stages.SubmissionRevisionStage(name='Revision',
+            submission_revision_stage = openreview.stages.SubmissionRevisionStage(name='Full_Submission',
                 start_date=stage.exp_date,
                 due_date=stage.second_due_date,
                 additional_fields=stage.second_deadline_additional_fields if stage.second_deadline_additional_fields else stage.additional_fields,

--- a/tests/test_emnlp_conference.py
+++ b/tests/test_emnlp_conference.py
@@ -199,7 +199,7 @@ class TestEMNLPConference():
             }
         ))
         helpers.await_queue()
-        helpers.await_queue_edit(openreview_client, 'EMNLP/2023/Conference/-/Revision-0-1', count=1)
+        helpers.await_queue_edit(openreview_client, 'EMNLP/2023/Conference/-/Full_Submission-0-1', count=1)
 
         submission_invitation = openreview_client.get_invitation('EMNLP/2023/Conference/-/Submission')
         assert submission_invitation
@@ -209,7 +209,7 @@ class TestEMNLPConference():
         assert 'TLDR' not in submission_invitation.edit['note']['content']
         assert 'pdf' not in submission_invitation.edit['note']['content']
 
-        revision_invitation = openreview_client.get_invitation('EMNLP/2023/Conference/-/Revision')
+        revision_invitation = openreview_client.get_invitation('EMNLP/2023/Conference/-/Full_Submission')
         assert submission_invitation.expdate == revision_invitation.cdate
         invitation_due_date = revision_invitation.edit['invitation']['duedate']
         assert invitation_due_date == openreview.tools.datetime_millis(due_date.replace(hour=0, minute=0, second=0, microsecond=0))
@@ -341,10 +341,10 @@ class TestEMNLPConference():
 
         helpers.await_queue()
         helpers.await_queue_edit(openreview_client, 'EMNLP/2023/Conference/-/Post_Submission-0-0')
-        helpers.await_queue_edit(openreview_client, 'EMNLP/2023/Conference/-/Revision-0-0')
+        helpers.await_queue_edit(openreview_client, 'EMNLP/2023/Conference/-/Full_Submission-0-0')
         helpers.await_queue_edit(openreview_client, 'EMNLP/2023/Conference/-/Deletion-0-0')
 
-        invitations = openreview_client.get_invitations(invitation='EMNLP/2023/Conference/-/Revision')
+        invitations = openreview_client.get_invitations(invitation='EMNLP/2023/Conference/-/Full_Submission')
         assert len(invitations) == 5
         assert invitations[0].duedate == openreview.tools.datetime_millis(due_date.replace(hour=0, minute=0, second=0, microsecond=0))
 
@@ -353,12 +353,12 @@ class TestEMNLPConference():
         assert not invitations[0].duedate
 
         tasks_url = 'http://localhost:3030/group?id=EMNLP/2023/Conference/Authors#author-tasks'
-        request_page(selenium, tasks_url, test_client.token, wait_for_element='Submission1 Revision')
+        request_page(selenium, tasks_url, test_client.token, wait_for_element='Submission1 Full Submission')
 
         task_panel = selenium.find_element(By.LINK_TEXT, "Author Tasks")
         task_panel.click()
 
-        assert selenium.find_element(By.LINK_TEXT, 'Submission1 Revision')
+        assert selenium.find_element(By.LINK_TEXT, 'Submission1 Full Submission')
         with pytest.raises(NoSuchElementException):
             selenium.find_element(By.LINK_TEXT, 'Submission1 Deletion')
 
@@ -412,10 +412,10 @@ Please note that responding to this email will direct your reply to pc@emnlp.org
         authors_group = openreview_client.get_group('EMNLP/2023/Conference/Authors')
         assert 'EMNLP/2023/Conference/Submission5/Authors' not in authors_group.members
 
-        invitation = openreview_client.get_invitation('EMNLP/2023/Conference/Submission5/-/Revision')
+        invitation = openreview_client.get_invitation('EMNLP/2023/Conference/Submission5/-/Full_Submission')
         assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
         assert invitation.invitations == [
-            "EMNLP/2023/Conference/-/Revision",
+            "EMNLP/2023/Conference/-/Full_Submission",
             "EMNLP/2023/Conference/-/Deletion_Expiration"
         ]
 
@@ -456,10 +456,10 @@ Please note that responding to this email will direct your reply to pc@emnlp.org
         authors_group = openreview_client.get_group('EMNLP/2023/Conference/Authors')
         assert 'EMNLP/2023/Conference/Submission5/Authors' in authors_group.members
 
-        invitation = openreview_client.get_invitation('EMNLP/2023/Conference/Submission5/-/Revision')
+        invitation = openreview_client.get_invitation('EMNLP/2023/Conference/Submission5/-/Full_Submission')
         assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
         assert invitation.invitations == [
-            "EMNLP/2023/Conference/-/Revision",
+            "EMNLP/2023/Conference/-/Full_Submission",
             "EMNLP/2023/Conference/-/Deletion_Expiration"
         ]
 
@@ -511,7 +511,7 @@ Please note that responding to this email will direct your reply to pc@emnlp.org
         helpers.await_queue_edit(openreview_client, 'EMNLP/2023/Conference/-/Supplementary_Material-0-1', count=1)
 
         # assert revision invitation did not change
-        revision_invitation = openreview_client.get_invitation('EMNLP/2023/Conference/-/Revision')
+        revision_invitation = openreview_client.get_invitation('EMNLP/2023/Conference/-/Full_Submission')
         assert 'pdf' in revision_invitation.edit['invitation']['edit']['note']['content']
         assert 'optional' not in revision_invitation.edit['invitation']['edit']['note']['content']['pdf']['value']['param']
         assert 'optional' not in revision_invitation.edit['invitation']['edit']['note']['content']['submission_type']['value']['param']

--- a/tests/test_iclr_conference_v2.py
+++ b/tests/test_iclr_conference_v2.py
@@ -280,7 +280,7 @@ class TestICLRConference():
         # Author revises submission license
         author_client = openreview.api.OpenReviewClient(username='peter@mail.com', password=helpers.strong_password)
         revision_note = author_client.post_note_edit(
-            invitation = f'ICLR.cc/2024/Conference/Submission{submission.number}/-/Revision',
+            invitation = f'ICLR.cc/2024/Conference/Submission{submission.number}/-/Full_Submission',
             signatures = [f'ICLR.cc/2024/Conference/Submission{submission.number}/Authors'],
             note = openreview.api.Note(
                 license = 'CC0 1.0',
@@ -340,9 +340,9 @@ class TestICLRConference():
         helpers.await_queue_edit(openreview_client, 'ICLR.cc/2024/Conference/-/Desk_Rejection-0-1', count=2)
 
         # Author can't revise license after paper deadline
-        with pytest.raises(openreview.OpenReviewException, match=r'The Invitation ICLR.cc/2024/Conference/Submission1/-/Revision has expired'):
+        with pytest.raises(openreview.OpenReviewException, match=r'The Invitation ICLR.cc/2024/Conference/Submission1/-/Full_Submission has expired'):
             revision_note = author_client.post_note_edit(
-                invitation = f'ICLR.cc/2024/Conference/Submission{submission.number}/-/Revision',
+                invitation = f'ICLR.cc/2024/Conference/Submission{submission.number}/-/Full_Submission',
                 signatures = [f'ICLR.cc/2024/Conference/Submission{submission.number}/Authors'],
                 note = openreview.api.Note(
                     license = 'CC BY 4.0',

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -895,7 +895,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
 
         helpers.await_queue()
         helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Conference/-/Post_Submission-0-0')
-        helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Conference/-/Revision-0-0')
+        helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Conference/-/Full_Submission-0-0')
 
         post_submission_note=pc_client.post_note(openreview.Note(
             content= {
@@ -920,7 +920,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         assert notes[0].readers == ['NeurIPS.cc/2023/Conference', 'NeurIPS.cc/2023/Conference/Submission5/Authors']
         assert notes[0].content['keywords']['readers'] == ['NeurIPS.cc/2023/Conference', 'NeurIPS.cc/2023/Conference/Submission5/Authors']
 
-        revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Conference/Submission5/-/Revision')
+        revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Conference/Submission5/-/Full_Submission')
         assert revision_inv
         assert ['NeurIPS.cc/2023/Conference', 'NeurIPS.cc/2023/Conference/Submission5/Authors'] == revision_inv.readers
         assert 'readers' in revision_inv.edit['note']['content']['authors']
@@ -960,7 +960,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
 
         helpers.await_queue_edit(openreview_client, edit_id=pc_revision['id'])
 
-        revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Conference/Submission4/-/Revision')
+        revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Conference/Submission4/-/Full_Submission')
         assert revision_inv.edit['note']['content']['authors']['value'] == [
           'SomeFirstName User',
           'Peter SomeLastName',
@@ -974,7 +974,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
           'celeste@yahoo.com'
         ]
 
-        revision_inv = test_client.get_invitation('NeurIPS.cc/2023/Conference/Submission2/-/Revision')
+        revision_inv = test_client.get_invitation('NeurIPS.cc/2023/Conference/Submission2/-/Full_Submission')
         assert revision_inv.edit['note']['content']['authors']['value'] == [
           'SomeFirstName User',
           'Peter SomeLastName',
@@ -990,7 +990,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
           '~Melisa_Gilbert2'
         ]
 
-        revision_note = test_client.post_note_edit(invitation='NeurIPS.cc/2023/Conference/Submission2/-/Revision',
+        revision_note = test_client.post_note_edit(invitation='NeurIPS.cc/2023/Conference/Submission2/-/Full_Submission',
             signatures=['NeurIPS.cc/2023/Conference/Submission2/Authors'],
             note=openreview.api.Note(
                 content={
@@ -1022,7 +1022,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         ]
 
         ## update submission
-        revision_note = test_client.post_note_edit(invitation='NeurIPS.cc/2023/Conference/Submission4/-/Revision',
+        revision_note = test_client.post_note_edit(invitation='NeurIPS.cc/2023/Conference/Submission4/-/Full_Submission',
             signatures=['NeurIPS.cc/2023/Conference/Submission4/Authors'],
             note=openreview.api.Note(
                 content={
@@ -1076,7 +1076,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         ))
 
         helpers.await_queue()
-        helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Conference/-/Revision-0-1', count=4)
+        helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Conference/-/Full_Submission-0-1', count=4)
 
         notes = test_client.get_notes(content= { 'venueid': 'NeurIPS.cc/2023/Conference/Submission' }, sort='number:desc')
         assert len(notes) == 4

--- a/tests/test_neurips_track_conference.py
+++ b/tests/test_neurips_track_conference.py
@@ -200,7 +200,7 @@ class TestNeurIPSTrackConference():
         
         helpers.await_queue()
         helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/-/Post_Submission-0-0')
-        helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/-/Revision-0-0')
+        helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/-/Full_Submission-0-0')
 
         notes = test_client.get_notes(content= { 'venueid': 'NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission' }, sort='number:desc')
         assert len(notes) == 5
@@ -208,14 +208,14 @@ class TestNeurIPSTrackConference():
         assert notes[0].readers == ['NeurIPS.cc/2023/Track/Datasets_and_Benchmarks', 'NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission5/Authors']
         assert notes[0].content['keywords']['readers'] == ['NeurIPS.cc/2023/Track/Datasets_and_Benchmarks', 'NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission5/Authors']
 
-        assert test_client.get_invitation('NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission5/-/Revision')
+        assert test_client.get_invitation('NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission5/-/Full_Submission')
 
         post_submission =  openreview_client.get_invitation('NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/-/Post_Submission')
         assert 'authors' in post_submission.edit['note']['content']
         assert 'authorids' in post_submission.edit['note']['content']
         assert 'keywords' in post_submission.edit['note']['content']
 
-        revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission4/-/Revision')
+        revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission4/-/Full_Submission')
 
         assert 'param' in revision_inv.edit['note']['content']['authorids']['value']
         assert 'regex' in revision_inv.edit['note']['content']['authorids']['value']['param']
@@ -225,7 +225,7 @@ class TestNeurIPSTrackConference():
 
 
         ## update submission
-        revision_note = test_client.post_note_edit(invitation='NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission4/-/Revision',
+        revision_note = test_client.post_note_edit(invitation='NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission4/-/Full_Submission',
             signatures=['NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission4/Authors'],
             note=openreview.api.Note(
                 content={
@@ -265,7 +265,7 @@ class TestNeurIPSTrackConference():
         author_group = openreview_client.get_group('NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission4/Authors')
         assert ['test@mail.com', 'andrew@google.com', 'peter@mail.com', 'melisa@google.com', 'celeste@yahoo.com' ] == author_group.members
 
-        revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission4/-/Revision')
+        revision_inv =  test_client.get_invitation('NeurIPS.cc/2023/Track/Datasets_and_Benchmarks/Submission4/-/Full_Submission')
 
         assert 'param' in revision_inv.edit['note']['content']['authorids']['value']
         assert 'regex' in revision_inv.edit['note']['content']['authorids']['value']['param']


### PR DESCRIPTION
* Changes second deadline revision invitation name to `Full_Submission` in order to avoid it getting overwritten by PCs enabling a `Revision` invitation.