### PR TITLE
Feature: ARR Rebuttal Comment Email Threshold

### DIFF
--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -87,6 +87,7 @@ class ARR(object):
         self.source_submissions_query_mapping = {}
         self.sac_paper_assignments = False
         self.submission_assignment_max_reviewers = None
+        self.comment_notification_threshold = None
 
     def copy_to_venue(self):
 
@@ -135,6 +136,7 @@ class ARR(object):
         self.venue.source_submissions_query_mapping = self.source_submissions_query_mapping
         self.venue.sac_paper_assignments = self.sac_paper_assignments
         self.venue.submission_assignment_max_reviewers = self.submission_assignment_max_reviewers
+        self.venue.comment_notification_threshold = self.comment_notification_threshold
 
         self.submission_stage.hide_fields = self.submission_stage.hide_fields + hide_fields
         self.venue.submission_stage = self.submission_stage
@@ -487,6 +489,7 @@ class ARR(object):
 
     def create_comment_stage(self):
         self.venue.comment_stage = self.comment_stage
+        self.venue.comment_stage.process_path = '../arr/process/comment_process.py'
         return self.venue.create_comment_stage()
 
     def create_decision_stage(self):

--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -2,6 +2,7 @@ import openreview
 from enum import Enum
 from datetime import datetime, timedelta
 from openreview.venue import matching
