### PR TITLE
Feature/ Remove calls to add and remove members endpoints from v2 client

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1825,7 +1825,7 @@ class OpenReviewClient(object):
 
         return response.json()
 
-    def add_members_to_group(self, group, members, edit_invitation=None):
+    def add_members_to_group(self, group, members):
         """
         Adds members to a group
 
@@ -1839,7 +1839,7 @@ class OpenReviewClient(object):
         """
         def add_member(group, members):
             group = self.get_group(group) if type(group) in string_types else group
-            self.post_group_edit(invitation = edit_invitation if edit_invitation else f'{group.domain}/-/Edit', 
+            self.post_group_edit(invitation = f'{group.domain}/-/Edit', 
                 signatures = group.signatures, 
                 group = Group(
                     id = group.id, 

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1825,7 +1825,7 @@ class OpenReviewClient(object):
 
         return response.json()
 
-    def add_members_to_group(self, group, members):
+    def add_members_to_group(self, group, members, edit_invitation=None):
         """
         Adds members to a group
 
@@ -1839,7 +1839,7 @@ class OpenReviewClient(object):
         """
         def add_member(group, members):
             group = self.get_group(group) if type(group) in string_types else group
-            self.post_group_edit(invitation = f'{group.domain}/-/Edit', 
+            self.post_group_edit(invitation = edit_invitation if edit_invitation else f'{group.domain}/-/Edit', 
                 signatures = group.signatures, 
                 group = Group(
                     id = group.id, 

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1839,24 +1839,18 @@ class OpenReviewClient(object):
         """
         def add_member(group, members):
             group = self.get_group(group) if type(group) in string_types else group
-            if group.invitations:
-                self.post_group_edit(invitation = f'{group.domain}/-/Edit', 
-                    signatures = group.signatures, 
-                    group = Group(
-                        id = group.id, 
-                        members = {
-                            'append': list(set(members))
-                        }
-                    ), 
-                    readers=group.signatures, 
-                    writers=group.signatures
-                )
-                return self.get_group(group.id)
-            else:
-                if members:
-                    response = self.session.put(self.groups_url + '/members', json = {'id': group.id, 'members': members}, headers = self.headers)
-                    response = self.__handle_response(response)
-                    return Group.from_json(response.json())
+            self.post_group_edit(invitation = f'{group.domain}/-/Edit', 
+                signatures = group.signatures, 
+                group = Group(
+                    id = group.id, 
+                    members = {
+                        'append': list(set(members))
+                    }
+                ), 
+                readers=group.signatures, 
+                writers=group.signatures
+            )
+            return self.get_group(group.id)
 
         member_type = type(members)
         if member_type in string_types:
@@ -1880,26 +1874,21 @@ class OpenReviewClient(object):
         def remove_member(group, members):
             members_to_remove = list(set(members))
             group = self.get_group(group if type(group) in string_types else group.id)
-            if group.invitations:
 
-                members_to_remove = group.transform_to_anon_ids(members_to_remove)
+            members_to_remove = group.transform_to_anon_ids(members_to_remove)
 
-                self.post_group_edit(invitation = f'{group.domain}/-/Edit', 
-                    signatures = group.signatures, 
-                    group = Group(
-                        id = group.id, 
-                        members = {
-                            'remove': members_to_remove
-                        }
-                    ), 
-                    readers=group.signatures, 
-                    writers=group.signatures
-                )
-                return self.get_group(group.id)
-            else:
-                response = self.session.delete(self.groups_url + '/members', json = {'id': group.id, 'members': members}, headers = self.headers)
-                response = self.__handle_response(response)
-                return Group.from_json(response.json())                           
+            self.post_group_edit(invitation = f'{group.domain}/-/Edit', 
+                signatures = group.signatures, 
+                group = Group(
+                    id = group.id, 
+                    members = {
+                        'remove': members_to_remove
+                    }
+                ), 
+                readers=group.signatures, 
+                writers=group.signatures
+            )
+            return self.get_group(group.id)                      
 
         member_type = type(members)
         if member_type in string_types:

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -1915,8 +1915,28 @@ The OpenReview Team.
         assert openreview_client.get_group('harold@profile.org').members == ['~Harold_Last1']
         with pytest.raises(openreview.OpenReviewException, match=r'Group Not Found: alternate_harold@profile.org'):
             assert openreview_client.get_group('alternate_harold@profile.org').members == []
-        openreview_client.add_members_to_group('~Harold_Last1', 'alternate_harold@profile.org')
-        openreview_client.add_members_to_group('alternate_harold@profile.org', '~Harold_Last1')
+
+        openreview_client.post_group_edit(invitation = 'openreview.net/-/Edit', 
+            signatures = ['~Super_User1'], 
+            group = openreview.api.Group(
+                id = '~Harold_Last1', 
+                members = {
+                    'append': ['alternate_harold@profile.org']
+                },
+                signatures = ['~Super_User1']
+            )
+        )
+
+        openreview_client.post_group_edit(invitation = 'openreview.net/-/Edit', 
+            signatures = ['~Super_User1'], 
+            group = openreview.api.Group(
+                id = 'alternate_harold@profile.org', 
+                members = {
+                    'append': ['~Harold_Last1']
+                },
+                signatures = ['~Super_User1']
+            )
+        )
 
         ## Try to remove the unexisting name and get an error
         with pytest.raises(openreview.OpenReviewException, match=r'Profile not found for ~Harold_Lastt1'):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -652,7 +652,7 @@ class TestTools():
         
         openreview_client.post_group_edit(invitation = 'openreview.net/-/Edit', 
             signatures = ['~Super_User1'], 
-            group = Group(
+            group = openreview.api.Group(
                 id = '~SomeFirstName_User1', 
                 members = {
                     'append': ['alternate@mail.com']
@@ -662,7 +662,7 @@ class TestTools():
 
         openreview_client.post_group_edit(invitation = 'openreview.net/-/Edit', 
             signatures = ['~Super_User1'], 
-            group = Group(
+            group = openreview.api.Group(
                 id = 'alternate@mail.com', 
                 members = {
                     'append': ['~SomeFirstName_User1']

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -649,8 +649,28 @@ class TestTools():
         assert openReviewError.value.args[0].get('name') == 'ForbiddenError'
 
     def test_get_profiles_as_dict(self, openreview_client, test_client):
-        openreview_client.add_members_to_group(openreview_client.get_group('~SomeFirstName_User1'), 'alternate@mail.com', 'openreview.net/-/Edit')
-        openreview_client.add_members_to_group(openreview_client.get_group('alternate@mail.com'), '~SomeFirstName_User1', 'openreview.net/-/Edit')
+        
+        openreview_client.post_group_edit(invitation = 'openreview.net/-/Edit', 
+            signatures = ['~Super_User1'], 
+            group = Group(
+                id = '~SomeFirstName_User1', 
+                members = {
+                    'append': ['alternate@mail.com']
+                }
+            )
+        )
+
+        openreview_client.post_group_edit(invitation = 'openreview.net/-/Edit', 
+            signatures = ['~Super_User1'], 
+            group = Group(
+                id = 'alternate@mail.com', 
+                members = {
+                    'append': ['~SomeFirstName_User1']
+                }
+            )
+        )        
+        
+        
         profiles = openreview.tools.get_profiles(
             openreview_client, ids_or_emails=['~SomeFirstName_User1', '~Another_Name1', 'user@gmail.com', 'test_user@mail.com', 'test@mail.com', 'alternate@mail.com', '~Test_Name1'], as_dict=True
         )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -649,8 +649,8 @@ class TestTools():
         assert openReviewError.value.args[0].get('name') == 'ForbiddenError'
 
     def test_get_profiles_as_dict(self, openreview_client, test_client):
-        openreview_client.add_members_to_group(openreview_client.get_group('~SomeFirstName_User1'), 'alternate@mail.com')
-        openreview_client.add_members_to_group(openreview_client.get_group('alternate@mail.com'), '~SomeFirstName_User1')
+        openreview_client.add_members_to_group(openreview_client.get_group('~SomeFirstName_User1'), 'alternate@mail.com', 'openreview.net/-/Edit')
+        openreview_client.add_members_to_group(openreview_client.get_group('alternate@mail.com'), '~SomeFirstName_User1', 'openreview.net/-/Edit')
         profiles = openreview.tools.get_profiles(
             openreview_client, ids_or_emails=['~SomeFirstName_User1', '~Another_Name1', 'user@gmail.com', 'test_user@mail.com', 'test@mail.com', 'alternate@mail.com', '~Test_Name1'], as_dict=True
         )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -656,7 +656,8 @@ class TestTools():
                 id = '~SomeFirstName_User1', 
                 members = {
                     'append': ['alternate@mail.com']
-                }
+                },
+                signatures = ['~Super_User1']
             )
         )
 
@@ -666,7 +667,8 @@ class TestTools():
                 id = 'alternate@mail.com', 
                 members = {
                     'append': ['~SomeFirstName_User1']
-                }
+                },
+                signatures = ['~Super_User1']
             )
         )        
         


### PR DESCRIPTION
this pr contains changes related to 
https://github.com/openreview/openreview-api/pull/495
and
https://github.com/openreview/openreview-web/pull/2028

to remove call to add/remove members endpoints because they are removed in https://github.com/openreview/openreview-api/pull/495