### PR TITLE
Fix/ Venue redeploy

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -119,7 +119,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
             venue = openreview.arr.ARR(openreview_client, note.content['venue_id'], support_user, venue=venue)
 
         venue_group = openreview.tools.get_group(openreview_client, note.content['venue_id'])
-        venue_content = venue_group.content if venue_group else {}
+        venue_content = venue_group.content if venue_group and venue_group.content else {}
         
         ## Run test faster
         if 'openreview.net' in support_user:


### PR DESCRIPTION
When there is an error in the deployment of a venue, sometimes the content of the group is not saved. When we try to make the deployment again, there is an error because we assume that is the venue group exists, then the content exists too. 