+import time
 
 
 from openreview.stages.arr_content import (
@@ -37,6 +38,7 @@ from openreview.stages.arr_content import (
 from openreview.stages.default_content import comment_v2
 
 class ARRWorkflow(object):
+    UPDATE_WAIT_TIME = 5000
     CONFIGURATION_INVITATION_CONTENT = {
         "form_expiration_date": {
             "description": "What should the default expiration date be? Please enter a time and date in GMT using the following format: YYYY/MM/DD HH:MM (e.g. 2019/01/31 23:59). All dates on this form should be in this format.",
@@ -1117,6 +1119,7 @@ class ARRWorkflow(object):
                 stage.set_stage(
                     self.client, self.client_v2, self.venue, self.invitation_builder, self.request_form_id
                 )
+                time.sleep(ARRStage.UPDATE_WAIT_TIME)
 
 
 class ARRStage(object):

--- a/openreview/arr/process/comment_process.py
+++ b/openreview/arr/process/comment_process.py
@@ -1,0 +1,148 @@
+def process(client, edit, invitation):
+
+    domain = client.get_group(edit.domain)
+    venue_id = domain.id
+    meta_invitation_id = domain.get_content_value('meta_invitation_id')
+    short_name = domain.get_content_value('subtitle')
+    contact = domain.get_content_value('contact')
+    authors_name = domain.get_content_value('authors_name')
+    submission_name = domain.get_content_value('submission_name')
+    reviewers_name = domain.get_content_value('reviewers_name')
+    reviewers_anon_name = domain.get_content_value('reviewers_anon_name')
+    reviewers_submitted_name = domain.get_content_value('reviewers_submitted_name')
+    sender = domain.get_content_value('message_sender')
+
+    submission = client.get_note(edit.note.forum)
+    comment = client.get_note(edit.note.id)
+    paper_group_id=f'{venue_id}/{submission_name}{submission.number}'
+
+    ### TODO: Fix this, we should notify the use when the review is updated
+    if comment.tcdate != comment.tmdate:
+        return    
+
+    ignore_groups = comment.nonreaders if comment.nonreaders else []
+    ignore_groups.append(edit.tauthor)
+
+    signature = comment.signatures[0].split('/')[-1]
+    pretty_signature = openreview.tools.pretty_id(signature)
+    pretty_signature = 'An author' if pretty_signature == 'Authors' else pretty_signature
+
+    content = f'''
+    
+Paper number: {submission.number}
+
+Paper title: {submission.content['title']['value']}
+
+Comment: {comment.content['comment']['value']}
+
+To view the comment, click here: https://openreview.net/forum?id={submission.id}&noteId={comment.id}'''
+
+    program_chairs_id = domain.get_content_value('program_chairs_id')
+    if domain.get_content_value('comment_email_pcs') and (program_chairs_id in comment.readers or 'everyone' in comment.readers):
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=[program_chairs_id],
+            ignoreRecipients = ignore_groups,
+            subject=f'''[{short_name}] {pretty_signature} commented on a paper. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Program Chair.{content}''',
+            signature=venue_id,
+            sender=sender
+        )
+
+    senior_area_chairs_name = domain.get_content_value('senior_area_chairs_name')
+    paper_senior_area_chairs_id = f'{paper_group_id}/{senior_area_chairs_name}'
+    paper_senior_area_chairs_group = openreview.tools.get_group(client, paper_senior_area_chairs_id)
+
+    email_SAC = ((len(comment.readers)==3 and paper_senior_area_chairs_id in comment.readers and program_chairs_id in comment.readers) or domain.get_content_value('comment_email_sacs'))
+    if paper_senior_area_chairs_group and senior_area_chairs_name and email_SAC:
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=[paper_senior_area_chairs_id],
+            ignoreRecipients = ignore_groups,
+            subject=f'''[{short_name}] {pretty_signature} commented on a paper in your area. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Senior Area Chair.{content}''',
+            replyTo=contact,
+            signature=venue_id,
+            sender=sender
+        )
+
+    area_chairs_name = domain.get_content_value('area_chairs_name')
+    paper_area_chairs_id = f'{paper_group_id}/{area_chairs_name}'
+    paper_area_chairs_group = openreview.tools.get_group(client, paper_area_chairs_id)
+    if paper_area_chairs_group and area_chairs_name and (paper_area_chairs_id in comment.readers or 'everyone' in comment.readers):
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=[paper_area_chairs_id],
+            ignoreRecipients=ignore_groups,
+            subject=f'''[{short_name}] {pretty_signature} commented on a paper in your area. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Area Chair.{content}''',
+            replyTo=contact,
+            signature=venue_id,
+            sender=sender
+        )
+
+    paper_reviewers_id = f'{paper_group_id}/{reviewers_name}'
+    paper_reviewers_group = openreview.tools.get_group(client, paper_reviewers_id)
+    paper_reviewers_submitted_id = f'{paper_reviewers_id}/{reviewers_submitted_name}'
+    paper_reviewers_submitted_group = openreview.tools.get_group(client, paper_reviewers_submitted_id)
+    if paper_reviewers_group and ('everyone' in comment.readers or paper_reviewers_id in comment.readers):
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=[paper_reviewers_id],
+            ignoreRecipients=ignore_groups,
+            subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
+            replyTo=contact,
+            signature=venue_id,
+            sender=sender
+        )
+    elif paper_reviewers_submitted_group and paper_reviewers_submitted_id in comment.readers:
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=[paper_reviewers_submitted_id],
+            ignoreRecipients=ignore_groups,
+            subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+            message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
+            replyTo=contact,
+            signature=venue_id,
+            sender=sender
+        )
+    else:
+        anon_reviewers = [reader for reader in comment.readers if reader.find(reviewers_anon_name) >=0]
+        anon_reviewers_group = client.get_groups(prefix=f'{paper_group_id}/{reviewers_anon_name}.*')
+        if anon_reviewers_group and anon_reviewers:
+            client.post_message(
+                invitation=meta_invitation_id,
+                recipients=anon_reviewers,
+                ignoreRecipients=ignore_groups,
+                subject=f'''[{short_name}] {pretty_signature} commented on a paper you are reviewing. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+                message=f'''{pretty_signature} commented on a paper for which you are serving as Reviewer.{content}''',
+                replyTo=contact,
+                signature=venue_id,
+                sender=sender
+            )
+
+    #send email to author of comment
+    client.post_message(
+        invitation=meta_invitation_id,
+        recipients=[edit.tauthor] if edit.tauthor != 'OpenReview.net' else [],
+        subject=f'''[{short_name}] Your comment was received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+        message=f'''Your comment was received on a submission to {short_name}.{content}''',
+        replyTo=contact,
+        signature=venue_id,
+        sender=sender
+    )
+
+    #send email to paper authors
+    paper_authors_id = f'{paper_group_id}/{authors_name}'
+    if paper_authors_id in comment.readers or 'everyone' in comment.readers:
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=submission.content['authorids']['value'],
+            ignoreRecipients=ignore_groups,
+            subject=f'''[{short_name}] {pretty_signature} commented on your submission. Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+            message=f'''{pretty_signature} commented on your submission.{content}''',
+            replyTo=contact,
+            signature=venue_id,
+            sender=sender
+        )

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -150,6 +150,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.source_submissions_query_mapping = note.content.get('source_submissions_query_mapping', {})
         venue.sac_paper_assignments = note.content.get('senior_area_chairs_assignment', 'Area Chairs') == 'Submissions'
         venue.submission_assignment_max_reviewers = int(note.content.get('submission_assignment_max_reviewers')) if note.content.get('submission_assignment_max_reviewers') is not None else None
+        venue.comment_notification_threshold = int(note.content.get('comment_notification_threshold')) if note.content.get('comment_notification_threshold') is not None else None
         venue.preferred_emails_groups = note.content.get('preferred_emails_groups', [])
         venue.iThenticate_plagiarism_check = note.content.get('iThenticate_plagiarism_check', 'No') == 'Yes'
         venue.iThenticate_plagiarism_check_api_key = note.content.get('iThenticate_plagiarism_check_api_key', '')

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -994,6 +994,8 @@ class CommentStage(object):
         self.readers = readers
         self.invitees = invitees
         self.enable_chat = enable_chat
+        self.preprocess_path = 'process/comment_pre_process.js'
+        self.process_path = 'process/comment_process.py'
 
     def get_readers(self, conference, number, api_version='1'):
 

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -312,6 +312,9 @@ class GroupBuilder(object):
         if self.venue.submission_assignment_max_reviewers:
             content['submission_assignment_max_reviewers'] = { 'value': self.venue.submission_assignment_max_reviewers }
 
+        if self.venue.comment_notification_threshold:
+            content['comment_notification_threshold'] = { 'value': self.venue.comment_notification_threshold }
+
         update_content = self.get_update_content(venue_group.content, content)
         if update_content:
             self.client.post_group_edit(

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -1345,10 +1345,10 @@ class InvitationBuilder(object):
             }],
             content={
                 'comment_preprocess_script': {
-                    'value': self.get_process_content('process/comment_pre_process.js')
+                    'value': self.get_process_content(comment_stage.preprocess_path)
                 },
                 'comment_process_script': {
-                    'value': self.get_process_content('process/comment_process.py')
+                    'value': self.get_process_content(comment_stage.process_path)
                 },
                 'email_pcs': {
                     'value': comment_stage.email_pcs

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -86,6 +86,7 @@ class Venue(object):
         self.iThenticate_plagiarism_check_api_key = ''
         self.iThenticate_plagiarism_check_api_base_url = ''
         self.iThenticate_plagiarism_check_committee_readers = []
+        self.comment_notification_threshold = None
 
     def get_id(self):
         return self.venue_id

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1655,6 +1655,12 @@ class VenueRequest():
                 'order': 53,
                 'required': False,
                 'hidden': True
+            },
+            'comment_notification_threshold': {
+                'value-regex': '.*',
+                'order': 54,
+                'required': False,
+                'hidden': True
             }
         }
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -4127,6 +4127,8 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         ac_client = openreview.api.OpenReviewClient(username = 'ac1@aclrollingreview.com', password=helpers.strong_password)
         clients = [reviewer_client, test_client]
         signatures = [anon_id, f'aclweb.org/ACL/ARR/2023/August/Submission{submissions[1].number}/Authors']
+        root_note_id = None
+
         for i in range(1, 5):
             client = clients[i % 2]
             signature = signatures[i % 2]
@@ -4135,7 +4137,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                 writers=['aclweb.org/ACL/ARR/2023/August'],
                 signatures=[signature],
                 note=openreview.api.Note(
-                    replyto=submissions[1].id,
+                    replyto=submissions[1].id if i == 1 else root_note_id,
                     readers=[
                         'aclweb.org/ACL/ARR/2023/August/Program_Chairs',
                         f'aclweb.org/ACL/ARR/2023/August/Submission{submissions[1].number}/Senior_Area_Chairs',
@@ -4149,6 +4151,8 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                 )
             )
             helpers.await_queue_edit(openreview_client, edit_id=comment_edit['id'])
+            if i == 1:
+                root_note_id = comment_edit['note']['id']
 
         assert len(
             openreview_client.get_messages(
@@ -4186,6 +4190,71 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                 subject=f'[ARR - August 2023] Your comment was received on Paper Number: 2, Paper Title: "Paper title 2"'
             )
         ) == 2
+
+        # Test new thread
+        for i in range(1, 5):
+            client = clients[i % 2]
+            signature = signatures[i % 2]
+            comment_edit = client.post_note_edit(
+                invitation=f"aclweb.org/ACL/ARR/2023/August/Submission{submissions[1].number}/-/Official_Comment",
+                writers=['aclweb.org/ACL/ARR/2023/August'],
+                signatures=[signature],
+                note=openreview.api.Note(
+                    replyto=submissions[1].id if i == 1 else root_note_id,
+                    readers=[
+                        'aclweb.org/ACL/ARR/2023/August/Program_Chairs',
+                        f'aclweb.org/ACL/ARR/2023/August/Submission{submissions[1].number}/Senior_Area_Chairs',
+                        f'aclweb.org/ACL/ARR/2023/August/Submission{submissions[1].number}/Area_Chairs',
+                        f'aclweb.org/ACL/ARR/2023/August/Submission{submissions[1].number}/Reviewers',
+                        f'aclweb.org/ACL/ARR/2023/August/Submission{submissions[1].number}/Authors'
+                    ],
+                    content={
+                        "comment": { "value": "This is a comment, thread2"}
+                    }
+                )
+            )
+            helpers.await_queue_edit(openreview_client, edit_id=comment_edit['id'])
+            if i == 1:
+                root_note_id = comment_edit['note']['id']
+
+        assert len(
+            openreview_client.get_messages(
+                to='ac1@aclrollingreview.com',
+                subject=f'[ARR - August 2023] Reviewer {anon_id.split("_")[-1]} commented on a paper in your area. Paper Number: 2, Paper Title: "Paper title 2"'
+            )
+        ) == 2
+        assert len(
+            openreview_client.get_messages(
+                to='ac1@aclrollingreview.com',
+                subject=f'[ARR - August 2023] An author commented on a paper in your area. Paper Number: 2, Paper Title: "Paper title 2"'
+            )
+        ) == 4
+        assert len(
+            openreview_client.get_messages(
+                to='reviewer2@aclrollingreview.com',
+                subject=f'[ARR - August 2023] An author commented on a paper you are reviewing. Paper Number: 2, Paper Title: "Paper title 2"'
+            )
+        ) == 4
+        assert len(
+            openreview_client.get_messages(
+                to='reviewer2@aclrollingreview.com',
+                subject=f'[ARR - August 2023] Your comment was received on Paper Number: 2, Paper Title: "Paper title 2"'
+            )
+        ) == 4
+        assert len(
+            openreview_client.get_messages(
+                to='test@mail.com',
+                subject=f'[ARR - August 2023] Reviewer {anon_id.split("_")[-1]} commented on your submission. Paper Number: 2, Paper Title: "Paper title 2"'
+            )
+        ) == 4
+        assert len(
+            openreview_client.get_messages(
+                to='test@mail.com',
+                subject=f'[ARR - August 2023] Your comment was received on Paper Number: 2, Paper Title: "Paper title 2"'
+            )
+        ) == 4
+
+
         assert openreview_client.get_messages(to='sac2@aclrollingreview.com', subject='[ARR - August 2023] Program Chairs commented on a paper in your area. Paper Number: 3, Paper Title: "Paper title 3"')   
 
         # Close author response

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -121,7 +121,8 @@ class TestARRVenueV2():
                 'use_recruitment_template': 'Yes',
                 'api_version': '2',
                 'submission_license': ['CC BY-SA 4.0'],
-                'submission_assignment_max_reviewers': '3'
+                'submission_assignment_max_reviewers': '3',
+                'comment_notification_threshold': '3'
             }))
 
         helpers.await_queue()


### PR DESCRIPTION
Resolves #2265

This PR adds a new hidden field `comment_notification_threshold` to the request form and stores the variable in the domain and the Venue class. It also parameterizes the process/pre-process function scripts.

The ARR class passes in its own Official_Comment process function that counts (each reply is only counted once):
1) the number of comments (including the newest one) written by the signature
2) the number of comments in the author-reviewer discussion that's visible to the signature

The process function only emails the SACs/ACs if:
1) the comment threshold wasn't set
2) the comment was written by an author/reviewer and the total count is below the threshold
3) the comment was written by an AC/SAC/PC

I also added a small delay between the stages to stabilize the tests when its creating the custom stages