### PR TITLE
Group recruitment: let remind members that haven't responsed the invitation

### DIFF
--- a/openreview/workflows/process/reviewers_invited_edit_reminder_process.py
+++ b/openreview/workflows/process/reviewers_invited_edit_reminder_process.py
@@ -1,0 +1,52 @@
+def process(client, edit, invitation):
+
+    domain = client.get_group(invitation.domain)
+    reviewers_invited_id= domain.content['reviewers_invited_id']['value']
+    reviewers_id = domain.content['reviewers_id']['value']
+    reviewers_declined_id = domain.content['reviewers_declined_id']['value']
+    reviewers_invited_response_id = domain.content['reviewers_invited_response_id']['value']
+    reviewers_invited_message_id = domain.content['reviewers_invited_message_id']['value']
+    reviewers_invited_response_invitation = client.get_invitation(reviewers_invited_response_id)
+    hash_seed = reviewers_invited_response_invitation.content['hash_seed']['value']
+
+    recruitment_status = {
+        'reminded': []
+    }
+
+    print("Sending reminders for invited reviewers")
+
+    invitees = [ l.split(',')[0].strip() for l in edit.content['invitee_details']['value'].strip().split('\n') ]
+    
+    reviewers_invited_group = client.get_group(reviewers_invited_id)
+    recruitment_message_subject = reviewers_invited_group.content['invite_reminder_message_subject_template']['value']
+    recruitment_message_content = reviewers_invited_group.content['invite_reminder_message_body_template']['value']
+
+    reviewers_invited_profiles = openreview.tools.get_profiles(client, invitees, as_dict=True)
+    reviewers_profiles = { p.id: p for p in openreview.tools.get_profiles(client, client.get_group(reviewers_id).members) }
+    reviewers_declined_profiles = { p.id: p for p in openreview.tools.get_profiles(client, client.get_group(reviewers_declined_id).members)}
+
+    def remind_reviewer(invitee):
+
+        invitee_profile_id = reviewers_invited_profiles.get(invitee, { id: invitee }).id
+
+        if invitee_profile_id in reviewers_profiles or invitee_profile_id in reviewers_declined_profiles:
+            return None
+        
+        hash_key = openreview.tools.get_user_hash_key(invitee, hash_seed)
+        user_parse = openreview.tools.get_user_parse(invitee)
+
+        url = f'https://openreview.net/invitation?id={reviewers_invited_response_id}&user={user_parse}&key={hash_key}'
+
+        personalized_message = recruitment_message_content
+        personalized_message = personalized_message.replace("{{invitation_url}}", url)
+
+        client.post_message(recruitment_message_subject, [invitee], personalized_message, invitation=reviewers_invited_message_id)
+
+        return invitee
+        
+    reminded_reviewers = openreview.tools.concurrent_requests(remind_reviewer, invitees, desc='send_recruitment_reminder_invitations')
+    recruitment_status['reminded'] = [r for r in reminded_reviewers if r is not None]
+
+    print("Recruitment status:", recruitment_status)
+
+      

