### PR TITLE
Add setting for main EiC

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -171,6 +171,18 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
         ## Add editors in chief to have all the permissions
         self.client.add_members_to_group(venue_group, editor_in_chief_id)
 
+        ## main editor in chief group
+        if self.journal.has_main_editor_in_chief():
+            main_editor_in_chief_id = self.journal.get_main_editor_in_chief_id()
+            main_editor_in_chief_group = openreview.tools.get_group(self.client, main_editor_in_chief_id)
+            if not main_editor_in_chief_group:
+                main_editor_in_chief_group=self.post_group(Group(id=main_editor_in_chief_id,
+                                readers=['everyone'],
+                                writers=[venue_id],
+                                signatures=[venue_id],
+                                signatories=[venue_id, main_editor_in_chief_id],
+                                members=[]))
+
         ## publication editors group
         if self.journal.has_publication_chairs():
             publication_chairs_id = self.journal.get_publication_chairs_id()

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -80,6 +80,9 @@ class Journal(object):
     def get_editors_in_chief_id(self):
         return f'{self.venue_id}/{self.editors_in_chief_name}'
 
+    def get_main_editor_in_chief_id(self):
+        return f'{self.venue_id}/Main_Editor_In_Chief'
+
     def get_publication_chairs_id(self):
         return f'{self.venue_id}/Publication_Chairs'
     
@@ -515,7 +518,10 @@ class Journal(object):
         return self.settings.get('expert_reviewers', False) 
 
     def has_external_reviewers(self):
-        return self.settings.get('external_reviewers', True)            
+        return self.settings.get('external_reviewers', True)
+
+    def has_main_editor_in_chief(self):
+        return self.settings.get('has_main_editor_in_chief', False)            
 
     def get_number_of_reviewers(self):
         return self.settings.get('number_of_reviewers', 3)

--- a/openreview/journal/process/author_submission_process.py
+++ b/openreview/journal/process/author_submission_process.py
@@ -27,10 +27,12 @@ def process(client, edit, invitation):
 
     if note.tcdate == note.tmdate and journal.should_eic_submission_notification():
         eic_group = client.get_group(journal.get_editors_in_chief_id())
+        recipients = journal.get_main_editor_in_chief_id() if journal.has_main_editor_in_chief() else journal.get_editors_in_chief_id()
+
         client.post_message(
             invitation=journal.get_meta_invitation_id(),
             subject=f'[{journal.short_name}] New submission to {journal.short_name}: {note.content["title"]["value"]}',
-            recipients=[journal.get_editors_in_chief_id()],
+            recipients=[recipients],
             message=eic_group.content['new_submission_email_template_script']['value'].format(
                 short_name=journal.short_name,
                 submission_id=note.id,

--- a/tests/test_melba_journal.py
+++ b/tests/test_melba_journal.py
@@ -32,6 +32,7 @@ class TestJournal():
 
         ## Editors in Chief
         helpers.create_user('msabuncu@cornell.edu', 'Mert', 'Sabuncu')
+        helpers.create_user('eic@mail.com', 'EiC', 'One') # Main EiC
 
         ## Publication Chair
         helpers.create_user('publication@melba.com', 'Publication', 'Chair')
@@ -42,7 +43,7 @@ class TestJournal():
         aasa_client = helpers.create_user('aasa@mailtwo.com', 'Aasa', 'Feragen')
         xukun_client = helpers.create_user('xukun@mail.com', 'Xukun', 'Liu')
         melisa_client = helpers.create_user('ana@mail.com', 'Ana', 'Martinez')
-        celeste_client = helpers.create_user('celesste@mail.com', 'Celeste', 'Martinez')
+        celeste_client = helpers.create_user('celeste@mail.com', 'Celeste', 'Martinez')
 
         ## Reviewers
         david_client=helpers.create_user('rev1@mailone.com', 'MELBARev', 'One')
@@ -63,7 +64,7 @@ class TestJournal():
                     'contact_info': {'value': 'editors@melba-journal.org'},
                     'secret_key': {'value': '1234'},
                     'support_role': {'value': '~Adrian_Dalca1' },
-                    'editors': {'value': ['~Mert_Sabuncu1', '~Adrian_Dalca1'] },
+                    'editors': {'value': ['~Mert_Sabuncu1', '~Adrian_Dalca1', '~EiC_One1'] },
                     'website': {'value': 'melba-journal.org' },
                     'settings': {
                         'value': {
@@ -73,6 +74,8 @@ class TestJournal():
                             'show_conflict_details': True,
                             'has_publication_chairs': True,
                             'expert_reviewers': False,
+                            "eic_submission_notification": True,
+                            "has_main_editor_in_chief": True,
                             'submission_additional_fields': {
                                 'additional_field': {
                                     'order': 98,
@@ -118,6 +121,9 @@ class TestJournal():
         assert tabs[1].text == 'Accepted Papers'
         assert tabs[2].text == 'Under Review Submissions'
         assert tabs[3].text == 'All Submissions'
+
+        assert openreview_client.get_group('MELBA/Main_Editor_In_Chief')
+        openreview_client.add_members_to_group('MELBA/Main_Editor_In_Chief', '~EiC_One1')
 
     def test_invite_action_editors(self, journal, openreview_client, request_page, selenium, helpers):
 
@@ -223,6 +229,13 @@ The MELBA Editors-in-Chief
 
 Please note that responding to this email will direct your reply to editors@melba-journal.org.
 '''
+
+        messages = openreview_client.get_messages(subject = '[MELBA] New submission to MELBA: Paper title')
+        assert len(messages) == 3 # 2 authors + 1 main EiC
+
+        recipients = [m['content']['to'] for m in messages]
+        assert 'eic@mail.com' in recipients
+        assert 'msabuncu@cornell.edu' not in recipients
 
     def test_ae_assignment(self, journal, openreview_client, test_client, helpers):
 


### PR DESCRIPTION
This PR adds a setting to the journal called `has_main_editor_in_chief`. This is for a request from MELBA.

It's a boolean value and, if true, will create a group called `/Main_Editor_In_Chief`. Currently, this will be used to:

1. Email only the main EiC for each new submission (instead of all EiCs).
2. [TODO] Give them access to an EiC assignment notification invitation. This will allow the main EiC to select an EiC to "assign" to that paper. The assignment is just an email notification.


The name `Main EiC` may be renamed to something else.