### PR TITLE
Fix/deprecated utcnow function

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -2793,7 +2793,7 @@ class Invitation(object):
         return pp.pformat(vars(self))
     
     def is_active(self):
-        now = tools.datetime_millis(datetime.datetime.utcnow())
+        now = tools.datetime_millis(datetime.datetime.now())
         cdate = self.cdate if self.cdate else now
         edate = self.expdate if self.expdate else now
         return cdate <= now and now <= edate

--- a/openreview/arr/management/setup_ae_matching.py
+++ b/openreview/arr/management/setup_ae_matching.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_metareview_release.py
+++ b/openreview/arr/management/setup_metareview_release.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_proposed_assignments.py
+++ b/openreview/arr/management/setup_proposed_assignments.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_rebuttal_end.py
+++ b/openreview/arr/management/setup_rebuttal_end.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_rebuttal_start.py
+++ b/openreview/arr/management/setup_rebuttal_start.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_review_release.py
+++ b/openreview/arr/management/setup_review_release.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_reviewer_matching.py
+++ b/openreview/arr/management/setup_reviewer_matching.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_sae_ae_assignments.py
+++ b/openreview/arr/management/setup_sae_ae_assignments.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_sae_matching.py
+++ b/openreview/arr/management/setup_sae_matching.py
@@ -1,6 +1,6 @@
 def process(client, invitation):
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/management/setup_shared_data.py
+++ b/openreview/arr/management/setup_shared_data.py
@@ -1,7 +1,7 @@
 def process(client, invitation):
     # TODO: Store registration and max load names in domain content to parameterize them
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:
@@ -68,7 +68,7 @@ def process(client, invitation):
     domain = client.get_group(invitation.domain)
     venue_id = domain.id
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/arr/process/preprint_release_submission_process.py
+++ b/openreview/arr/process/preprint_release_submission_process.py
@@ -5,7 +5,7 @@ def process(client, invitation):
     submission_venue_id = domain.content['submission_venue_id']['value']
     venue_name = domain.content['title']['value']
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:
@@ -23,7 +23,7 @@ def process(client, invitation):
                     'value': openreview.tools.generate_bibtex(
                         note=submission,
                         venue_fullname=venue_name,
-                        year=str(datetime.datetime.utcnow().year),
+                        year=str(datetime.datetime.now().year),
                         url_forum=submission.forum,
                         paper_status='under review',
                         anonymous=True

--- a/openreview/arr/process/verification_process.py
+++ b/openreview/arr/process/verification_process.py
@@ -20,7 +20,7 @@ def process(client, edit, invitation):
                 replacement=False,
                 invitation=openreview.api.Invitation(
                         id=verification_invitation.id,
-                        expdate=openreview.tools.datetime_millis(datetime.datetime.utcnow() + datetime.timedelta(days=60)),
+                        expdate=openreview.tools.datetime_millis(datetime.datetime.now() + datetime.timedelta(days=60)),
                         signatures=[venue_id]
                     )
             )
@@ -39,7 +39,7 @@ def process(client, edit, invitation):
                 replacement=False,
                 invitation=openreview.api.Invitation(
                         id=verification_invitation.id,
-                        expdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                        expdate=openreview.tools.datetime_millis(datetime.datetime.now()),
                         signatures=[venue_id]
                     )
             )

--- a/openreview/journal/assignment.py
+++ b/openreview/journal/assignment.py
@@ -223,7 +223,7 @@ class Assignment(object):
         self.client.delete_edges(invitation=journal.get_ae_local_custom_max_papers_id(), soft_delete=True, wait_to_finish=True)
 
         max_active_submissions = 2
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         inclusion_date = now - datetime.timedelta(days=inclusion_day_limit) if inclusion_day_limit else None
 
         custom_load_edges = []
@@ -308,7 +308,7 @@ class Assignment(object):
         submission_by_id = { s.id: s for s in self.client.get_all_notes(invitation=journal.get_author_submission_id()) }
 
         to_delete_assignments = []
-        now = tools.datetime_millis(datetime.datetime.utcnow())
+        now = tools.datetime_millis(datetime.datetime.now())
         for head, tails in tqdm(proposed_assignments.items()):
             assignment_edges = assignments.get(head)
             for edge in assignment_edges:

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -167,18 +167,18 @@ class InvitationBuilder(object):
         if not invitation:
             return
         
-        if invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow()):
+        if invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now()):
             return
 
         self.post_invitation_edit(invitation=Invitation(id=invitation.id,
-                expdate=expdate if expdate else openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                expdate=expdate if expdate else openreview.tools.datetime_millis(datetime.datetime.now()),
                 signatures=[self.venue_id]
             )
         )
 
     def expire_paper_invitations(self, note):
 
-        now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        now = openreview.tools.datetime_millis(datetime.datetime.now())
         invitations = self.client.get_invitations(prefix=f'{self.venue_id}/Paper{note.number}/.*', type='all')
         exceptions = ['Public_Comment', 'Official_Comment', 'Moderation']
 
@@ -202,14 +202,14 @@ class InvitationBuilder(object):
 
     def expire_reviewer_responsibility_invitations(self):
 
-        now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        now = openreview.tools.datetime_millis(datetime.datetime.now())
         invitations = self.client.get_invitations(invitation=self.journal.get_reviewer_responsibility_id())
 
         for invitation in invitations:
             self.expire_invitation(invitation.id, now)
 
     def expire_assignment_availability_invitations(self):
-        now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        now = openreview.tools.datetime_millis(datetime.datetime.now())
         self.expire_invitation(self.journal.get_ae_availability_id(), now)
         self.expire_invitation(self.journal.get_reviewer_availability_id(), now)
 

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -592,7 +592,7 @@ class Journal(object):
                           self.get_authors_id(number)]
 
     def get_due_date(self, days=0, weeks=0):
-        due_date = datetime.datetime.utcnow().replace(hour=23, minute=59, second=59, microsecond=999999) + datetime.timedelta(days=days, weeks=weeks)
+        due_date = datetime.datetime.now().replace(hour=23, minute=59, second=59, microsecond=999999) + datetime.timedelta(days=days, weeks=weeks)
         return due_date
 
     def get_bibtex(self, note, new_venue_id, anonymous=False, certifications=None):
@@ -610,7 +610,7 @@ class Journal(object):
 
         first_word = re.sub('[^a-zA-Z]', '', note.content['title']['value'].split(' ')[0].lower())
         bibtex_title = u.unicode_to_latex(note.content['title']['value'])
-        year = datetime.datetime.utcnow().year
+        year = datetime.datetime.now().year
 
         if new_venue_id == self.under_review_venue_id:
 
