### PR TITLE
Fix/avoid support email on reply

### DIFF
--- a/openreview/venue_request/process/commentProcess.js
+++ b/openreview/venue_request/process/commentProcess.js
@@ -10,6 +10,7 @@ function(){
     var forumNote = result.notes[0];
     var prettySignature = note.signatures[0].startsWith('~') ? note.signatures[0].replace(/~|\d+/g, '').replace(/_/g, ' ') : 'Support';
     var commentTitle = note.content.title ? note.content.title : 'Comment by ' + prettySignature;
+    var promises = [];
 
     var message = {
       groups: note.readers,
@@ -18,18 +19,19 @@ function(){
       message: 'A comment was posted to your service request. \n\nComment title: ' + commentTitle + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id + '\n\nPlease note that with the exception of urgent issues, requests made on weekends or US holidays can expect to receive a response on the following business day. Thank you for your patience!'
     };
 
-    if (commentTitle.includes('Process Completed')) {
-      return or3client.or3request(or3client.mailUrl, message, 'POST', token)
+    promises.push(or3client.or3request(or3client.mailUrl, message, 'POST', token));
+
+    if (note.signatures[0] !== SUPPORT_GROUP) {
+      var support_message = {
+        groups: [SUPPORT_GROUP],
+        subject: 'Comment posted to a service request: ' + forumNote.content.title,
+        message: 'A comment was posted to a service request. \n\nComment title: ' + commentTitle + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+      };
+
+      promises.push(or3client.or3request(or3client.mailUrl, support_message, 'POST', token));
     }
 
-    var support_message = {
-      groups: [SUPPORT_GROUP],
-      subject: 'Comment posted to a service request: ' + forumNote.content.title,
-      message: 'A comment was posted to a service request. \n\nComment title: ' + commentTitle + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
-    };
-
-    return or3client.or3request(or3client.mailUrl, message, 'POST', token)
-    .then(result => or3client.or3request(or3client.mailUrl, support_message, 'POST', token));
+    return Promise.all(promises);
   })
   .then(result => done())
   .catch(error => done(error));

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -968,6 +968,9 @@ reviewer6@yahoo.com, Reviewer ICMLSix
         assert messages and len(messages) == 6
         assert 'Comment title: Post Submission Process Completed' in messages[-1]['content']['text']
 
+        messages = openreview_client.get_messages(to='support@openreview.net', subject='Comment posted to a service request: Thirty-ninth International Conference on Machine Learning')
+        assert len(messages) == 0        
+
         ac_client = openreview.api.OpenReviewClient(username = 'ac1@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
         assert len(submissions) == 101
@@ -1008,7 +1011,8 @@ reviewer6@yahoo.com, Reviewer ICMLSix
         assert messages and len(messages) == 7
         assert 'Comment title: Post Submission Process Completed' in messages[-1]['content']['text']
 
-
+        messages = openreview_client.get_messages(to='support@openreview.net', subject='Comment posted to a service request: Thirty-ninth International Conference on Machine Learning')
+        assert len(messages) == 0
 
         submissions = venue.get_submissions(sort='number:asc')
         assert len(submissions) == 101
@@ -1378,6 +1382,9 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         assert messages and len(messages) == 8
         assert 'Comment title: Post Submission Process Completed' in messages[-1]['content']['text']
 
+        messages = openreview_client.get_messages(to='support@openreview.net', subject='Comment posted to a service request: Thirty-ninth International Conference on Machine Learning')
+        assert len(messages) == 0        
+
         ac_client = openreview.api.OpenReviewClient(username = 'ac1@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
         assert len(submissions) == 100
@@ -1419,8 +1426,7 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         # check email is not sent to support
         messages = openreview_client.get_messages(to='support@openreview.net', subject='Comment posted to a service request: Thirty-ninth International Conference on Machine Learning')
-        assert messages and len(messages) == 1
-        assert 'Comment title: Bid Stage Process Completed' not in messages[0]['content']['text']
+        assert len(messages) == 0        
 
         # check email is sent to pcs
         messages = openreview_client.get_messages(to='pc@icml.cc', subject='Comment posted to your request for service: Thirty-ninth International Conference on Machine Learning')
@@ -1449,6 +1455,9 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         messages = openreview_client.get_messages(to='pc@icml.cc', subject='Comment posted to your request for service: Thirty-ninth International Conference on Machine Learning')
         assert messages and len(messages) == 10
         assert 'Comment title: Post Submission Process Completed' in messages[-1]['content']['text']
+
+        messages = openreview_client.get_messages(to='support@openreview.net', subject='Comment posted to a service request: Thirty-ninth International Conference on Machine Learning')
+        assert len(messages) == 0        
 
         ac_client = openreview.api.OpenReviewClient(username = 'ac1@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')
@@ -2390,6 +2399,9 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
         messages = openreview_client.get_messages(to='pc@icml.cc', subject='Comment posted to your request for service: Thirty-ninth International Conference on Machine Learning')
         assert messages and len(messages) == 11
         assert 'Comment title: Post Submission Process Completed' in messages[-1]['content']['text']
+
+        messages = openreview_client.get_messages(to='support@openreview.net', subject='Comment posted to a service request: Thirty-ninth International Conference on Machine Learning')
+        assert len(messages) == 0        
 
         ac_client = openreview.api.OpenReviewClient(username='ac1@icml.cc', password=helpers.strong_password)
         submissions = ac_client.get_notes(invitation='ICML.cc/2023/Conference/-/Submission', sort='number:asc')

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -165,6 +165,7 @@ class TestVenueRequest():
         request_page(selenium, 'http://localhost:3030/group?id={}'.format(support_group_id), client.token)
 
         helpers.create_user('pc_venue_v2@mail.com', 'ProgramChair', 'User')
+        pc_client = openreview.Client(baseurl='http://localhost:3000', username='pc_venue_v2@mail.com', password=helpers.strong_password)
 
         support_group = client.get_group(support_group_id)
         client.add_members_to_group(group=support_group, members=['~Support_User1'])
@@ -221,13 +222,13 @@ class TestVenueRequest():
             })
 
         with pytest.raises(openreview.OpenReviewException, match=r'contact_email must be a single, valid email address'):
-            client.post_note(request_form_note)
+            pc_client.post_note(request_form_note)
 
         request_form_note.content['contact_email'] = 'pc_venue_v2@mail.com'
-        request_form_note = client.post_note(request_form_note)
+        request_form_note = pc_client.post_note(request_form_note)
 
         assert request_form_note
-        request_page(selenium, 'http://localhost:3030/forum?id=' + request_form_note.forum, client.token)
+        request_page(selenium, 'http://localhost:3030/forum?id=' + request_form_note.forum, pc_client.token)
 
         messages = client.get_messages(
             to='pc_venue_v2@mail.com',
@@ -242,7 +243,7 @@ class TestVenueRequest():
         assert messages and len(messages) == 1
         assert messages[0]['content']['text'].startswith(f'A request for service has been submitted by TestVenue@OR2022. Check it here: https://openreview.net/forum?id={request_form_note.forum}')
 
-        client.post_note(openreview.Note(
+        comment_note = pc_client.post_note(openreview.Note(
             content={
                 'title': 'Urgent',
                 'comment': 'Please deploy ASAP.'
@@ -260,6 +261,79 @@ class TestVenueRequest():
         ))
 
         helpers.await_queue()
+
+        messages = client.get_messages(
+            to='support@openreview.net',
+            subject='Comment posted to a service request: Test 2022 Venue'
+        )
+        assert len(messages) == 1
+        assert messages[0]['content']['text'] == f'''A comment was posted to a service request. 
+
+Comment title: Urgent\n\nComment: Please deploy ASAP.
+
+To view the comment, click here: http://localhost:3030/forum?id={request_form_note.forum}&noteId={comment_note.id}'''
+
+        messages = client.get_messages(
+            to='pc_venue_v2@mail.com',
+            subject='Comment posted to your request for service: Test 2022 Venue'
+        )
+        assert len(messages) == 1
+        assert messages[0]['content']['text'] == f'''A comment was posted to your service request. 
+
+Comment title: Urgent\n\nComment: Please deploy ASAP.
+
+To view the comment, click here: http://localhost:3030/forum?id={request_form_note.forum}&noteId={comment_note.id}
+
+Please note that with the exception of urgent issues, requests made on weekends or US holidays can expect to receive a response on the following business day. Thank you for your patience!'''
+        
+        messages = client.get_messages(
+            to='tom_venue@mail.com',
+            subject='Comment posted to your request for service: Test 2022 Venue'
+        )
+        assert len(messages) == 1
+        assert messages[0]['content']['text'] == f'''A comment was posted to your service request. 
+
+Comment title: Urgent\n\nComment: Please deploy ASAP.
+
+To view the comment, click here: http://localhost:3030/forum?id={request_form_note.forum}&noteId={comment_note.id}
+
+Please note that with the exception of urgent issues, requests made on weekends or US holidays can expect to receive a response on the following business day. Thank you for your patience!'''
+        client.post_note(openreview.Note(
+            content={
+                'title': 'Will be deployed tomorrow',
+                'comment': 'Will be deployed tomorrow.'
+            },
+            forum=request_form_note.forum,
+            invitation='{}/-/Request{}/Comment'.format(venue.support_group_id, request_form_note.number),
+            readers=[
+                support_group_id,
+                'pc_venue_v2@mail.com',
+                'tom_venue@mail.com'
+            ],
+            replyto=None,
+            signatures=['openreview.net/Support'],
+            writers=[]
+        ))
+
+        helpers.await_queue()
+
+        messages = client.get_messages(
+            to='support@openreview.net',
+            subject='Comment posted to a service request: Test 2022 Venue'
+        )
+        assert len(messages) == 1
+
+        messages = client.get_messages(
+            to='pc_venue_v2@mail.com',
+            subject='Comment posted to your request for service: Test 2022 Venue'
+        )
+        assert len(messages) == 2
+
+        messages = client.get_messages(
+            to='tom_venue@mail.com',
+            subject='Comment posted to your request for service: Test 2022 Venue'
+        )
+        assert len(messages) == 2
 
         # Test Deploy
         deploy_note = client.post_note(openreview.Note(


### PR DESCRIPTION
Do not send any emails to our support email account when the comment is posted by the support user