### PR TITLE
Feat: Add script to deploy openreview-py to the expertise instance

### DIFF
--- a/.github/workflows/deploy-expertise.yml
+++ b/.github/workflows/deploy-expertise.yml
@@ -1,0 +1,69 @@
+# This workflow deploys any branch, tag, or commit hash to the production environment.
+
+name: Production Deployment Expertise
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The branch, tag, or commit hash to deploy
+        required: false
+        default: master
+        type: string
+
+jobs:
+  deploy:
+    # Allow the job to fetch a GitHub ID token
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.inputs.tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Add SSH key
+        run: |
+          mkdir -p /home/runner/.ssh
+          echo "${{ secrets.GCLOUD_SSH_KEY }}" > /home/runner/.ssh/google_compute_engine
+          echo "${{ secrets.GCLOUD_SSH_KEY_PUB }}" > /home/runner/.ssh/google_compute_engine.pub
+          chmod 600 /home/runner/.ssh/google_compute_engine
+          chmod 600 /home/runner/.ssh/google_compute_engine.pub
+      - name: Authenticate with Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          cleanup_credentials: true
+          export_environment_variables: true
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Run deploy script
+        run: |
+          gsutil cp gs://openreview-general/conf/deployment.conf ./deployment.conf
+          sed -i "s/OPENREVIEW_PY_EXPERTISE_TAG=.*/OPENREVIEW_PY_EXPERTISE_TAG=\"$TAG\"/" ./deployment.conf
+          gsutil cp ./deployment.conf gs://openreview-general/conf/deployment.conf
+
+          instance_prefix='instance-matching-server-gpu'
+
+          instances=$(gcloud compute instances list | grep "$instance_prefix" | grep RUNNING | tr -s ' ' | cut -d' ' -f1,2)
+
+          instances_arr=(${instances// / })
+
+          instance_names=()
+          zones=()
+          for i in ${!instances_arr[@]}; do
+            if echo "${instances_arr[$i]}" | grep -q "$instance_prefix"; then
+              instance_names+=(${instances_arr[$i]})
+            else
+              zones+=(${instances_arr[$i]})
+            fi
+          done
+
+          for i in ${!instance_names[@]}; do
+            echo Deploying to ${instance_names[$i]}
+            gcloud compute ssh --zone ${zones[$i]} openreview@${instance_names[$i]} --command "bash bin/deploy-openreview-py.sh ${TAG}"
+          done


### PR DESCRIPTION
This script deploys openreview-py to the expertise instance. Currently when we deploy any version of the expertise to the instance, the master branch of openreview-py is also deployed.

@haroldrubio how is vertex AI installing openreview-py? What version is it using?

Depending on the answer, we may need to change how the deployment for openreview-py is done.