--- a/openreview/workflows/process/reviewers_invited_members_reminder_process.py
+++ b/openreview/workflows/process/reviewers_invited_members_reminder_process.py
@@ -1,0 +1,51 @@
+def process(client, edit, invitation):
+
+    domain = client.get_group(invitation.domain)
+    reviewers_invited_id= domain.content['reviewers_invited_id']['value']
+    reviewers_id = domain.content['reviewers_id']['value']
+    reviewers_declined_id = domain.content['reviewers_declined_id']['value']
+    reviewers_invited_response_id = domain.content['reviewers_invited_response_id']['value']
+    reviewers_invited_message_id = domain.content['reviewers_invited_message_id']['value']
+    reviewers_invited_response_invitation = client.get_invitation(reviewers_invited_response_id)
+    hash_seed = reviewers_invited_response_invitation.content['hash_seed']['value']
+
+    recruitment_status = {
+        'reminded': []
+    }
+
+    print("Sending reminders for invited reviewers")
+    
+    recruitment_message_subject = edit.content['invite_reminder_message_subject_template']['value']
+    recruitment_message_content = edit.content['invite_reminder_message_body_template']['value']
+
+
+    reviewers_invited_group = client.get_group(reviewers_invited_id)
+    reviewers_invited_profiles = openreview.tools.get_profiles(client, reviewers_invited_group.members, as_dict=True)
+    reviewers_profiles = { p.id: p for p in openreview.tools.get_profiles(client, client.get_group(reviewers_id).members) }
+    reviewers_declined_profiles = { p.id: p for p in openreview.tools.get_profiles(client, client.get_group(reviewers_declined_id).members)}
+
+    def remind_reviewer(invitee):
+
+        invitee_profile_id = reviewers_invited_profiles.get(invitee, { id: invitee }).id
+
+        if invitee_profile_id in reviewers_profiles or invitee_profile_id in reviewers_declined_profiles:
+            return None
+        
+        hash_key = openreview.tools.get_user_hash_key(invitee, hash_seed)
+        user_parse = openreview.tools.get_user_parse(invitee)
+
+        url = f'https://openreview.net/invitation?id={reviewers_invited_response_id}&user={user_parse}&key={hash_key}'
+
+        personalized_message = recruitment_message_content
+        personalized_message = personalized_message.replace("{{invitation_url}}", url)
+
+        client.post_message(recruitment_message_subject, [invitee], personalized_message, invitation=reviewers_invited_message_id)
+
+        return invitee
+        
+    reminded_reviewers = openreview.tools.concurrent_requests(remind_reviewer, reviewers_invited_group.members, desc='send_recruitment_reminder_invitations')
+    recruitment_status['reminded'] = [r for r in reminded_reviewers if r is not None]
+
+    print("Recruitment status:", recruitment_status)
+
+      

--- a/openreview/workflows/simple_dual_anonymous_workflow/process/authors_group_template_process.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/process/authors_group_template_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     venue_id = edit.content['venue_id']['value']
 
     domain = client.get_group(venue_id)
+    support_user = f'{invitation.domain}/Support'
 
     authors_name = edit.content['authors_name']['value']
 
@@ -18,3 +19,17 @@ def process(client, edit, invitation):
             }
         )
     )
+
+    client.post_invitation_edit(
+        invitations=f'{support_user}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Group_Message_Template',
+        signatures=[support_user],
+        content={
+            'venue_id': { 'value': venue_id },
+            'group_id': { 'value': edit.group.id },
+            'message_reply_to': { 'value': domain.content['contact']['value'] },
+            'venue_short_name': { 'value': domain.content['subtitle']['value'] },
+            'venue_from_email': { 'value': f"{domain.content['subtitle']['value'].replace(' ', '').replace(':', '-').replace('@', '').replace('(', '').replace(')', '').replace(',', '-').lower()}-notifications@openreview.net" }
+        },
+        invitation=openreview.api.Invitation(),
+        await_process=True
+    )     

--- a/openreview/workflows/simple_dual_anonymous_workflow/process/reviewers_group_template_process.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/process/reviewers_group_template_process.py
@@ -3,6 +3,7 @@ def process(client, edit, invitation):
     venue_id = edit.content['venue_id']['value']
 
     domain = client.get_group(venue_id)
+    support_user = f'{invitation.domain}/Support'    
 
     reviewers_name = edit.content['reviewers_name']['value']
     reviewers_anon_name = f'{reviewers_name[:-1] if reviewers_name.endswith("s") else reviewers_name}_'
@@ -20,3 +21,17 @@ def process(client, edit, invitation):
             }
         )
     )
+
+    client.post_invitation_edit(
+        invitations=f'{support_user}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Group_Message_Template',
+        signatures=[support_user],
+        content={
+            'venue_id': { 'value': venue_id },
+            'group_id': { 'value': edit.group.id },
+            'message_reply_to': { 'value': domain.content['contact']['value'] },
+            'venue_short_name': { 'value': domain.content['subtitle']['value'] },
+            'venue_from_email': { 'value': f"{domain.content['subtitle']['value'].replace(' ', '').replace(':', '-').replace('@', '').replace('(', '').replace(')', '').replace(',', '-').lower()}-notifications@openreview.net" }
+        },
+        invitation=openreview.api.Invitation(),
+        await_process=True
+    )    