@@ -1830,7 +1830,7 @@ OpenReview Team'''
                                 if invitation_edges:
                                     invitation_edge = invitation_edges[0]
                                     print(f'User invited twice, remove double invitation edge {invitation_edge.id}')
-                                    invitation_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+                                    invitation_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
                                     client.post_edge(invitation_edge)
 
                                 # Check conflicts

--- a/openreview/journal/process/action_editor_edge_reminder_process.py
+++ b/openreview/journal/process/action_editor_edge_reminder_process.py
@@ -4,7 +4,7 @@ def process(client, invitation):
 
     submission = client.get_note(invitation.edit['head']['param']['const'])
     duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     task = "Reviewer Assignment"
 
     edges = client.get_edges(invitation=journal.get_reviewer_assignment_id(), head=submission.id)

--- a/openreview/journal/process/action_editor_reminder_process.py
+++ b/openreview/journal/process/action_editor_reminder_process.py
@@ -4,7 +4,7 @@ def process(client, invitation):
 
     submission = client.get_note(invitation.edit['note']['forum'])
     duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     task = invitation.pretty_id()
 
     late_invitees = journal.get_late_invitees(invitation.id)

--- a/openreview/journal/process/author_edge_reminder_process.py
+++ b/openreview/journal/process/author_edge_reminder_process.py
@@ -5,7 +5,7 @@ def process(client, invitation):
     submission = client.get_note(invitation.edit['head']['param']['const'])
     assigned_action_editor = submission.content.get('assigned_action_editor', {}).get('value')
     duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     task = invitation.pretty_id()
 
     edges_count = client.get_edges_count(invitation=journal.get_ae_recommendation_id(), head=submission.id)

--- a/openreview/journal/process/author_reminder_process.py
+++ b/openreview/journal/process/author_reminder_process.py
@@ -5,7 +5,7 @@ def process(client, invitation):
     submission = client.get_note(invitation.edit['note']['forum'])
     assigned_action_editor = submission.content.get('assigned_action_editor', {}).get('value')
     duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     task = invitation.pretty_id()
 
     late_invitees = journal.get_late_invitees(invitation.id)

--- a/openreview/journal/process/camera_ready_verification_process.py
+++ b/openreview/journal/process/camera_ready_verification_process.py
@@ -46,7 +46,7 @@ def process(client, edit, invitation):
     acceptance_note = client.post_note_edit(invitation=journal.get_accepted_id(),
                         signatures=[venue_id],
                         note=openreview.api.Note(id=submission.id,
-                            pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                            pdate = openreview.tools.datetime_millis(datetime.datetime.now()),
                             content= content
                         )
                     )

--- a/openreview/journal/process/eic_reminder_process.py
+++ b/openreview/journal/process/eic_reminder_process.py
@@ -4,7 +4,7 @@ def process(client, invitation):
 
     submission = client.get_note(invitation.edit['note']['forum'])
     duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     task = invitation.pretty_id()
 
     replies = client.get_notes(invitation=invitation.id)

--- a/openreview/journal/process/official_recommendation_reminder_process.py
+++ b/openreview/journal/process/official_recommendation_reminder_process.py
@@ -4,7 +4,7 @@ def process(client, invitation):
 
     submission = client.get_note(invitation.edit['note']['forum']['value'])
     duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     task = 'Official Recommendation'
 
     reviews = client.get_notes(forum=submission.id, invitation=invitation.id)

--- a/openreview/journal/process/remind_ae_unavailable_process.py
+++ b/openreview/journal/process/remind_ae_unavailable_process.py
@@ -8,8 +8,8 @@ def process(client, invitation):
         return
     
     edges = [openreview.api.Edge.from_json(e) for e in grouped_edges[0]['values']]
-    reminder_period = openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(weeks = journal.unavailable_reminder_period))
-    back_to_available_period = openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(weeks = 2 * journal.unavailable_reminder_period))
+    reminder_period = openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(weeks = journal.unavailable_reminder_period))
+    back_to_available_period = openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(weeks = 2 * journal.unavailable_reminder_period))
 
     reminder_subject=f'[{journal.short_name}] Consider updating your availability for {journal.short_name}'
 

--- a/openreview/journal/process/remind_invited_reviewer_process.py
+++ b/openreview/journal/process/remind_invited_reviewer_process.py
@@ -9,8 +9,8 @@ def process(client, invitation):
     
     edges = [openreview.api.Edge.from_json(edge['values'][0]) for edge in grouped_edges]
 
-    start_reminder_period = openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(weeks = journal.invite_assignment_reminder_period, days=1))
-    end_reminder_period = openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(weeks = journal.invite_assignment_reminder_period))
+    start_reminder_period = openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(weeks = journal.invite_assignment_reminder_period, days=1))
+    end_reminder_period = openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(weeks = journal.invite_assignment_reminder_period))
     one_week = datetime.timedelta(weeks=1)
     
     print(f'reminder period between {start_reminder_period} and {end_reminder_period}')

--- a/openreview/journal/process/remind_reviewer_unavailable_process.py
+++ b/openreview/journal/process/remind_reviewer_unavailable_process.py
@@ -7,7 +7,7 @@ def process(client, invitation):
         return
     
     edges = [openreview.api.Edge.from_json(e) for e in grouped_edges[0]['values']]
-    reminder_period = openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(weeks = journal.unavailable_reminder_period))
+    reminder_period = openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(weeks = journal.unavailable_reminder_period))
 
     subject=f'[{journal.short_name}] Consider updating your availability for {journal.short_name}'
 

--- a/openreview/journal/process/review_approval_process.py
+++ b/openreview/journal/process/review_approval_process.py
@@ -25,7 +25,7 @@ def process(client, edit, invitation):
         return client.post_note_edit(invitation= journal.get_under_review_id(),
                                 signatures=[venue_id],
                                 note=openreview.api.Note(id=edit.note.forum,
-                                odate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if journal.is_submission_public() else None,
+                                odate = openreview.tools.datetime_millis(datetime.datetime.now()) if journal.is_submission_public() else None,
                                 content={
                                     '_bibtex': {
                                         'value': journal.get_bibtex(submission, journal.under_review_venue_id)

--- a/openreview/journal/process/review_reminder_with_no_ACK_process.py
+++ b/openreview/journal/process/review_reminder_with_no_ACK_process.py
@@ -5,7 +5,7 @@ def process(client, invitation):
     submission = client.get_note(invitation.edit['note']['forum'])
     assigned_action_editor = submission.content.get('assigned_action_editor', {}).get('value')
     duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     task = invitation.pretty_id()
 
     late_invitees = journal.get_late_invitees(invitation.id)

--- a/openreview/journal/process/reviewer_assignment_process.py
+++ b/openreview/journal/process/reviewer_assignment_process.py
@@ -34,7 +34,7 @@ def process_update(client, edge, invitation, existing_edge):
         if submission_edges:
             print('Mark task as uncomplete')
             submission_edge = submission_edges[0]
-            submission_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+            submission_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
             client.post_edge(submission_edge)
 
     ## Enable reviewer responsibility task

--- a/openreview/journal/process/reviewer_reminder_process.py
+++ b/openreview/journal/process/reviewer_reminder_process.py
@@ -5,7 +5,7 @@ def process(client, invitation):
     submission = client.get_note(invitation.edit['note']['forum'])
     assigned_action_editor = submission.content.get('assigned_action_editor', {}).get('value')
     duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     task = invitation.pretty_id()
 
     late_invitees = journal.get_late_invitees(invitation.id)

--- a/openreview/journal/process/submission_decision_approval_process.py
+++ b/openreview/journal/process/submission_decision_approval_process.py
@@ -33,7 +33,7 @@ To know more about the decision, please follow this link: https://openreview.net
 
     if journal.should_archive_previous_year_assignments():
         year_submitted = datetime.datetime.fromtimestamp(submission.tcdate/1000.0).year
-        current_year = datetime.datetime.utcnow().year
+        current_year = datetime.datetime.now().year
 
         if year_submitted < current_year:
             #if submission was submitted previous year, archive assignments once it is finished
@@ -122,7 +122,7 @@ To know more about the decision, please follow this link: https://openreview.net
         client.post_note_edit(invitation=journal.get_accepted_id(),
             signatures=[venue_id],
             note=openreview.api.Note(id=submission.id,
-                pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                pdate = openreview.tools.datetime_millis(datetime.datetime.now()),
                 content= content
             )
         )        

--- a/openreview/profile/management.py
+++ b/openreview/profile/management.py
@@ -1239,3 +1239,9 @@ class ProfileManagement():
                 )
             )           
 
+    @classmethod
+    def upload_dblp_publications(ProfileManagenment, client, url):
+
+        requests.get(url)
+
+        

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -343,7 +343,7 @@ class SubmissionStage(object):
         return (['authors', 'authorids'] if self.double_blind and not self.author_names_revealed else []) + self.hide_fields
 
     def is_under_submission(self):
-        return self.due_date is None or datetime.datetime.utcnow() < self.due_date
+        return self.due_date is None or datetime.datetime.now() < self.due_date
 
     def get_withdrawal_readers(self, conference, number):
 

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1242,8 +1242,7 @@ def datetime_millis(dt):
     :rtype: int
     """
     if isinstance(dt, datetime.datetime):
-        epoch = datetime.datetime.utcfromtimestamp(0)
-        return int((dt - epoch).total_seconds() * 1000)
+        return int(dt.timestamp() * 1000)        
 
     return dt
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -86,7 +86,7 @@ class InvitationBuilder(object):
 
         if invitation:
             self.save_invitation(invitation=Invitation(id=invitation.id,
-                    expdate=tools.datetime_millis(datetime.datetime.utcnow()),
+                    expdate=tools.datetime_millis(datetime.datetime.now()),
                     signatures=[self.venue_id]
                 )
             )
@@ -144,7 +144,7 @@ class InvitationBuilder(object):
         note_readers = ['everyone'] if submission_stage.create_groups else [venue_id, '${2/content/authorids/value}']
 
         submission_id = submission_stage.get_submission_id(self.venue)
-        submission_cdate = tools.datetime_millis(submission_stage.start_date if submission_stage.start_date else datetime.datetime.utcnow())
+        submission_cdate = tools.datetime_millis(submission_stage.start_date if submission_stage.start_date else datetime.datetime.now())
 
         submission_invitation = Invitation(
             id=submission_id,
@@ -238,7 +238,7 @@ class InvitationBuilder(object):
         invitation_name = 'Deletion'
         revision_stage = submission_revision_stage
         deletion_invitation_id = self.venue.get_invitation_id(invitation_name)
-        deletion_cdate = tools.datetime_millis(revision_stage.start_date if revision_stage.start_date else datetime.datetime.utcnow())
+        deletion_cdate = tools.datetime_millis(revision_stage.start_date if revision_stage.start_date else datetime.datetime.now())
         deletion_expdate = tools.datetime_millis(revision_stage.due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)) if revision_stage.due_date else None
 
         invitation = Invitation(id=deletion_invitation_id,
@@ -503,7 +503,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         review_stage = self.venue.review_stage
         review_invitation_id = self.venue.get_invitation_id(review_stage.name)
-        review_cdate = tools.datetime_millis(review_stage.start_date if review_stage.start_date else datetime.datetime.utcnow())
+        review_cdate = tools.datetime_millis(review_stage.start_date if review_stage.start_date else datetime.datetime.now())
         review_duedate = tools.datetime_millis(review_stage.due_date) if review_stage.due_date else None
         review_expdate = tools.datetime_millis(review_stage.exp_date) if review_stage.exp_date else None
         if not review_expdate:
@@ -723,7 +723,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         review_rebuttal_stage = self.venue.review_rebuttal_stage
         review_rebuttal_invitation_id = self.venue.get_invitation_id(review_rebuttal_stage.name)
-        review_rebuttal_cdate = tools.datetime_millis(review_rebuttal_stage.start_date if review_rebuttal_stage.start_date else datetime.datetime.utcnow())
+        review_rebuttal_cdate = tools.datetime_millis(review_rebuttal_stage.start_date if review_rebuttal_stage.start_date else datetime.datetime.now())
         review_rebuttal_duedate = tools.datetime_millis(review_rebuttal_stage.due_date) if review_rebuttal_stage.due_date else None
         review_rebuttal_expdate = tools.datetime_millis(review_rebuttal_stage.due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)) if review_rebuttal_stage.due_date else None
 
@@ -872,7 +872,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         meta_review_stage = self.venue.meta_review_stage
         meta_review_invitation_id = self.venue.get_invitation_id(meta_review_stage.name)
-        meta_review_cdate = tools.datetime_millis(meta_review_stage.start_date if meta_review_stage.start_date else datetime.datetime.utcnow())
+        meta_review_cdate = tools.datetime_millis(meta_review_stage.start_date if meta_review_stage.start_date else datetime.datetime.now())
         meta_review_duedate = tools.datetime_millis(meta_review_stage.due_date) if meta_review_stage.due_date else None
         meta_review_expdate = tools.datetime_millis(meta_review_stage.exp_date) if meta_review_stage.exp_date else None
         if not meta_review_expdate:
@@ -1333,7 +1333,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         comment_stage = self.venue.comment_stage
         official_comment_invitation_id = self.venue.get_invitation_id(comment_stage.official_comment_name)
-        comment_cdate = tools.datetime_millis(comment_stage.start_date if comment_stage.start_date else datetime.datetime.utcnow())
+        comment_cdate = tools.datetime_millis(comment_stage.start_date if comment_stage.start_date else datetime.datetime.now())
         comment_expdate = tools.datetime_millis(comment_stage.end_date) if comment_stage.end_date else None
 
         content = deepcopy(default_content.comment_v2)
@@ -1494,7 +1494,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         comment_stage = self.venue.comment_stage
         public_comment_invitation = self.venue.get_invitation_id(comment_stage.public_name)
-        comment_cdate = tools.datetime_millis(comment_stage.start_date if comment_stage.start_date else datetime.datetime.utcnow())
+        comment_cdate = tools.datetime_millis(comment_stage.start_date if comment_stage.start_date else datetime.datetime.now())
         comment_expdate = tools.datetime_millis(comment_stage.end_date) if comment_stage.end_date else None
 
         content = deepcopy(default_content.comment_v2)
@@ -1605,7 +1605,7 @@ class InvitationBuilder(object):
         comment_stage = self.venue.comment_stage
         chat_invitation = self.venue.get_invitation_id('Chat')
         emoji_chat_invitation = self.venue.get_invitation_id('Chat_Reaction')
-        comment_cdate = tools.datetime_millis(comment_stage.start_date if comment_stage.start_date else datetime.datetime.utcnow())
+        comment_cdate = tools.datetime_millis(comment_stage.start_date if comment_stage.start_date else datetime.datetime.now())
         comment_expdate = tools.datetime_millis(comment_stage.end_date) if comment_stage.end_date else None
 
         if not comment_stage.enable_chat:
@@ -1618,7 +1618,7 @@ class InvitationBuilder(object):
                         id = chat_invitation,
                         edit = {
                             'invitation': {
-                                'expdate': tools.datetime_millis(datetime.datetime.utcnow())
+                                'expdate': tools.datetime_millis(datetime.datetime.now())
                             }
                         }
                     )
@@ -1640,7 +1640,7 @@ class InvitationBuilder(object):
                         id = emoji_chat_invitation,
                         edit = {
                             'invitation': {
-                                'expdate': tools.datetime_millis(datetime.datetime.utcnow())
+                                'expdate': tools.datetime_millis(datetime.datetime.now())
                             }
                         }
                     )
@@ -1874,7 +1874,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         decision_stage = self.venue.decision_stage
         decision_invitation_id = self.venue.get_invitation_id(decision_stage.name)
-        decision_cdate = tools.datetime_millis(decision_stage.start_date if decision_stage.start_date else datetime.datetime.utcnow())
+        decision_cdate = tools.datetime_millis(decision_stage.start_date if decision_stage.start_date else datetime.datetime.now())
         decision_due_date = tools.datetime_millis(decision_stage.due_date) if decision_stage.due_date else None
         decision_expdate = tools.datetime_millis(decision_stage.due_date + datetime.timedelta(days = LONG_BUFFER_DAYS)) if decision_stage.due_date else None
 
@@ -2573,7 +2573,7 @@ class InvitationBuilder(object):
         submission_license = self.venue.submission_license
         revision_stage = submission_revision_stage if submission_revision_stage else self.venue.submission_revision_stage
         revision_invitation_id = self.venue.get_invitation_id(revision_stage.name)
-        revision_cdate = tools.datetime_millis(revision_stage.start_date if revision_stage.start_date else datetime.datetime.utcnow())
+        revision_cdate = tools.datetime_millis(revision_stage.start_date if revision_stage.start_date else datetime.datetime.now())
         revision_duedate = tools.datetime_millis(revision_stage.due_date) if revision_stage.due_date else None
         revision_expdate = tools.datetime_millis(revision_stage.due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)) if revision_stage.due_date else None
 
@@ -2713,7 +2713,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         custom_stage = self.venue.custom_stage
         custom_stage_invitation_id = self.venue.get_invitation_id(custom_stage.name)
-        custom_stage_cdate = tools.datetime_millis(custom_stage.start_date if custom_stage.start_date else datetime.datetime.utcnow())
+        custom_stage_cdate = tools.datetime_millis(custom_stage.start_date if custom_stage.start_date else datetime.datetime.now())
         custom_stage_duedate = tools.datetime_millis(custom_stage.due_date) if custom_stage.due_date else None
         custom_stage_expdate = tools.datetime_millis(custom_stage.exp_date) if custom_stage.exp_date else None
         if not custom_stage_expdate:
@@ -3556,7 +3556,7 @@ class InvitationBuilder(object):
             readers=[venue_id],
             writers=[venue_id],
             signatures=[venue_id],
-            cdate=tools.datetime_millis(datetime.datetime.utcnow()),
+            cdate=tools.datetime_millis(datetime.datetime.now()),
             date_processes=[{
                 'dates': ["#{4/cdate}", self.update_date_string],
                 'script': self.group_edit_process
@@ -3609,7 +3609,7 @@ class InvitationBuilder(object):
         venue_id = self.venue_id
         ethics_review_stage = self.venue.ethics_review_stage
         ethics_review_invitation_id = self.venue.get_invitation_id(ethics_review_stage.name)
-        ethics_review_cdate = tools.datetime_millis(ethics_review_stage.start_date if ethics_review_stage.start_date else datetime.datetime.utcnow())
+        ethics_review_cdate = tools.datetime_millis(ethics_review_stage.start_date if ethics_review_stage.start_date else datetime.datetime.now())
         ethics_review_duedate = tools.datetime_millis(ethics_review_stage.due_date) if ethics_review_stage.due_date else None
         ethics_review_expdate = tools.datetime_millis(ethics_review_stage.exp_date) if ethics_review_stage.exp_date else None
         if not ethics_review_expdate:
@@ -3812,7 +3812,7 @@ class InvitationBuilder(object):
         if ethics_review_stage:
             sac_ethics_flag_name = f'SAC_{ethics_review_stage.name}_Flag'
             sac_ethics_flag_id = f'{venue_id}/-/{sac_ethics_flag_name}'
-            cdate = tools.datetime_millis(datetime.datetime.utcnow())
+            cdate = tools.datetime_millis(datetime.datetime.now())
 
             invitation = Invitation(id=sac_ethics_flag_id,
                 invitees=[venue_id],

--- a/openreview/venue/process/desk_rejected_submission_process.py
+++ b/openreview/venue/process/desk_rejected_submission_process.py
@@ -22,7 +22,7 @@ def process(client, edit, invitation):
 
     invitations = client.get_invitations(replyForum=submission.id, prefix=paper_group_id)
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
 
     for invitation in invitations:
         print(f'Expiring invitation {invitation.id}')

--- a/openreview/venue/process/desk_rejection_reversion_submission_process.py
+++ b/openreview/venue/process/desk_rejection_reversion_submission_process.py
@@ -13,7 +13,7 @@ def process(client, edit, invitation):
     sender = domain.get_content_value('message_sender')
     decision_name = domain.get_content_value('decision_name')
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     submission = client.get_note(edit.note.forum)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'    
 

--- a/openreview/venue/process/desk_rejection_submission_process.py
+++ b/openreview/venue/process/desk_rejection_submission_process.py
@@ -17,7 +17,7 @@ def process(client, edit, invitation):
                                         'value':openreview.tools.generate_bibtex(
                                             note=submission,
                                             venue_fullname=venue_name,
-                                            year=str(datetime.datetime.utcnow().year),
+                                            year=str(datetime.datetime.now().year),
                                             url_forum=submission.forum,
                                             paper_status='rejected',
                                             anonymous=not reveal_authors

--- a/openreview/venue/process/ethics_flag_process.py
+++ b/openreview/venue/process/ethics_flag_process.py
@@ -183,7 +183,7 @@ def process(client, edit, invitation):
                 replacement=False,
                 invitation=openreview.api.Invitation(
                         id=ethics_invitation.id,
-                        expdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                        expdate=openreview.tools.datetime_millis(datetime.datetime.now()),
                         signatures=[venue_id]
                     )
             )

--- a/openreview/venue/process/group_edit_process.py
+++ b/openreview/venue/process/group_edit_process.py
@@ -4,7 +4,7 @@ def process(client, invitation):
     venue_id = domain.id
     submission_venue_id = domain.content['submission_venue_id']['value']
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -15,7 +15,7 @@ def process(client, invitation):
     ethics_reviewers_name = domain.content.get('ethics_reviewers_name', {}).get('value')
     release_to_ethics_chairs = domain.get_content_value('release_submissions_to_ethics_chairs')
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.edit['invitation']['cdate'] if 'cdate' in invitation.edit['invitation'] else invitation.cdate
 
     if cdate > now and not client.get_invitations(invitation=invitation.id, limit=1):
@@ -25,7 +25,7 @@ def process(client, invitation):
 
     def expire_existing_invitations():
 
-        new_expdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        new_expdate = openreview.tools.datetime_millis(datetime.datetime.now())
 
         def expire_invitation(child_invitation):
             client.post_invitation_edit(

--- a/openreview/venue/process/post_submission_process.py
+++ b/openreview/venue/process/post_submission_process.py
@@ -5,7 +5,7 @@ def process(client, invitation):
     submission_venue_id = domain.content['submission_venue_id']['value']
     venue_name = domain.content['title']['value']
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:
@@ -26,7 +26,7 @@ def process(client, invitation):
                     'value': openreview.tools.generate_bibtex(
                         note=submission,
                         venue_fullname=venue_name,
-                        year=str(datetime.datetime.utcnow().year),
+                        year=str(datetime.datetime.now().year),
                         url_forum=submission.forum,
                         paper_status='under review',
                         anonymous='readers' in submission.content['authors'] or 'readers' in invitation.edit.get('note', {}).get('content', {}).get('authors', {})

--- a/openreview/venue/process/submission_deletion_process.py
+++ b/openreview/venue/process/submission_deletion_process.py
@@ -17,7 +17,7 @@ def process(client, edit, invitation):
     paper_group_id=f'{venue_id}/{submission_name}{note.number}'
     authors_group_id=f'{paper_group_id}/{authors_name}'
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
 
     if action == 'deleted':
 

--- a/openreview/venue/process/withdrawal_reversion_submission_process.py
+++ b/openreview/venue/process/withdrawal_reversion_submission_process.py
@@ -13,7 +13,7 @@ def process(client, edit, invitation):
     sender = domain.get_content_value('message_sender')
     decision_name = domain.get_content_value('decision_name')
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     submission = client.get_note(edit.note.forum)
     paper_group_id=f'{venue_id}/{submission_name}{submission.number}'    
 

--- a/openreview/venue/process/withdrawal_submission_process.py
+++ b/openreview/venue/process/withdrawal_submission_process.py
@@ -17,7 +17,7 @@ def process(client, edit, invitation):
                                         'value':openreview.tools.generate_bibtex(
                                             note=submission,
                                             venue_fullname=venue_name,
-                                            year=str(datetime.datetime.utcnow().year),
+                                            year=str(datetime.datetime.now().year),
                                             url_forum=submission.forum,
                                             paper_status='rejected',
                                             anonymous=not reveal_authors

--- a/openreview/venue/process/withdrawn_submission_process.py
+++ b/openreview/venue/process/withdrawn_submission_process.py
@@ -22,7 +22,7 @@ def process(client, edit, invitation):
 
     invitations = client.get_invitations(replyForum=submission.id, prefix=paper_group_id)
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
 
     for invitation in invitations:
         print(f'Expiring invitation {invitation.id}')

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -109,7 +109,7 @@ class Venue(object):
         }
     
     def get_edges_archive_date(self):
-        archive_date = datetime.datetime.utcnow()
+        archive_date = datetime.datetime.now()
         if self.start_date:
             try:
                 archive_date = datetime.datetime.strptime(self.start_date, '%Y/%m/%d')
@@ -818,7 +818,7 @@ Total Errors: {len(errors)}
                 'value': tools.generate_bibtex(
                     note=submission,
                     venue_fullname=self.name,
-                    year=str(datetime.datetime.utcnow().year),
+                    year=str(datetime.datetime.now().year),
                     url_forum=submission.forum,
                     paper_status = 'accepted' if note_accepted else 'rejected',
                     anonymous=anonymous
@@ -832,8 +832,8 @@ Total Errors: {len(errors)}
                 note=openreview.api.Note(id=submission.id,
                         readers = submission_readers,
                         content = content,
-                        odate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if (submission.odate is None and 'everyone' in submission_readers) else None,
-                        pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if (submission.pdate is None and note_accepted) else None
+                        odate = openreview.tools.datetime_millis(datetime.datetime.now()) if (submission.odate is None and 'everyone' in submission_readers) else None,
+                        pdate = openreview.tools.datetime_millis(datetime.datetime.now()) if (submission.pdate is None and note_accepted) else None
                     )
                 )
         tools.concurrent_requests(update_note, submissions)
@@ -1483,7 +1483,7 @@ OpenReview Team'''
                                             if invitation_edges:
                                                 invitation_edge = invitation_edges[0]
                                                 print(f'User invited twice, remove double invitation edge {invitation_edge.id}')
-                                                invitation_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+                                                invitation_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
                                                 client.post_edge(invitation_edge)
 
                                             ## Check conflicts

--- a/openreview/venue_request/process/revisionProcess.py
+++ b/openreview/venue_request/process/revisionProcess.py
@@ -169,7 +169,7 @@ Program Chairs
                 if remind_recruitment_invitation:
                     remind_recruitment_invitation.reply['content']['invitee_role']['value-dropdown'] = conference.get_roles()
                     client.post_invitation(remind_recruitment_invitation)
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now()
             if (
                     conference.submission_stage.second_due_date and conference.submission_stage.second_due_date < now) or (
                     conference.submission_stage.due_date and conference.submission_stage.due_date < now):
