### PR TITLE
Feat/add to index option in request form

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -155,6 +155,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.iThenticate_plagiarism_check_api_key = note.content.get('iThenticate_plagiarism_check_api_key', '')
         venue.iThenticate_plagiarism_check_api_base_url = note.content.get('iThenticate_plagiarism_check_api_base_url', '')
         venue.iThenticate_plagiarism_check_committee_readers = note.content.get('iThenticate_plagiarism_check_committee_readers', '')
+        venue.iThenticate_plagiarism_check_add_to_index = note.content.get('iThenticate_plagiarism_check_add_to_index', 'No') == 'Yes'
 
         venue.submission_stage = get_submission_stage(note, venue)
         venue.review_stage = get_review_stage(note)

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -206,6 +206,7 @@ class GroupBuilder(object):
                 'value': self.venue.iThenticate_plagiarism_check_api_base_url,
                 'readers': [self.venue.id],
             }
+            content['iThenticate_plagiarism_check_add_to_index'] = { 'value': self.venue.iThenticate_plagiarism_check_add_to_index }
             content['iThenticate_plagiarism_check_invitation_id'] = { 'value': self.venue.get_iThenticate_plagiarism_check_invitation_id() }
             content['iThenticate_plagiarism_check_committee_readers'] = { 'value': self.venue.iThenticate_plagiarism_check_committee_readers }
 

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -86,6 +86,7 @@ class Venue(object):
         self.iThenticate_plagiarism_check_api_key = ''
         self.iThenticate_plagiarism_check_api_base_url = ''
         self.iThenticate_plagiarism_check_committee_readers = []
+        self.iThenticate_plagiarism_check_add_to_index = False
 
     def get_id(self):
         return self.venue_id
@@ -1111,7 +1112,7 @@ Total Errors: {len(errors)}
                     owner_profile = self.client.get_profile(owner)
                     
 
-                eula_version = submission.content.get("iThenticate_agreement", {}).get("value", "v1beta").split(":")[-1].strip()
+                eula_version = submission.content.get("iThenticate_agreement", {}).get("value").split(":")[-1].strip()
 
                 timestamp = datetime.datetime.fromtimestamp(
                         submission.tcdate / 1000, tz=datetime.timezone.utc
@@ -1260,7 +1261,7 @@ Total Errors: {len(errors)}
                             "CROSSREF_POSTED_CONTENT",
                         ],
                         indexing_settings={
-                            "add_to_index": True
+                            "add_to_index": self.iThenticate_plagiarism_check_add_to_index
                         },
                         auto_exclude_self_matching_scope="ALL",
                     )
@@ -1300,6 +1301,9 @@ Total Errors: {len(errors)}
                         "CROSSREF",
                         "CROSSREF_POSTED_CONTENT",
                     ],
+                    indexing_settings={
+                        "add_to_index": self.iThenticate_plagiarism_check_add_to_index
+                    },
                 )
             except Exception as err:
                 updated_edge.label = "File Uploaded"

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1651,7 +1651,7 @@ class VenueRequest():
                 'hidden': True
             },
             'iThenticate_plagiarism_check_add_to_index': {
-                'description': 'The Add to Index option controls whether or not the submission is added to the iThenticate account\'s repository. If set to "Yes", future submissions may match against the submission. If set to "No", future submissions will not match against the submission.',
+                'description': 'Your iThenticate account has a repository. This option controls whether or not the submission is added to your iThenticate account\'s repository. If set to Yes, future submissions can match against the indexed submissions. Your account repository is private and no other institutions can search against your indexed documents.',
                 'value-radio': ['Yes', 'No'],
                 'default': 'No',
                 'order': 53,

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1650,9 +1650,16 @@ class VenueRequest():
                 'required': False,
                 'hidden': True
             },
+            'iThenticate_plagiarism_check_add_to_index': {
+                'value-radio': ['Yes', 'No'],
+                'default': 'No',
+                'order': 53,
+                'required': False,
+                'hidden': True
+            },
             'submission_assignment_max_reviewers': {
                 'value-regex': '.*',
-                'order': 53,
+                'order': 54,
                 'required': False,
                 'hidden': True
             }

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1651,6 +1651,7 @@ class VenueRequest():
                 'hidden': True
             },
             'iThenticate_plagiarism_check_add_to_index': {
+                'description': 'The Add to Index option controls whether or not the submission is added to the iThenticate account\'s repository. If set to "Yes", future submissions may match against the submission. If set to "No", future submissions will not match against the submission.',
                 'value-radio': ['Yes', 'No'],
                 'default': 'No',
                 'order': 53,

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1625,6 +1625,7 @@ class VenueRequest():
                 'hidden': True
             },
             'iThenticate_plagiarism_check': {
+                'description': 'Indicate whether you would like to use iThenticate with OpenReview for plagiarism report generation.',
                 'value-radio': ['Yes', 'No'],
                 'default': 'No',
                 'order': 49,
@@ -1632,18 +1633,21 @@ class VenueRequest():
                 'hidden': True
             },
             'iThenticate_plagiarism_check_api_key': {
+                'description': 'iThenticate API key',
                 'value-regex': '.*',
                 'order': 50,
                 'required': False,
                 'hidden': True
             },
             'iThenticate_plagiarism_check_api_base_url': {
+                'description': 'The base URL for your iThenticate account (eg. openreview.turnitin.com)',
                 'value-regex': '.*',
                 'order': 51,
                 'required': False,
                 'hidden': True
             },
             'iThenticate_plagiarism_check_committee_readers': {
+                'description': 'Roles that should be allowed to access the iThenticate plagiarism reports.',
                 'values-regex': '.*',
                 'order': 52,
                 'default': [],

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -1651,7 +1651,7 @@ class VenueRequest():
                 'hidden': True
             },
             'iThenticate_plagiarism_check_add_to_index': {
-                'description': 'Your iThenticate account has a repository. This option controls whether or not the submission is added to your iThenticate account\'s repository. If set to Yes, future submissions can match against the indexed submissions. Your account repository is private and no other institutions can search against your indexed documents.',
+                'description': 'Your iThenticate account has a repository. Your account repository is private and no other iThenticate account can search against your indexed documents. The add to index option controls whether or not submissions are added to your iThenticate account\'s repository. If set to Yes, the submissions will be indexed and can be matched with future submissions made to the venue.',
                 'value-radio': ['Yes', 'No'],
                 'default': 'No',
                 'order': 53,

--- a/tests/test_aaai_conference.py
+++ b/tests/test_aaai_conference.py
@@ -69,6 +69,7 @@ class TestAAAIConference():
                 'iThenticate_plagiarism_check_api_key': '1234',
                 'iThenticate_plagiarism_check_api_base_url': 'test.turnitin.com',
                 'iThenticate_plagiarism_check_committee_readers': ['Area_Chairs', 'Senior_Program_Committee'],
+                'iThenticate_plagiarism_check_add_to_index': 'Yes',
             }))
 
         helpers.await_queue()


### PR DESCRIPTION
These changes enable the venue to set the value for the add_to_index option in iThenticate. 

Also removed the default value for the EULA version.