--- a/openreview/workflows/simple_dual_anonymous_workflow/process/reviewers_invited_group_template_process.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/process/reviewers_invited_group_template_process.py
@@ -75,11 +75,11 @@ def process(client, edit, invitation):
     )    
 
     invitation_edit = client.post_invitation_edit(
-        invitations=f'{support_user}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Reviewers_Invited_Message_Template',
+        invitations=f'{support_user}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Group_Message_Template',
         signatures=[support_user],
         content={
             'venue_id': { 'value': venue_id },
-            'reviewers_invited_id': { 'value': edit.group.id },
+            'group_id': { 'value': edit.group.id },
             'message_reply_to': { 'value': domain.content['contact']['value'] },
             'venue_short_name': { 'value': domain.content['subtitle']['value'] },
             'venue_from_email': { 'value': f"{domain.content['subtitle']['value'].replace(' ', '').replace(':', '-').replace('@', '').replace('(', '').replace(')', '').replace(',', '-').lower()}-notifications@openreview.net" }

--- a/openreview/workflows/simple_dual_anonymous_workflow/process/reviewers_invited_group_template_process.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/process/reviewers_invited_group_template_process.py
@@ -22,21 +22,29 @@ def process(client, edit, invitation):
         content={
             'venue_id': { 'value': venue_id },
             'reviewers_invited_id': { 'value': edit.group.id },
-            'venue_short_name': { 'value': domain.content['subtitle']['value'] },
-            'venue_contact': { 'value': domain.content['contact']['value'] },
+            'reminder_delay': { 'value': 3000 if (invitation.domain == 'openreview.net') else (1000 * 60 * 60 * 24 * 7)  }
         },
         invitation=openreview.api.Invitation(),
         await_process=True
     )
 
     client.post_invitation_edit(
+        invitations=f'{support_user}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Reviewers_Invited_Reminder_Template',
+        signatures=[support_user],
+        content={
+            'venue_id': { 'value': venue_id },
+            'reviewers_invited_id': { 'value': edit.group.id }
+        },
+        invitation=openreview.api.Invitation(),
+        await_process=True
+    )    
+
+    client.post_invitation_edit(
         invitations=f'{support_user}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Reviewers_Invited_Emails_Template',
         signatures=[support_user],
         content={
             'venue_id': { 'value': venue_id },
-            'reviewers_invited_id': { 'value': edit.group.id },
-            'venue_short_name': { 'value': domain.content['subtitle']['value'] },
-            'venue_contact': { 'value': domain.content['contact']['value'] },
+            'reviewers_invited_id': { 'value': edit.group.id }
         },
         invitation=openreview.api.Invitation(),
         await_process=True

--- a/openreview/workflows/simple_dual_anonymous_workflow/process/venue_group_template_process.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/process/venue_group_template_process.py
@@ -185,4 +185,17 @@ def process(client, edit, invitation):
                 }
             }
         )
-    )    
+    )
+
+    client.post_invitation_edit(
+        invitations=f'{support_user}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Venue_Message_Template',
+        signatures=[support_user],
+        content={
+            'venue_id': { 'value': venue_id },
+            'message_reply_to': { 'value': edit.group.content['contact']['value'] },
+            'venue_short_name': { 'value': edit.group.content['subtitle']['value'] },
+            'venue_from_email': { 'value': f"{edit.group.content['subtitle']['value'].replace(' ', '').replace(':', '-').replace('@', '').replace('(', '').replace(')', '').replace(',', '-').lower()}-notifications@openreview.net" }
+        },
+        invitation=openreview.api.Invitation(),
+        await_process=True
+    )     

--- a/openreview/workflows/simple_dual_anonymous_workflow/process/venue_group_template_process.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/process/venue_group_template_process.py
@@ -164,9 +164,7 @@ def process(client, edit, invitation):
                         'description': 'Venue home page',
                         'value': {
                             'param': {
-                                'type': 'string',
-                                'input': 'textarea',
-                                'markdown': True
+                                'type': 'script'
                             }
                         }
                     }