@@ -278,7 +278,7 @@ Program Chairs
             if forum_note.content.get('api_version') == '2':
 
                 review_due_date = forum_note.content.get('review_deadline').strip()
-                cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+                cdate = openreview.tools.datetime_millis(datetime.datetime.now())
                 if review_due_date:
                     try:
                         review_due_date = datetime.datetime.strptime(review_due_date, '%Y/%m/%d %H:%M')
@@ -488,7 +488,7 @@ Best,
             }
 
             decision_due_date = forum_note.content.get('decision_deadline').strip()
-            cdate = datetime.datetime.utcnow()
+            cdate = datetime.datetime.now()
             if decision_due_date:
                 try:
                     decision_due_date = datetime.datetime.strptime(decision_due_date, '%Y/%m/%d %H:%M')

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -46,7 +46,7 @@ class EditInvitationsBuilder(object):
 
         if invitation:
             self.save_invitation(invitation=Invitation(id=invitation.id,
-                    expdate=tools.datetime_millis(datetime.datetime.utcnow()),
+                    expdate=tools.datetime_millis(datetime.datetime.now()),
                     signatures=[self.venue_id]
                 )
             )

--- a/openreview/workflows/process/decision_process.py
+++ b/openreview/workflows/process/decision_process.py
@@ -63,6 +63,6 @@ def process(client, edit, invitation):
                 'value': venue
              }
           },
-          pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) if (submission.pdate is None and note_accepted) else None
+          pdate = openreview.tools.datetime_millis(datetime.datetime.now()) if (submission.pdate is None and note_accepted) else None
        )
     )

--- a/openreview/workflows/process/deploy_assignments_process.py
+++ b/openreview/workflows/process/deploy_assignments_process.py
@@ -19,7 +19,7 @@ def process(client, invitation):
     if not deploy_date:
         raise openreview.OpenReviewException('Select a valid date to deploy reviewer assignments')
     
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     if deploy_date > now:
         # is this an error? Should this be posted to the request form
         return

--- a/openreview/workflows/process/desk_rejected_submission_process.py
+++ b/openreview/workflows/process/desk_rejected_submission_process.py
@@ -21,7 +21,7 @@ def process(client, edit, invitation):
 
     invitations = client.get_invitations(replyForum=submission.id, prefix=paper_group_id)
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
 
     for invitation in invitations:
         print(f'Expiring invitation {invitation.id}')

--- a/openreview/workflows/process/desk_rejection_reversion_process_script.py
+++ b/openreview/workflows/process/desk_rejection_reversion_process_script.py
@@ -13,7 +13,7 @@ def process(client, edit, invitation):
     sender = domain.get_content_value('message_sender')
     decision_name = domain.get_content_value('decision_name')
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     submission = client.get_note(edit.note.forum)
     paper_group_id=f'{venue_id}/{submission_name}/{submission.number}'    
 

