### PR TITLE
Feature: ARR email option for reminding reviewers about rebuttals

### DIFF
--- a/openreview/arr/webfield/programChairsWebfield.js
+++ b/openreview/arr/webfield/programChairsWebfield.js
@@ -172,40 +172,27 @@ return {
     reviewerEmailFuncs: [
       {
         label: 'Reviewers with No Rebuttal Responses', filterFunc: `
-        console.log(row);
         if (row.notesInfo.length <= 0){
           return false;
         }
-        console.log('pass notes validation')
 
         const buildReplyToMap = (note) => {
-          console.log('building map now');
           const replyToMap = new Map();
-          console.log('map initialized');
           (note?.details?.replies ?? []).forEach((reply) => {
-            console.log('in reply iteration');
             if (!replyToMap.has(reply.replyto)) {
               replyToMap.set(reply.replyto, []);
             }
             replyToMap.get(reply.replyto).push(reply);
           });
-          console.log('map building complete');
           return replyToMap;
         }
-        console.log('pass declare build')
-
+        
         const childrenWithSignature = (reply, signature, replyToMap) => {
-          console.log(signature);
           const queue = replyToMap.get(reply.id) ?? [];
-          console.log(reply.id);
-          console.log(queue);
           const matchingReplies = [];
           const count = 0;
-          console.log('starting queue');
-          console.log(queue);
           while (queue.length > 0) {
             const nextReply = queue.pop();
-            console.log(nextReply);
             if (nextReply.signatures[0].includes(signature) && nextReply.readers.some(reader => reader.includes('/Authors')) && nextReply.readers.some(reader => reader.includes('/Reviewers'))) {
               matchingReplies.push(nextReply);
             }
@@ -214,27 +201,18 @@ return {
           return matchingReplies;
         }
 
-        console.log('pass declare children')
-
         return row.notesInfo.some(noteObj =>{
-          console.log('in note iteration');
-          const anonId = noteObj.anonymousId;
-          console.log('about to call buildReplyToMap');
           const noteReplyMap = buildReplyToMap(noteObj.note);
-          console.log('done to call buildReplyToMap');
-          console.log(noteObj.note?.details?.replies);
-          const officialReview = (noteObj.note?.details?.replies ?? []).filter(
-            reply => reply.signatures[0].includes(anonId) &&
-                     reply.invitations[0].includes('Official_Review')
-          );
-          if (officialReview.length <= 0) {
+          const officialReview = noteObj?.officialReview
+          if (!officialReview) {
             return false;
           }
-          const authorReplies = childrenWithSignature(officialReview[0], '/Authors', noteReplyMap);
+          const anonId = officialReview.anonymousId;
+          const authorReplies = childrenWithSignature(officialReview, '/Authors', noteReplyMap);
           if (authorReplies.length <= 0) {
             return false;
           }
-          const reviewerResponses = childrenWithSignature(officialReview[0], anonId, noteReplyMap);
+          const reviewerResponses = childrenWithSignature(officialReview, anonId, noteReplyMap);
           return reviewerResponses.length < authorReplies.length;
         })
         `

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3797,13 +3797,14 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         assert openreview_client.get_messages(to='sac2@aclrollingreview.com', subject='[ARR - August 2023] Program Chairs commented on a paper in your area. Paper Number: 3, Paper Title: "Paper title 3"')   
 
         # Post comment to review
+        submissions = venue.get_submissions(details='replies', sort='number:asc')
         author_client = openreview.api.OpenReviewClient(username='test@mail.com', password=helpers.strong_password)
         official_review = [
             reply for reply in submissions[2].details['replies'] if 'Official_Review' in reply['invitations'][0]
         ][0]
         author_client.post_note_edit(
             invitation=f"aclweb.org/ACL/ARR/2023/August/Submission3/-/Official_Comment",
-            writers=[f'aclweb.org/ACL/ARR/2023/August/Submission3/Authors'],
+            writers=[f'aclweb.org/ACL/ARR/2023/August'],
             signatures=['aclweb.org/ACL/ARR/2023/August/Submission3/Authors'],
             note=openreview.api.Note(
                 replyto=official_review['id'],
@@ -3811,7 +3812,8 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                     'aclweb.org/ACL/ARR/2023/August/Program_Chairs',
                     f'aclweb.org/ACL/ARR/2023/August/Submission3/Senior_Area_Chairs',
                     f'aclweb.org/ACL/ARR/2023/August/Submission3/Area_Chairs',
-                    f'aclweb.org/ACL/ARR/2023/August/Submission3/Reviewers'
+                    f'aclweb.org/ACL/ARR/2023/August/Submission3/Reviewers',
+                    f'aclweb.org/ACL/ARR/2023/August/Submission3/Authors'
                 ],
                 content={
                     "comment": { "value": "This is an author response"}


### PR DESCRIPTION
This PR adds a new option to the ARR PC console to email reviewers that have not responded to their rebuttals. This will send an email if any of their assigned papers is missing a reviewer response to an author rebuttal of their official review.