### PR TITLE
Fix/Venue: Chat process and date process

### DIFF
--- a/openreview/venue/process/chat_comment_process.py
+++ b/openreview/venue/process/chat_comment_process.py
@@ -19,6 +19,11 @@ def process(client, edit, invitation):
     if not comment_email_sacs and senior_area_chairs_name:
         ignore_recipients.append(f'{venue_id}/{submission_name}{submission.number}/{senior_area_chairs_name}')
 
+    final_recipients = []
+    for group in comment.readers:
+        if openreview.tools.get_group(client, group):
+            final_recipients.append(group)
+
     invitation = client.get_invitation(invitation.id)
     if invitation.date_processes[0].get('cron') is None:
         ## Activate date process to run every 4 hours
@@ -41,7 +46,7 @@ def process(client, edit, invitation):
         client.post_message(
             invitation=meta_invitation_id,
             subject = f'[{short_name}] New conversation in committee members chat for submission {submission.number}: {submission.content["title"]["value"]}',
-            recipients = comment.readers,
+            recipients = final_recipients,
             message = f'''Hi {{{{fullname}}}},
             
 A new conversation has been started in the {short_name} forum for submission {submission.number}: {submission.content['title']['value']}
@@ -95,7 +100,7 @@ You can view the conversation here: https://openreview.net/forum?id={submission.
         client.post_message(
             invitation=meta_invitation_id,
             subject = f'[{short_name}] New messages in committee members chat for submission {submission.number}: {submission.content["title"]["value"]}',
-            recipients = comment.readers,
+            recipients = final_recipients,
             message = f'''Hi {{{{fullname}}}},
             
 New comments have been posted for the conversation in the {short_name} forum for submission {submission.number}: {submission.content['title']['value']}

--- a/openreview/venue/process/chat_date_comment_process.py
+++ b/openreview/venue/process/chat_date_comment_process.py
@@ -29,12 +29,17 @@ def process(client, invitation):
     
     ignore_recipients = new_comments[-1].signatures + ([program_chairs_id] if not comment_email_pcs else [])
     if not comment_email_sacs and senior_area_chairs_name:
-        ignore_recipients.append(f'{venue_id}/{submission_name}{submission.number}/{senior_area_chairs_name}')    
+        ignore_recipients.append(f'{venue_id}/{submission_name}{submission.number}/{senior_area_chairs_name}')
+
+    final_recipients = []
+    for group in new_comments[-1].readers:
+        if openreview.tools.get_group(client, group):
+            final_recipients.append(group)
     
     client.post_message(
         invitation = meta_invitation_id,
         subject = f'[{short_name}] New message{"s" if len(new_comments) > 1 else ""} in committee members chat for submission {submission.number}: {submission.content["title"]["value"]}',
-        recipients = new_comments[-1].readers,
+        recipients = final_recipients,
         message = f'''Hi {{{{fullname}}}},
         
 New comment{"s have" if len(new_comments) > 1 else " has"} been posted for the conversation in the {short_name} forum for submission {submission.number}: {submission.content['title']['value']}

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -5525,7 +5525,7 @@ Best,
 
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Chat')
         assert invitation.date_processes[0].get('dates') is None
-        assert invitation.date_processes[0].get('cron') == '0 */4 * * *'        
+        assert invitation.date_processes[0].get('cron') == '0 */4 * * *'
 
         assert len(openreview_client.get_messages(to='reviewer1@icml.cc', subject='[ICML 2023] New conversation in committee members chat for submission 1: Paper title 1 Version 2 UPDATED')) == 0
         assert len(openreview_client.get_messages(to='reviewer2@icml.cc', subject='[ICML 2023] New conversation in committee members chat for submission 1: Paper title 1 Version 2 UPDATED')) == 1
@@ -5666,6 +5666,34 @@ Best,
 
         tags = openreview_client.get_tags(invitation='ICML.cc/2023/Conference/Submission1/-/Chat_Reaction', mintmdate=tag.tmdate - 5000)
         assert len(tags) == 1
+
+        submission = openreview_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', number=4)[0]
+
+        reviewer_client = openreview.api.OpenReviewClient(username='reviewer1@icml.cc', password=helpers.strong_password)
+
+        anon_groups = reviewer_client.get_groups(prefix='ICML.cc/2023/Conference/Submission4/Reviewer_', signatory='~Reviewer_ICMLOne1')
+        anon_group_id = anon_groups[0].id
+
+        # assert there is no error if Reviewer/Submitted group does not exist
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission4/-/Chat')
+        assert invitation.date_processes[0].get('dates') == []
+
+        note_edit = reviewer_client.post_note_edit(
+            invitation='ICML.cc/2023/Conference/Submission4/-/Chat',
+            signatures=[anon_group_id],
+            note=openreview.api.Note(
+                replyto=submission.id,
+                content={
+                    'message': { 'value': 'Hi AC, I will be late in completing my review.' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=note_edit['id'])
+
+        invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission4/-/Chat')
+        assert invitation.date_processes[0].get('dates') is None
+        assert invitation.date_processes[0].get('cron') == '0 */4 * * *'
 
         ## Disable chat
         pc_client=openreview.Client(username='pc@icml.cc', password=helpers.strong_password)


### PR DESCRIPTION
Check if the group exists before trying to send the email. 
We got many errors because the Reviewers/Submitted group for some papers might not exist at the time when the Chat invitation is enabled. 