### PR TITLE
Assignment preprocesses: Fix domain content keys

### DIFF
--- a/openreview/venue/process/assignment_pre_process.js
+++ b/openreview/venue/process/assignment_pre_process.js
@@ -8,8 +8,8 @@ async function process(client, edge, invitation) {
   const reviewName = invitation.content.review_name?.value
   const reviewersAnonName = invitation.content.reviewers_anon_name?.value
   const reviewersName = invitation.content.reviewers_name?.value
-  const quota = domain.content?.['submission_assignment_max_' + reviewersName.toLowerCase()]?.value
-  const inviteAssignmentId = domain.content?.[reviewersName.toLowerCase() + '_invite_assignment_id']?.value
+  const quota = domain.content?.['submission_assignment_max_reviewers']?.value
+  const inviteAssignmentId = domain.content?.['reviewers_invite_assignment_id']?.value
 
   const { notes } = await client.getNotes({ id: edge.head })
   const submission = notes[0]

--- a/openreview/venue/process/invite_assignment_pre_process.js
+++ b/openreview/venue/process/invite_assignment_pre_process.js
@@ -10,8 +10,7 @@ async function process(client, edge, invitation) {
   const inviteLabel = invitation.content.invite_label?.value
   const conflictPolicy = domain.content.reviewers_conflict_policy?.value
   const conflictNYears = domain.content.reviewers_conflict_n_years?.value
-  const reviewersName = reviewersId.split('/').pop().toLowerCase()
-  const quota = domain.content?.['submission_assignment_max_' + reviewersName]?.value
+  const quota = domain.content?.['submission_assignment_max_reviewers']?.value
 
   if (edge.ddate && edge.label !== inviteLabel) {
     return Promise.reject(new OpenReviewError({ name: 'Error', message: `Cannot cancel the invitation since it has status: "${edge.label}"` }))

--- a/openreview/venue/process/proposed_assignment_pre_process.js
+++ b/openreview/venue/process/proposed_assignment_pre_process.js
@@ -4,9 +4,15 @@ async function process(client, edge, invitation) {
   const committeeName = invitation.content.committee_name?.value;
   const { groups } = await client.getGroups({ id: invitation.domain });
   const domain = groups[0];
-  const quota = domain.content?.['submission_assignment_max_' + committeeName.toLowerCase()]?.value
-
-  const customMaxPapersId = domain.content[committeeName.toLowerCase() + '_custom_max_papers_id']?.value;
+  const reviewersName = domain.content['reviewers_name']?.value
+  const areaChairsName = domain.content['area_chairs_name']?.value
+  const roleMap = {
+    [reviewersName]: 'reviewers',
+    [areaChairsName]: 'area_chairs',
+  };
+  const internalRole = roleMap[committeeName]
+  const customMaxPapersId = domain.content[`${internalRole}_custom_max_papers_id`]?.value;
+  const quota = domain.content?.[`submission_assignment_max_${internalRole}`]?.value
 
   if (edge.ddate) {
     return
@@ -41,7 +47,7 @@ async function process(client, edge, invitation) {
   }
 
   if (quota && (submissionEdges.length + 1) > quota) {
-    return Promise.reject(new OpenReviewError({ name: 'Error', message: `You cannot assign more than ${quota} ${committeeName.toLowerCase()} to this paper` }));
+    return Promise.reject(new OpenReviewError({ name: 'Error', message: `You cannot assign more than ${quota} ${committeeName.toLowerCase().replaceAll('_',' ')} to this paper` }));
   }
 
 }


### PR DESCRIPTION
- Fixes the issue mentioned here: https://github.com/openreview/openreview-py/pull/2201#discussion_r1700795788

In some preprocess functions we retrieve fields from the domain using the committee name in the key. The problem is that these fields are hardcoded and don't use the committee name. It's an issue for venues that use custom role names.