### PR TITLE
Test improvements to setup the running time and avoid time out errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
             pip install pytest-selenium
             pip install -e .
             TEST_FILES=$(circleci tests glob "tests/test_*.py")
-            echo "$TEST_FILES" | circleci tests run --command="xargs pytest tests/test_arr_venue_v2.py --durations=0 -v -o junit_family=legacy --junitxml=test-reports/junit.xml --driver Firefox --driver-path tests/drivers/geckodriver" --verbose --split-by=timings
+            echo "$TEST_FILES" | circleci tests run --command="xargs pytest --durations=0 -v -o junit_family=legacy --junitxml=test-reports/junit.xml --driver Firefox --driver-path tests/drivers/geckodriver" --verbose --split-by=timings
       - run:
           name: Stop all services
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
             pip install pytest-selenium
             pip install -e .
             TEST_FILES=$(circleci tests glob "tests/test_*.py")
-            echo "$TEST_FILES" | circleci tests run --command="xargs pytest --durations=0 -v -o junit_family=legacy --junitxml=test-reports/junit.xml --driver Firefox --driver-path tests/drivers/geckodriver" --verbose --split-by=timings
+            echo "$TEST_FILES" | circleci tests run --command="xargs pytest tests/test_arr_venue_v2.py --durations=0 -v -o junit_family=legacy --junitxml=test-reports/junit.xml --driver Firefox --driver-path tests/drivers/geckodriver" --verbose --split-by=timings
       - run:
           name: Stop all services
           command: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,4 @@ include openreview/venue/webfield/*.js
 include openreview/arr/process/*.js
 include openreview/arr/process/*.py
 include openreview/arr/management/*.py
+include openreview/arr/webfield/*.js

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ class Helpers:
         cycles = 60 * 1 / wait_time # print every 1 minutes
         while True:
             process_logs = super_client.get_process_logs(id=edit_id, invitation=invitation)
-            if len(process_logs) >= count and all(process_log['status'] in finished_status):
+            if len(process_logs) >= count and all(process_log['status'] in finished_status for process_log in process_logs):
                 for process_log in process_logs:
                     assert process_log['status'] == (expected_status), process_log.get('log', 'No log available')
                     return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,8 +96,8 @@ class Helpers:
         cycles = 60 * 1 / wait_time # print every 1 minutes
         while True:
             process_logs = super_client.get_process_logs(id=edit_id, invitation=invitation)
-            if len(process_logs) >= count and all(process_log['status'] == expected_status for process_log in process_logs):
-                break
+            if len(process_logs) >= count:
+                assert all(process_log['status'] == expected_status for process_log in process_logs)
 
             time.sleep(wait_time)
             if counter % cycles == 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,9 @@ class Helpers:
         while True:
             process_logs = super_client.get_process_logs(id=edit_id, invitation=invitation)
             if len(process_logs) >= count:
-                assert all(process_log['status'] == expected_status for process_log in process_logs)
+                #assert all(process_log['status'] == expected_status for process_log in process_logs)
+                for process_log in process_logs:
+                    assert process_log['status'] == (expected_status), process_log['log']
 
             time.sleep(wait_time)
             if counter % cycles == 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,7 @@ class Helpers:
                 #assert all(process_log['status'] == expected_status for process_log in process_logs)
                 for process_log in process_logs:
                     assert process_log['status'] == (expected_status), process_log['log']
+                    return
 
             time.sleep(wait_time)
             if counter % cycles == 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,15 +91,15 @@ class Helpers:
     def await_queue_edit(super_client, edit_id=None, invitation=None, count=1, error=False):
         super_client = Helpers.get_user('openreview.net')
         expected_status = 'error' if error else 'ok'
+        finished_status = ['error', 'ok']
         counter = 0
         wait_time = 0.5
         cycles = 60 * 1 / wait_time # print every 1 minutes
         while True:
             process_logs = super_client.get_process_logs(id=edit_id, invitation=invitation)
-            if len(process_logs) >= count:
-                #assert all(process_log['status'] == expected_status for process_log in process_logs)
+            if len(process_logs) >= count and all(process_log['status'] in finished_status):
                 for process_log in process_logs:
-                    assert process_log['status'] == (expected_status), process_log['log']
+                    assert process_log['status'] == (expected_status), process_log.get('log', 'No log available')
                     return
 
             time.sleep(wait_time)

--- a/tests/test_acl_commitment.py
+++ b/tests/test_acl_commitment.py
@@ -5,6 +5,7 @@ import time
 import os
 import re
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestACLCommitment():
 
     @pytest.fixture(scope="class")

--- a/tests/test_agora.py
+++ b/tests/test_agora.py
@@ -5,6 +5,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestAgora():
 
     def test_setup(self, client, helpers, request_page, selenium):

--- a/tests/test_arr_venue.py
+++ b/tests/test_arr_venue.py
@@ -10,6 +10,7 @@ import csv
 import random
 from selenium.webdriver.common.by import By
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestARRVenue():
 
     @pytest.fixture(scope="class")

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -416,6 +416,11 @@ class TestARRVenueV2():
             venue.get_area_chairs_id(),
             venue.get_senior_area_chairs_id()
         ]
+
+        assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Reviewers/-/Max_Load_And_Unavailability_Request')
+        assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Area_Chairs/-/Max_Load_And_Unavailability_Request')
+        assert openreview_client.get_invitation('aclweb.org/ACL/ARR/2023/August/Senior_Area_Chairs/-/Max_Load_And_Unavailability_Request')
+
         for role, task_field in zip(venue_roles, task_array):
             m = matching.Matching(venue, venue.client.get_group(role), None, None)
             m._create_edge_invitation(venue.get_custom_max_papers_id(m.match_group.id))

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -1508,6 +1508,8 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         ))
 
         helpers.await_queue()
+        helpers.await_queue_edit(openreview_client, 'aclweb.org/ACL/ARR/2023/June/Reviewers/-/Submission_Group-0-1', count=2)
+        helpers.await_queue_edit(openreview_client, 'aclweb.org/ACL/ARR/2023/June/Area_Chairs/-/Submission_Group-0-1', count=2)
 
     def test_no_assignment_preprocess(self, client, openreview_client, test_client, helpers):
         # If reviewer assignment quota is not set, check that pre-processes don't fail
@@ -1517,6 +1519,15 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         june_venue = openreview.helpers.get_conference(client, request_form.id, 'openreview.net/Support')
         test_client = openreview.api.OpenReviewClient(token=test_client.token)
         submissions = june_venue.get_submissions()
+        assert len(submissions) == 3
+        assert pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission1/Reviewers')
+        assert pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission2/Reviewers')
+        assert pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission3/Reviewers')
+
+        assert pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission1/Area_Chairs')
+        assert pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission2/Area_Chairs')
+        assert pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission3/Area_Chairs')
+
 
         client.post_note(openreview.Note(
             content={

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -1518,7 +1518,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
         june_venue = openreview.helpers.get_conference(client, request_form.id, 'openreview.net/Support')
         test_client = openreview.api.OpenReviewClient(token=test_client.token)
-        submissions = june_venue.get_submissions()
+        submissions = june_venue.get_submissions(sort='number:asc')
         assert len(submissions) == 3
         assert pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission1/Reviewers')
         assert pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission2/Reviewers')

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -11,6 +11,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestBuilder():
 
     def test_override_homepage(self, client, selenium, request_page):

--- a/tests/test_builder_console.py
+++ b/tests/test_builder_console.py
@@ -5,6 +5,7 @@ import openreview
 import pytest
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestBuilderConsoles():
 
     def test_PC_console_web_edit(self, client, test_client, selenium, request_page, helpers):

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -13,6 +13,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestCommentNotification():
 
     def test_notify_all(self, client, test_client, helpers):

--- a/tests/test_cvpr_conference.py
+++ b/tests/test_cvpr_conference.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestCVPRSConference():
 
     @pytest.fixture(scope="class")

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -15,6 +15,7 @@ from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestDoubleBlindConference():
 
     def test_create_conference(self, client):

--- a/tests/test_eccv_conference.py
+++ b/tests/test_eccv_conference.py
@@ -17,6 +17,7 @@ from selenium.common.exceptions import NoSuchElementException
 
 from openreview.conference import invitation
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestECCVConference():
 
     @pytest.fixture(scope="class")

--- a/tests/test_eswc_conference.py
+++ b/tests/test_eswc_conference.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestESWCConference():
 
     @pytest.fixture(scope="class")

--- a/tests/test_iclr_conference.py
+++ b/tests/test_iclr_conference.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestICLRConference():
 
     @pytest.fixture(scope="class")

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -13,6 +13,7 @@ from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestMatching():
 
     @pytest.fixture(scope="class")

--- a/tests/test_multiple_roles.py
+++ b/tests/test_multiple_roles.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestMultipleRoles():
 
     @pytest.fixture(scope="class")

--- a/tests/test_neurips_conference.py
+++ b/tests/test_neurips_conference.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestNeurIPSConference():
 
     @pytest.fixture(scope="class")

--- a/tests/test_open_submissions.py
+++ b/tests/test_open_submissions.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestOpenSubmissions():
 
     @pytest.fixture(scope="class")

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -11,6 +11,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestReviewersConference():
 
     def test_set_reviewers_name(self, client, test_client, selenium, request_page):

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -7,6 +7,7 @@ import datetime
 import time
 import os
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestSingleBlindConference():
 
     def test_create_single_blind_conference(self, client, selenium, request_page) :

--- a/tests/test_single_blind_private_conference.py
+++ b/tests/test_single_blind_private_conference.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestSingleBlindPrivateConference():
 
     @pytest.fixture(scope="class")

--- a/tests/test_submission_readers.py
+++ b/tests/test_submission_readers.py
@@ -4,6 +4,7 @@ import datetime
 from selenium.common.exceptions import NoSuchElementException
 from openreview import VenueRequest
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestSubmissionReaders():
 
     @pytest.fixture(scope='class')

--- a/tests/test_venue_request.py
+++ b/tests/test_venue_request.py
@@ -13,6 +13,7 @@ import csv
 import os
 import random
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestVenueRequest():
 
     @pytest.fixture(scope='class')

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -12,6 +12,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 
+@pytest.mark.skip(reason="Skipping all tests in this class because it is an API v1 venue")
 class TestWorkshop():
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
- Skip API V1 tests
- ARR make sure process functions finished and assert the group creation
- Check that all process logs match with the same status and finish.