--- a/openreview/workflows/process/desk_rejection_submission_process.py
+++ b/openreview/workflows/process/desk_rejection_submission_process.py
@@ -17,7 +17,7 @@ def process(client, edit, invitation):
                                         'value':openreview.tools.generate_bibtex(
                                             note=submission,
                                             venue_fullname=venue_name,
-                                            year=str(datetime.datetime.utcnow().year),
+                                            year=str(datetime.datetime.now().year),
                                             url_forum=submission.forum,
                                             paper_status='rejected',
                                             anonymous=not reveal_authors

--- a/openreview/workflows/process/group_edit_process.py
+++ b/openreview/workflows/process/group_edit_process.py
@@ -4,7 +4,7 @@ def process(client, invitation):
     venue_id = domain.id
     submission_venue_id = domain.content['submission_venue_id']['value']
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:

--- a/openreview/workflows/process/invitation_edit_process.py
+++ b/openreview/workflows/process/invitation_edit_process.py
@@ -15,7 +15,7 @@ def process(client, invitation):
     ethics_reviewers_name = domain.content.get('ethics_reviewers_name', {}).get('value')
     release_to_ethics_chairs = domain.get_content_value('release_submissions_to_ethics_chairs')
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.edit['invitation']['cdate'] if 'cdate' in invitation.edit['invitation'] else invitation.cdate
 
     if cdate > now and not client.get_invitations(invitation=invitation.id, limit=1):
@@ -25,7 +25,7 @@ def process(client, invitation):
 
     def expire_existing_invitations():
 
-        new_expdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        new_expdate = openreview.tools.datetime_millis(datetime.datetime.now())
 
         def expire_invitation(child_invitation):
             client.post_invitation_edit(

--- a/openreview/workflows/process/invitation_edit_process_decision.py
+++ b/openreview/workflows/process/invitation_edit_process_decision.py
@@ -23,7 +23,7 @@ def process(client, invitation):
     release_to_ethics_chairs = domain.get_content_value('release_submissions_to_ethics_chairs')
     program_chairs_id = domain.get_content_value('program_chairs_id')
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.edit['invitation']['cdate'] if 'cdate' in invitation.edit['invitation'] else invitation.cdate
 
     if cdate > now and not client.get_invitations(invitation=invitation.id, limit=1):
@@ -33,7 +33,7 @@ def process(client, invitation):
 
     def expire_existing_invitations():
 
-        new_expdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        new_expdate = openreview.tools.datetime_millis(datetime.datetime.now())
 
         def expire_invitation(child_invitation):
             client.post_invitation_edit(

--- a/openreview/workflows/process/post_submission_process.py
+++ b/openreview/workflows/process/post_submission_process.py
@@ -6,7 +6,7 @@ def process(client, invitation):
     submission_venue_id = domain.content['submission_venue_id']['value']
     venue_name = domain.content['title']['value']
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     cdate = invitation.cdate
 
     if cdate > now:
@@ -27,7 +27,7 @@ def process(client, invitation):
                     'value': openreview.tools.generate_bibtex(
                         note=submission,
                         venue_fullname=venue_name,
-                        year=str(datetime.datetime.utcnow().year),
+                        year=str(datetime.datetime.now().year),
                         url_forum=submission.forum,
                         paper_status='under review',
                         anonymous='readers' in submission.content['authors'] or 'readers' in invitation.edit.get('note', {}).get('content', {}).get('authors', {})

--- a/openreview/workflows/process/withdrawal_reversion_submission_process.py
+++ b/openreview/workflows/process/withdrawal_reversion_submission_process.py
@@ -13,7 +13,7 @@ def process(client, edit, invitation):
     sender = domain.get_content_value('message_sender')
     decision_name = domain.get_content_value('decision_name')
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
     submission = client.get_note(edit.note.forum)
     paper_group_id=f'{venue_id}/{submission_name}/{submission.number}'    
 

--- a/openreview/workflows/process/withdrawal_submission_process.py
+++ b/openreview/workflows/process/withdrawal_submission_process.py
@@ -21,7 +21,7 @@ def process(client, edit, invitation):
                                         'value':openreview.tools.generate_bibtex(
                                             note=submission,
                                             venue_fullname=venue_name,
-                                            year=str(datetime.datetime.utcnow().year),
+                                            year=str(datetime.datetime.now().year),
                                             url_forum=submission.forum,
                                             paper_status='rejected',
                                             anonymous=not reveal_authors

--- a/openreview/workflows/process/withdrawn_submission_process.py
+++ b/openreview/workflows/process/withdrawn_submission_process.py
@@ -21,7 +21,7 @@ def process(client, edit, invitation):
 
     invitations = client.get_invitations(replyForum=submission.id, prefix=paper_group_id)
 
-    now = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
 
     for invitation in invitations:
         print(f'Expiring invitation {invitation.id}')

--- a/tests/test_aaai_conference.py
+++ b/tests/test_aaai_conference.py
@@ -13,7 +13,7 @@ class TestAAAIConference():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # Post the request form note
@@ -352,7 +352,7 @@ program_committee4@yahoo.com, Program Committee AAAIFour
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
         ## close the submissions
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(days=1)
         exp_date = now + datetime.timedelta(days=10)
         pc_client.post_note(openreview.Note(
@@ -571,7 +571,7 @@ program_committee4@yahoo.com, Program Committee AAAIFour
     def test_bid_stage(self, client, openreview_client, helpers, test_client, request_page, selenium):
         pc_client=openreview.Client(username='pc@aaai.org', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         ## Hide the pdf
@@ -704,7 +704,7 @@ program_committee4@yahoo.com, Program Committee AAAIFour
         pc_client=openreview.Client(username='pc@aaai.org', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -775,7 +775,7 @@ program_committee4@yahoo.com, Program Committee AAAIFour
         helpers.await_queue_edit(openreview_client, edit_id=review_edit['id'])
 
         ## Close Phase 1 review stage
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(days=1)
         review_stage_note=pc_client.post_note(openreview.Note(
             content={
@@ -801,7 +801,7 @@ program_committee4@yahoo.com, Program Committee AAAIFour
         pc_client=openreview.Client(username='pc@aaai.org', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -966,7 +966,7 @@ program_committee4@yahoo.com, Program Committee AAAIFour
         helpers.await_queue_edit(openreview_client, edit_id=meta_review['id'])
 
         # Close meta review stage
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now - datetime.timedelta(days=1)
 
@@ -1022,7 +1022,7 @@ program_committee4@yahoo.com, Program Committee AAAIFour
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Post a decision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -1158,7 +1158,7 @@ program_committee4@yahoo.com, Program Committee AAAIFour
                 'value': openreview.tools.generate_bibtex(
                     note=submission_2,
                     venue_fullname=venue.name,
-                    year=str(datetime.datetime.utcnow().year),
+                    year=str(datetime.datetime.now().year),
                     url_forum=submission_2.forum,
                     paper_status = 'rejected',
                     anonymous=True
@@ -1275,7 +1275,7 @@ AAAI 2025 Program Chairs'''
         venue = openreview.helpers.get_conference(pc_client, request_form.id, setup=False)
         submissions = pc_client_v2.get_notes(content= { 'venueid': 'AAAI.org/2025/Conference/Submission'}, sort='number:asc')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -1317,7 +1317,7 @@ AAAI 2025 Program Chairs'''
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         venue.custom_stage = openreview.stages.CustomStage(name='Final_Meta_Review',
@@ -1403,7 +1403,7 @@ AAAI 2025 Program Chairs'''
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Run decision stage to change decision options first
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         decision_stage_invitation = f'openreview.net/Support/-/Request{request_form.number}/Decision_Stage'
@@ -1448,7 +1448,7 @@ AAAI 2025 Program Chairs'''
         url = pc_client.put_attachment(os.path.join(os.path.dirname(__file__), 'data/ICML_decisions.csv'), decision_stage_invitation, 'decisions_file')
 
         # Post decisions from request form
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -1503,7 +1503,7 @@ AAAI 2025 Program Chairs'''
         venue = openreview.helpers.get_conference(pc_client, request_form.id, setup=False)
 
         invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Post_Decision_Stage')
-        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.now())
         client.post_invitation(invitation)
 
         short_name = 'AAAI 2025'
@@ -1567,7 +1567,7 @@ Best,
         pc_client=openreview.Client(username='pc@aaai.org', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 

--- a/tests/test_acl_commitment_v2.py
+++ b/tests/test_acl_commitment_v2.py
@@ -13,7 +13,7 @@ class TestACLCommitment():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # Post the request form note

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -29,7 +29,7 @@ class TestARRVenueV2():
 
     def test_august_cycle(self, client, openreview_client, helpers, test_client, request_page, selenium):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # Post the request form note
@@ -370,7 +370,7 @@ class TestARRVenueV2():
 
         assert client.get_invitation(f'openreview.net/Support/-/Request{request_form_note.number}/ARR_Configuration')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
 
         registration_name = 'Registration'
         max_load_name = 'Max_Load_And_Unavailability_Request'
@@ -467,7 +467,7 @@ class TestARRVenueV2():
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password=helpers.strong_password)
         pc_client_v2 = openreview.api.OpenReviewClient(username='pc@aclrollingreview.org', password=helpers.strong_password)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         request_form_note = pc_client.post_note(openreview.Note(
@@ -662,7 +662,7 @@ class TestARRVenueV2():
         helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/June/-/Submission', count=1)
 
         # Create ethics review stage to add values into domain
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         stage_note = pc_client.post_note(openreview.Note(
@@ -1298,7 +1298,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             "Association_for_Computational_Linguistics_-_Blind_Submission_License_Agreement": { 'value': "On behalf of all authors, I do not agree" }
         }
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         invitation_builder = openreview.arr.InvitationBuilder(june_venue)
@@ -1676,13 +1676,13 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[1]
         august_venue = openreview.helpers.get_conference(client, request_form.id, 'openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
 
         pc_client.post_note(
             openreview.Note(
                 content={
                     'previous_cycle': 'aclweb.org/ACL/ARR/2023/June',
-                    'setup_shared_data_date': (openreview.tools.datetime.datetime.utcnow() - datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M')
+                    'setup_shared_data_date': (openreview.tools.datetime.datetime.now() - datetime.timedelta(minutes=10)).strftime('%Y/%m/%d %H:%M')
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,
@@ -1701,7 +1701,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             openreview.Note(
                 content={
                     'previous_cycle': 'aclweb.org/ACL/ARR/2023/June',
-                    'setup_shared_data_date': (openreview.tools.datetime.datetime.utcnow() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
+                    'setup_shared_data_date': (openreview.tools.datetime.datetime.now() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,
@@ -1780,7 +1780,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         # invitations and test that each note posts an edge
 
         # Load the venues
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password=helpers.strong_password)
         pc_client_v2=openreview.api.OpenReviewClient(username='pc@aclrollingreview.org', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
@@ -2143,7 +2143,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
 
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password=helpers.strong_password)
         request_form_note=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[1]
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         june_submission = openreview_client.get_all_notes(invitation='aclweb.org/ACL/ARR/2023/June/-/Submission')[0]
@@ -2318,7 +2318,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[1]
 
         ## close the submissions
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(days=1)
         pc_client.post_note(openreview.Note(
             content={
@@ -2364,7 +2364,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         #assert len(pc_client_v2.get_all_invitations(invitation='aclweb.org/ACL/ARR/2023/August/-/Desk_Reject_Verification')) == 101        
 
         # Open comments
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
 
         pc_client.post_note(
             openreview.Note(
@@ -2424,7 +2424,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client.post_note(
             openreview.Note(
                 content={
-                    'preprint_release_submission_date': (openreview.tools.datetime.datetime.utcnow() - datetime.timedelta(minutes=2)).strftime('%Y/%m/%d %H:%M')
+                    'preprint_release_submission_date': (openreview.tools.datetime.datetime.now() - datetime.timedelta(minutes=2)).strftime('%Y/%m/%d %H:%M')
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,
@@ -2623,7 +2623,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         test_client = openreview.api.OpenReviewClient(token=test_client.token)
 
         # Create review stages
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         pc_client.post_note(
             openreview.Note(
@@ -2705,7 +2705,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         test_client = openreview.api.OpenReviewClient(token=test_client.token)
 
         # Create review stages
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         pc_client.post_note(
             openreview.Note(
@@ -2970,7 +2970,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         submissions = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', sort='number:asc')
 
         ## Create June review stages
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         pc_client.post_note(
@@ -3536,7 +3536,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             ))
 
         # Revert the data to preserve the rest of the tests
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         rev_2_edge.ddate = openreview.tools.datetime_millis(now)
         rev_3_edge.ddate = openreview.tools.datetime_millis(now)
         openreview_client.post_edge(
@@ -3551,7 +3551,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client.post_note(
             openreview.Note(
                 content={
-                    'setup_sae_ae_assignment_date': (openreview.tools.datetime.datetime.utcnow() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
+                    'setup_sae_ae_assignment_date': (openreview.tools.datetime.datetime.now() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,
@@ -3574,7 +3574,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         sac_client = openreview.api.OpenReviewClient(username = 'sac2@aclrollingreview.com', password=helpers.strong_password)
         assert len(sac_client.get_edges(invitation = 'aclweb.org/ACL/ARR/2023/August/Area_Chairs/-/Assignment', head=submissions[1].id, tail='~AC_ARRTwo1')) == 1
         ac_edge = sac_client.get_edges(invitation = 'aclweb.org/ACL/ARR/2023/August/Area_Chairs/-/Assignment', head=submissions[1].id, tail='~AC_ARRTwo1')[0]
-        ac_edge.ddate = openreview.tools.datetime_millis(openreview.tools.datetime.datetime.utcnow())
+        ac_edge.ddate = openreview.tools.datetime_millis(openreview.tools.datetime.datetime.now())
         openreview_client.post_edge(ac_edge)
 
         helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/Area_Chairs/-/Assignment')
@@ -3596,7 +3596,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client.post_note(
             openreview.Note(
                 content={
-                    'setup_proposed_assignments_date': (openreview.tools.datetime.datetime.utcnow() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M'),
+                    'setup_proposed_assignments_date': (openreview.tools.datetime.datetime.now() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M'),
                     'reviewer_assignments_title': 'reviewer-assignments'
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
@@ -3807,7 +3807,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             return chk_edit, pc_client_v2.get_note(test_submission.id)
         
         def now():
-            return openreview.tools.datetime_millis(datetime.datetime.utcnow())
+            return openreview.tools.datetime_millis(datetime.datetime.now())
 
         checklist_inv = test_data_templates[venue.get_reviewers_id()]['checklist_invitation']
         user = test_data_templates[venue.get_reviewers_id()]['user']
@@ -4119,7 +4119,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             return rev_edit, pc_client_v2.get_note(test_submission.id)
         
         def now():
-            return openreview.tools.datetime_millis(datetime.datetime.utcnow())
+            return openreview.tools.datetime_millis(datetime.datetime.now())
 
         review_inv = test_data_templates[venue.get_reviewers_id()]['review_invitation']
         user = test_data_templates[venue.get_reviewers_id()]['user']
@@ -4382,7 +4382,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client.post_note(
             openreview.Note(
                 content={
-                    'setup_review_release_date': (openreview.tools.datetime.datetime.utcnow() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
+                    'setup_review_release_date': (openreview.tools.datetime.datetime.now() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,
@@ -4418,7 +4418,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client.post_note(
             openreview.Note(
                 content={
-                    'setup_author_response_date': (datetime.datetime.utcnow() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
+                    'setup_author_response_date': (datetime.datetime.now() - datetime.timedelta(minutes=3)).strftime('%Y/%m/%d %H:%M')
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,
@@ -4604,7 +4604,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client.post_note(
             openreview.Note(
                 content={
-                    'close_author_response_date': (datetime.datetime.utcnow() - datetime.timedelta(minutes=6)).strftime('%Y/%m/%d %H:%M')
+                    'close_author_response_date': (datetime.datetime.now() - datetime.timedelta(minutes=6)).strftime('%Y/%m/%d %H:%M')
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,
@@ -4636,7 +4636,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         registration_name = 'Registration'
         max_load_name = 'Max_Load_And_Unavailability_Request'
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=5)
 
         # Original due dates were at +3, now at +5
@@ -4807,7 +4807,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             return rev_edit, pc_client_v2.get_note(test_submission.id)
         
         def now():
-            return openreview.tools.datetime_millis(datetime.datetime.utcnow())
+            return openreview.tools.datetime_millis(datetime.datetime.now())
 
         review_inv = test_data_templates[venue.get_area_chairs_id()]['review_invitation']
         user = test_data_templates[venue.get_area_chairs_id()]['user']
@@ -4887,7 +4887,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         pc_client.post_note(
             openreview.Note(
                 content={
-                    'setup_meta_review_release_date': (openreview.tools.datetime.datetime.utcnow() - datetime.timedelta(minutes=6)).strftime('%Y/%m/%d %H:%M')
+                    'setup_meta_review_release_date': (openreview.tools.datetime.datetime.now() - datetime.timedelta(minutes=6)).strftime('%Y/%m/%d %H:%M')
                 },
                 invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
                 forum=request_form.id,
@@ -4917,14 +4917,14 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         # invitations and test that each note posts an edge
 
         # Load the venues
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password=helpers.strong_password)
         pc_client_v2=openreview.api.OpenReviewClient(username='pc@aclrollingreview.org', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[1]
         venue = openreview.helpers.get_conference(client, request_form.id, 'openreview.net/Support')
         invitation_builder = openreview.arr.InvitationBuilder(venue)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         pc_client.post_note(
@@ -5153,7 +5153,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             assert all(weight < 10 for weight in aggregate_score_edges[user])
 
     def test_review_issue_forms(self, client, openreview_client, helpers, test_client):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         pc_client=openreview.Client(username='pc@aclrollingreview.org', password=helpers.strong_password)
         pc_client_v2=openreview.api.OpenReviewClient(username='pc@aclrollingreview.org', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[1]
@@ -5161,7 +5161,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         invitation_builder = openreview.arr.InvitationBuilder(venue)
         test_client = openreview.api.OpenReviewClient(token=test_client.token)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         pc_client.post_note(
@@ -5502,7 +5502,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
 
     def test_commitment_venue(self, client, test_client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # Post the request form note

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -216,7 +216,7 @@ class TestClient():
 
     def test_get_notes_by_content(self, client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         builder = openreview.conference.ConferenceBuilder(client, support_user='openreview.net/Support')
         assert builder, 'builder is None'
 

--- a/tests/test_cvpr_conference_v2.py
+++ b/tests/test_cvpr_conference_v2.py
@@ -12,7 +12,7 @@ class TestCVPRConference():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         abstract_date = now + datetime.timedelta(days=1)
         due_date = now + datetime.timedelta(days=3)
 
@@ -148,7 +148,7 @@ class TestCVPRConference():
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
         ## close the submissions
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(days=1)
         abstract_date = now - datetime.timedelta(minutes=28)
         pc_client.post_note(openreview.Note(
@@ -367,7 +367,7 @@ class TestCVPRConference():
         venue.set_assignments(assignment_title='ac-matching', committee_id='thecvf.com/CVPR/2024/Conference/Area_Chairs')
 
         # open reviewer recommendation
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.open_reviewer_recommendation_stage(
             due_date = now + datetime.timedelta(days=3),
             total_recommendations = 5
@@ -396,7 +396,7 @@ class TestCVPRConference():
         assert recommendation_edge.weight == 5
 
         ## delete recommendation edge
-        recommendation_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        recommendation_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         ac_client.post_edge(recommendation_edge)
         assert not ac_client.get_edges(invitation=venue.get_recommendation_id(), tail='~Reviewer_CVPROne1')
         
@@ -448,7 +448,7 @@ class TestCVPRConference():
 
         helpers.await_queue()        
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         review_stage_note = openreview.Note(
@@ -577,7 +577,7 @@ class TestCVPRConference():
         # enable review rating stage
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         venue.custom_stage = openreview.stages.CustomStage(name='Rating',
             reply_to=openreview.stages.CustomStage.ReplyTo.REVIEWS,
@@ -772,7 +772,7 @@ class TestCVPRConference():
         pc_client_v2=openreview.api.OpenReviewClient(username='pc@cvpr.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         pc_client.post_note(openreview.Note(
@@ -855,7 +855,7 @@ class TestCVPRConference():
         )
 
         ## Start official comment
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         pc_client.post_note(openreview.Note(
@@ -901,8 +901,8 @@ class TestCVPRConference():
         )
 
         ## setup the metareview confirmation
-        start_date = openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(weeks = 1))
-        due_date = openreview.tools.datetime_millis(datetime.datetime.utcnow() + datetime.timedelta(weeks = 1))
+        start_date = openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(weeks = 1))
+        due_date = openreview.tools.datetime_millis(datetime.datetime.now() + datetime.timedelta(weeks = 1))
 
         # create metareview confirmation super invitation
         venue_id = 'thecvf.com/CVPR/2024/Conference'
@@ -1074,7 +1074,7 @@ class TestCVPRConference():
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
         
         # Open meta review revision for final recommendation, allow metareview to be modified
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=2)
         
         meta_review_revision_content = {

--- a/tests/test_dmlr_journal.py
+++ b/tests/test_dmlr_journal.py
@@ -451,7 +451,7 @@ note={Under review}
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi David Bo,
 
-With this email, we request that you submit, within 4 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 4)).strftime("%b %d")}) a review for your newly assigned DMLR submission "1: Paper title".
+With this email, we request that you submit, within 4 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 4)).strftime("%b %d")}) a review for your newly assigned DMLR submission "1: Paper title".
 
 Please acknowledge on OpenReview that you have received this review assignment by following this link: https://openreview.net/forum?id={note_id_1}
 
@@ -630,7 +630,7 @@ Please note that responding to this email will direct your reply to andrew@dmlrz
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 1000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 1000,
                 signatures=['DMLR/Editors_In_Chief']
             )
         )

--- a/tests/test_emnlp_conference.py
+++ b/tests/test_emnlp_conference.py
@@ -11,7 +11,7 @@ class TestEMNLPConference():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now + datetime.timedelta(days=1)
 
@@ -247,7 +247,7 @@ class TestEMNLPConference():
                 note=note)   
             
         ## finish abstract deadline
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now - datetime.timedelta(minutes=28)
 
@@ -378,7 +378,7 @@ class TestEMNLPConference():
         deletion_edit = test_client.post_note_edit(invitation='EMNLP/2023/Conference/Submission5/-/Deletion',
             signatures=['EMNLP/2023/Conference/Submission5/Authors'],
             note=openreview.api.Note(
-                ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+                ddate = openreview.tools.datetime_millis(datetime.datetime.now())
             ))
         helpers.await_queue_edit(openreview_client, edit_id=deletion_edit['id'])
 
@@ -413,7 +413,7 @@ Please note that responding to this email will direct your reply to pc@emnlp.org
         assert 'EMNLP/2023/Conference/Submission5/Authors' not in authors_group.members
 
         invitation = openreview_client.get_invitation('EMNLP/2023/Conference/Submission5/-/Full_Submission')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
         assert invitation.invitations == [
             "EMNLP/2023/Conference/-/Full_Submission",
             "EMNLP/2023/Conference/-/Deletion_Expiration"
@@ -457,7 +457,7 @@ Please note that responding to this email will direct your reply to pc@emnlp.org
         assert 'EMNLP/2023/Conference/Submission5/Authors' in authors_group.members
 
         invitation = openreview_client.get_invitation('EMNLP/2023/Conference/Submission5/-/Full_Submission')
-        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.now())
         assert invitation.invitations == [
             "EMNLP/2023/Conference/-/Full_Submission",
             "EMNLP/2023/Conference/-/Deletion_Expiration"
@@ -999,7 +999,7 @@ url={https://openreview.net/forum?id='''
         ethics_chairs_group = openreview_client.get_group('EMNLP/2023/Conference/Ethics_Chairs')
         openreview_client.add_members_to_group(ethics_chairs_group, ['ethics_chair1@google.com', 'ethics_chair2@emnlp.com'])
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         stage_note = pc_client.post_note(openreview.Note(
@@ -1102,7 +1102,7 @@ url={https://openreview.net/forum?id='''
 
         venue = openreview.helpers.get_conference(pc_client, request_form.id, setup=False)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
             
         venue.custom_stage = openreview.stages.CustomStage(name='Ethics_Meta_Review',
@@ -1269,7 +1269,7 @@ url={https://openreview.net/forum?id='''
                 "everyone"
             ]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         ## run review stage

--- a/tests/test_group_recruitment.py
+++ b/tests/test_group_recruitment.py
@@ -33,7 +33,7 @@ class TestGroupRecruitment():
         venue.contact = 'venue@contact.com'
         venue.reviewer_identity_readers = [openreview.stages.IdentityReaders.PROGRAM_CHAIRS, openreview.stages.IdentityReaders.AREA_CHAIRS_ASSIGNED]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.submission_stage = SubmissionStage(
             double_blind=True,
             due_date=now + datetime.timedelta(minutes = 30),

--- a/tests/test_iclr_conference_v2.py
+++ b/tests/test_iclr_conference_v2.py
@@ -13,7 +13,7 @@ class TestICLRConference():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         abstract_date = now + datetime.timedelta(days=1)
         due_date = now + datetime.timedelta(days=3)
 
@@ -225,7 +225,7 @@ class TestICLRConference():
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
         ## close abstract submission
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         abstract_date = now - datetime.timedelta(minutes=28)
         due_date = now + datetime.timedelta(days=3)        
         pc_client.post_note(openreview.Note(
@@ -299,7 +299,7 @@ class TestICLRConference():
         assert matching_invitation.cdate == abstract_date_ms
 
         ## close full paper submission
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         abstract_date = now - datetime.timedelta(days=2)
         due_date = now - datetime.timedelta(minutes=28)        
         pc_client.post_note(openreview.Note(
@@ -376,7 +376,7 @@ class TestICLRConference():
 
         openreview_client.add_members_to_group('ICLR.cc/2024/Conference/Submission1/Reviewers', ['~Reviewer_ICLROne1', '~Reviewer_ICLRTwo1', '~Reviewer_ICLRThree1'])
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         pc_client=openreview.Client(username='pc@iclr.cc', password=helpers.strong_password)
@@ -568,7 +568,7 @@ class TestICLRConference():
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Post an official comment stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         comment_stage_note = pc_client.post_note(openreview.Note(
@@ -755,7 +755,7 @@ class TestICLRConference():
                                          decision_stage_invitation, 'decisions_file')
         
         ## enable decision stage
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         end_date = now + datetime.timedelta(days=3)
         decision_stage_note = pc_client.post_note(openreview.Note(
             content={
@@ -791,7 +791,7 @@ class TestICLRConference():
             author_client.get_group('ICLR.cc/2024/Conference/Authors/Accepted')
 
         ## upload decisions
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         end_date = now + datetime.timedelta(days=3)
         decision_stage_note = pc_client.post_note(openreview.Note(
             content={
@@ -814,11 +814,11 @@ class TestICLRConference():
         helpers.await_queue()
 
         invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Post_Decision_Stage')
-        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.now())
         client.post_invitation(invitation)
 
         # Post revision stage note before releasing authors to the public
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=5)
         revision_stage_note = pc_client.post_note(openreview.Note(
@@ -925,7 +925,7 @@ Best,
             author_client.get_group('ICLR.cc/2024/Conference/Authors/Accepted')        
 
         # Post revision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=5)
         revision_stage_note = pc_client.post_note(openreview.Note(

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -13,7 +13,7 @@ class TestICMLConference():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # Post the request form note
@@ -243,7 +243,7 @@ class TestICMLConference():
         pc_client=openreview.Client(username='pc@icml.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         pc_client.post_note(openreview.Note(
@@ -579,7 +579,7 @@ reviewer6@yahoo.com, Reviewer ICMLSix
             signatures=['~Super_User1'],
             invitation=openreview.api.Invitation(
                 id='ICML.cc/2023/Conference/-/Preferred_Emails',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 2000,
             )
         )
 
@@ -594,7 +594,7 @@ reviewer6@yahoo.com, Reviewer ICMLSix
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         venue.registration_stages.append(openreview.stages.RegistrationStage(committee_id = venue.get_senior_area_chairs_id(),
             name = 'Registration',
@@ -728,7 +728,7 @@ reviewer6@yahoo.com, Reviewer ICMLSix
             signatures=['~SomeFirstName_User1'],
             note=openreview.api.Note(
                 id = submission.id,
-                ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                ddate = openreview.tools.datetime_millis(datetime.datetime.now()),
                 content = {
                     'title': submission.content['title'],
                     'abstract': submission.content['abstract'],
@@ -817,7 +817,7 @@ reviewer6@yahoo.com, Reviewer ICMLSix
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
         ## close the submissions
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(days=1)
         exp_date = now + datetime.timedelta(days=10)
         pc_client.post_note(openreview.Note(
@@ -1350,7 +1350,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert affinity_scores
         assert len(affinity_scores) == 100 * 5 ## submissions * reviewers
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         ## Hide the pdf and supplementary material
@@ -1623,7 +1623,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         # remove duplicate edge and make sure assignment still remains
         assignment_edge = assignment_edges[0]
-        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment_edge.cdate = None
         edge = pc_client_v2.post_edge(assignment_edge)
 
@@ -1640,7 +1640,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         ### Reviewers reassignment of proposed assignments
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         venue.setup_assignment_recruitment(committee_id='ICML.cc/2023/Conference/Reviewers', assignment_title='reviewer-matching', hash_seed='1234', due_date=due_date)
 
@@ -1764,7 +1764,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         # delete Invitation Sent edge for submission 1
         invite_edge=ac_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment', head=submissions[0].id, tail='~Emilia_ICML1')[0]
-        invite_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invite_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         edge = ac_client.post_edge(invite_edge)
 
         time.sleep(5) ## wait until the process function runs
@@ -1843,7 +1843,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         # try to remove Invite_Assignment edge with label == 'Pending Sign Up'
         with pytest.raises(openreview.OpenReviewException, match=r'Cannot cancel the invitation since it has status: "Pending Sign Up"'):
             invite_edge=pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment', head=submissions[0].id, tail='melisa@icml.cc')[0]
-            invite_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+            invite_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
             pc_client_v2.post_edge(invite_edge)
 
         ## Run Job
@@ -1900,7 +1900,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert 'reviewers_proposed_assignment_title' not in venue_group.content
 
         proposed_recruitment_inv = openreview_client.get_invitation('ICML.cc/2023/Conference/Reviewers/-/Proposed_Assignment_Recruitment')
-        assert proposed_recruitment_inv.expdate and proposed_recruitment_inv.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert proposed_recruitment_inv.expdate and proposed_recruitment_inv.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
 
         invite_edges=pc_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment', head=submissions[0].id, tail='~Javier_ICML1')
         assert len(invite_edges) == 1
@@ -1928,7 +1928,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         ## Change assigned SAC
         assignment_edge = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Senior_Area_Chairs/-/Assignment', head='~AC_ICMLTwo1', tail='~SAC_ICMLOne1')[0]
-        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment_edge.cdate = None
         pc_client_v2.post_edge(assignment_edge)
 
@@ -1974,7 +1974,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert ['~SAC_ICMLOne1','~SAC_ICMLTwo1'] == sac_group.members
 
         assignment_edge = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[0].id, tail='~AC_ICMLOne1')[0]
-        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment_edge.cdate = None
         edge = pc_client_v2.post_edge(assignment_edge)
 
@@ -2244,7 +2244,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         # try to delete Invite Assignment edge after reviewer Accepted
         with pytest.raises(openreview.OpenReviewException, match=r'Cannot cancel the invitation since it has status: "Accepted"'):
             invite_edge=ac_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment', head=submissions[0].id, tail='~Reviewer_ICMLFour1')[0]
-            invite_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+            invite_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
             ac_client.post_edge(invite_edge)
 
         reviewers_group = pc_client.get_group('ICML.cc/2023/Conference/Submission1/Reviewers')
@@ -2317,7 +2317,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         # delete invite assignment edge
         invite_assignment = pc_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Invite_Assignment', head=submissions[0].id, tail='~Ana_ICML1')[0]
-        invite_assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invite_assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         invite_assignment.cdate = None
         pc_client.post_edge(invite_assignment)
 
@@ -2331,7 +2331,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         #delete assignments before review stage and not get key error
         assignment = pc_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Assignment', head=submissions[10].id, tail='~Reviewer_ICMLThree1')[0]
-        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment.cdate = None
         edge = pc_client.post_edge(assignment)
 
@@ -2342,7 +2342,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert '~Reviewer_ICMLThree1' not in reviewers_group.members
 
         assignment = pc_client.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[10].id, tail='~AC_ICMLOne1')[0]
-        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment.cdate = None
         edge = pc_client.post_edge(assignment)
 
@@ -2408,7 +2408,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert 'pdf' in submissions[0].content
         assert 'supplementary_material' in submissions[0].content
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -2822,7 +2822,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         invitation = openreview_client.get_invitation('ICML.cc/2023/Conference/Submission1/-/Official_Review')
         assert 'summarry' not in invitation.edit['note']['content']
         assert 'summary' in invitation.edit['note']['content']
-        assert invitation.cdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.cdate < openreview.tools.datetime_millis(datetime.datetime.now())
         # duedate + 2 days
         exp_date = invitation.duedate + (2*24*60)
 
@@ -3052,7 +3052,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         venue.custom_stage = openreview.stages.CustomStage(name='Rating',
             reply_to=openreview.stages.CustomStage.ReplyTo.REVIEWS,
@@ -3244,7 +3244,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assignment = ac_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Assignment', head=submissions[0].id, tail='~Reviewer_ICMLOne1')[0]
 
         anon_group_id = ac_client.get_groups(prefix='ICML.cc/2023/Conference/Submission1/Area_Chair_', signatory='~AC_ICMLTwo1')[0].id
-        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment.cdate = None
         assignment.signatures = [anon_group_id]
 
@@ -3252,7 +3252,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
             ac_client.post_edge(assignment)
 
         assignment = ac_client.get_edges(invitation='ICML.cc/2023/Conference/Reviewers/-/Assignment', head=submissions[0].id, tail='~Celeste_ICML1')[0]
-        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment.signatures = [anon_group_id]
         assignment.cdate = None
         ac_client.post_edge(assignment)
@@ -3261,7 +3261,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         pc_client_v2=openreview.api.OpenReviewClient(username='pc@icml.cc', password=helpers.strong_password)
 
         assignment = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[0].id, tail='~AC_ICMLTwo1')[0]
-        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment.cdate = None
         pc_client_v2.post_edge(assignment)
 
@@ -3333,7 +3333,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert len(group.members) == 1
         assert 'reviewerethics@yahoo.com' in group.members
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         stage_note = pc_client.post_note(openreview.Note(
@@ -3464,7 +3464,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert 'ICML.cc/2023/Conference/Submission1/Ethics_Reviewers' in invitation.invitees
 
         # re-run ethics review stage
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=1)
         stage_note = pc_client.post_note(openreview.Note(
             content={
@@ -3716,7 +3716,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Post an official comment stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         comment_stage_note = pc_client.post_note(openreview.Note(
@@ -3866,7 +3866,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert submissions and len(submissions) == 100
         assert 'flagged_for_ethics_review' in submissions[4].content and not submissions[4].content['flagged_for_ethics_review']['value']
         invitation = openreview_client.get_invitations(id='ICML.cc/2023/Conference/Submission5/-/Ethics_Review')[0]
-        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
         ethics_group = openreview_client.get_group('ICML.cc/2023/Conference/Submission5/Ethics_Reviewers')
         assert ethics_group and '~Celeste_ICML1' in ethics_group.members
 
@@ -3963,7 +3963,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         # Enable Author-AC confidential comments
         venue = openreview.helpers.get_conference(pc_client, request_form.id, setup=False)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
 
@@ -4076,7 +4076,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         pc_client=openreview.Client(username='pc@icml.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
 
         # create rebuttal stage in request form
         client.post_invitation(openreview.Invitation(
@@ -4352,7 +4352,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
             assert edit.readers == edit.note.readers
             assert '${2/note/readers}' not in edit.readers
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         comment_stage_note = pc_client.post_note(openreview.Note(
@@ -4400,11 +4400,11 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         helpers.await_queue_edit(openreview_client, edit_id=comment_edit['id'])
 
         invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Rebuttal_Stage')
-        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.now())
         client.post_invitation(invitation)
 
         # post a rebuttal stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         pc_client.post_note(openreview.Note(
@@ -4547,7 +4547,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # post a rebuttal stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         pc_client.post_note(openreview.Note(
@@ -4593,7 +4593,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         pc_client_v2=openreview.api.OpenReviewClient(username='pc@icml.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         exp_date = due_date + datetime.timedelta(days=2)
@@ -4711,7 +4711,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         #try to delete AC assignment of paper with a submitted metareview
         assignment = pc_client_v2.get_edges(invitation='ICML.cc/2023/Conference/Area_Chairs/-/Assignment', head=submissions[0].id, tail='~AC_ICMLTwo1')[0]
-        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         assignment.cdate = None
 
         with pytest.raises(openreview.OpenReviewException, match=r'Can not remove assignment, the user ~AC_ICMLTwo1 already posted a Meta Review.'):
@@ -4766,7 +4766,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         venue.custom_stage = openreview.stages.CustomStage(name='Meta_Review_Agreement',
             reply_to=openreview.stages.CustomStage.ReplyTo.METAREVIEWS,
@@ -4919,7 +4919,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Post a decision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -5148,7 +5148,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert not submissions[1].odate
 
         invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Post_Decision_Stage')
-        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.now())
         client.post_invitation(invitation)
 
         invitation = pc_client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Post_Decision_Stage')
@@ -5208,7 +5208,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert len(authors_accepted_group.members) == num_accepted_papers
 
         #run post submission, give publication chairs access to accepted papers
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         short_name = 'ICML 2023'
         post_decision_stage_note = pc_client.post_note(openreview.Note(
             content={
@@ -5292,7 +5292,7 @@ Best,
         assert 'ICML.cc/2023/Conference/Publication_Chairs' not in rejected_submissions[0].content['authorids']['readers']
 
         # enable camera-ready revisions
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         revision_stage_note = pc_client.post_note(openreview.Note(
@@ -5345,7 +5345,7 @@ Best,
         assert 'ICML.cc/2023/Conference/Publication_Chairs' not in rejected_submissions[0].content['authorids']['readers']
 
         #Post a post decision note, unhide financial_aid and hide pdf
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         short_name = 'ICML 2023'
@@ -5476,7 +5476,7 @@ url={https://openreview.net/forum?id='''
         assert '_bibtex' in rejected_submissions[0].content and rejected_submissions[0].content['_bibtex']['value'] == valid_bibtex
 
         #Post another post decision note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         short_name = 'ICML 2023'
         post_decision_stage_note = pc_client.post_note(openreview.Note(
             content={
@@ -5763,7 +5763,7 @@ Best,
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Post an official comment stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         comment_stage_note = pc_client.post_note(openreview.Note(

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -344,7 +344,7 @@ class TestJournal():
         peter_client=helpers.create_user('petersnow@yahoo.com', 'Peter', 'Snow')
 
         guest_client=OpenReviewClient()
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
 
         ## Post the submission 1
         submission_note_1 = test_client.post_note_edit(invitation='TMLR/-/Submission',
@@ -454,7 +454,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/Action_Editors/-/Recommendation',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 1)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 1)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -512,7 +512,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/Action_Editors/-/Recommendation',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 7)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 7)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -631,7 +631,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             weight=1
         ))
 
-        paper_assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        paper_assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         paper_assignment_edge = raia_client.post_edge(paper_assignment_edge)
 
         messages = journal.client.get_messages(to = 'joelle@mailseven.com', subject = '[TMLR] Assignment to new TMLR submission 1: Paper title UPDATED')
@@ -692,7 +692,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         ## Check action editor recommendation is expired
         invitation = openreview_client.get_invitation(id='TMLR/Paper1/Action_Editors/-/Recommendation')
         assert invitation.expdate is not None
-        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
         assert openreview_client.get_invitation('TMLR/Paper1/-/Review_Approval')
 
         joelle_paper1_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper1/Action_Editor_.*', signatory='~Joelle_Pineau1')
@@ -772,7 +772,7 @@ note={Under review}
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi Joelle Pineau,
 
-With this email, we request that you assign 3 reviewers to your assigned TMLR submission "1: Paper title UPDATED". The assignments must be completed **within 1 week** ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 1)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/group?id=TMLR/Action_Editors and click on "Edit Assignment" for that paper in your "Assigned Papers" console.
+With this email, we request that you assign 3 reviewers to your assigned TMLR submission "1: Paper title UPDATED". The assignments must be completed **within 1 week** ({(datetime.datetime.now() + datetime.timedelta(weeks = 1)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/group?id=TMLR/Action_Editors and click on "Edit Assignment" for that paper in your "Assigned Papers" console.
 
 As a reminder, up to their annual quota of 6 reviews per year, reviewers are expected to review all assigned submissions that fall within their expertise. Acceptable exceptions are 1) if they have an unsubmitted review for another TMLR submission or 2) situations where exceptional personal circumstances (e.g. vacation, health problems) render them incapable of fully performing their reviewing duties.
 
@@ -841,7 +841,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         time.sleep(5)
 
         # remove first assigned AE
-        paper_assignment_edge_one.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        paper_assignment_edge_one.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         paper_assignment_edge_one = raia_client.post_edge(paper_assignment_edge_one)
 
         helpers.await_queue_edit(openreview_client, invitation='TMLR/Action_Editors/-/Assignment', count=6)
@@ -873,7 +873,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper2/-/Desk_Rejection_Approval',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 7)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 7)) + 2000,
                 signatures=[venue_id]
             )
         )
@@ -1023,7 +1023,7 @@ note={Withdrawn}
             signatures=['~Super_User1'],
             invitation=openreview.api.Invitation(
                 id='TMLR/-/Preferred_Emails',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 2000,
             )
         )
 
@@ -1044,7 +1044,7 @@ note={Withdrawn}
         ))
 
         # immediately remove assignment of David Belanger
-        paper_assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        paper_assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         paper_assignment_edge = joelle_client.post_edge(paper_assignment_edge)
 
         # wait for process function delay (5 seconds) and check no email is sent
@@ -1068,7 +1068,7 @@ note={Withdrawn}
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi David Belanger,
 
-With this email, we request that you submit, within 2 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 2)).strftime("%b %d")}) a review for your newly assigned TMLR submission "1: Paper title UPDATED". If the submission is longer than 12 pages (excluding any appendix), you may request more time to the AE.
+With this email, we request that you submit, within 2 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 2)).strftime("%b %d")}) a review for your newly assigned TMLR submission "1: Paper title UPDATED". If the submission is longer than 12 pages (excluding any appendix), you may request more time to the AE.
 
 Please acknowledge on OpenReview that you have received this review assignment by following this link: https://openreview.net/forum?id={note_id_1}&invitationId=TMLR/Paper1/Reviewers/-/~David_Belanger1/Assignment/Acknowledgement
 
@@ -1089,7 +1089,7 @@ Please note that responding to this email will direct your reply to joelle@mails
         assert messages[0]['content']['replyTo'] == 'joelle@mailseven.com'
 
         # remove assignment of David Belanger
-        paper_assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        paper_assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         paper_assignment_edge = joelle_client.post_edge(paper_assignment_edge)
 
         # check that David Belanger has been removed from reviewer group
@@ -1144,7 +1144,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi Carlos Mondragon,
 
-With this email, we request that you submit, within 2 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 2)).strftime("%b %d")}) a review for your newly assigned TMLR submission "1: Paper title UPDATED". If the submission is longer than 12 pages (excluding any appendix), you may request more time to the AE.
+With this email, we request that you submit, within 2 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 2)).strftime("%b %d")}) a review for your newly assigned TMLR submission "1: Paper title UPDATED". If the submission is longer than 12 pages (excluding any appendix), you may request more time to the AE.
 
 Please acknowledge on OpenReview that you have received this review assignment by following this link: https://openreview.net/forum?id={note_id_1}&invitationId=TMLR/Paper1/Reviewers/-/~Carlos_Mondragon1/Assignment/Acknowledgement
 
@@ -1170,7 +1170,7 @@ Please note that responding to this email will direct your reply to joelle@mails
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/Reviewers/-/Assignment',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 1)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 1)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -1217,7 +1217,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi Javier Burroni,
 
-With this email, we request that you submit, within 2 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 2)).strftime("%b %d")}) a review for your newly assigned TMLR submission "1: Paper title UPDATED". If the submission is longer than 12 pages (excluding any appendix), you may request more time to the AE.
+With this email, we request that you submit, within 2 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 2)).strftime("%b %d")}) a review for your newly assigned TMLR submission "1: Paper title UPDATED". If the submission is longer than 12 pages (excluding any appendix), you may request more time to the AE.
 
 Please acknowledge on OpenReview that you have received this review assignment by following this link: https://openreview.net/forum?id={note_id_1}&invitationId=TMLR/Paper1/Reviewers/-/~Javier_Burroni1/Assignment/Acknowledgement
 
@@ -1538,7 +1538,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Review',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 1)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 1)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -1580,7 +1580,7 @@ Please note that responding to this email will direct your reply to joelle@mails
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Review',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 7)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 7)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -1619,7 +1619,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Review',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 14)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 14)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -1663,7 +1663,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Review',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 30)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 30)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -1722,7 +1722,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/Reviewers/-/~Carlos_Mondragon1/Assignment/Acknowledgement',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 1)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 1)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -1757,7 +1757,7 @@ Please note that responding to this email will direct your reply to joelle@mails
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/Reviewers/-/~Carlos_Mondragon1/Assignment/Acknowledgement',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 5)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 5)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -1792,7 +1792,7 @@ Please note that responding to this email will direct your reply to joelle@mails
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/Reviewers/-/~Carlos_Mondragon1/Assignment/Acknowledgement',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 12)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 12)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -1829,7 +1829,7 @@ Please note that responding to this email will direct your reply to joelle@mails
         assert len(carlos_anon_groups) == 1
 
         ## post the assignment ack
-        formatted_date = (datetime.datetime.utcnow() + datetime.timedelta(weeks = 2)).strftime("%b %d, %Y")
+        formatted_date = (datetime.datetime.now() + datetime.timedelta(weeks = 2)).strftime("%b %d, %Y")
         assignment_ack_note = carlos_client.post_note_edit(invitation=f'TMLR/Paper1/Reviewers/-/~Carlos_Mondragon1/Assignment/Acknowledgement',
             signatures=[carlos_anon_groups[0].id],
             note=Note(
@@ -1922,7 +1922,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
 Now that 3 reviews have been submitted for your submission  1: Paper title UPDATED, all reviews have been made public. If you haven't already, please read the reviews and start engaging with the reviewers to attempt to address any concern they may have about your submission.
 
-You will have 2 weeks to respond to the reviewers. To maximise the period of interaction and discussion, please respond as soon as possible. The reviewers will be using this time period to hear from you and gather all the information they need. In about 2 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 2)).strftime("%b %d")}), and no later than 4 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 4)).strftime("%b %d")}), reviewers will submit their formal decision recommendation to the Action Editor in charge of your submission.
+You will have 2 weeks to respond to the reviewers. To maximise the period of interaction and discussion, please respond as soon as possible. The reviewers will be using this time period to hear from you and gather all the information they need. In about 2 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 2)).strftime("%b %d")}), and no later than 4 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 4)).strftime("%b %d")}), reviewers will submit their formal decision recommendation to the Action Editor in charge of your submission.
 
 Visit the following link to respond to the reviews: https://openreview.net/forum?id={note_id_1}
 
@@ -2095,7 +2095,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert reviews[3].signatures == [hugo_anon_groups[0].id]
 
         invitation = raia_client.get_invitation(f'{venue_id}/Paper1/-/Official_Recommendation')
-        assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.now())
         assert invitation.edit['note']['content']['certification_recommendations']['value']['param']['enum'] == ['Featured Certification', 'Reproducibility Certification', 'Survey Certification']
 
         raia_client.post_invitation_edit(
@@ -2104,7 +2104,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 1000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 1000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -2121,7 +2121,7 @@ Thank you for submitting your review and engaging with the authors of TMLR submi
 
 You may now submit your official recommendation for the submission. Before doing so, make sure you have sufficiently discussed with the authors (and possibly the other reviewers and AE) any concerns you may have about the submission.
 
-We ask that you submit your recommendation within 2 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 4)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={note_id_1}&invitationId=TMLR/Paper1/-/Official_Recommendation
+We ask that you submit your recommendation within 2 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 4)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={note_id_1}&invitationId=TMLR/Paper1/-/Official_Recommendation
 
 For more details and guidelines on performing your review, visit jmlr.org/tmlr.
 
@@ -2256,7 +2256,7 @@ All reviewers have submitted their official recommendation of a decision for the
 - Make sure you have sufficiently discussed with the authors (and possibly the reviewers) any concern you may have about the submission.
 - Rate the quality of the reviews submitted by the reviewers. **You will not be able to submit your decision until these ratings have been submitted**. To rate a review, go on the submission's page and click on button "Rating" for each of the reviews.
 
-We ask that you submit your decision **within 1 week** ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 1)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={note_id_1}&invitationId=TMLR/Paper1/-/Decision
+We ask that you submit your decision **within 1 week** ({(datetime.datetime.now() + datetime.timedelta(weeks = 1)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={note_id_1}&invitationId=TMLR/Paper1/-/Decision
 
 The possible decisions are:
 - **Accept as is**: once its camera ready version is submitted, the manuscript will be marked as accepted.
@@ -2407,8 +2407,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         helpers.await_queue_edit(openreview_client, edit_id=approval_note['id'])
 
-        assert openreview_client.get_invitation(f"{venue_id}/Paper1/-/Review").expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
-        assert openreview_client.get_invitation(f"{venue_id}/Paper1/-/Official_Recommendation").expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert openreview_client.get_invitation(f"{venue_id}/Paper1/-/Review").expdate < openreview.tools.datetime_millis(datetime.datetime.now())
+        assert openreview_client.get_invitation(f"{venue_id}/Paper1/-/Official_Recommendation").expdate < openreview.tools.datetime_millis(datetime.datetime.now())
 
         decision_note = raia_client.get_note(decision_note.id)
         assert decision_note.readers == ['everyone']
@@ -2433,7 +2433,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
 We are happy to inform you that, based on the evaluation of the reviewers and the recommendation of the assigned Action Editor, your TMLR submission "1: Paper title UPDATED" is accepted as is.
 
-To know more about the decision and submit the deanonymized camera ready version of your manuscript, please follow this link and click on button "Camera Ready Revision": https://openreview.net/forum?id={note_id_1}. Please submit the final version of your paper within 4 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 4)).strftime("%b %d")}).
+To know more about the decision and submit the deanonymized camera ready version of your manuscript, please follow this link and click on button "Camera Ready Revision": https://openreview.net/forum?id={note_id_1}. Please submit the final version of your paper within 4 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 4)).strftime("%b %d")}).
 
 In addition to your final manuscript, we strongly encourage you to submit a link to 1) code associated with your and 2) a short video presentation of your work. You can provide these links to the corresponding entries on the revision page.
 
@@ -2456,7 +2456,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Camera_Ready_Revision',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 1)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 1)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -2494,7 +2494,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Camera_Ready_Revision',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 7)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 7)) + 2000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -2546,7 +2546,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Camera_Ready_Verification',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 7)) + 2000
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 7)) + 2000
             )
         )
 