--- a/openreview/workflows/simple_dual_anonymous_workflow/simple_dual_anonymous_workflow.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/simple_dual_anonymous_workflow.py
@@ -4542,7 +4542,7 @@ If you would like to change your decision, please follow the link in the previou
                         'signature': '${3/content/venue_id/value}',
                         'fromName': '${3/content/venue_short_name/value}',
                         'fromEmail': '${3/content/venue_from_email/value}',
-                        'useJob': False
+                        'useJob': { 'param': { 'enum': [True, False], 'optional': True } },
                     }
                 }
             }
@@ -4617,7 +4617,7 @@ If you would like to change your decision, please follow the link in the previou
                         'signature': '${3/content/venue_id/value}',
                         'fromName': '${3/content/venue_short_name/value}',
                         'fromEmail': '${3/content/venue_from_email/value}',
-                        'useJob': False
+                        'useJob': { 'param': { 'enum': [True, False], 'optional': True } },
                     }
                 }
             }

--- a/openreview/workflows/simple_dual_anonymous_workflow/simple_dual_anonymous_workflow.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/simple_dual_anonymous_workflow.py
@@ -55,6 +55,7 @@ class Simple_Dual_Anonymous_Workflow():
         self.setup_submission_reviewer_group_invitation()
         self.setup_authors_group_template_invitation()
         self.setup_authors_accepted_group_template_invitation()
+        self.setup_group_message_template_invitation()
 
         # setup workflow template invitations
         self.setup_submission_template_invitation()
@@ -4408,137 +4409,7 @@ If you would like to change your decision, please follow the link in the previou
             }
         )
 
