### PR TITLE
Fix/tmlr requests

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -2291,7 +2291,13 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                         'default': 'Invitation Sent'
                     }
                 }
-            }
+            },
+            date_processes=[
+                {
+                    'cron': '0 0 * * *',
+                    'script': self.get_process_content('process/remind_invited_reviewer_process.py')
+                }
+            ]
         )
 
         self.save_invitation(invitation)

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -2144,7 +2144,8 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                 },
                 'weight': {
                     'param': {
-                        'minimum': -1
+                        'minimum': -1,
+                        'default': 0
                     }
                 }
             }

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -56,6 +56,7 @@ class Journal(object):
         self.assignment = Assignment(self)
         self.recruitment = Recruitment(self)
         self.unavailable_reminder_period = 4 # weeks
+        self.invite_assignment_reminder_period = 1 # week
 
     def __get_group_id(self, name, number=None):
         if number:

--- a/openreview/journal/process/remind_invited_reviewer_process.py
+++ b/openreview/journal/process/remind_invited_reviewer_process.py
@@ -1,0 +1,50 @@
+def process(client, invitation):
+
+    print('Remind invited reviewers')
+    journal = openreview.journal.Journal()
+    grouped_edges = client.get_grouped_edges(invitation=journal.get_reviewer_invite_assignment_id(), label='Invitation Sent', groupby='id')
+    
+    if len(grouped_edges) == 0:
+        return
+    
+    edges = [openreview.api.Edge.from_json(edge['values'][0]) for edge in grouped_edges]
+
+    start_reminder_period = openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(weeks = journal.invite_assignment_reminder_period, days=1))
+    end_reminder_period = openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(weeks = journal.invite_assignment_reminder_period))
+    one_week = datetime.timedelta(weeks=1)
+    
+    print(f'reminder period between {start_reminder_period} and {end_reminder_period}')
+    for edge in edges:
+        if start_reminder_period < edge.tcdate and edge.tcdate < end_reminder_period:
+
+            notes=client.get_notes(id=edge.head)
+            if not notes:
+                continue
+            submission=notes[0]
+            user = edge.tail
+            user_profile=openreview.tools.get_profile(client, user)
+
+            if not user_profile:
+                user_profile=openreview.Profile(id=user,
+                    content={
+                        'names': [],
+                        'emails': [user],
+                        'preferredEmail': user
+                    })
+                
+            last_modified = datetime.timedelta(milliseconds=edge.tmdate - edge.tcdate)
+
+            if last_modified < one_week:
+                subject=f'[{journal.short_name}] Invitation to review paper titled "{submission.content["title"]["value"]}"'
+
+                previous_message = client.get_messages(to=user_profile.get_preferred_email(), subject=subject)
+                if previous_message:
+                    print(f"remind: {edge.tail}")
+                    reminder_subject = f'[{journal.short_name}] Reminder: Invitation to review paper titled "{submission.content["title"]["value"]}"'
+                    replace_sentence = f'''Please note that responding to this email will direct your reply to {previous_message[0]['content']['replyTo']}.'''
+                    message = previous_message[0]['content']['text'].replace(replace_sentence, '')
+                    client.post_message(reminder_subject, [user_profile.id], message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=previous_message[0]['content']['replyTo'], sender=journal.get_message_sender())
+                    ## update edge to reset the reminder counter
+                    client.post_edge(edge)
+            else:
+                print('User was just reminded!')

--- a/openreview/journal/process/reviewer_invitation_assignment_process.py
+++ b/openreview/journal/process/reviewer_invitation_assignment_process.py
@@ -24,6 +24,9 @@ def process(client, edge, invitation):
         inviter_profile=openreview.tools.get_profile(client, edge.tauthor)
         inviter_preferred_name=inviter_profile.get_preferred_name(pretty=True) if inviter_profile else edge.signatures[0]
 
+        user_preferred_name=user_profile.get_preferred_name(pretty=True) if user_profile else user
+        reply_to = user_profile.get_preferred_name() if user_profile else user
+
         if not user_profile:
             user_profile=openreview.Profile(id=user,
                 content={
@@ -48,7 +51,7 @@ def process(client, edge, invitation):
 
         # format the message defined above
         subject=f'[{short_phrase}] Invitation to review paper titled "{submission.content["title"]["value"]}"'
-        message=f'''Hi {{{{fullname}}}},
+        message=f'''Hi {user_preferred_name},
 
 You were invited to review the paper number: {submission.number}, title: "{submission.content['title']['value']}".
 
@@ -64,6 +67,25 @@ Thanks,
         
         ## - Send email
         response = client.post_message(subject, [user_profile.id], message, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=inviter_profile.get_preferred_name(), sender=journal.get_message_sender())
+
+        message_AE = f'''Hi {{{{fullname}}}},
+
+The following invitation email was sent to {user_preferred_name}:
+
+Hi {user_preferred_name},
+
+You were invited to review the paper number: {submission.number}, title: "{submission.content['title']['value']}".
+
+Abstract: {submission.content['abstract']['value']}
+
+{invitation_links}
+
+Thanks,
+
+{inviter_id}
+{inviter_preferred_name}'''
+
+        response = client.post_message(subject, [inviter_profile.id], message_AE, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, replyTo=reply_to, sender=journal.get_message_sender())
 
         ## - Update edge to INVITED_LABEL
         edge.label=invite_label

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -5265,6 +5265,10 @@ note={Expert Certification}
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi Melisa Bok,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=~Melisa_Bok1&key=da9c8e30376e445b0d18011af6a8ca7863e5037e3f9aebc6aa4294e5aaa5c216&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {joelle_paper13_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to samy@bengio.com.\n'''
 
+        messages = openreview_client.get_messages(to = 'samy@bengio.com', subject = '[TMLR] Invitation to review paper titled "Paper title 14"')
+        assert len(messages) == 1
+        assert messages[0]['content']['text'] == f'''Hi Samy Bengio,\n\nThe following invitation email was sent to Melisa Bok:\n\nHi Melisa Bok,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=~Melisa_Bok1&key=da9c8e30376e445b0d18011af6a8ca7863e5037e3f9aebc6aa4294e5aaa5c216&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {joelle_paper13_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to melisa@mailten.com.\n'''
+
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
 


### PR DESCRIPTION
1. Adds default:0 to Pending Reviews invitation
2. Sends copy of invite assignment email sent to a reviewer to the AE
3. Sends a one-time reminder about invite assignment emails to reviewers who have not accepted/declines the invitation