@@ -2581,7 +2581,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Camera_Ready_Verification',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 30)) + 2000
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 30)) + 2000
             )
         )
 
@@ -2826,7 +2826,7 @@ note={Retracted after acceptance}
         andrew_client=OpenReviewClient(username='andrewmc@mailfour.com', password=helpers.strong_password)
         hugo_client=OpenReviewClient(username='hugo@mailsix.com', password=helpers.strong_password)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
 
         ## Post the submission 4
         submission_note_4 = test_client.post_note_edit(invitation='TMLR/-/Submission',
@@ -2898,7 +2898,7 @@ note={Retracted after acceptance}
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi David Belanger,
 
-With this email, we request that you submit, within 4 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 4)).strftime("%b %d")}) a review for your newly assigned TMLR submission "4: Paper title 4". If the submission is longer than 12 pages (excluding any appendix), you may request more time to the AE.
+With this email, we request that you submit, within 4 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 4)).strftime("%b %d")}) a review for your newly assigned TMLR submission "4: Paper title 4". If the submission is longer than 12 pages (excluding any appendix), you may request more time to the AE.
 
 Please acknowledge on OpenReview that you have received this review assignment by following this link: https://openreview.net/forum?id={note_id_4}&invitationId=TMLR/Paper4/Reviewers/-/~David_Belanger1/Assignment/Acknowledgement
 
