### PR TITLE
ARR: Fix submission preprocess

### DIFF
--- a/openreview/arr/process/submission_preprocess.py
+++ b/openreview/arr/process/submission_preprocess.py
@@ -8,36 +8,34 @@ def process(client, edit, invitation):
     volunteers = edit.note.content.get('reviewing_volunteers', {}).get('value', [])
     authorids = edit.note.content.get('authorids').get('value')
 
-    if paper_link:
+    paper_forum = paper_link.split('?id=')[-1]
 
-        if '&' in paper_link:
-            raise openreview.OpenReviewException('Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.')
+    if '&' in paper_link:
+        raise openreview.OpenReviewException('Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.')
 
-        paper_forum = paper_link.split('?id=')[-1]
-        client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
+    client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
 
-        try:
-            arr_submission_v1 = client_v1.get_note(paper_forum)
-        except:
-            arr_submission_v1 = None
+    try:
+        arr_submission_v1 = client_v1.get_note(paper_forum)
+    except:
+        arr_submission_v1 = None
 
-        try:
-            arr_submission_v2 = client.get_note(paper_forum)
-        except:
-            arr_submission_v2 = None
+    try:
+        arr_submission_v2 = client.get_note(paper_forum)
+    except:
+        arr_submission_v2 = None
 
-        
-        if not arr_submission_v1 and not arr_submission_v2:
-            raise openreview.OpenReviewException('Provided paper link does not correspond to a submission in OpenReview')
+    if not arr_submission_v1 and not arr_submission_v2:
+        raise openreview.OpenReviewException('Provided paper link does not correspond to a submission in OpenReview')
 
-        if (arr_submission_v1 and 'aclweb.org/ACL/ARR' not in arr_submission_v1.invitation) or (arr_submission_v2 and not any('aclweb.org/ACL/ARR' in inv for inv in arr_submission_v2.invitations)):
-            raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission')
+    if (arr_submission_v1 and 'aclweb.org/ACL/ARR' not in arr_submission_v1.invitation) or (arr_submission_v2 and not any('aclweb.org/ACL/ARR' in inv for inv in arr_submission_v2.invitations)):
+        raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission')
 
-        if (arr_submission_v1 and arr_submission_v1.id != arr_submission_v1.forum) or (arr_submission_v2 and arr_submission_v2.id != arr_submission_v2.forum):
-            raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
+    if (arr_submission_v1 and arr_submission_v1.id != arr_submission_v1.forum) or (arr_submission_v2 and arr_submission_v2.id != arr_submission_v2.forum):
+        raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
 
-        if arr_submission_v1 and 'aclweb.org/ACL/ARR' in arr_submission_v1.invitation and not arr_submission_v1.invitation.endswith('Blind_Submission'):
-            raise openreview.OpenReviewException('Provided paper link does not point to a blind submission. Make sure you get the url to your submission from the browser')
+    if arr_submission_v1 and 'aclweb.org/ACL/ARR' in arr_submission_v1.invitation and not arr_submission_v1.invitation.endswith('Blind_Submission'):
+        raise openreview.OpenReviewException('Provided paper link does not point to a blind submission. Make sure you get the url to your submission from the browser')
 
     # If provided previous URL but left a reassignment request blank
     if paper_link and (not editor_reassignment_request or not reviewer_reassignment_request):

--- a/openreview/arr/process/submission_preprocess.py
+++ b/openreview/arr/process/submission_preprocess.py
@@ -8,43 +8,44 @@ def process(client, edit, invitation):
     volunteers = edit.note.content.get('reviewing_volunteers', {}).get('value', [])
     authorids = edit.note.content.get('authorids').get('value')
 
-    paper_forum = paper_link.split('?id=')[-1]
-
-    if '&' in paper_link:
-        raise openreview.OpenReviewException('Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.')
-
-    client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
-
-    try:
-        arr_submission_v1 = client_v1.get_note(paper_forum)
-    except:
-        arr_submission_v1 = None
-
-    try:
-        arr_submission_v2 = client.get_note(paper_forum)
-    except:
-        arr_submission_v2 = None
-
-    if not arr_submission_v1 and not arr_submission_v2:
-        raise openreview.OpenReviewException('Provided paper link does not correspond to a submission in OpenReview')
-
-    if (arr_submission_v1 and 'aclweb.org/ACL/ARR' not in arr_submission_v1.invitation) or (arr_submission_v2 and not any('aclweb.org/ACL/ARR' in inv for inv in arr_submission_v2.invitations)):
-        raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission')
-
-    if (arr_submission_v1 and arr_submission_v1.id != arr_submission_v1.forum) or (arr_submission_v2 and arr_submission_v2.id != arr_submission_v2.forum):
-        raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
-
-    if arr_submission_v1 and 'aclweb.org/ACL/ARR' in arr_submission_v1.invitation and not arr_submission_v1.invitation.endswith('Blind_Submission'):
-        raise openreview.OpenReviewException('Provided paper link does not point to a blind submission. Make sure you get the url to your submission from the browser')
-
-    # If provided previous URL but left a reassignment request blank
-    if paper_link and (not editor_reassignment_request or not reviewer_reassignment_request):
-      raise openreview.OpenReviewException('Since you are re-submitting, please indicate if you would like the same editors/reviewers as your indicated previous submission')
-
     # If no previous URL but selected reassignment
     if not paper_link and (editor_reassignment_request or reviewer_reassignment_request):
