### PR TITLE
create stage if invitation exists

### DIFF
--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -1039,6 +1039,8 @@ class Matching(object):
 
             invitation = openreview.tools.get_invitation(self.client, venue.get_bid_id(self.match_group.id))
             if invitation:
+                if not venue.bid_stages:
+                    venue.bid_stages = [openreview.stages.BidStage(committee_id=self.match_group.id)]
                 score_spec[invitation.id] = venue.bid_stages[0].default_scores_spec
 
             invitation = openreview.tools.get_invitation(self.client, venue.get_recommendation_id(self.match_group.id))


### PR DESCRIPTION
ICLR SAC-AC setup matching failed because the Bid stage was created manually. This should fix the issue where the invitation exists, but it was not created from the request form. We only need the stage in order to read the `default_scores_spec` from it. 