### PR TITLE
ARR: Prevent assigning too many submissions

### DIFF
--- a/openreview/arr/management/setup_reassignment_data.py
+++ b/openreview/arr/management/setup_reassignment_data.py
@@ -199,7 +199,7 @@ def process(client, invitation):
         )
         openreview.tools.post_bulk_edges(client=client, edges=cmp_to_post)
     
-
+    reviewer_exceptions, ae_exceptions = {}, {}
     for submission in resubmissions:
         print(f"rewriting {submission.id}")
         # 1) Find all reassignments and reassignment requests -> 0 out or set to 3
@@ -276,16 +276,22 @@ def process(client, invitation):
                     }
                 )
                 # Handle case where user has max load 0 but accepts resubmissions
-                if id_to_load_note.get(reviewer_id) and int(id_to_load_note[reviewer_id].content['maximum_load_this_cycle']['value']) == 0 and 'Yes' in id_to_load_note[reviewer_id].content['maximum_load_this_cycle_for_resubmissions']['value']:
+                if id_to_load_note.get(reviewer_id) and \
+                    int(id_to_load_note[reviewer_id].content['maximum_load_this_cycle']['value']) == 0 and \
+                        'Yes' in id_to_load_note[reviewer_id].content['maximum_load_this_cycle_for_resubmissions']['value']:
                     only_resubmissions.append({
                         'role': reviewers_id,
                         'name': reviewer_id
                     })
                     reviewer_cmp_edge = rev_cmp[reviewer_id] ##note implies cmp edge
+                    if reviewer_id not in reviewer_exceptions:
+                        reviewer_exceptions[reviewer_id] = 0
+                    reviewer_exceptions[reviewer_id] += 1
+
                     replace_edge(
                         existing_edge=reviewer_cmp_edge,
                         edge_inv=rev_cmp_inv,
-                        new_weight=reviewer_cmp_edge['weight'] + 1,
+                        new_weight=reviewer_exceptions[reviewer_id],
                         profile_id=reviewer_id,
                         edge_readers=[venue_id, senior_area_chairs_id, area_chairs_id, reviewer_id]
                     )
@@ -340,16 +346,22 @@ def process(client, invitation):
                     }
                 )
                 # Handle case where user has max load 0 but accepts resubmissions
-                if id_to_load_note.get(ae_id) and int(id_to_load_note[ae_id].content['maximum_load_this_cycle']['value']) == 0 and 'Yes' in id_to_load_note[ae_id].content['maximum_load_this_cycle_for_resubmissions']['value']:
+                if id_to_load_note.get(ae_id) and \
+                    int(id_to_load_note[ae_id].content['maximum_load_this_cycle']['value']) == 0 and \
+                    'Yes' in id_to_load_note[ae_id].content['maximum_load_this_cycle_for_resubmissions']['value']:
                     only_resubmissions.append({
                         'role': area_chairs_id,
                         'name': ae_id
                     })
                     ae_cmp_edge = ae_cmp[ae_id] ##note implies cmp edge
+                    if ae_id not in ae_exceptions:
+                        ae_exceptions[ae_id] = 0
+                    ae_exceptions[ae_id] += 1
+
                     replace_edge(
                         existing_edge=ae_cmp_edge,
                         edge_inv=ae_cmp_inv,
-                        new_weight=ae_cmp_edge['weight'] + 1,
+                        new_weight=ae_exceptions[ae_id],
                         profile_id=ae_id,
                         edge_readers=[venue_id, senior_area_chairs_id, ae_id]
                     )

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -2993,6 +2993,31 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         )
 
         helpers.await_queue_edit(openreview_client, 'aclweb.org/ACL/ARR/2023/August/-/Setup_Tracks_And_Reassignments-0-1', count=1)
+        cmp_edges_5 = openreview_client.get_all_edges(invitation='aclweb.org/ACL/ARR/2023/August/Reviewers/-/Custom_Max_Papers', tail='~Reviewer_ARRFive1')
+        assert len(cmp_edges_5) == 1
+        assert cmp_edges_5[0].weight == 1
+
+        # Call the stage a second time
+        pc_client.post_note(
+            openreview.Note(
+                content={
+                    'setup_tracks_and_reassignment_date': (openreview.tools.datetime.datetime.utcnow() - datetime.timedelta(minutes=1)).strftime('%Y/%m/%d %H:%M')
+                },
+                invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
+                forum=request_form.id,
+                readers=['aclweb.org/ACL/ARR/2023/August/Program_Chairs', 'openreview.net/Support'],
+                referent=request_form.id,
+                replyto=request_form.id,
+                signatures=['~Program_ARRChair1'],
+                writers=[],
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, 'aclweb.org/ACL/ARR/2023/August/-/Setup_Tracks_And_Reassignments-0-1', count=2)
+        cmp_edges_5 = openreview_client.get_all_edges(invitation='aclweb.org/ACL/ARR/2023/August/Reviewers/-/Custom_Max_Papers', tail='~Reviewer_ARRFive1')
+        assert len(cmp_edges_5) == 1
+        assert cmp_edges_5[0].weight == 1
+
         # Check reviewers groups
         assert 'aclweb.org/ACL/ARR/2023/August/Submission2/Reviewers/Submitted' in openreview_client.get_group('aclweb.org/ACL/ARR/2023/June/Submission2/Reviewers').members
         assert 'aclweb.org/ACL/ARR/2023/August/Submission2/Reviewers/Submitted' in openreview_client.get_group('aclweb.org/ACL/ARR/2023/June/Submission2/Reviewers/Submitted').members


### PR DESCRIPTION
Resolves #2347 

This PR is a bug fix for reviewers who only want to review resubmissions (requested a maximum load of 0 but notes that they will review resubmissions)

Previously, the script would increment the existing custom max papers edge, but re-running it would increase their load beyond the number of resubmissions for them. The value of their new custom max papers edge is now computed starting at 0 each time the script is run