-      raise openreview.OpenReviewException('You have selected a reassignment request with no previous URL. Please enter a URL or close and re-open the submission form to clear your reassignment request')
-    
+        raise openreview.OpenReviewException('You have selected a reassignment request with no previous URL. Please enter a URL or close and re-open the submission form to clear your reassignment request')
+
+    if paper_link:
+        paper_forum = paper_link.split('?id=')[-1]
+
+        if '&' in paper_link:
+            raise openreview.OpenReviewException('Invalid paper link. Please make sure not to provide anything after the character "&" in the paper link.')
+
+        client_v1=openreview.Client(baseurl=openreview.tools.get_base_urls(client)[0], token=client.token)
+
+        try:
+            arr_submission_v1 = client_v1.get_note(paper_forum)
+        except:
+            arr_submission_v1 = None
+
+        try:
+            arr_submission_v2 = client.get_note(paper_forum)
+        except:
+            arr_submission_v2 = None
+
+        if not arr_submission_v1 and not arr_submission_v2:
+            raise openreview.OpenReviewException('Provided paper link does not correspond to a submission in OpenReview')
+
+        if (arr_submission_v1 and 'aclweb.org/ACL/ARR' not in arr_submission_v1.invitation) or (arr_submission_v2 and not any('aclweb.org/ACL/ARR' in inv for inv in arr_submission_v2.invitations)):
+            raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission')
+
+        if (arr_submission_v1 and arr_submission_v1.id != arr_submission_v1.forum) or (arr_submission_v2 and arr_submission_v2.id != arr_submission_v2.forum):
+            raise openreview.OpenReviewException('Provided paper link does not correspond to an ARR submission. Make sure the link points to a submission and not to a reply.')
+
+        if arr_submission_v1 and 'aclweb.org/ACL/ARR' in arr_submission_v1.invitation and not arr_submission_v1.invitation.endswith('Blind_Submission'):
+            raise openreview.OpenReviewException('Provided paper link does not point to a blind submission. Make sure you get the url to your submission from the browser')
+
+        # If provided previous URL but left a reassignment request blank
+        if (not editor_reassignment_request or not reviewer_reassignment_request):
+            raise openreview.OpenReviewException('Since you are re-submitting, please indicate if you would like the same editors/reviewers as your indicated previous submission')
+        
     for v in volunteers:
         if v not in authorids:
             raise openreview.OpenReviewException(f'Volunteer {v} is not an author of this submission')

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -1201,6 +1201,19 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                     note=openreview.api.Note(
                     content = {
                         **generic_note_content,
+                        'previous_URL': { 'value': f"https://openreview.net//forum?id={allowed_note['note']['id']}" },
+                        'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
+                        'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },
+                        'justification_for_not_keeping_action_editor_or_reviewers': { 'value': 'We would like to keep the same reviewers and action editor because they are experts in the field and have provided valuable feedback on our previous submission.' }
+                    }
+                ))
+
+        with pytest.raises(openreview.OpenReviewException, match=r'previous_URL value must be a valid link to an OpenReview submission'):
+            test_client.post_note_edit(invitation='aclweb.org/ACL/ARR/2023/June/-/Submission',
+                    signatures=['~SomeFirstName_User1'],
+                    note=openreview.api.Note(
+                    content = {
+                        **generic_note_content,
                         'previous_URL': { 'value': 'https://openreview.net/pdf?id=1234' },
                         'reassignment_request_action_editor': {'value': 'No, I want the same action editor from our previous submission and understand that a new action editor may be assigned if the previous one is unavailable' },
                         'reassignment_request_reviewers': { 'value': 'Yes, I want a different set of reviewers' },


### PR DESCRIPTION
Resolves #2226 

Synchronizes the submission preprocess function for ARR with the commitment submission preprocess

Adds a test to verify that double slashes will raise an exception 