### PR TITLE
Fix: Preserve transitive membership

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -769,7 +769,7 @@ class OpenReviewClient(object):
         return response.json()
 
 
-    def get_groups(self, id=None, prefix=None, member=None, signatory=None, web=None, limit=None, offset=None, after=None, stream=None, sort=None, with_count=False):
+    def get_groups(self, id=None, prefix=None, member=None, members=None, signatory=None, web=None, limit=None, offset=None, after=None, stream=None, sort=None, with_count=False):
         """
         Gets list of Group objects based on the filters provided. The Groups that will be returned match all the criteria passed in the parameters.
 
@@ -777,8 +777,10 @@ class OpenReviewClient(object):
         :type id: str, optional
         :param prefix: Prefix that matches several Group ids
         :type prefix: str, optional
-        :param member: Groups that contain this member
+        :param member: Groups that that are trasitive members of the member value
         :type member: str, optional
+        :param members: Groups that contain the value members in the members field
+        :type members: str, optional
         :param signatory: Groups that contain this signatory
         :type signatory: str, optional
         :param web: Groups that contain a web field value
@@ -798,6 +800,8 @@ class OpenReviewClient(object):
             params['prefix'] = prefix
         if member is not None:
             params['member'] = member
+        if members is not None:
+            params['members'] = members
         if signatory is not None:
             params['signatory'] = signatory
         if sort is not None:
@@ -822,7 +826,7 @@ class OpenReviewClient(object):
 
         return groups
 
-    def get_all_groups(self, id=None, parent=None, prefix=None, member=None, domain=None, signatory=None, web=None, sort=None, with_count=False):
+    def get_all_groups(self, id=None, parent=None, prefix=None, member=None, members=None, domain=None, signatory=None, web=None, sort=None, with_count=False):
         """
         Gets list of Group objects based on the filters provided. The Groups that will be returned match all the criteria passed in the parameters.
 
@@ -832,8 +836,10 @@ class OpenReviewClient(object):
         :type parent: str, optional
         :param prefix: Prefix that matches several Group ids
         :type prefix: str, optional
-        :param member: Groups that contain this member
+        :param member: Groups that that are trasitive members of the member value
         :type member: str, optional
+        :param members: Groups that contain the value members in the members field
+        :type members: str, optional
         :param signatory: Groups that contain this signatory
         :type signatory: str, optional
         :param web: Groups that contain a web field value
@@ -859,6 +865,8 @@ class OpenReviewClient(object):
             params['prefix'] = prefix
         if member is not None:
             params['member'] = member
+        if members is not None:
+            params['members'] = members
         if signatory is not None:
             params['signatory'] = signatory
         if domain is not None:

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -777,7 +777,7 @@ class OpenReviewClient(object):
         :type id: str, optional
         :param prefix: Prefix that matches several Group ids
         :type prefix: str, optional
-        :param member: Groups that that are trasitive members of the member value
+        :param member: Groups that that are transitive members of the member value
         :type member: str, optional
         :param members: Groups that contain the value members in the members field
         :type members: str, optional

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -2227,6 +2227,36 @@ The OpenReview Team.
         assert openreview_client.get_group('~Harold_Last1').members == ['harold@profile.org']
         assert openreview_client.get_group('harold@profile.org').members == ['~Harold_Last1']
 
+    def test_remove_email_from_merged_profile(self, openreview_client, helpers):
+
+        tidus_client = helpers.create_user('tidus@profile.org', 'Tidus', 'Mondragon', alternates=[], institution='google.com')
+
+        profile = tidus_client.get_profile()
+        profile.content['homepage'] = 'https://carlos.google.com'
+
+        tidus_client.post_profile(profile)
+
+        helpers.create_user('tidus_two@profile.org', 'Tidus', 'Chapa', alternates=[], institution='deepmind.com')
+
+        openreview_client.merge_profiles('~Tidus_Mondragon1', '~Tidus_Chapa1')
+
+        edit = openreview_client.post_note_edit(
+            invitation = 'openreview.net/Support/-/Profile_Email_Removal',
+            signatures=['openreview.net/Support'],
+            note = openreview.api.Note(
+                content={
+                    'email': { 'value': 'tidus_two@profile.org' },
+                    'profile_id': { 'value':'~Tidus_Mondragon1' },
+                    'comment': { 'value': 'email is silly' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
+
+        profile = tidus_client.get_profile()
+
+        tidus_client.post_profile(profile)
 
     def test_update_relation_after_signup(self, helpers):
 


### PR DESCRIPTION
This PR should fix the issue when two profiles are merged and then an email is removed, there is a chance that the transitive members will break. 