@@ -2989,7 +2989,7 @@ Please note that responding to this email will direct your reply to joelle@mails
             signatures=['~Celeste_Ana_Martinez1'],
             note=Note(
                 id=volunteer_to_review_note['note']['id'],
-                ddate=openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                ddate=openreview.tools.datetime_millis(datetime.datetime.now()),
                 content={
                     'solicit': { 'value': 'I solicit to review this paper.' },
                     'comment': { 'value': 'I can review this paper.' }
@@ -3030,7 +3030,7 @@ Please consult the request and either accept or reject it, by visiting this link
 
 https://openreview.net/forum?id={note_id_4}&noteId={volunteer_to_review_note['note']['id']}
 
-We ask that you provide a response within 1 week, by {(datetime.datetime.utcnow() + datetime.timedelta(weeks = 1)).strftime("%b %d")}. Note that it is your responsibility to ensure that this submission is assigned to qualified reviewers and is evaluated fairly. Therefore, make sure to overview the user’s profile (https://openreview.net/profile?id=~Tom_Rain1) before making a decision.
+We ask that you provide a response within 1 week, by {(datetime.datetime.now() + datetime.timedelta(weeks = 1)).strftime("%b %d")}. Note that it is your responsibility to ensure that this submission is assigned to qualified reviewers and is evaluated fairly. Therefore, make sure to overview the user’s profile (https://openreview.net/profile?id=~Tom_Rain1) before making a decision.
 
 We thank you for your contribution to TMLR!
 
@@ -3165,7 +3165,7 @@ To view the comment, click here: https://openreview.net/forum?id={note_id_4}&not
 
 This is to inform you that your request to act as a reviewer for TMLR submission 4: Paper title 4 has been accepted by the Action Editor (AE).
 
-You are required to submit your review within 4 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 4)).strftime("%b %d")}). If the submission is longer than 12 pages (excluding any appendix), you may request more time from the AE.
+You are required to submit your review within 4 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 4)).strftime("%b %d")}). If the submission is longer than 12 pages (excluding any appendix), you may request more time from the AE.
 
 To submit your review, please follow this link: https://openreview.net/forum?id={note_id_4}&invitationId=TMLR/Paper4/-/Review or check your tasks in the Reviewers Console: https://openreview.net/group?id=TMLR/Reviewers
 
@@ -3276,7 +3276,7 @@ Please note that responding to this email will direct your reply to joelle@mails
         assert joelle_client.get_edges(invitation='TMLR/Reviewers/-/Pending_Reviews', tail='~Antony_Bal1')[0].weight == 0
 
         invitation = raia_client.get_invitation(f'{venue_id}/Paper4/-/Official_Recommendation')
-        #assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        #assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         raia_client.post_invitation_edit(
             invitations='TMLR/-/Edit',
@@ -3284,7 +3284,7 @@ Please note that responding to this email will direct your reply to joelle@mails
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper4/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 1000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 1000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -3517,7 +3517,7 @@ note={Rejected}
         andrew_client=OpenReviewClient(username='andrewmc@mailfour.com', password=helpers.strong_password)
         hugo_client=OpenReviewClient(username='hugo@mailsix.com', password=helpers.strong_password)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
 
         ## Post the submission 5
         submission_note_5 = raia_client.post_note_edit(invitation='TMLR/-/Submission',
@@ -3584,7 +3584,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper5/-/Review_Approval',
-                duedate=openreview.tools.datetime_millis(datetime.datetime.utcnow() - datetime.timedelta(days = 30)) + 2000,
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 30)) + 2000,
                 signatures=['TMLR']
             )
         )
@@ -3712,7 +3712,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
 
         invitation = cho_client.get_invitation(f'{venue_id}/Paper5/-/Official_Recommendation')
-        #assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        #assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         cho_client.post_invitation_edit(
             invitations='TMLR/-/Edit',
@@ -3720,7 +3720,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper5/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()),
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -3835,7 +3835,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
 We are happy to inform you that, based on the evaluation of the reviewers and the recommendation of the assigned Action Editor, your TMLR submission "5: Paper title 5" is accepted with minor revision.
 
-To know more about the decision and submit the deanonymized camera ready version of your manuscript, please follow this link and click on button "Camera Ready Revision": https://openreview.net/forum?id={note_id_5}. Please submit the final version of your paper, including the minor revisions requested by the Action Editor, within 4 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 4)).strftime("%b %d")}).
+To know more about the decision and submit the deanonymized camera ready version of your manuscript, please follow this link and click on button "Camera Ready Revision": https://openreview.net/forum?id={note_id_5}. Please submit the final version of your paper, including the minor revisions requested by the Action Editor, within 4 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 4)).strftime("%b %d")}).
 
 The Action Editor responsible for your submission will have provided a description of the revision expected for accepting your final manuscript.
 
@@ -3881,7 +3881,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         andrew_client=OpenReviewClient(username='andrewmc@mailfour.com', password=helpers.strong_password)
         hugo_client=OpenReviewClient(username='hugo@mailsix.com', password=helpers.strong_password)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
 
         ## Post the submission 6
         submission_note_6 = test_client.post_note_edit(invitation='TMLR/-/Submission',
@@ -4033,7 +4033,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
 
         invitation = cho_client.get_invitation(f'{venue_id}/Paper6/-/Official_Recommendation')
-        #assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        #assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         cho_client.post_invitation_edit(
             invitations='TMLR/-/Edit',
@@ -4041,7 +4041,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper6/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()),
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -4490,7 +4490,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         # Assign another Action Editor and the submission should be updated
         current_assignment = raia_client.get_edges(invitation='TMLR/Action_Editors/-/Assignment', head=note_id_8)[0]
-        current_assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        current_assignment.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         raia_client.post_edge(current_assignment)
 
         helpers.await_queue_edit(openreview_client, edit_id=current_assignment.id, count=2)
@@ -5116,7 +5116,7 @@ note={Under review}
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper13/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 1000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 1000,
                 signatures=['TMLR/Editors_In_Chief']
             )
         )
@@ -5575,7 +5575,7 @@ note={Expert Certification}
             signatures=['~Super_User1'],
             invitation=openreview.api.Invitation(
                 id='TMLR/-/Preferred_Emails',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 2000,
             )
         )
 

--- a/tests/test_matching_v2.py
+++ b/tests/test_matching_v2.py
@@ -38,7 +38,7 @@ class TestMatching():
         venue.area_chair_roles = ['Senior_Program_Committee']
         venue.reviewers_name = 'Program_Committee'
         venue.reviewer_roles = ['Program_Committee']
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.submission_stage = openreview.stages.SubmissionStage(
             due_date = now + datetime.timedelta(minutes = 40),
             double_blind=True, 
@@ -156,8 +156,8 @@ class TestMatching():
 
         helpers.await_queue_edit(openreview_client, edit_id=note_3['id'])
 
-        venue.submission_stage.due_date = datetime.datetime.utcnow()
-        venue.submission_stage.exp_date = datetime.datetime.utcnow() + datetime.timedelta(seconds = 90)
+        venue.submission_stage.due_date = datetime.datetime.now()
+        venue.submission_stage.exp_date = datetime.datetime.now() + datetime.timedelta(seconds = 90)
         venue.create_submission_stage()
         helpers.await_queue_edit(openreview_client, f'{venue.id}/-/Post_Submission-0-0')
         # Set up reviewer matching
@@ -221,15 +221,15 @@ class TestMatching():
         assert 'scores_specification' in invitation.edit['note']['content']
         assert f'{venue.id}/Program_Committee/-/Bid' in invitation.edit['note']['content']['scores_specification']['value']['param']['default']
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Custom_Max_Papers')
-        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.now())
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Conflict')
-        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.now())
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Aggregate_Score')
-        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.now())
         with pytest.raises(openreview.OpenReviewException, match=r'The Invitation VenueV2.cc/Program_Committee/-/Assignment was not found'):
             assert pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Assignment')
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Proposed_Assignment')
-        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         # Set up AC matching
         venue.setup_committee_matching(committee_id=venue.get_area_chairs_id(), compute_conflicts=True)
@@ -407,10 +407,10 @@ class TestMatching():
         assert 'def process_update(client, edge, invitation, existing_edge):' in assignment_inv.process
 
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Assignment')
-        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Proposed_Assignment')
-        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
 
         venue.unset_assignments(assignment_title='rev-matching', committee_id=f'{venue.id}/Program_Committee')
 
@@ -426,7 +426,7 @@ class TestMatching():
         assert openreview_client.get_edges_count(f'{venue.id}/Program_Committee/-/Assignment') == 0
 
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Assignment')
-        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
 
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Proposed_Assignment')
         assert invitation.expdate == None
@@ -462,13 +462,13 @@ class TestMatching():
         assert 'def process_update(client, edge, invitation, existing_edge):' in assignment_inv.process
 
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Assignment')
-        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.responseArchiveDate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         invitation = pc_client.get_invitation(id=f'{venue.id}/Program_Committee/-/Proposed_Assignment')
-        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
 
         ## Set the review stage and try to undo the assignments
-        venue.review_stage = openreview.stages.ReviewStage(due_date = datetime.datetime.utcnow() + datetime.timedelta(minutes = 10))
+        venue.review_stage = openreview.stages.ReviewStage(due_date = datetime.datetime.now() + datetime.timedelta(minutes = 10))
         venue.create_review_stage()
 
         helpers.await_queue_edit(openreview_client, 'VenueV2.cc/-/Official_Review-0-1', count=1)
@@ -503,7 +503,7 @@ class TestMatching():
             signatures=[anon_group_id],
             note=openreview.api.Note(
                 id = review_edit['note']['id'],
-                ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                ddate = openreview.tools.datetime_millis(datetime.datetime.now()),
                 content={
                     'title': { 'value': 'Review title'},
                     'review': { 'value': 'good paper' },
@@ -856,7 +856,7 @@ class TestMatching():
         # delete AC Assignment edge
         edge = pc_client.get_edges(invitation=f'{venue.id}/Senior_Program_Committee/-/Assignment', head=notes[0].id, tail='ac2_venue@umass.edu')[0]
         assert edge
-        edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         pc_client.post_edge(edge)
 
         helpers.await_queue_edit(openreview_client, edge.id)

--- a/tests/test_melba_journal.py
+++ b/tests/test_melba_journal.py
@@ -389,7 +389,7 @@ Please note that responding to this email will direct your reply to editors@melb
         assert reviews[2].readers == [f"{venue_id}/Editors_In_Chief", f"{venue_id}/Action_Editors", f"{venue_id}/Paper1/Reviewers", f"{venue_id}/Paper1/Authors"]
 
         invitation = eic_client.get_invitation(f'{venue_id}/Paper1/-/Official_Recommendation')
-        assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         eic_client.post_invitation_edit(
             invitations='MELBA/-/Edit',
@@ -397,7 +397,7 @@ Please note that responding to this email will direct your reply to editors@melb
             writers=[venue_id],
             signatures=[venue_id],
             invitation=openreview.api.Invitation(id=f'{venue_id}/Paper1/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 1000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 1000,
                 signatures=['MELBA/Editors_In_Chief']
             )
         )

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -18,7 +18,7 @@ class TestNeurIPSConference():
 
     def test_create_conference(self, client, openreview_client, helpers, selenium, request_page):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now + datetime.timedelta(days=1)
 
@@ -121,7 +121,7 @@ class TestNeurIPSConference():
         pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now + datetime.timedelta(days=1)
 
@@ -310,7 +310,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date  = now.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=2)
         expdate = now.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=5)
 
