### PR TITLE
Await process logs for ARR

### DIFF
--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -1,4 +1,5 @@
 import openreview
+import time
 from enum import Enum
 from datetime import datetime, timedelta
 from openreview.venue import matching
@@ -820,8 +821,8 @@ class ARRWorkflow(object):
                 due_date=self.configuration_note.content.get('reviewer_checklist_due_date'),
                 exp_date=self.configuration_note.content.get('reviewer_checklist_exp_date'),
                 #start_date=self.venue.submission_stage.exp_date.strftime('%Y/%m/%d %H:%M'), Discuss with Harold
-                process='process/checklist_process.py',
-                preprocess='process/checklist_preprocess.py',
+                process='../arr/process/checklist_process.py',
+                preprocess='../arr/process/checklist_preprocess.py',
                 extend=ARRWorkflow._extend_reviewer_checklist
             ),
             ARRStage(
@@ -844,8 +845,8 @@ class ARRWorkflow(object):
                 due_date=self.configuration_note.content.get('ae_checklist_due_date'),
                 exp_date=self.configuration_note.content.get('ae_checklist_exp_date'),
                 #start_date=self.venue.submission_stage.exp_date.strftime('%Y/%m/%d %H:%M'), Discuss with Harold
-                process='process/checklist_process.py',
-                preprocess='process/checklist_preprocess.py',
+                process='../arr/process/checklist_process.py',
+                preprocess='../arr/process/checklist_preprocess.py',
                 extend=ARRWorkflow._extend_ae_checklist
             ),
             ARRStage(
@@ -864,7 +865,7 @@ class ARRWorkflow(object):
                 },
                 exp_date=self.configuration_note.content.get('form_expiration_date'),
                 #start_date=self.venue.submission_stage.exp_date.strftime('%Y/%m/%d %H:%M'), Discuss with Harold
