### PR TITLE
Custom Stage: add venue id as committee instead of PCs + Invite Assignment fix

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1461,7 +1461,7 @@ class CustomStage(object):
         self.allow_de_anonymization = allow_de_anonymization
 
     def get_invitees(self, conference, number):
-        invitees = [conference.get_program_chairs_id()]
+        invitees = [conference.id]
 
         if conference.use_senior_area_chairs and self.Participants.SENIOR_AREA_CHAIRS_ASSIGNED in self.invitees:
             invitees.append(conference.get_senior_area_chairs_id(number))

--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -132,14 +132,16 @@ Thanks,
 
         preferred_name=user_profile.get_preferred_name(pretty=True)
 
-        if paper_reviewer_invited_id:
-            paper_reviewers_invited_id=paper_reviewer_invited_id.replace('{number}', str(submission.number))
-            ## Paper invited group
-            client.remove_members_from_group(paper_reviewers_invited_id, [user_profile.id])
+        invite_assignment_invitations = client.get_edges(invitation=edge.invitation, tail=user_profile.id)
+        if not invite_assignment_invitations:
+            if paper_reviewer_invited_id:
+                paper_reviewers_invited_id=paper_reviewer_invited_id.replace('{number}', str(submission.number))
+                ## Paper invited group
+                client.remove_members_from_group(paper_reviewers_invited_id, [user_profile.id])
 
-        if committee_invited_id:
-            ## General invited group
-            client.remove_members_from_group(committee_invited_id, [user_profile.id])
+            if committee_invited_id:
+                ## General invited group
+                client.remove_members_from_group(committee_invited_id, [user_profile.id])
 
         ## Send email
         subject=f'[{short_phrase}] Invitation canceled {action_string} paper titled "{submission.content["title"]["value"]}"'

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3547,7 +3547,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         assert f'aclweb.org/ACL/ARR/2023/August/Submission{test_submission.number}/Ethics_Reviewers' in test_submission.readers
 
         # desk-reject paper