@@ -381,7 +381,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
         venue.setup_committee_matching(committee_id='NeurIPS.cc/2023/Conference/Senior_Area_Chairs', compute_conflicts=False, compute_affinity_scores=os.path.join(os.path.dirname(__file__), 'data/sac_affinity_scores.csv'))
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.bid_stages = [openreview.stages.BidStage(due_date=now + datetime.timedelta(days=3), committee_id='NeurIPS.cc/2023/Conference/Senior_Area_Chairs', score_ids=['NeurIPS.cc/2023/Conference/Senior_Area_Chairs/-/Affinity_Score'])]
         venue.create_bid_stages()
 
@@ -662,7 +662,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now + datetime.timedelta(days=1)
 
@@ -861,7 +861,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
 
 
         ## finish abstract deadline
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now - datetime.timedelta(minutes=27)
 
@@ -1041,7 +1041,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         revision_note = test_client.post_note_edit(invitation='NeurIPS.cc/2023/Conference/Submission5/-/Deletion',
             signatures=['NeurIPS.cc/2023/Conference/Submission5/Authors'],
             note=openreview.api.Note(
-                ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+                ddate = openreview.tools.datetime_millis(datetime.datetime.now())
             ))
         helpers.await_queue_edit(openreview_client, edit_id=revision_note['id'])
 
