### PR TITLE
Feature/email ethics chairs

### DIFF
--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -1622,6 +1622,20 @@ To view the submission, click here: https://openreview.net/forum?id={}'''.format
                 'Ethics_Review',
                 value = False
             )
+
+        subject = f'[{short_name}] A submission has been unflagged for ethics reviewing'
+        message = '''Paper {} has been unflagged for ethics review.'''.format(forum.number, forum.id)
+        client.post_message(
+            invitation=meta_invitation_id,
+            signature=venue_id,
+            replyTo=contact,
+            sender=sender,
+            recipients=[domain.content['ethics_chairs_id']['value']],
+            ignoreRecipients=[edit.tauthor],
+            subject=subject,
+            message=message
+        )
+
 def get_resubmissions(submissions, previous_url_field):
     return list(filter(
         lambda s: previous_url_field in s.content and 'value' in s.content[previous_url_field] and len(s.content[previous_url_field]['value']) > 0, 

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -265,7 +265,7 @@ class GroupBuilder(object):
             content['ethics_reviewers_name'] = { 'value': self.venue.ethics_reviewers_name }
             content['ethics_review_name'] = { 'value': self.venue.ethics_review_stage.name }
             content['anon_ethics_reviewer_name'] = { 'value': self.venue.anon_ethics_reviewers_name() }
-            content['release_to_chairs'] = { 'value': self.venue.ethics_review_stage.release_to_chairs }
+            content['release_submissions_to_ethics_chairs'] = { 'value': self.venue.ethics_review_stage.release_to_chairs }
 
         if venue_group.content.get('enable_reviewers_reassignment'):
             content['enable_reviewers_reassignment'] = venue_group.content.get('enable_reviewers_reassignment')

--- a/openreview/venue/process/desk_rejected_submission_process.py
+++ b/openreview/venue/process/desk_rejected_submission_process.py
@@ -15,7 +15,7 @@ def process(client, edit, invitation):
     program_chairs_id = domain.content['program_chairs_id']['value']
     sender = domain.get_content_value('message_sender')
     authors_accepted_id = domain.get_content_value('authors_accepted_id')
-    release_to_ethics_chairs = domain.get_content_value('release_to_chairs')
+    release_to_ethics_chairs = domain.get_content_value('release_submissions_to_ethics_chairs')
 
     submission = client.get_note(edit.note.id)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -11,7 +11,7 @@ def process(client, edit, invitation):
     ae_checklist_name = invitation.get_content_value('ae_checklist_name')
     reviewer_checklist_name = invitation.get_content_value('reviewer_checklist_name')
     ethics_chairs_id = domain.get_content_value('ethics_chairs_id')
-    release_to_ethics_chairs = domain.get_content_value('release_to_chairs')
+    release_to_ethics_chairs = domain.get_content_value('release_submissions_to_ethics_chairs')
     contact = domain.content['contact']['value']
     sender = domain.get_content_value('message_sender')
     short_name = domain.content['subtitle']['value']

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -12,6 +12,9 @@ def process(client, edit, invitation):
     reviewer_checklist_name = invitation.get_content_value('reviewer_checklist_name')
     ethics_chairs_id = domain.get_content_value('ethics_chairs_id')
     release_to_ethics_chairs = domain.get_content_value('release_to_chairs')
+    contact = domain.content['contact']['value']
+    sender = domain.get_content_value('message_sender')
+    short_name = domain.content['subtitle']['value']
 
     submission = client.get_note(edit.note.id)
 

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -12,9 +12,6 @@ def process(client, edit, invitation):
     reviewer_checklist_name = invitation.get_content_value('reviewer_checklist_name')
     ethics_chairs_id = domain.get_content_value('ethics_chairs_id')
     release_to_ethics_chairs = domain.get_content_value('release_submissions_to_ethics_chairs')
-    contact = domain.content['contact']['value']
-    sender = domain.get_content_value('message_sender')
-    short_name = domain.content['subtitle']['value']
 
     submission = client.get_note(edit.note.id)
 

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -13,7 +13,7 @@ def process(client, invitation):
     meta_review_name = domain.content.get('meta_review_name', {}).get('value')
     ethics_chairs_id = domain.content.get('ethics_chairs_id', {}).get('value')
     ethics_reviewers_name = domain.content.get('ethics_reviewers_name', {}).get('value')
-    release_to_ethics_chairs = domain.get_content_value('release_to_chairs')
+    release_to_ethics_chairs = domain.get_content_value('release_submissions_to_ethics_chairs')
 
     now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
     cdate = invitation.edit['invitation']['cdate'] if 'cdate' in invitation.edit['invitation'] else invitation.cdate

--- a/openreview/venue/process/withdrawn_submission_process.py
+++ b/openreview/venue/process/withdrawn_submission_process.py
@@ -15,6 +15,7 @@ def process(client, edit, invitation):
     program_chairs_id = domain.content['program_chairs_id']['value']
     sender = domain.get_content_value('message_sender')
     authors_accepted_id = domain.get_content_value('authors_accepted_id')
+    release_to_ethics_chairs = domain.get_content_value('release_to_chairs')
 
     submission = client.get_note(edit.note.id)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'    
@@ -66,3 +67,21 @@ For more information, click here https://openreview.net/forum?id={submission.id}
 '''
 
     client.post_message(email_subject, final_committee, email_body, invitation=meta_invitation_id, signature=venue_id, ignoreRecipients=ignoreRecipients, replyTo=contact, sender=sender)
+
+    if submission.content.get('flagged_for_ethics_review', {}).get('value'):
+
+        if release_to_ethics_chairs and 'everyone' not in submission.readers:
+            ethics_chairs_id = domain.get_content_value('ethics_chairs_id')
+
+            client.post_note_edit(invitation=meta_invitation_id,
+                signatures=[venue_id],
+                note=openreview.api.Note(
+                    id=submission.id,
+                    readers={
+                        'append': [ethics_chairs_id]
+                    }
+                )
+            )
+
+        # email ethics chairs
+        client.post_message(email_subject, [ethics_chairs_id], email_body, invitation=meta_invitation_id, signature=venue_id, ignoreRecipients=ignoreRecipients, replyTo=contact, sender=sender)

--- a/openreview/venue/process/withdrawn_submission_process.py
+++ b/openreview/venue/process/withdrawn_submission_process.py
@@ -15,7 +15,7 @@ def process(client, edit, invitation):
     program_chairs_id = domain.content['program_chairs_id']['value']
     sender = domain.get_content_value('message_sender')
     authors_accepted_id = domain.get_content_value('authors_accepted_id')
-    release_to_ethics_chairs = domain.get_content_value('release_to_chairs')
+    release_to_ethics_chairs = domain.get_content_value('release_submissions_to_ethics_chairs')
 
     submission = client.get_note(edit.note.id)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'    

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -409,7 +409,7 @@ class VenueStages():
                     'Yes, release flagged submissions to the ethics chairs.',
                     'No, do not release flagged submissions to the ethics chairs.'
                 ],
-                "default": "No, do not release flagged submissions to the ethics chairs"
+                "default": "No, do not release flagged submissions to the ethics chairs."
             },
             "release_submissions_to_ethics_reviewers": {
                 "description": "Confirm that you want to release the submissions to the ethics reviewers if they are no currently released.",


### PR DESCRIPTION
Fixes #2252 and #2253

@haroldrubio I added the email about a submission being unflagged to arr/helpers.py. Let me know if this is not the right place for that. 

For withdrawn and desk-rejected submissions, I am checking if they are flagged, I re-add the ethics chairs as readers (but not the ethics reviewers). This is not reverted if the desk-rejection/withdrawal is reversed, as I expect the submission would first be reversed and then unflagged if needs be. 