-        desk_reject_edit = pc_client_v2.post_note_edit(invitation=f'aclweb.org/ACL/ARR/2023/August/Submission3/-/Desk_Rejection',
+        desk_reject_edit = pc_client_v2.post_note_edit(invitation='aclweb.org/ACL/ARR/2023/August/Submission3/-/Desk_Rejection',
             signatures=['aclweb.org/ACL/ARR/2023/August/Program_Chairs'],
             note=openreview.api.Note(
                 content={
@@ -3557,6 +3557,13 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         )
         helpers.await_queue_edit(openreview_client, edit_id=desk_reject_edit['id'])
         helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/-/Desk_Rejected_Submission')
+
+        checklist_invitation = openreview_client.get_invitations('aclweb.org/ACL/ARR/2023/August/Submission3/-/Reviewer_Checklist', expired=True)[0]
+        assert checklist_invitation.expdate < now()
+        checklist_invitation = openreview_client.get_invitations('aclweb.org/ACL/ARR/2023/August/Submission3/-/Action_Editor_Checklist', expired=True)[0]
+        assert checklist_invitation.expdate < now()
+        comment_invitation = openreview_client.get_invitations('aclweb.org/ACL/ARR/2023/August/Submission3/-/Author-Editor_Confidential_Comment', expired=True)[0]
+        assert comment_invitation.expdate < now()
 
         submission = openreview_client.get_note(desk_reject_edit['note']['forum'])
         assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' in submission.readers

--- a/tests/test_cvpr_conference_v2.py
+++ b/tests/test_cvpr_conference_v2.py
@@ -633,7 +633,7 @@ class TestCVPRConference():
         assert len(reviews) == 2
 
         invitation = openreview_client.get_invitation('thecvf.com/CVPR/2024/Conference/Submission1/Official_Review1/-/Rating')
-        assert invitation.invitees == ['thecvf.com/CVPR/2024/Conference/Program_Chairs', 'thecvf.com/CVPR/2024/Conference/Submission1/Area_Chairs']
+        assert invitation.invitees == ['thecvf.com/CVPR/2024/Conference', 'thecvf.com/CVPR/2024/Conference/Submission1/Area_Chairs']
         assert invitation.noninvitees == ['thecvf.com/CVPR/2024/Conference/Submission1/Secondary_Area_Chairs']
         assert 'rating' in invitation.edit['note']['content']
         assert invitation.edit['note']['forum'] == submissions[0].id

--- a/tests/test_emnlp_conference.py
+++ b/tests/test_emnlp_conference.py
@@ -1197,7 +1197,7 @@ url={https://openreview.net/forum?id='''
         invitations = openreview_client.get_invitations(invitation='EMNLP/2023/Conference/-/Ethics_Meta_Review')
         assert len(invitations) == 1
         invitation = openreview_client.get_invitation(id='EMNLP/2023/Conference/Submission3/-/Ethics_Meta_Review')
-        assert invitation.invitees == ['EMNLP/2023/Conference/Program_Chairs', 'EMNLP/2023/Conference/Ethics_Chairs']
+        assert invitation.invitees == ['EMNLP/2023/Conference', 'EMNLP/2023/Conference/Ethics_Chairs']
         assert invitation.edit['note']['forum']== submissions[0].id
         assert invitation.edit['note']['replyto'] == submissions[0].id
         assert 'ethics_review_recommendation' in invitations[0].edit['note']['content']

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -3036,7 +3036,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Rating')) == 3
 
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/Official_Review1/-/Rating')
-        assert invitation.invitees == ['ICML.cc/2023/Conference/Program_Chairs', 'ICML.cc/2023/Conference/Submission1/Area_Chairs']
+        assert invitation.invitees == ['ICML.cc/2023/Conference', 'ICML.cc/2023/Conference/Submission1/Area_Chairs']
         assert 'review_quality' in invitation.edit['note']['content']
         assert invitation.edit['note']['forum'] == submissions[0].id
         assert invitation.edit['note']['replyto'] == reviews[0]['id']
@@ -3165,7 +3165,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Rating')) == 4
 
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission3/Official_Review1/-/Rating')
-        assert invitation.invitees == ['ICML.cc/2023/Conference/Program_Chairs', 'ICML.cc/2023/Conference/Submission3/Area_Chairs']
+        assert invitation.invitees == ['ICML.cc/2023/Conference', 'ICML.cc/2023/Conference/Submission3/Area_Chairs']
         assert 'review_quality' in invitation.edit['note']['content']
         assert invitation.edit['note']['forum'] == review_edit['note']['forum']
         assert invitation.edit['note']['replyto'] == review_edit['note']['id']
@@ -3938,7 +3938,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Author_AC_Confidential_Comment')) == 100
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Author_AC_Confidential_Comment')
         assert invitation.invitees == [
-            'ICML.cc/2023/Conference/Program_Chairs',
+            'ICML.cc/2023/Conference',
             'ICML.cc/2023/Conference/Submission1/Area_Chairs',
             'ICML.cc/2023/Conference/Submission1/Authors'
         ]

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -2029,7 +2029,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         anon_group_id = anon_groups[0].id
 
         invitation = openreview_client.get_invitation('V2.cc/2030/Conference/Submission1/Official_Review1/-/Author_Review_Rating')
-        assert invitation.invitees == ['V2.cc/2030/Conference/Program_Chairs', 'V2.cc/2030/Conference/Submission1/Authors']
+        assert invitation.invitees == ['V2.cc/2030/Conference', 'V2.cc/2030/Conference/Submission1/Authors']
         assert 'review_quality' in invitation.edit['note']['content']
         assert invitation.edit['note']['forum'] == submissions[0].id
         assert invitation.edit['note']['replyto'] == reviews[0]['id']
@@ -2122,7 +2122,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
 
         assert len(openreview_client.get_invitations(invitation='V2.cc/2030/Conference/-/Rating')) == 3
         invitation = openreview_client.get_invitation('V2.cc/2030/Conference/Submission1/Official_Review1/-/Rating')
-        assert invitation.invitees == ['V2.cc/2030/Conference/Program_Chairs', 'V2.cc/2030/Conference/Submission1/Area_Chairs']
+        assert invitation.invitees == ['V2.cc/2030/Conference', 'V2.cc/2030/Conference/Submission1/Area_Chairs']
         assert invitation.edit['readers'] == [
             "V2.cc/2030/Conference/Program_Chairs",
             "V2.cc/2030/Conference/Submission1/Area_Chairs"

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -877,7 +877,7 @@ To view your submission, click here: https://openreview.net/forum?id={updated_no
         assert openreview_client.get_invitation('TestVenue.cc/-/Camera_Ready_Verification')
         invitation = openreview.tools.get_invitation(openreview_client, 'TestVenue.cc/Submission1/-/Camera_Ready_Verification')
         assert invitation
-        assert invitation.invitees == ['TestVenue.cc/Program_Chairs']
+        assert invitation.invitees == ['TestVenue.cc']
         assert invitation.edit['note']['readers'] == [
             'TestVenue.cc/Program_Chairs',
             'TestVenue.cc/Submission1/Area_Chairs',


### PR DESCRIPTION
Fixes #2261

The reason the desk-rejection process function is not getting some invitations to expire them is because those invitations have PCs as invitees instead of the venue id. This was being done by the custom stage, so I am changing it there.

Also fixes #2262