-                process='process/verification_process.py',
+                process='../arr/process/verification_process.py',
                 extend=ARRWorkflow._extend_desk_reject_verification
             ),
             ARRStage(
@@ -1197,6 +1198,7 @@ class ARRStage(object):
     FIELD_READERS = {
     }
     UPDATE_WAIT_TIME = 5
+    PROCESS_LOG_TIMEOUT = 360 # 360 iterations for 30 minutes total
 
     def __init__(self,
         type = None,
@@ -1446,6 +1448,10 @@ class ARRStage(object):
             self._post_new_dates(client, venue, current_invitation)
         else:
             self._set_field_readers(venue)
+            expected_statuses = ['error', 'ok']
+            current_log_count = len(
+                [log for log in client.get_process_logs(invitation=self.super_invitation_id) if log['status'] in expected_statuses]
+            )
 
             if self.type == ARRStage.Type.REGISTRATION_STAGE:
                 venue.registration_stages = [openreview.stages.RegistrationStage(**self.stage_arguments)]
@@ -1482,6 +1488,21 @@ class ARRStage(object):
                 invitation_builder.set_process_invitation(self)
 
             if self.extend:
+                # Wait until previous changes are done
+                times_polled = 0
+                completed_logs = len(
+                    [log for log in client.get_process_logs(invitation=self.super_invitation_id) if log['status'] in expected_statuses]
+                )
+                print(f"check for {self.super_invitation_id} to be updated | original={current_log_count} current={completed_logs}")
+                while times_polled <= ARRStage.PROCESS_LOG_TIMEOUT and completed_logs < current_log_count:
+                    print(f"waiting for {self.super_invitation_id} to be updated | {current_log_count}")
+                    time.sleep(ARRStage.UPDATE_WAIT_TIME)
+                    completed_logs = len(
+                        [log for log in client.get_process_logs(invitation=self.super_invitation_id) if log['status'] in expected_statuses]
+                    )
+                    times_polled += 1
+                print(f"finished waiting {completed_logs} > {current_log_count}")
+
                 self.extend(
                     client, venue, invitation_builder, request_form_note
                 )

--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -1494,7 +1494,7 @@ class ARRStage(object):
                     [log for log in client.get_process_logs(invitation=self.super_invitation_id) if log['status'] in expected_statuses]
                 )
                 print(f"check for {self.super_invitation_id} to be updated | original={current_log_count} current={completed_logs}")
-                while times_polled <= ARRStage.PROCESS_LOG_TIMEOUT and completed_logs < current_log_count:
+                while times_polled <= ARRStage.PROCESS_LOG_TIMEOUT and completed_logs <= current_log_count:
                     print(f"waiting for {self.super_invitation_id} to be updated | {current_log_count}")
                     time.sleep(ARRStage.UPDATE_WAIT_TIME)
                     completed_logs = len(

--- a/openreview/arr/invitation.py
+++ b/openreview/arr/invitation.py
@@ -56,16 +56,9 @@ class InvitationBuilder(object):
 
     # Non-blocking custom stage with process/pre-process arguments
     def set_custom_stage_invitation(self, process_script = None, preprocess_script = None):
+        self.venue.custom_stage.process_path = process_script
+        self.venue.custom_stage.preprocess_path = preprocess_script
         invitation = self.venue_invitation_builder.set_custom_stage_invitation()
-        if not process_script and not preprocess_script:
-            return invitation
-
-        if process_script:
-            invitation.content['custom_stage_process_script'] = { 'value': self.get_process_content(process_script)}
-        if preprocess_script:
-            invitation.edit['invitation']['preprocess'] = self.get_process_content(preprocess_script)
-
-        self.save_invitation(invitation, replacement=False)
         return invitation
 
     def get_process_content(self, file_path):

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1472,6 +1472,8 @@ class CustomStage(object):
         self.notify_readers = notify_readers
         self.email_template = email_template
         self.allow_de_anonymization = allow_de_anonymization
+        self.process_path = None
+        self.preprocess_path = None
 
     def get_invitees(self, conference, number):
         invitees = [conference.id]

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2755,6 +2755,7 @@ class InvitationBuilder(object):
                 note_nonreaders = []
                 all_signatures = ['${7/content/replytoSignatures/value}']
 
+        process_path = 'process/custom_stage_process.py' if custom_stage.process_path is None else custom_stage.process_path
         invitation_content = {
             'source': { 'value': custom_stage_source },
             'reply_to': { 'value': custom_stage_replyto },
@@ -2762,7 +2763,7 @@ class InvitationBuilder(object):
             'email_sacs': { 'value': custom_stage.email_sacs },
             'notify_readers': { 'value': custom_stage.notify_readers },
             'email_template': { 'value': custom_stage.email_template if custom_stage.email_template else '' },
-            'custom_stage_process_script': { 'value': self.get_process_content('process/custom_stage_process.py')}
+            'custom_stage_process_script': { 'value': self.get_process_content(process_path)}
         }
 
         invitation = Invitation(id=custom_stage_invitation_id,
@@ -2889,6 +2890,8 @@ class InvitationBuilder(object):
             invitation.edit['invitation']['expdate'] = custom_stage_expdate
         if not custom_stage.multi_reply:
             invitation.edit['invitation']['maxReplies'] = 1
+        if custom_stage.preprocess_path:
+            invitation.edit['invitation']['preprocess'] = self.get_process_content(custom_stage.preprocess_path)
 
         self.save_invitation(invitation, replacement=False)
         return invitation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ class Helpers:
 
         if not [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']:
             for idx, l in enumerate(super_client.get_process_logs(status='error')):
-                print(f"Error {idx}:")
+                print(f"Error {idx}: {l['id']}")
                 print(l['log'])
 
         assert not [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,11 @@ class Helpers:
 
             time.sleep(0.5)
 
+        if not [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']:
+            for idx, l in enumerate(super_client.get_process_logs(status='error')):
+                print(f"Error {idx}:")
+                print(l['log'])
+
         assert not [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ class Helpers:
 
         if [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']:
             for idx, l in enumerate(super_client.get_process_logs(status='error')):
-                print(f"Error {idx}: {l['id']}")
+                print(f"Error {idx}: {l['invitation']}")
                 print(l['log'])
 
         assert not [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ class Helpers:
 
             time.sleep(0.5)
 
-        if not [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']:
+        if [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']:
             for idx, l in enumerate(super_client.get_process_logs(status='error')):
                 print(f"Error {idx}: {l['id']}")
                 print(l['log'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,11 +75,6 @@ class Helpers:
 
             time.sleep(0.5)
 
-        if [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']:
-            for idx, l in enumerate(super_client.get_process_logs(status='error')):
-                print(f"Error {idx}: {l['invitation']}")
-                print(l['log'])
-
         assert not [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']
 
     @staticmethod


### PR DESCRIPTION
This PR checks to see that the previous date process has finished running before making a new change by checking process logs that have completed in `okay` or `error`.

The ARR class was actually making 3 edits, the initial edit, one to add the pre-process and one to change the invitation to support ethics review flagging.
The custom stage was modified to support process and pre-process paths so that the ARR stage would only make 2 edits.