### PR TITLE
Feat: Add use_job param to messages requests

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1804,6 +1804,10 @@ class OpenReviewClient(object):
         :type recipients: list[str]
         :param message: Message in the e-mail
         :type message: str
+        :param invitation: Invitation ID of the invitation that allows to send the message
+        :type invitation: str
+        :param signature: Signature of the user sending the message
+        :type signature: str
         :param ignoreRecipients: List of groups ids to be ignored from the recipient list
         :type subject: list[str]
         :param sender: Specify the from address and name of the email, the dictionary should have two keys: 'name' and 'email'
@@ -1812,6 +1816,8 @@ class OpenReviewClient(object):
         :type replyTo: str
         :param parentGroup: parent group recipients of e-mail belong to
         :type parentGroup: str
+        :param use_job: If True, the message will be sent using the job queue
+        :type use_job: bool
 
         :return: Contains the message that was sent to each Group
         :rtype: dict
@@ -1874,6 +1880,8 @@ class OpenReviewClient(object):
         :type replyTo: str
         :param parentGroup: parent group recipients of e-mail belong to
         :type parentGroup: str
+        :param use_job: If True, the message will be sent using the job queue
+        :type use_job: bool
 
         :return: Contains the message that was sent to each Group
         :rtype: dict

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1794,7 +1794,7 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return response.json()
 
-    def post_message(self, subject, recipients, message, invitation=None, signature=None, ignoreRecipients=None, sender=None, replyTo=None, parentGroup=None):
+    def post_message(self, subject, recipients, message, invitation=None, signature=None, ignoreRecipients=None, sender=None, replyTo=None, parentGroup=None, use_job=False):
         """
         Posts a message to the recipients and consequently sends them emails
 
@@ -1842,14 +1842,17 @@ class OpenReviewClient(object):
             json['replyTo'] = replyTo
 
         if parentGroup:
-            json['parentGroup'] = parentGroup        
+            json['parentGroup'] = parentGroup
+
+        if use_job is not None:
+            json['useJob'] = use_job
 
         response = self.session.post(self.messages_url, json = json, headers = self.headers)
         response = self.__handle_response(response)
 
         return response.json()
     
-    def post_message_request(self, subject, recipients, message, invitation=None, signature=None, ignoreRecipients=None, sender=None, replyTo=None, parentGroup=None):
+    def post_message_request(self, subject, recipients, message, invitation=None, signature=None, ignoreRecipients=None, sender=None, replyTo=None, parentGroup=None, use_job=False):
         """
         Posts a message to the recipients and consequently sends them emails
 
@@ -1901,7 +1904,10 @@ class OpenReviewClient(object):
             json['replyTo'] = replyTo
 
         if parentGroup:
-            json['parentGroup'] = parentGroup        
+            json['parentGroup'] = parentGroup
+
+        if use_job is not None:
+            json['useJob'] = use_job
 
         response = self.session.post(self.messages_requests_url, json = json, headers = self.headers)
         response = self.__handle_response(response)


### PR DESCRIPTION
This PR adds `use_job` param to `POST /messages` (deprecated) and `POST /messages/requests`