-        self.post_invitation_edit(invitation)
-
-        invitation_id = f'{support_group_id}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Reviewers_Invited_Message_Template'
-
-        invitation = Invitation(id=invitation_id,
-            invitees=['~Super_User1'],
-            readers=['everyone'],
-            writers=['~Super_User1'],
-            signatures=['~Super_User1'],
-            edit = {
-                'signatures': [support_group_id],
-                'readers': [support_group_id],
-                'writers': [support_group_id],
-                'content': {
-                    'venue_id': {
-                        'order': 1,
-                        'description': 'Venue Id',
-                        'value': {
-                            'param': {
-                                'type': 'domain'
-                            }
-                        }
-                    },
-                    'reviewers_invited_id': {
-                        'order': 2,
-                        'description': 'Venue reviewers name',
-                        'value': {
-                            'param': {
-                                'type': 'string'
-                            }
-                        }
-                    },
-                    'message_reply_to': {
-                        'order': 3,
-                        'description': 'Venue reviewers name',
-                        'value': {
-                            'param': {
-                                'type': 'string'
-                            }
-                        }
-                    },
-                    'venue_short_name': {
-                        'order': 4,
-                        'description': 'Venue reviewers name',
-                        'value': {
-                            'param': {
-                                'type': 'string'
-                            }
-                        }
-                    },
-                    'venue_from_email': {
-                        'order': 5,
-                        'description': 'Venue reviewers name',
-                        'value': {
-                            'param': {
-                                'type': 'string'
-                            }
-                        }
-                    }
-                },
-                'domain': '${1/content/venue_id/value}',
-                'invitation': {
-                    'id': '${2/content/reviewers_invited_id/value}/-/Message',
-                    'invitees': ['${3/content/venue_id/value}'],
-                    'signatures': ['${3/content/venue_id/value}'], 
-                    'readers': ['${3/content/venue_id/value}'],
-                    'writers': ['${3/content/venue_id/value}'],
-                    'description': '<span class="text-muted">Invited reviewers can receive email notifications to accept or decline the invitation</span>',
-#                     'content': {
-#                         'invite_message_subject_template': {
-#                             'value': '[${4/content/venue_short_name/value}] Invitation to serve as Reviewer'
-#                         },
-#                         'invite_message_content_template': {
-#                             'value': '''Dear {{fullname}},
-
-# You have been nominated by the program chair committee of ${4/content/venue_short_name/value} to serve as reviewer. As a respected researcher in the area, we hope you will accept and help us make ${4/content/venue_short_name/value} a success.
-
-# You are also welcome to submit papers, so please also consider submitting to ${4/content/venue_short_name/value}.
-
-# We will be using OpenReview.net with the intention of have an engaging reviewing process inclusive of the whole community.
-
-# To respond the invitation, please click on the following link:
-
-# {{invitation_url}}
-
-# Please answer within 10 days.
-
-# If you accept, please make sure that your OpenReview account is updated and lists all the emails you are using.  Visit http://openreview.net/profile after logging in.
-
-# If you have any questions, please contact ${4/content/message_reply_to/value}.
-
-# Cheers!
-
-# Program Chairs'''
-#                         },
-#                         'declined_message_subject_template': {
-#                             'value': '[${4/content/venue_short_name/value}] Reviewers Invitation declined'
-#                         },                        
-#                         'declined_message_content_template': {
-#                             'value': '''You have declined the invitation to become a reviewer for ${4/content/venue_short_name/value}.
-
-# If you would like to change your decision, please follow the link in the previous invitation email and click on the "Accept" button.'''
-#                         },
-#                         'accepted_message_subject_template': {
-#                             'value': '[${4/content/venue_short_name/value}] Reviewers Invitation accepted'
-#                         },                        
-#                         'accepted_message_content_template': {
-#                             'value': '''Thank you for accepting the invitation to be a reviewers for ${4/content/venue_short_name/value}.
-
-# The ${4/content/venue_short_name/value} program chairs will be contacting you with more information regarding next steps soon. In the meantime, please add noreply@openreview.net to your email contacts to ensure that you receive all communications.
-
-# If you would like to change your decision, please follow the link in the previous invitation email and click on the "Decline" button.'''
-#                         },
-#                     },
-                    'message': {
-                        'replyTo': '${3/content/message_reply_to/value}',
-                        'subject': { 'param': { 'minLength': 1 } },
-                        'message': { 'param': { 'minLength': 1 } },
-                        'groups': { 'param': { 'inGroup': '${5/content/reviewers_invited_id/value}' } },
-                        'parentGroup': '${3/content/reviewers_invited_id/value}',
-                        'ignoreGroups': { 'param': { 'regex': r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})', 'optional': True } },
-                        'signature': '${3/content/venue_id/value}',
-                        'fromName': '${3/content/venue_short_name/value}',
-                        'fromEmail': '${3/content/venue_from_email/value}',
-                        'useJob': False
-                    }
-                }
-            }
-        )
-
-        self.post_invitation_edit(invitation)        
+        self.post_invitation_edit(invitation)       
 
     def setup_authors_group_template_invitation(self):
 
@@ -4592,6 +4463,168 @@ If you would like to change your decision, please follow the link in the previou
 
         self.post_invitation_edit(invitation)
 
