### PR TITLE
ARR: Enable SACs/ACs to add/remove others from commenting

### DIFF
--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -163,6 +163,9 @@ class ARR(object):
         )
         workflow.set_workflow()
 
+    def create_commentary_control_stage(self, cdate=None, expdate=None):
+        return self.invitation_builder.set_commentary_control_invitation(cdate=cdate, expdate=expdate)
+
     def get_id(self):
         return self.venue.get_id()
 

--- a/openreview/arr/process/commentary_control_process.py
+++ b/openreview/arr/process/commentary_control_process.py
@@ -1,0 +1,107 @@
+def process(client, edit, invitation):
+
+    domain = client.get_group(edit.domain)
+    venue_id = domain.id
+    meta_invitation_id = domain.content['meta_invitation_id']['value']
+    short_name = domain.get_content_value('subtitle')
+    contact = domain.get_content_value('contact')
+    sender = domain.get_content_value('message_sender')
+    authors_name = domain.get_content_value('authors_name')
+    submission_name = domain.get_content_value('submission_name')
+    reviewers_name = domain.get_content_value('reviewers_name')
+    area_chairs_name = domain.get_content_value('area_chairs_name')
+    senior_area_chairs_name = domain.get_content_value('senior_area_chairs_name')
+    reviewers_submitted_name = domain.get_content_value('reviewers_submitted_name')
+    review_name = domain.get_content_value('review_name')
+
+    submission = client.get_note(invitation.content['forum']['value'])
+    paper_number = submission.number
+    comment_invitation = client.get_invitation(id=f"{venue_id}/Submission{paper_number}/-/Official_Comment")
+
+    if 'yes' in edit.note.content['enable_author_commentary']['value'].lower():
+        new_participants = ['Authors']
+    else:
+        new_participants = []
+    
+    readers_to_ids = {
+        "Assigned Reviewers": f"{venue_id}/Submission{paper_number}/Reviewers",
+        "Assigned Submitted Reviewers": f"{venue_id}/Submission{paper_number}/Reviewers/Submitted",
+        "Authors": f"{venue_id}/Submission{paper_number}/Authors"
+    }
+    required_invitees = [readers_to_ids[r] for r in new_participants]
+    missing_invitees = set(required_invitees).difference(set(comment_invitation.invitees))
+    extra_invitees = (set(comment_invitation.invitees).intersection(set(readers_to_ids.values()))).difference(set(required_invitees))
+    
+    final_invitees = [i for i in comment_invitation.invitees if i not in extra_invitees] + list(missing_invitees)
+    print(missing_invitees)
+    print(extra_invitees)
+    print(final_invitees)
+    
+    readers_to_prefix = {
+        "Assigned Reviewers": f"{venue_id}/Submission{paper_number}/Reviewer_.*",
+        "Assigned Submitted Reviewers": f"{venue_id}/Submission{paper_number}/Reviewer_.*",
+        "Authors": f"{venue_id}/Submission{paper_number}/Authors"
+    }
+    required_signatures = [readers_to_prefix[r] for r in new_participants]
+    signatures = [item['prefix'] if 'prefix' in item else item['value'] for item in comment_invitation.edit['signatures']['param']['items']]
+    missing_signatures = set(required_signatures).difference(set(signatures))
+    extra_signatures = (set(signatures).intersection(set(readers_to_prefix.values()))).difference(set(required_signatures))
+    
+    final_signatures = []
+    for item in comment_invitation.edit['signatures']['param']['items']:
+        value = item['prefix'] if 'prefix' in item else item['value']
+        if value not in extra_signatures:
+            final_signatures.append(item)
+    for signature in missing_signatures:
+        if signature.endswith('.*'):
+            final_signatures.append({
+                'prefix': signature,
+                'optional': True
+            })
+        else:
+            final_signatures.append({
+                'value': signature,
+                'optional': True
+            })
+    
+    print(missing_signatures)
+    print(extra_signatures)
+    print(final_signatures)
+    
+    possible_readers = set(readers_to_prefix.values()).union(set(readers_to_ids.values()))
+    required_readers = set(required_signatures).union(required_invitees)
+    readers = comment_invitation.edit['note']['readers']['param']['enum']
+    missing_readers = required_readers.difference(set(readers))
+    extra_readers = (set(readers).intersection(possible_readers)).difference(required_readers)
+    
+    final_readers = [r for r in readers if r not in extra_readers] + list(missing_readers)
+    
+    print(missing_readers)
+    print(extra_readers)
+    print(final_readers)
+    
+    client.post_invitation_edit(
+        invitations=meta_invitation_id,
+        readers=[venue_id],
+        writers=[venue_id],
+        signatures=[venue_id],
+        invitation=openreview.api.Invitation(
+            id=comment_invitation.id,
+            signatures=[venue_id],
+            invitees=final_invitees,
+            edit={
+                'signatures': {
+                    'param': {
+                        'items': final_signatures
+                    }
+                },
+                'note': {
+                    'readers': {
+                        'param': {
+                            'enum': final_readers
+                        }
+                    }
+                }
+            }
+        )
+    )