@@ -1088,7 +1088,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         assert len(reply_invitations) == 1
         assert 'NeurIPS.cc/2023/Conference/Submission4/-/Withdrawal' == reply_invitations[0].id
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now
         due_date = now + datetime.timedelta(days=3)
         revision_stage_note = pc_client.post_note(openreview.Note(
@@ -1327,7 +1327,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
 
         helpers.await_queue_edit(openreview_client, 'NeurIPS.cc/2023/Conference/-/Post_Submission-0-1', count=5)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
@@ -1616,7 +1616,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Post an official comment stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         comment_stage_note = pc_client.post_note(openreview.Note(
@@ -1687,7 +1687,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         assert len(group.members) == 1
         assert 'reviewerethics@neurips.com' in group.members
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         stage_note = pc_client.post_note(openreview.Note(
@@ -1839,7 +1839,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
 
     def test_release_reviews(self, helpers, openreview_client, request_page, selenium):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         pc_client=openreview.Client(username='pc@neurips.cc', password=helpers.strong_password)
@@ -2086,11 +2086,11 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Rebuttal_Stage')
-        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.now())
         client.post_invitation(invitation)
 
         # post a rebuttal stage note to enbale one rebuttal per review
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         pc_client.post_note(openreview.Note(
@@ -2175,7 +2175,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         # use custom stage to enable one author rebuttal per paper
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         venue.custom_stage = openreview.stages.CustomStage(name='Author_Rebuttal',
             reply_to=openreview.stages.CustomStage.ReplyTo.FORUM,
@@ -2273,7 +2273,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # release rebuttals to reviewers
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         pc_client.post_note(openreview.Note(
@@ -2323,7 +2323,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
         # release author rebuttals with custom stage
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         venue.custom_stage = openreview.stages.CustomStage(name='Author_Rebuttal',
             reply_to=openreview.stages.CustomStage.ReplyTo.FORUM,
@@ -2380,7 +2380,7 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Post an official comment stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         comment_stage_note = pc_client.post_note(openreview.Note(

--- a/tests/test_neurips_track_conference.py
+++ b/tests/test_neurips_track_conference.py
@@ -18,7 +18,7 @@ class TestNeurIPSTrackConference():
 
     def test_create_conference(self, client, openreview_client, helpers, selenium, request_page):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now + datetime.timedelta(days=1)
 
@@ -164,7 +164,7 @@ class TestNeurIPSTrackConference():
         helpers.await_queue()
 
         ## finish submission deadline
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now - datetime.timedelta(minutes=27)               
 

--- a/tests/test_non_anonnymous_venue.py
+++ b/tests/test_non_anonnymous_venue.py
@@ -33,7 +33,7 @@ class TestNonAnonymousVenue():
         venue.contact = 'testvenue@contact.com'
         venue.reviewer_identity_readers = [openreview.stages.IdentityReaders.PROGRAM_CHAIRS]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.submission_stage = SubmissionStage(
             double_blind=False,
             due_date=now + datetime.timedelta(minutes = 30),
@@ -91,7 +91,7 @@ class TestNonAnonymousVenue():
     def test_post_submission_stage(self, venue, openreview_client, helpers):
                 
         venue.submission_stage.readers = [SubmissionStage.Readers.REVIEWERS, SubmissionStage.Readers.AREA_CHAIRS]
-        venue.submission_stage.exp_date = datetime.datetime.utcnow() + datetime.timedelta(seconds = 90)
+        venue.submission_stage.exp_date = datetime.datetime.now() + datetime.timedelta(seconds = 90)
         venue.create_submission_stage()
 
         helpers.await_queue_edit(openreview_client, 'TestNonAnonymousVenue.cc/-/Post_Submission-0-0')
@@ -121,7 +121,7 @@ class TestNonAnonymousVenue():
         with pytest.raises(openreview.OpenReviewException, match=r'The Invitation TestNonAnonymousVenue.cc/Submission1/-/Official_Review was not found'):
             assert openreview_client.get_invitation('TestNonAnonymousVenue.cc/Submission1/-/Official_Review')
 
-        new_cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000
+        new_cdate = openreview.tools.datetime_millis(datetime.datetime.now()) + 2000
         openreview_client.post_invitation_edit(
             invitations='TestNonAnonymousVenue.cc/-/Edit',
             readers=['TestNonAnonymousVenue.cc'],

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -1289,7 +1289,7 @@ The OpenReview Team.
         journal.setup(support_role='test@mail.com', editors=[])
 
         venue = Venue(openreview_client, 'ACMM.org/2023/Conference', 'openreview.net/Support')        
-        venue.submission_stage = openreview.stages.SubmissionStage(double_blind=True, due_date=datetime.datetime.utcnow() + datetime.timedelta(minutes = 30))
+        venue.submission_stage = openreview.stages.SubmissionStage(double_blind=True, due_date=datetime.datetime.now() + datetime.timedelta(minutes = 30))
         venue.review_stage = openreview.stages.ReviewStage()
         venue.comment_stage = openreview.stages.CommentStage(enable_chat=True)
         venue.setup(program_chair_ids=['venue_pc@mail.com'])
@@ -1422,7 +1422,7 @@ The OpenReview Team.
         acceptance_note = openreview_client.post_note_edit(invitation=journal.get_accepted_id(),
             signatures=['CABJ'],
             note=openreview.api.Note(id=submission.id,
-                pdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()),
+                pdate = openreview.tools.datetime_millis(datetime.datetime.now()),
                 content= {
                     '_bibtex': {
                         'value': journal.get_bibtex(submission, journal.accepted_venue_id, certifications=[])

--- a/tests/test_react_note_editor.py
+++ b/tests/test_react_note_editor.py
@@ -33,7 +33,7 @@ class TestReactNoteEditor():
         venue.contact = 'testvenue@contact.com'
         venue.reviewer_identity_readers = [openreview.stages.IdentityReaders.PROGRAM_CHAIRS, openreview.stages.IdentityReaders.AREA_CHAIRS_ASSIGNED]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.submission_stage = SubmissionStage(
             double_blind=True,
             due_date=now + datetime.timedelta(minutes = 30),

--- a/tests/test_sac_paper_matching.py
+++ b/tests/test_sac_paper_matching.py
@@ -12,7 +12,7 @@ class TestSACAssignments():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         first_date = now + datetime.timedelta(days=1)
 
@@ -104,7 +104,7 @@ class TestSACAssignments():
                 note=note)  
             
         #close submissions and hide pdfs for bidding
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(days=1)
 
         pc_client = openreview.Client(username='pc@matching.org', password=helpers.strong_password)
@@ -279,7 +279,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert conflict_invitation.id in assignment_config_inv.edit['note']['content']['conflicts_invitation']['value']['param']['default']
 
         # enable bidding
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=1)
         bid_stage_note = pc_client.post_note(openreview.Note(
             content={
@@ -474,7 +474,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         # change assigned SAC
         edge = pc_client_v2.get_edges(invitation='TSACM/2024/Conference/Senior_Area_Chairs/-/Assignment', head=submissions[0].id, tail='~SAC_MatchingTwo1')[0]
         assert edge
-        edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         pc_client_v2.post_edge(edge)
 
         helpers.await_queue_edit(openreview_client, edge.id)

--- a/tests/test_simple_dual_anonymous_venue.py
+++ b/tests/test_simple_dual_anonymous_venue.py
@@ -28,7 +28,7 @@ class TestSimpleDualAnonymous():
         assert openreview_client.get_invitation('openreview.net/Support/Simple_Dual_Anonymous/-/Venue_Configuration_Request')
         assert openreview_client.get_invitation('openreview.net/Support/-/Deployment')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=1)
 
         request = pc_client.post_note_edit(invitation='openreview.net/Support/Simple_Dual_Anonymous/-/Venue_Configuration_Request',
@@ -136,7 +136,7 @@ class TestSimpleDualAnonymous():
         assert openreview_client.get_invitation('ABCD.cc/2025/Conference/Reviewers/-/Submission_Group')
 
         # extend submission deadline
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now - datetime.timedelta(days=3))
         new_duedate = openreview.tools.datetime_millis(now + datetime.timedelta(days=3))
 
@@ -291,7 +291,7 @@ class TestSimpleDualAnonymous():
         pc_client=openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
 
         # expire submission deadline
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now - datetime.timedelta(days=1))
         new_duedate = openreview.tools.datetime_millis(now - datetime.timedelta(minutes=31))
 
@@ -358,7 +358,7 @@ class TestSimpleDualAnonymous():
         assert bid_invitation.minReplies == 50
 
         #open bidding
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
         new_duedate = openreview.tools.datetime_millis(now + datetime.timedelta(days=5))
 
@@ -435,7 +435,7 @@ class TestSimpleDualAnonymous():
         assert domain_content['reviewers_conflict_n_years']['value'] == 3
 
         # trigger date process
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
         pc_client.post_invitation_edit(
             invitations='ABCD.cc/2025/Conference/-/Reviewer_Conflict/Dates',
@@ -472,7 +472,7 @@ class TestSimpleDualAnonymous():
         )
 
         # trigger affinity score upload
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
         pc_client.post_invitation_edit(
             invitations='ABCD.cc/2025/Conference/-/Reviewer_Paper_Affinity_Score/Dates',
@@ -548,7 +548,7 @@ class TestSimpleDualAnonymous():
         match_invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Deploy_Reviewer_Assignment/Match')
         assert match_invitation.edit['content']['match_name']['value']['param']['enum'] == ['rev-matching-1']
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         now = openreview.tools.datetime_millis(now)
 
         # try to deploy initialized configuration and get an error
@@ -620,7 +620,7 @@ class TestSimpleDualAnonymous():
         )
 
         # deploy assignments
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         cdate = openreview.tools.datetime_millis(now)
         openreview_client.post_invitation_edit(
             invitations='ABCD.cc/2025/Conference/-/Deploy_Reviewer_Assignment/Match',
@@ -754,7 +754,7 @@ class TestSimpleDualAnonymous():
         ]
 
         # create child invitations
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
         new_duedate = openreview.tools.datetime_millis(now + datetime.timedelta(days=3))
 
@@ -833,7 +833,7 @@ class TestSimpleDualAnonymous():
         helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Comment-0-1', count=2)
 
         # create child invitations
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
         new_duedate = openreview.tools.datetime_millis(now + datetime.timedelta(days=3))
 
@@ -962,7 +962,7 @@ class TestSimpleDualAnonymous():
         ]
 
         # create child invitations
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
         new_duedate = openreview.tools.datetime_millis(now + datetime.timedelta(days=3))
 
@@ -1012,7 +1012,7 @@ class TestSimpleDualAnonymous():
 
         assert 'accept_decision_options' in invitation.content and invitation.content['accept_decision_options']['value'] == ['Accept (Oral)', 'Accept (Poster)']
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
         new_duedate = openreview.tools.datetime_millis(now + datetime.timedelta(days=3))
 

--- a/tests/test_single_blind_conference_v2.py
+++ b/tests/test_single_blind_conference_v2.py
@@ -29,7 +29,7 @@ class TestSingleBlindVenueV2():
         support_group = client.get_group(support_group_id)
         client.add_members_to_group(group=support_group, members=['~Support_User1'])
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=3)
         withdraw_exp_date = due_date + datetime.timedelta(days=1)
 
@@ -186,7 +186,7 @@ class TestSingleBlindVenueV2():
 
     def test_post_decision_stage(self, helpers, venue, test_client, client, openreview_client):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now - datetime.timedelta(hours=1)
 
@@ -254,7 +254,7 @@ class TestSingleBlindVenueV2():
         assert submissions[1].content['pdf']['readers'] == ['V2.cc/2050/Conference_Single_Blind','V2.cc/2050/Conference_Single_Blind/Submission2/Authors']
 
         # Post a decision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -343,10 +343,10 @@ class TestSingleBlindVenueV2():
         assert decision_note.writers == ['V2.cc/2050/Conference_Single_Blind', 'V2.cc/2050/Conference_Single_Blind/Submission1/Area_Chairs', 'V2.cc/2050/Conference_Single_Blind/Program_Chairs'] 
 
         invitation = client.get_invitation('{}/-/Request{}/Post_Decision_Stage'.format(venue['support_group_id'], venue['request_form_note'].number))
-        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.now())
         client.post_invitation(invitation)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         short_name = "TestVenueSingleBlind@OR'2050V2"

--- a/tests/test_tacl_journal.py
+++ b/tests/test_tacl_journal.py
@@ -275,7 +275,7 @@ note={Under review}
         assert len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi David Bensusan,
 
-With this email, we request that you submit, within 2 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 2)).strftime("%b %d")}) a review for your newly assigned TACL submission "1: Paper title UPDATED".
+With this email, we request that you submit, within 2 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 2)).strftime("%b %d")}) a review for your newly assigned TACL submission "1: Paper title UPDATED".
 
 Please acknowledge on OpenReview that you have received this review assignment by following this link: https://openreview.net/forum?id={note_id_1}&invitationId=TACL/Paper1/Reviewers/-/~David_Bensusan1/Assignment/Acknowledgement
 
@@ -418,7 +418,7 @@ Please note that responding to this email will direct your reply to graham@mails
         javier_client = OpenReviewClient(username='javier@tacltwo.com', password=helpers.strong_password)
 
         invitation = brian_client.get_invitation('TACL/Paper1/-/Official_Recommendation')
-        assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         brian_client.post_invitation_edit(
             invitations='TACL/-/Edit',
@@ -426,7 +426,7 @@ Please note that responding to this email will direct your reply to graham@mails
             writers=['TACL'],
             signatures=['TACL'],
             invitation=openreview.api.Invitation(id=f'TACL/Paper1/-/Official_Recommendation',
-                cdate=openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 1000,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now()) + 1000,
                 signatures=['TACL/Editors_In_Chief']
             )
         )
@@ -443,7 +443,7 @@ Thank you for submitting your review and engaging with the authors of TACL submi
 
 You may now submit your official recommendation for the submission. Before doing so, make sure you have sufficiently discussed with the authors (and possibly the other reviewers and AE) any concerns you may have about the submission.
 
-We ask that you submit your recommendation within 2 weeks ({(datetime.datetime.utcnow() + datetime.timedelta(weeks = 4)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={note_id_1}&invitationId=TACL/Paper1/-/Official_Recommendation
+We ask that you submit your recommendation within 2 weeks ({(datetime.datetime.now() + datetime.timedelta(weeks = 4)).strftime("%b %d")}). To do so, please follow this link: https://openreview.net/forum?id={note_id_1}&invitationId=TACL/Paper1/-/Official_Recommendation
 
 For more details and guidelines on performing your review, visit transacl.org.
 

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -29,7 +29,7 @@ class TestVenueRequest():
         support_group = client.get_group(support_group_id)
         client.add_members_to_group(group=support_group, members=['~Support_User1'])
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=3)
         withdraw_exp_date = due_date + datetime.timedelta(days=1)
 
@@ -172,7 +172,7 @@ class TestVenueRequest():
         support_members = client.get_group(support_group_id).members
         assert support_members and len(support_members) == 1
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         abstract_due_date = now + datetime.timedelta(minutes=15)
         due_date = now + datetime.timedelta(minutes=30)
@@ -386,7 +386,7 @@ class TestVenueRequest():
         assert title_tag
         assert title_tag.text == venue['request_form_note'].content['title']
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -881,7 +881,7 @@ Program Chairs
 '''
 
     def test_reviewer_registration_stage(self, client, test_client, selenium, request_page, venue, helpers, openreview_client):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=2)
         registration_stage_note = test_client.post_note(openreview.Note(
             content={
@@ -969,7 +969,7 @@ Program Chairs
         assert 'emergency_reviews' in invitation.edit['note']['content']
 
     def test_venue_bid_stage_error(self, client, test_client, selenium, request_page, helpers, venue):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         bid_stage_note = test_client.post_note(openreview.Note(
@@ -1007,7 +1007,7 @@ Program Chairs
         reviewer_group = openreview_client.get_group(reviewer_group_id)
         openreview_client.add_members_to_group(reviewer_group, '~VenueTwo_Reviewer1')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -1051,7 +1051,7 @@ Program Chairs
         ## activate matching setup invitation
         matching_setup_invitation = '{}/-/Request{}/Paper_Matching_Setup'.format(venue['support_group_id'], venue['request_form_note'].number)
         matching_inv = client.get_invitation(matching_setup_invitation)
-        activation = datetime.datetime.utcnow()
+        activation = datetime.datetime.now()
         matching_inv.cdate = openreview.tools.datetime_millis(activation)
         matching_inv = client.post_invitation(matching_inv)
         assert matching_inv
@@ -1421,7 +1421,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
 
     def test_venue_review_stage(self, client, test_client, selenium, request_page, helpers, venue, openreview_client):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now - datetime.timedelta(hours=1)
 
@@ -1474,7 +1474,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         helpers.await_queue()
 
         # Post a review stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         review_stage_note = openreview.Note(
@@ -1623,7 +1623,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
     def test_release_reviews_to_authors(self, client, test_client, selenium, request_page, helpers, venue, openreview_client):
 
         # Post a review stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now - datetime.timedelta(hours=1)
         review_exp_date = now + datetime.timedelta(days=1)
@@ -1691,7 +1691,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert 'readers' not in reviews[0].content['review_rating']
 
         #hide ratings from authors without changing readers of reviews
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now - datetime.timedelta(hours=1)
         review_exp_date = now + datetime.timedelta(days=1)
@@ -1765,7 +1765,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
 
     def test_rebuttal_stage(self, client, test_client, venue, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         rebuttal_stage_note = test_client.post_note(openreview.Note(
@@ -1856,7 +1856,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
 
         venue = openreview.get_conference(client, venue['request_form_note'].id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=2)
         venue.custom_stage = openreview.stages.CustomStage(name='Review_Revision',
             reply_to=openreview.stages.CustomStage.ReplyTo.REVIEWS,
@@ -2014,7 +2014,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
 
         venue_object = openreview.get_conference(client, venue['request_form_note'].id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
         venue_object.custom_stage = openreview.stages.CustomStage(name='Author_Review_Rating',
             reply_to=openreview.stages.CustomStage.ReplyTo.REVIEWS,
@@ -2096,7 +2096,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert review_rating.signatures == ['~VenueTwo_Author1']
 
         # enable review rating by ACs from request from
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         review_rating_stage_note = test_client.post_note(openreview.Note(
@@ -2180,7 +2180,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert ac_group and len(ac_group.members) == 2
 
         # Post a meta review stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         meta_review_stage_note = openreview.Note(
@@ -2280,7 +2280,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert len(anon_groups) == 1
         assert anon_groups[0].readers == ['V2.cc/2030/Conference', 'V2.cc/2030/Conference/Program_Chairs', 'V2.cc/2030/Conference/Submission1/Senior_Area_Chairs', anon_groups[0].id]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now - datetime.timedelta(hours=1)
 
@@ -2388,7 +2388,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
 
         venue = openreview.get_conference(client, venue['request_form_note'].id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=2)
         venue.custom_stage = openreview.stages.CustomStage(name='Meta_Review_Revision',
             reply_to=openreview.stages.CustomStage.ReplyTo.METAREVIEWS,
@@ -2458,7 +2458,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
     def test_release_meta_reviews_to_authors_and_reviewers(self, test_client, helpers, venue, openreview_client):
 
         # Post a meta review stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         meta_review_stage_note = test_client.post_note(openreview.Note(
@@ -2535,7 +2535,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert official_comment_invitation is None
 
         # Post an official comment stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         comment_stage_note = test_client.post_note(openreview.Note(
@@ -2615,7 +2615,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert decision_invitation is None
 
         # Post a decision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -3093,7 +3093,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         assert openReviewError.value.args[0].get('name') == 'NotFoundError'
 
         invitation = client.get_invitation('{}/-/Request{}/Post_Decision_Stage'.format(venue['support_group_id'], venue['request_form_note'].number))
-        assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.cdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
     def test_venue_submission_revision_stage(self, client, test_client, selenium, request_page, helpers, venue, openreview_client):
         submissions = openreview_client.get_notes(invitation='V2.cc/2030/Conference/-/Submission', sort='number:asc')
@@ -3104,7 +3104,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         author_client = OpenReviewClient(username='venue_author3_v2@mail.com', password=helpers.strong_password)
 
         # Post a revision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         revision_stage_note = test_client.post_note(openreview.Note(
@@ -3178,7 +3178,7 @@ Please note that responding to this email will direct your reply to test@mail.co
     def test_venue_submission_revision_stage_accepted_papers_only(self, client, test_client, helpers, venue, openreview_client):
 
         # Post a revision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         revision_stage_note = test_client.post_note(openreview.Note(
@@ -3239,7 +3239,7 @@ Please note that responding to this email will direct your reply to test@mail.co
             'V2.cc/2030/Conference/Submission2/Authors']
 
         invitation = client.get_invitation('{}/-/Request{}/Post_Decision_Stage'.format(venue['support_group_id'], venue['request_form_note'].number))
-        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.now())
         client.post_invitation(invitation)
 
         invitation = test_client.get_invitation('{}/-/Request{}/Post_Decision_Stage'.format(venue['support_group_id'], venue['request_form_note'].number))
@@ -3252,7 +3252,7 @@ Please note that responding to this email will direct your reply to test@mail.co
         assert invitation.reply['content']['home_page_tab_names']['default']['Reject'] == 'Reject'
 
         #Post a post decision note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         short_name = 'TestVenue@OR\'2030V2 Modified'
@@ -3359,7 +3359,7 @@ Best,
         assert tabs.find_element(By.LINK_TEXT, "Recent Activity")
 
         # Post another revision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=5)
         revision_stage_note = openreview.Note(
@@ -3479,7 +3479,7 @@ Best,
         assert submissions and len(submissions) == 3
 
         # Post an official comment stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         end_date = now + datetime.timedelta(days=3)
         comment_stage_note = test_client.post_note(openreview.Note(
@@ -3523,7 +3523,7 @@ Best,
     def test_supplementary_material_revision(self, client, test_client, selenium, request_page, helpers, venue, openreview_client):
 
         # Post another revision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=5)
         revision_stage_note = test_client.post_note(openreview.Note(
@@ -3693,7 +3693,7 @@ Best,
 
         venue = openreview.get_conference(client, venue['request_form_note'].id, support_user='openreview.net/Support')
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=2)
         venue.custom_stage = openreview.stages.CustomStage(name='Meta_Review_Rating',
             reply_to=openreview.stages.CustomStage.ReplyTo.METAREVIEWS,

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -33,7 +33,7 @@ class TestVenueSubmission():
         venue.contact = 'testvenue@contact.com'
         venue.reviewer_identity_readers = [openreview.stages.IdentityReaders.PROGRAM_CHAIRS, openreview.stages.IdentityReaders.AREA_CHAIRS_ASSIGNED]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.submission_stage = SubmissionStage(
             double_blind=True,
             due_date=now + datetime.timedelta(minutes = 30),
@@ -274,7 +274,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
     def test_post_submission_stage(self, venue, openreview_client, helpers):
                 
         venue.submission_stage.readers = [SubmissionStage.Readers.REVIEWERS, SubmissionStage.Readers.AREA_CHAIRS]
-        venue.submission_stage.exp_date = datetime.datetime.utcnow() + datetime.timedelta(seconds = 90)
+        venue.submission_stage.exp_date = datetime.datetime.now() + datetime.timedelta(seconds = 90)
         venue.create_submission_stage()
 
         helpers.await_queue_edit(openreview_client, 'TestVenue.cc/-/Post_Submission-0-0')
@@ -435,7 +435,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         # with pytest.raises(openreview.OpenReviewException, match=r'The Invitation TestVenue.cc/Submission1/-/Official_Review was not found'):
         #     assert openreview_client.get_invitation('TestVenue.cc/Submission1/-/Official_Review')
 
-        new_cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000
+        new_cdate = openreview.tools.datetime_millis(datetime.datetime.now()) + 2000
         openreview_client.post_invitation_edit(
             invitations='TestVenue.cc/-/Edit',
             readers=['TestVenue.cc'],
@@ -463,7 +463,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         assert invitation.cdate == new_cdate
         assert invitation.edit['note']['readers'] == ["TestVenue.cc/Program_Chairs", "TestVenue.cc/Submission1/Area_Chairs", "${3/signatures}"]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.review_stage = openreview.stages.ReviewStage(start_date=now - datetime.timedelta(minutes = 4), due_date=now + datetime.timedelta(minutes = 40), release_to_authors=True)
         venue.create_review_stage()
 
@@ -528,7 +528,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
                 signatures=['TestVenue.cc'],
                 edit = {
                     'invitation': {
-                        'cdate': openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000
+                        'cdate': openreview.tools.datetime_millis(datetime.datetime.now()) + 2000
                     }
                 }
             )
@@ -555,7 +555,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
                 signatures=['TestVenue.cc'],
                 edit = {
                     'invitation': {
-                        'cdate': openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000
+                        'cdate': openreview.tools.datetime_millis(datetime.datetime.now()) + 2000
                     }
                 }
             )
@@ -580,7 +580,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         assert submissions[2].readers == ['everyone']
         assert submissions[3].readers == ['everyone']
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.comment_stage = openreview.CommentStage(
             allow_public_comments=True,
             reader_selection=True,
@@ -626,13 +626,13 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         helpers.await_queue_edit(openreview_client, invitation='TestVenue.cc/-/Withdrawn_Submission')
 
         invitation = openreview_client.get_invitation('TestVenue.cc/Submission2/-/Meta_Review')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Official_Review')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Official_Comment')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())        
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())        
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Public_Comment')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())        
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())        
 
         messages = openreview_client.get_messages(to='celeste@maileleven.com', subject='[TV 22]: Paper #2 withdrawn by paper authors')
         assert len(messages) == 1
@@ -655,10 +655,10 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         helpers.await_queue_edit(openreview_client, edit_id=withdrawal_reversion_note['id'])
 
         invitation = openreview_client.get_invitation('TestVenue.cc/Submission2/-/Meta_Review')
-        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Official_Review')
-        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Official_Comment')
         assert invitation.expdate is None       
@@ -711,13 +711,13 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         helpers.await_queue_edit(openreview_client, invitation='TestVenue.cc/-/Desk_Rejected_Submission')
 
         invitation = openreview_client.get_invitation('TestVenue.cc/Submission2/-/Meta_Review')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Official_Review')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Official_Comment')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Public_Comment')
-        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate < openreview.tools.datetime_millis(datetime.datetime.now())
 
         messages = openreview_client.get_messages(to='celeste@maileleven.com', subject='[TV 22]: Paper #2 desk-rejected by Program Chairs')
         assert len(messages) == 1
@@ -744,10 +744,10 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         helpers.await_queue_edit(openreview_client, edit_id=desk_rejection_reversion_note['id'])
 
         invitation = openreview_client.get_invitation('TestVenue.cc/Submission2/-/Meta_Review')
-        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Official_Review')
-        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        assert invitation.expdate and invitation.expdate > openreview.tools.datetime_millis(datetime.datetime.now())
 
         invitation =  openreview_client.get_invitation('TestVenue.cc/Submission2/-/Official_Comment')
         assert invitation.expdate is None 
@@ -782,7 +782,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
             writer = csv.writer(file_handle)
             writer.writerow([submissions[0].number, 'Accept (Oral)', 'Good Paper'])
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         venue.decision_stage = openreview.DecisionStage(
             due_date=now + datetime.timedelta(minutes = 40)
         )
@@ -826,7 +826,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
                 signatures=['TestVenue.cc'],
                 edit = {
                     'invitation': {
-                        'cdate': openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000
+                        'cdate': openreview.tools.datetime_millis(datetime.datetime.now()) + 2000
                     }
                 }
             )
@@ -885,7 +885,7 @@ To view your submission, click here: https://openreview.net/forum?id={updated_no
                 signatures=['TestVenue.cc'],
                 edit = {
                     'invitation': {
-                        'cdate': openreview.tools.datetime_millis(datetime.datetime.utcnow()) + 2000
+                        'cdate': openreview.tools.datetime_millis(datetime.datetime.now()) + 2000
                     }
                 }
             )

--- a/tests/test_venue_with_tracks.py
+++ b/tests/test_venue_with_tracks.py
@@ -13,7 +13,7 @@ class TestVenueWithTracks():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # Post the request form note
@@ -405,7 +405,7 @@ class TestVenueWithTracks():
         venue = openreview.get_conference(client, request_form.id, support_user='openreview.net/Support')
 
         ## close the submissions
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(days=1)
         pc_client.post_note(openreview.Note(
             content={
@@ -774,7 +774,7 @@ ac{ac_counter + 1}@{'gmail' if ac_counter == 21 else 'webconf'}.com, Area ChairT
         ## Remove second AC
         edges = pc_client_v2.get_edges(invitation=f'{ac_id}/-/Assignment', head=submissions[0].id, tail='~AC_WebChairTwentyOne1')
         edge = edges[0]
-        edge.ddate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         posted_edge = pc_client_v2.post_edge(edge)
 
         helpers.await_queue_edit(openreview_client, posted_edge.id)                      

--- a/tests/test_workshop_no_anonymity.py
+++ b/tests/test_workshop_no_anonymity.py
@@ -22,7 +22,7 @@ class TestWorkshopV2():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # Post the request form note
@@ -207,7 +207,7 @@ class TestWorkshopV2():
             ))
 
         ## close the submission
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(hours=1)        
         pc_client.post_note(openreview.Note(
             content={
@@ -277,7 +277,7 @@ class TestWorkshopV2():
 
         helpers.await_queue_edit(openreview_client, 'PRL/2024/ICAPS/-/Post_Submission-0-1', count=3)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         pc_client.post_note(openreview.Note(

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -22,7 +22,7 @@ class TestWorkshopV2():
 
     def test_create_conference(self, client, openreview_client, helpers):
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # Post the request form note
@@ -134,7 +134,7 @@ class TestWorkshopV2():
                 note=note)
 
         # Post revision to remove abstract from submission form
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         pc_client.post_note(openreview.Note(
@@ -277,7 +277,7 @@ class TestWorkshopV2():
             ))
 
         ## close the submission
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now - datetime.timedelta(hours=1)        
         pc_client.post_note(openreview.Note(
             content={
@@ -352,7 +352,7 @@ class TestWorkshopV2():
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         # Post a decision stage note
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
 
@@ -447,7 +447,7 @@ class TestWorkshopV2():
             helpers.await_queue_edit(openreview_client, edit_id=decision['id'])
 
         invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/Post_Decision_Stage')
-        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.utcnow())
+        invitation.cdate = openreview.tools.datetime_millis(datetime.datetime.now())
         client.post_invitation(invitation)
 
         # add publication chairs
@@ -489,7 +489,7 @@ class TestWorkshopV2():
         assert 'PRL/2023/ICAPS/Publication_Chairs' in submission_revision_inv.invitees
 
         #Post a post decision note, release accepted papers to publication chair
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         start_date = now - datetime.timedelta(days=2)
         due_date = now + datetime.timedelta(days=3)
         short_name = 'PRL ICAPS 2023'
@@ -617,7 +617,7 @@ Best,
         publication_chair_client = openreview.Client(username='publicationchair@mail.com', password=helpers.strong_password)
         request_form=publication_chair_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=3)
 
         # post submission revision stage note


### PR DESCRIPTION
I don't remember why we have to create the dates in timezone utc, I don't think we need it. 

`utcnow` has been deprecated in the python version 3.12 (Oct, 2023) so it is time to remove it. 

**Note**: tools.py changes the way to translate a datetime to milliseconds but process functions in the live site still have `utcnow` in their code. Given the Google Cloud instances are in utc we shouldn't have a change, this is backward compatible.

 