+    def setup_group_message_template_invitation(self):
+
+        support_group_id = self.support_group_id
+        invitation_id = f'{support_group_id}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Group_Message_Template'
+
+        invitation = Invitation(id=invitation_id,
+            invitees=['~Super_User1'],
+            readers=['everyone'],
+            writers=['~Super_User1'],
+            signatures=['~Super_User1'],
+            edit = {
+                'signatures': [support_group_id],
+                'readers': [support_group_id],
+                'writers': [support_group_id],
+                'content': {
+                    'venue_id': {
+                        'order': 1,
+                        'description': 'Venue Id',
+                        'value': {
+                            'param': {
+                                'type': 'domain'
+                            }
+                        }
+                    },
+                    'group_id': {
+                        'order': 2,
+                        'description': 'Venue group id',
+                        'value': {
+                            'param': {
+                                'type': 'string'
+                            }
+                        }
+                    },
+                    'message_reply_to': {
+                        'order': 3,
+                        'description': 'Venue reply to address',
+                        'value': {
+                            'param': {
+                                'type': 'string'
+                            }
+                        }
+                    },
+                    'venue_short_name': {
+                        'order': 4,
+                        'description': 'Venue shot name',
+                        'value': {
+                            'param': {
+                                'type': 'string'
+                            }
+                        }
+                    },
+                    'venue_from_email': {
+                        'order': 5,
+                        'description': 'Venue from name',
+                        'value': {
+                            'param': {
+                                'type': 'string'
+                            }
+                        }
+                    }
+                },
+                'domain': '${1/content/venue_id/value}',
+                'invitation': {
+                    'id': '${2/content/group_id/value}/-/Message',
+                    'invitees': ['${3/content/venue_id/value}'],
+                    'signatures': ['${3/content/venue_id/value}'], 
+                    'readers': ['${3/content/venue_id/value}'],
+                    'writers': ['${3/content/venue_id/value}'],
+                    'description': 'Message any group members',
+                    'message': {
+                        'replyTo': '${3/content/message_reply_to/value}',
+                        'subject': { 'param': { 'minLength': 1 } },
+                        'message': { 'param': { 'minLength': 1 } },
+                        'groups': { 'param': { 'inGroup': '${5/content/group_id/value}' } },
+                        'parentGroup': '${3/content/group_id/value}',
+                        'ignoreGroups': { 'param': { 'regex': r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})', 'optional': True } },
+                        'signature': '${3/content/venue_id/value}',
+                        'fromName': '${3/content/venue_short_name/value}',
+                        'fromEmail': '${3/content/venue_from_email/value}',
+                        'useJob': False
+                    }
+                }
+            }
+        )
+
+        self.post_invitation_edit(invitation)        
+    
+        invitation_id = f'{support_group_id}/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Venue_Message_Template'
+
+        invitation = Invitation(id=invitation_id,
+            invitees=['~Super_User1'],
+            readers=['everyone'],
+            writers=['~Super_User1'],
+            signatures=['~Super_User1'],
+            edit = {
+                'signatures': [support_group_id],
+                'readers': [support_group_id],
+                'writers': [support_group_id],
+                'content': {
+                    'venue_id': {
+                        'order': 1,
+                        'description': 'Venue Id',
+                        'value': {
+                            'param': {
+                                'type': 'domain'
+                            }
+                        }
+                    },
+                    'message_reply_to': {
+                        'order': 3,
+                        'description': 'Venue reply to address',
+                        'value': {
+                            'param': {
+                                'type': 'string'
+                            }
+                        }
+                    },
+                    'venue_short_name': {
+                        'order': 4,
+                        'description': 'Venue shot name',
+                        'value': {
+                            'param': {
+                                'type': 'string'
+                            }
+                        }
+                    },
+                    'venue_from_email': {
+                        'order': 5,
+                        'description': 'Venue from name',
+                        'value': {
+                            'param': {
+                                'type': 'string'
+                            }
+                        }
+                    }
+                },
+                'domain': '${1/content/venue_id/value}',
+                'invitation': {
+                    'id': '${2/content/venue_id/value}/-/Message',
+                    'invitees': ['${3/content/venue_id/value}'],
+                    'signatures': ['${3/content/venue_id/value}'], 
+                    'readers': ['${3/content/venue_id/value}'],
+                    'writers': ['${3/content/venue_id/value}'],
+                    'description': 'Message any group members',
+                    'message': {
+                        'replyTo': '${3/content/message_reply_to/value}',
+                        'subject': { 'param': { 'minLength': 1 } },
+                        'message': { 'param': { 'minLength': 1 } },
+                        'groups': { 'param': { 'regex': '${5/content/venue_id/value}.*' } },
+                        'parentGroup': '${3/content/venue_id/value}',
+                        'ignoreGroups': { 'param': { 'regex': r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})', 'optional': True } },
+                        'signature': '${3/content/venue_id/value}',
+                        'fromName': '${3/content/venue_short_name/value}',
+                        'fromEmail': '${3/content/venue_from_email/value}',
+                        'useJob': False
+                    }
+                }
+            }
+        )
+
+        self.post_invitation_edit(invitation)    
+    
     def setup_reviewer_conflicts_template_invitation(self):
 
         support_group_id = self.support_group_id

