### PR TITLE
Fix/ DBLP record process error handling

### DIFF
--- a/openreview/profile/process/dblp_record_process.js
+++ b/openreview/profile/process/dblp_record_process.js
@@ -28,7 +28,7 @@ async function process(client, edit, invitation) {
       console.log('html field is empty');
     }
   } catch (error) {
-    console.log('error: ' + JSON.stringify(error.toJson()));
+    console.log('error: ' + JSON.stringify(error?.toJson?.()));
     abstractError = error;
   }
 


### PR DESCRIPTION
currently the dblp record process assumes that 
Tools.extractAbstract
will always return OpenReviewError which may not hold
extractAbstract returns OpenReviewError only when cloud function returns a response

when extractAbstract does not fail with OpenReviewError the toJson() method is not available and it will cause the process function to fail immediately and DBLP.org/-/Edit edit is not posted (ln35).

this pr should avoid the failure at toJson when error is not OpenReivewError