### PR TITLE
ARR test: remove loop to retry get notes and wait for process to finish instead

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1159,6 +1159,7 @@ class OpenReviewClient(object):
             offset = None,
             after = None,
             mintcdate = None,
+            domain = None,
             details = None,
             sort = None,
             with_count=False
@@ -1204,6 +1205,7 @@ class OpenReviewClient(object):
         :param mintcdate: Represents an Epoch time timestamp, in milliseconds. If provided, returns Notes
             whose "true creation date" (tcdate) is at least equal to the value of mintcdate.
         :type mintcdate: int, optional
+        :param domain: If provided, returns Notes whose domain field matches the given domain.
         :param details: TODO: What is a valid value for this field?
         :type details: optional
         :param sort: Sorts the output by field depending on the string passed. Possible values: number, cdate, ddate, tcdate, tmdate, replyCount (Invitation id needed in the invitation field).
@@ -1246,6 +1248,8 @@ class OpenReviewClient(object):
             params['offset'] = offset
         if mintcdate is not None:
             params['mintcdate'] = mintcdate
+        if domain is not None:
+            params['domain'] = domain
         if details is not None:
             params['details'] = details
         if after is not None:

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3561,26 +3561,6 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             reviewer_six_client.get_note(june_submissions[2].id, details='replies')
 
 
-
-        # ## Fetch corresponding June submissions with details replies using reviewer client, check replies for official reviews
-        # retries, MAX_RETRIES = 0, 10
-        # retry = True
-        # while retries < MAX_RETRIES and retry:
-        #     try:
-        #         reviewer_six_client.get_note(june_submissions[2].id, details='replies')
-        #         retry = True
-        #         retries += 1
-        #         time.sleep(2)
-        #     except Exception as e:
-        #         retry = False
-        #         break
-        # same_note = reviewer_six_client.get_note(june_submissions[1].id, details='replies')
-        # with pytest.raises(openreview.OpenReviewException, match=r'User Reviewer ARRSix does not have permission to see'):
-        #     reviewer_six_client.get_note(june_submissions[2].id, details='replies')
-        # assert len(
-        #     [r for r in same_note.details['replies'] if r['invitations'][0].endswith('Official_Review')]
-        # ) == 2
-
         ## Clean up data
         for edge in existing_edges:
             edge.ddate = openreview.tools.datetime_millis(now)
@@ -5547,7 +5527,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         assert len(notes) == 1
 
         notes = pc_client_v2.get_notes(forum=submssion3.id, domain='aclweb.org/ACL/ARR/2023/August')
-        assert len(notes) == 1
+        assert len(notes) == 3
         
         venue = openreview.helpers.get_conference(client, request_form_note.forum)
         venue.invitation_builder.expire_invitation('aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment/Senior_Area_Chairs/-/Submission_Group')

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3557,7 +3557,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         helpers.await_queue_edit(openreview_client, edit_id=existing_edges[-1].id)
 
         assert '~Reviewer_ARRSix1' in openreview_client.get_group('aclweb.org/ACL/ARR/2023/August/Submission3/Reviewers').members
-        with pytest.raises(openreview.OpenReviewException, match=r'User Reviewer ARRSix does not have permission to see'):
+        with pytest.raises(openreview.OpenReviewException, match=r'User Reviewer ARRSix does not have permission to see Note ' + june_submissions[2].id):
             reviewer_six_client.get_note(june_submissions[2].id, details='replies')
 
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3543,6 +3543,10 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         )))
         
         helpers.await_queue_edit(openreview_client, edit_id=existing_edges[-1].id)
+
+        assert '~Reviewer_ARRSix1' in openreview_client.get_group('aclweb.org/ACL/ARR/2023/August/Submission2/Reviewers').members
+        reviewer_six_client.get_note(june_submissions[1].id, details='replies')
+
         existing_edges.append(openreview_client.post_edge(openreview.api.Edge(
             invitation = 'aclweb.org/ACL/ARR/2023/August/Reviewers/-/Assignment',
             head = submissions[2].id,
@@ -3552,28 +3556,36 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         )))
         helpers.await_queue_edit(openreview_client, edit_id=existing_edges[-1].id)
 