--- a/openreview/workflows/simple_dual_anonymous_workflow/simple_dual_anonymous_workflow.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/simple_dual_anonymous_workflow.py
@@ -3792,7 +3792,7 @@ Program Chairs'''
                         'invite_reminder_message_body_template': {
                             'value': '''Dear {{fullname}},
 
-Reminder: please answer the invitation to serve as reviewer for ${4/content/venue_short_name/value}.
+Reminder: please respond to the invitation to serve as reviewer for ${4/content/venue_short_name/value}.
                             
 You have been nominated by the program chair committee of ${4/content/venue_short_name/value} to serve as reviewer. As a respected researcher in the area, we hope you will accept and help us make ${4/content/venue_short_name/value} a success.
 

--- a/openreview/workflows/simple_dual_anonymous_workflow/simple_dual_anonymous_workflow.py
+++ b/openreview/workflows/simple_dual_anonymous_workflow/simple_dual_anonymous_workflow.py
@@ -3800,7 +3800,7 @@ You are also welcome to submit papers, so please also consider submitting to ${4
 
 We will be using OpenReview.net with the intention of have an engaging reviewing process inclusive of the whole community.
 
-To respond the invitation, please click on the following link:
+To respond to the invitation, please click on the following link:
 
 {{invitation_url}}
 

--- a/tests/test_simple_dual_anonymous_venue.py
+++ b/tests/test_simple_dual_anonymous_venue.py
@@ -34,7 +34,8 @@ class TestSimpleDualAnonymous():
         assert openreview_client.get_invitation('openreview.net/Support/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Reviewers_Invited_Members_Template')
         assert openreview_client.get_invitation('openreview.net/Support/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Reviewers_Invited_Response_Template')
         assert openreview_client.get_invitation('openreview.net/Support/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Reviewers_Invited_Declined_Group_Template')
-        assert openreview_client.get_invitation('openreview.net/Support/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Reviewers_Invited_Message_Template')
+        assert openreview_client.get_invitation('openreview.net/Support/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Group_Message_Template')
+        assert openreview_client.get_invitation('openreview.net/Support/Simple_Dual_Anonymous/Venue_Configuration_Request/-/Venue_Message_Template')
 
         now = datetime.datetime.now()
         due_date = now + datetime.timedelta(days=2)
@@ -158,6 +159,9 @@ class TestSimpleDualAnonymous():
         assert openreview_client.get_invitation('ABCD.cc/2025/Conference/Reviewers_Invited/-/Members')
         assert openreview_client.get_invitation('ABCD.cc/2025/Conference/Reviewers_Invited/-/Response')
         assert openreview_client.get_invitation('ABCD.cc/2025/Conference/Reviewers_Invited/-/Message')
+        assert openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Message')
+        assert openreview_client.get_invitation('ABCD.cc/2025/Conference/Authors/-/Message')
+        assert openreview_client.get_invitation('ABCD.cc/2025/Conference/Reviewers/-/Message')
 
         # check domain object
         domain_content = openreview_client.get_group('ABCD.cc/2025/Conference').content
@@ -514,6 +518,17 @@ class TestSimpleDualAnonymous():
 
         desk_rejection_invitations = openreview_client.get_all_invitations(invitation='ABCD.cc/2025/Conference/-/Desk_Rejection')
         assert len(desk_rejection_invitations) == 10
+
+
+        ## test message all authors
+        pc_client.post_message(
+            invitation='ABCD.cc/2025/Conference/-/Message',
+            recipients=['ABCD.cc/2025/Conference/Authors'], 
+            subject='Test message to all authors', 
+            message='Test message to all authors')
+        
+        messages = openreview_client.get_messages(subject='Test message to all authors')
+        assert len(messages) == 12
 
     def test_reviewer_bidding(self, openreview_client, helpers, request_page, selenium):
 


### PR DESCRIPTION
There are two types of reminders:

1. An automatic reminder that is sent about a delay. This will remind all the invitees that haven't responded for that batch.
2. Reminder requested by the PCs using the UI: This will remind all the invitees of the group that haven't responsed.

The delay can be customized when the invitation is created. 

I changed the way we check the memberships, we should stop using get_groups(member=) and I get all the profiles and check the memberships in memory.