### PR TITLE
Fix/ Venue request emails to support 

### DIFF
--- a/openreview/venue_request/process/commentProcess.js
+++ b/openreview/venue_request/process/commentProcess.js
@@ -18,6 +18,10 @@ function(){
       message: 'A comment was posted to your service request. \n\nComment title: ' + commentTitle + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id + '\n\nPlease note that with the exception of urgent issues, requests made on weekends or US holidays can expect to receive a response on the following business day. Thank you for your patience!'
     };
 
+    if (commentTitle.includes('Process Completed')) {
+      return or3client.or3request(or3client.mailUrl, message, 'POST', token)
+    }
+
     var support_message = {
       groups: [SUPPORT_GROUP],
       subject: 'Comment posted to a service request: ' + forumNote.content.title,

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -1393,6 +1393,16 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Reviewers/-/Bid')
         assert invitation.edit['tail']['param']['options']['group'] == 'ICML.cc/2023/Conference/Reviewers'
 
+        # check email is not sent to support
+        messages = openreview_client.get_messages(to='support@openreview.net', subject='Comment posted to a service request: Thirty-ninth International Conference on Machine Learning')
+        assert messages and len(messages) == 1
+        assert 'Comment title: Bid Stage Process Completed' not in messages[0]['content']['text']
+
+        # check email is sent to pcs
+        messages = openreview_client.get_messages(to='pc@icml.cc', subject='Comment posted to your request for service: Thirty-ninth International Conference on Machine Learning')
+        assert messages and len(messages) == 6
+        assert 'Comment title: Bid Stage Process Completed' in messages[-1]['content']['text']
+
         ## Hide the pdf and supplementary material
         pc_client.post_note(openreview.Note(
             content= {


### PR DESCRIPTION
Rachel and I agreed that we do not need to get emails about completed processes. These emails should only be sent to PCs.