-        ## Fetch corresponding June submissions with details replies using reviewer client, check replies for official reviews
-        retries, MAX_RETRIES = 0, 10
-        retry = True
-        while retries < MAX_RETRIES and retry:
-            try:
-                reviewer_six_client.get_note(june_submissions[2].id, details='replies')
-                retry = True
-                time.sleep(2)
-            except Exception as e:
-                retry = False
-                break
-        same_note = reviewer_six_client.get_note(june_submissions[1].id, details='replies')
+        assert '~Reviewer_ARRSix1' in openreview_client.get_group('aclweb.org/ACL/ARR/2023/August/Submission3/Reviewers').members
         with pytest.raises(openreview.OpenReviewException, match=r'User Reviewer ARRSix does not have permission to see'):
             reviewer_six_client.get_note(june_submissions[2].id, details='replies')
-        assert len(
-            [r for r in same_note.details['replies'] if r['invitations'][0].endswith('Official_Review')]
-        ) == 2
+
+
+
+        # ## Fetch corresponding June submissions with details replies using reviewer client, check replies for official reviews
+        # retries, MAX_RETRIES = 0, 10
+        # retry = True
+        # while retries < MAX_RETRIES and retry:
+        #     try:
+        #         reviewer_six_client.get_note(june_submissions[2].id, details='replies')
+        #         retry = True
+        #         retries += 1
+        #         time.sleep(2)
+        #     except Exception as e:
+        #         retry = False
+        #         break
+        # same_note = reviewer_six_client.get_note(june_submissions[1].id, details='replies')
+        # with pytest.raises(openreview.OpenReviewException, match=r'User Reviewer ARRSix does not have permission to see'):
+        #     reviewer_six_client.get_note(june_submissions[2].id, details='replies')
+        # assert len(
+        #     [r for r in same_note.details['replies'] if r['invitations'][0].endswith('Official_Review')]
+        # ) == 2
 
         ## Clean up data
         for edge in existing_edges:
             edge.ddate = openreview.tools.datetime_millis(now)
             openreview_client.post_edge(edge)
+            helpers.await_queue_edit(openreview_client, edit_id=edge.id, count=2)
 
     def test_checklists(self, client, openreview_client, helpers, test_client, request_page, selenium):
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password=helpers.strong_password)
@@ -5513,6 +5525,10 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                     }
                 ))
         
+        pc_client_v2 = openreview.api.OpenReviewClient(username='pc@c3nlp.org', password=helpers.strong_password)
+        notes = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', number=3)
+        assert len(notes) == 0
+
         openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment')
         
         august_submissions = openreview_client.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', sort='number:asc')
@@ -5522,6 +5538,16 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
 
         reviews = openreview_client.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/Submission3/-/Official_Review')
         assert 'aclweb.org/ACL/ARR/2023/August/Submission3/Commitment_Readers' in reviews[0].readers
+
+        notes = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', number=3)
+        assert len(notes) == 1
+        submssion3 = notes[0]
+
+        notes = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/Submission3/-/Official_Review')
+        assert len(notes) == 1
+
+        notes = pc_client_v2.get_notes(forum=submssion3.id, domain='aclweb.org/ACL/ARR/2023/August')
+        assert len(notes) == 1
         
         venue = openreview.helpers.get_conference(client, request_form_note.forum)
         venue.invitation_builder.expire_invitation('aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment/Senior_Area_Chairs/-/Submission_Group')


### PR DESCRIPTION
- Remove infinite loop. 
- Assert that members were correctly added to the group members.
- Check correct exception is thrown.
- Add test to get notes by domain