--- a/openreview/arr/webfield/seniorAreaChairsWebfield.js
+++ b/openreview/arr/webfield/seniorAreaChairsWebfield.js
@@ -62,7 +62,7 @@ assignmentUrls[domain.content.reviewers_name?.value] = {
 }
 
 return {
-  component: 'SeniorAreaChairConsole',
+  component: 'ARRSeniorAreaChairConsole',
   version: 1,
   properties: {
     header: {
@@ -118,6 +118,7 @@ return {
       })
       return checklistReplies?.length??0;
       `
-    }
+    },
+    perPaperInvitationSuffixes: ['Commentary_Control']
   }
 }

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -4063,6 +4063,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password=helpers.strong_password)
         pc_client_v2=openreview.api.OpenReviewClient(username='pc@aclrollingreview.org', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[1]
+        form_expiration_date = request_form.content['form_expiration_date']
         venue = openreview.helpers.get_conference(client, request_form.id, 'openreview.net/Support')
         submissions = venue.get_submissions()
 
@@ -4070,7 +4071,8 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client.post_note(
             openreview.Note(
                 content={
-                    'setup_author_response_date': (datetime.datetime.utcnow() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
+                    'setup_author_response_date': (datetime.datetime.utcnow() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M'),
+                    'form_expiration_date': form_expiration_date
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,


### PR DESCRIPTION
Resolves #2263

Depends on [openreview-web#2133](https://github.com/openreview/openreview-web/pull/2133)

This PR adds a new type to the ARRStage `Commentary_Control` and builds the invitations similar to how the registration forms are generated:
- Create a super invitation `ARRCycle/-/Commentary_Control` to store the process script
- For each submission, post an invitation for `Commentary_Control_Form` and post a note to that invitation
- Use this new note as the forum and reply to for the child invitations `SubmissionX/-/Commentary_Control`

Replies to the child invitation will modify fields in the `SubmissionX/-/Official_Comment` invitation

The super invitation does not have the `invitation_edit_process` date process function since the child invitations require an extra field in their edit content:
```
'responseForumId': {
    'value': {
        'param': {
            'type': 'string'
        }
    }
}
```

TODO:
- [ ] Prevent request form overwriting in specific cases
- [ ] Adjust wording/invitation names to make sense
- [ ] Simplify process function logic (was originally designed to add/remove reviewers as well)

Links in the consoles:
<img width="394" alt="Screenshot 2024-10-16 at 7 45 07 AM" src="https://github.com/user-attachments/assets/6999d4cd-3d10-443a-b1af-08ab5a1c2d40">

Forum page example:
<img width="1150" alt="Screenshot 2024-10-16 at 7 45 37 AM" src="https://github.com/user-attachments/assets/74790760-fad1-449d-ae80-7c1629ec4be3">

