### PR TITLE
Test: Store API logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,11 +140,11 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/test_*.py" | circleci tests split --split-by=timings)
             mkdir test-reports
             pytest --durations=0 --junitxml=test-reports/junit.xml --driver Firefox --driver-path tests/drivers/geckodriver $TEST_FILES
-      # - run:
-      #     name: Copy API logs to artifacts
-      #     command: |
-      #       cp ~/openreview/logs/* ~/openreview-py-repo/test-reports/
-      #       cp ~/openreview-v2/logs/* ~/openreview-py-repo/test-reports/
+      - run:
+          name: Copy API logs to artifacts
+          command: |
+            cp ~/openreview/logs/* ~/openreview-py-repo/test-reports/
+            cp ~/openreview-v2/logs/* ~/openreview-py-repo/test-reports/
       - store_test_results:
           path: test-reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,11 +140,11 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/test_*.py" | circleci tests split --split-by=timings)
             mkdir test-reports
             pytest --durations=0 --junitxml=test-reports/junit.xml --driver Firefox --driver-path tests/drivers/geckodriver $TEST_FILES
-      - run:
-          name: Copy API logs to artifacts
-          command: |
-            cp ~/openreview/logs/* ~/openreview-py-repo/test-reports/
-            cp ~/openreview-v2/logs/* ~/openreview-py-repo/test-reports/
+      # - run:
+      #     name: Copy API logs to artifacts
+      #     command: |
+      #       cp ~/openreview/logs/* ~/openreview-py-repo/test-reports/
+      #       cp ~/openreview-v2/logs/* ~/openreview-py-repo/test-reports/
       - store_test_results:
           path: test-reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,11 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/test_*.py" | circleci tests split --split-by=timings)
             mkdir test-reports
             pytest --durations=0 --junitxml=test-reports/junit.xml --driver Firefox --driver-path tests/drivers/geckodriver $TEST_FILES
+      - run:
+          name: Copy API logs to artifacts
+          command: |
+            cp ~/openreview/logs/* ~/openreview-py-repo/test-reports/
+            cp ~/openreview-v2/logs/* ~/openreview-py-repo/test-reports/
       - store_test_results:
           path: test-reports
       - store_artifacts:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,7 @@ class Helpers:
         buttons = container.find_elements(By.TAG_NAME, "button")
 
         for button in buttons:
+            time.sleep(3)
             assert button.is_enabled()      
 
         if quota and accept:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,6 @@ class Helpers:
         buttons = container.find_elements(By.TAG_NAME, "button")
 
         for button in buttons:
-            time.sleep(3)
             assert button.is_enabled()      
 
         if quota and accept:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,8 @@ class Helpers:
             jobs = super_client.get_jobs_status()
             jobCount = 0
             for jobName, job in jobs.items():
+                if jobName == 'fileUploaderQueueStatus' or jobName == 'fileDeletionQueueStatus':
+                    continue
                 jobCount += job.get('waiting', 0) + job.get('active', 0) + job.get('delayed', 0)
 
             if jobCount == 0:


### PR DESCRIPTION
This PR stores the API logs in circleci artifacts. This is useful when debugging an issue that cannot be easily reproduced locally.