### PR TITLE
add ethics chairs as writers and readers of emergency group

### DIFF
--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -534,10 +534,12 @@ class GroupBuilder(object):
                             ))
            
 
-    def set_external_reviewer_recruitment_groups(self, name='External_Reviewers', create_paper_groups=False):
+    def set_external_reviewer_recruitment_groups(self, name='External_Reviewers', create_paper_groups=False, is_ethics_reviewer=False):
 
         venue = self.venue
         venue_id = self.venue_id
+
+        ethics_chairs_id = venue.get_ethics_chairs_id()
 
         if name == venue.reviewers_name:
             raise openreview.OpenReviewException(f'Can not use {name} as external reviewer name')
@@ -548,8 +550,8 @@ class GroupBuilder(object):
         parent_group = tools.get_group(self.client, parent_group_id)
         if not parent_group:
             parent_group=self.post_group(Group(id=parent_group_id,
-                            readers=[venue_id, parent_group_id],
-                            writers=[venue_id],
+                            readers=[venue_id, ethics_chairs_id, parent_group_id] if is_ethics_reviewer else [venue_id, parent_group_id],
+                            writers=[venue_id, ethics_chairs_id] if is_ethics_reviewer else [venue_id],
                             signatures=[venue_id],
                             signatories=[venue_id, parent_group_id],
                             members=[]
@@ -558,8 +560,8 @@ class GroupBuilder(object):
         parent_group_invited = tools.get_group(self.client, parent_group_invited_id)
         if not parent_group_invited:
             parent_group_invited=self.post_group(Group(id=parent_group_invited_id,
-                            readers=[venue_id],
-                            writers=[venue_id],
+                            readers=[venue_id, ethics_chairs_id] if is_ethics_reviewer else [venue_id],
+                            writers=[venue_id, ethics_chairs_id] if is_ethics_reviewer else [venue_id],
                             signatures=[venue_id],
                             signatories=[venue_id, parent_group_invited_id],
                             members=[]

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3985,7 +3985,18 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         # allow ethics chairs to invite ethics reviewers
         conference_matching = matching.Matching(venue, openreview_client.get_group(venue.get_ethics_reviewers_id()), None)
         conference_matching.setup_invite_assignment(hash_seed='1234', invited_committee_name=f'Emergency_{venue.get_ethics_reviewers_name(pretty=False)}')
-        venue.group_builder.set_external_reviewer_recruitment_groups(name=f'Emergency_{venue.get_ethics_reviewers_name(pretty=False)}')
+        venue.group_builder.set_external_reviewer_recruitment_groups(name=f'Emergency_{venue.get_ethics_reviewers_name(pretty=False)}', is_ethics_reviewer=True)
+
+        group = openreview_client.get_group('aclweb.org/ACL/ARR/2023/August/Emergency_Ethics_Reviewers')
+        assert group
+        assert group.readers == ['aclweb.org/ACL/ARR/2023/August', 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs', 'aclweb.org/ACL/ARR/2023/August/Emergency_Ethics_Reviewers']
+        assert group.writers == ['aclweb.org/ACL/ARR/2023/August', 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs']
+
+        group = openreview_client.get_group('aclweb.org/ACL/ARR/2023/August/Emergency_Ethics_Reviewers/Invited')
+        assert group
+        assert group.readers == ['aclweb.org/ACL/ARR/2023/August', 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs']
+        assert group.writers == ['aclweb.org/ACL/ARR/2023/August', 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs']
+
 
         invitation = openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Ethics_Reviewers/-/Invite_Assignment')
         assert invitation


### PR DESCRIPTION
Fixes #2247

It looks like we run `set_external_reviewer_recruitment_groups()` manually for ethics reviewers. In this case, we need to pass `is_ethics_reviewer=True` in order to add the Ethics Chairs groups as readers and writers.