### PR TITLE
ARR: Fix assignment quotas

### DIFF
--- a/openreview/venue/process/assignment_pre_process.js
+++ b/openreview/venue/process/assignment_pre_process.js
@@ -32,7 +32,7 @@ async function process(client, edge, invitation) {
     const filteredInviteAssignmentEdges = inviteAssignmentEdges.filter(e => !filteredLabels.includes(e?.label ?? ''))
 
     if (quota && filteredInviteAssignmentEdges.length + filteredAssignmentEdges.length > quota) {
-      return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not make assignment, total assignments and invitations must not exceed ${quota}` }))
+      return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not make assignment, total assignments and invitations must not exceed ${quota}; invite edge ids=${filteredInviteAssignmentEdges.map(e=>e.id)} assignment edge ids=${filteredAssignmentEdges.map(e=>e.id)}` }))
     }
     const { count } = await client.getGroups({ id: `${submissionGroupId}/${reviewersName}` })
     if ( count === 0) {

--- a/openreview/venue/process/assignment_pre_process.js
+++ b/openreview/venue/process/assignment_pre_process.js
@@ -31,7 +31,7 @@ async function process(client, edge, invitation) {
     // Filter invite assignment edges to exclude edges that are accepted
     const filteredInviteAssignmentEdges = inviteAssignmentEdges.filter(e => !filteredLabels.includes(e?.label ?? ''))
 
-    if (quota && filteredInviteAssignmentEdges.length + filteredAssignmentEdges.length > quota) {
+    if (quota && filteredInviteAssignmentEdges.length + filteredAssignmentEdges.length >= quota) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not make assignment, total assignments and invitations must not exceed ${quota}; invite edge ids=${filteredInviteAssignmentEdges.map(e=>e.id)} assignment edge ids=${filteredAssignmentEdges.map(e=>e.id)}` }))
     }
     const { count } = await client.getGroups({ id: `${submissionGroupId}/${reviewersName}` })

--- a/openreview/venue/process/invite_assignment_pre_process.js
+++ b/openreview/venue/process/invite_assignment_pre_process.js
@@ -40,12 +40,17 @@ async function process(client, edge, invitation) {
   }
 
   if (quota) {
+    const acceptLabel = invitation?.content?.accepted_label?.value ?? '';
+
     const [{ edges: inviteAssignmentEdges }, { edges: assignmentEdges }] = await Promise.all([
       client.getEdges({ invitation: edge.invitation, head: edge.head }),
       client.getEdges({ invitation: assignmentInvitationId, head: edge.head })
     ])
 
-    if (inviteAssignmentEdges.length + assignmentEdges.length >= quota) {
+    // Filter invite assignment edges to exclude edges that are accepted and the current edge.id
+    const filteredInviteAssignmentEdges = inviteAssignmentEdges.filter(e => !(e?.label ?? '').includes(acceptLabel) && e.id !== edge.id)
+
+    if (filteredInviteAssignmentEdges.length + assignmentEdges.length >= quota) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not invite assignment, total assignments and invitations must not exceed ${quota}` }))
     }
   }

--- a/openreview/venue/process/invite_assignment_pre_process.js
+++ b/openreview/venue/process/invite_assignment_pre_process.js
@@ -52,7 +52,7 @@ async function process(client, edge, invitation) {
     // Filter invite assignment edges to exclude edges that are accepted and the current edge.id
     const filteredInviteAssignmentEdges = inviteAssignmentEdges.filter(e => !filteredLabels.includes(e?.label ?? '') && e.id !== edge.id)
 
-    if (filteredInviteAssignmentEdges.length + assignmentEdges.length > quota) {
+    if (filteredInviteAssignmentEdges.length + assignmentEdges.length >= quota) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not invite assignment, total assignments and invitations must not exceed ${quota}; invite edge ids=${filteredInviteAssignmentEdges.map(e=>e.id)} assignment edge ids=${assignmentEdges.map(e=>e.id)}` }))
     }
   }

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3416,10 +3416,10 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         ]
         existing_edges = []
         for idx, reviewer_id in enumerate(test_reviewers):
-            inv_ending, label = 'Assignment', None
+            inv_ending = 'Invite_Assignment'
+            label = 'Invitation Sent'
             if idx == 1:
-                inv_ending = 'Invite_Assignment'
-                label = 'Invitation Sent'
+                inv_ending, label = 'Assignment', None
             existing_edges.append(
                 openreview_client.post_edge(openreview.api.Edge(
                     invitation = f'aclweb.org/ACL/ARR/2023/August/Reviewers/-/{inv_ending}',
@@ -3451,10 +3451,33 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                 label = "Invitation Sent"
             ))
 
+        messages = openreview_client.get_messages(to='reviewer3@aclrollingreview.com', subject=f'''[ARR - August 2023] Invitation to review paper titled "{submissions[1].content['title']['value']}"''')
+        assert len(messages) == 1
+
+        for idx, message in enumerate(messages):
+            text = message['content']['text']
+
+            invitation_url = re.search('https://.*\n', text).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+            helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
+
+        helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/Reviewers/-/Assignment_Recruitment', count=1)
+
+        openreview_client.remove_members_from_group(
+            'aclweb.org/ACL/ARR/2023/August/Submission2/Reviewers',
+            ['~Reviewer_ARRThree1']
+        )
+
         ## Clean up data
         for edge in existing_edges:
+            if edge.tail == '~Reviewer_ARRThree1':
+                continue
             edge.ddate = openreview.tools.datetime_millis(now)
             openreview_client.post_edge(edge)
+        edge = openreview_client.get_all_edges(invitation='aclweb.org/ACL/ARR/2023/August/Reviewers/-/Assignment', tail='~Reviewer_ARRThree1', head=submissions[1].id)
+        assert len(edge) == 1
+        edge = edge[0]
+        edge.ddate = openreview.tools.datetime_millis(now)
+        openreview_client.post_edge(edge)
 
         # Test resubmission visiblity on new reviewers
         ## Post new edge from ~Reviewer_ARRSix1 to submissions 1 (same) and 2 (not same)

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3467,7 +3467,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         for idx, reviewer_id in enumerate(test_reviewers):
             inv_ending = 'Invite_Assignment'
             label = 'Invitation Sent'
-            if idx == 1:
+            if idx == 1 or idx == 0:
                 inv_ending, label = 'Assignment', None
             existing_edges.append(
                 openreview_client.post_edge(openreview.api.Edge(


### PR DESCRIPTION
This PR resolves an issue where, if the 3rd edge (out of the Assignment + Invite_Assignment edges) posted to a paper is an Invite_Assignment edge, the process function fails because the pre-process saw it as posting a 4th edge.

The pre-process functions are changed to exclude the posted edge from the edge count if there is already an edge with that ID.

To allow the Assignment_Recruitment process function to complete, only non-accepted and non-declined Invite_Assignment edges are counted. The logic is still preserved because if an Invite_Assignment edge is accepted, then there must be an Assignment edge which are counted