### PR TITLE
Fix/ Venue: Rebuttal Stage

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -749,11 +749,13 @@ def get_rebuttal_stage(request_forum):
         readers = [openreview.stages.ReviewRebuttalStage.Readers.EVERYONE]
 
     email_pcs = 'Yes' in request_forum.content.get('email_program_chairs_about_rebuttals', '')
+    email_acs = 'Yes' in request_forum.content.get('email_area_chairs_about_rebuttals', '')
 
     return openreview.stages.ReviewRebuttalStage(
         start_date = rebuttal_start_date,
         due_date = rebuttal_due_date,
         email_pcs = email_pcs,
+        email_acs = email_acs,
         additional_fields = rebuttal_form_additional_options,
         single_rebuttal = single_rebuttal,
         unlimited_rebuttals = unlimited_rebuttal,

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -837,11 +837,12 @@ class ReviewRebuttalStage(object):
         REVIEWERS_ASSIGNED = 6
         REVIEWERS_SUBMITTED = 7
 
-    def __init__(self, start_date = None, due_date = None, name = 'Rebuttal', email_pcs = False, additional_fields = {}, single_rebuttal = False, unlimited_rebuttals = False, readers = []):
+    def __init__(self, start_date = None, due_date = None, name = 'Rebuttal', email_pcs = False, email_acs = False, additional_fields = {}, single_rebuttal = False, unlimited_rebuttals = False, readers = []):
         self.start_date = start_date
         self.due_date = due_date
         self.name = name
         self.email_pcs = email_pcs
+        self.email_acs = email_acs
         self.additional_fields = additional_fields
         self.remove_fields = []
         self.single_rebuttal = single_rebuttal

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -285,7 +285,6 @@ class GroupBuilder(object):
 
         if self.venue.review_rebuttal_stage:
             content['rebuttal_name'] = { 'value': self.venue.review_rebuttal_stage.name }
-            content['rebuttal_email_pcs'] = { 'value': self.venue.review_rebuttal_stage.email_pcs}
 
         if self.venue.use_ethics_chairs:
             content['ethics_chairs_id'] = { 'value': self.venue.get_ethics_chairs_id() }

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -869,7 +869,7 @@ class InvitationBuilder(object):
                 }
             }
 
-        self.save_invitation(invitation, replacement=False)
+        self.save_invitation(invitation, replacement=True)
         return invitation
 
     def set_meta_review_invitation(self):

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -762,6 +762,12 @@ class InvitationBuilder(object):
                 },
                 'reply_to': {
                     'value': 'reviews' if not review_rebuttal_stage.single_rebuttal and not review_rebuttal_stage.unlimited_rebuttals else 'forum'
+                },
+                'rebuttal_email_pcs': {
+                    'value': review_rebuttal_stage.email_pcs
+                },
+                'rebuttal_email_acs': {
+                    'value': review_rebuttal_stage.email_acs
                 }
             },
             edit={

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -24,7 +24,7 @@ def process(client, invitation):
         print('invitation is not yet active and no child invitations created', cdate)
         return
 
-    def delete_invitation(child_invitation):
+    def delete_invitation(child_invitation, ddate):
         client.post_invitation_edit(
             invitations=meta_invitation_id,
             readers=[venue_id],
@@ -32,16 +32,9 @@ def process(client, invitation):
             signatures=[venue_id],
             invitation=openreview.api.Invitation(
                 id=child_invitation.id,
-                ddate=now
+                ddate=ddate
             )
         )
-
-    def delete_existing_invitations():
-
-        invitations = client.get_all_invitations(invitation=invitation.id)        
-        print(f'deleting {len(invitations)} child invitations')
-        openreview.tools.concurrent_requests(delete_invitation, invitations, desc=f'delete_invitations_process')            
-    
     
     def get_children_notes():
         source = invitation.content.get('source', {}).get('value', 'all_submissions') if invitation.content else False
@@ -56,7 +49,6 @@ def process(client, invitation):
             if not source_submissions and decision_name:
                 under_review_submissions = client.get_all_notes(content={ 'venueid': submission_venue_id }, sort='number:asc', details='replies')
                 source_submissions = [s for s in under_review_submissions if len([r for r in s.details['replies'] if f'{venue_id}/{submission_name}{s.number}/-/{decision_name}' in r['invitations'] and openreview.tools.is_accept_decision(r['content'][decision_field_name]['value'], accept_options) ]) > 0]
-            delete_existing_invitations()
         else:
             source_submissions = client.get_all_notes(content={ 'venueid': submission_venue_id }, sort='number:asc', details='replies')
             if not source_submissions:
@@ -213,4 +205,4 @@ def process(client, invitation):
 
     for current_invitation in current_child_invitations:
         if current_invitation.id not in posted_invitations_by_id:
-            delete_invitation(current_invitation)
+            delete_invitation(current_invitation, now)

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -24,21 +24,19 @@ def process(client, invitation):
         print('invitation is not yet active and no child invitations created', cdate)
         return
 
-    def delete_existing_invitations():
-
-        ddate = openreview.tools.datetime_millis(datetime.datetime.now())
-
-        def delete_invitation(child_invitation):
-            client.post_invitation_edit(
-                invitations=meta_invitation_id,
-                readers=[venue_id],
-                writers=[venue_id],
-                signatures=[venue_id],
-                invitation=openreview.api.Invitation(
-                    id=child_invitation.id,
-                    ddate=ddate
-                )
+    def delete_invitation(child_invitation):
+        client.post_invitation_edit(
+            invitations=meta_invitation_id,
+            readers=[venue_id],
+            writers=[venue_id],
+            signatures=[venue_id],
+            invitation=openreview.api.Invitation(
+                id=child_invitation.id,
+                ddate=now
             )
+        )
+
+    def delete_existing_invitations():
 
         invitations = client.get_all_invitations(invitation=invitation.id)        
         print(f'deleting {len(invitations)} child invitations')
@@ -203,6 +201,16 @@ def process(client, invitation):
         if paper_invitation.edit and paper_invitation.edit.get('note'):
             update_note_readers(note, paper_invitation)
 
+        return paper_invitation
+
     notes = get_children_notes()
+
+    current_child_invitations = client.get_all_invitations(invitation=invitation.id)
+
     print(f'create or update {len(notes)} child invitations')
-    openreview.tools.concurrent_requests(post_invitation, notes, desc=f'edit_invitation_process')
+    posted_invitations = openreview.tools.concurrent_requests(post_invitation, notes, desc=f'edit_invitation_process')
+    posted_invitations_by_id = { i.id: i for i in posted_invitations}
+
+    for current_invitation in current_child_invitations:
+        if current_invitation.id not in posted_invitations_by_id:
+            delete_invitation(current_invitation)

--- a/openreview/venue/process/review_rebuttal_process.py
+++ b/openreview/venue/process/review_rebuttal_process.py
@@ -7,7 +7,9 @@ def process(client, edit, invitation):
     contact = domain.get_content_value('contact')
     submission_name = domain.get_content_value('submission_name')
     program_chairs_id = domain.get_content_value('program_chairs_id')
-    email_pcs = domain.get_content_value('rebuttal_email_pcs')
+    super_invitation = client.get_invitation(invitation.invitations[0])
+    email_pcs = super_invitation.get_content_value('rebuttal_email_pcs', False)
+    email_acs = super_invitation.get_content_value('rebuttal_email_acs', False)
     sender = domain.get_content_value('message_sender')
     
     submission = client.get_note(edit.note.forum)
@@ -73,7 +75,7 @@ Title: {submission.content['title']['value']}
     # email ACs
     area_chairs_name = domain.get_content_value('area_chairs_name')
     paper_area_chairs_id = f'{paper_group_id}/{area_chairs_name}'
-    if area_chairs_name and (paper_area_chairs_id in rebuttal.readers or 'everyone' in rebuttal.readers):
+    if email_acs and area_chairs_name and (paper_area_chairs_id in rebuttal.readers or 'everyone' in rebuttal.readers):
         client.post_message(
             invitation=meta_invitation_id,
             signature=venue_id,

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -321,6 +321,14 @@ class VenueStages():
                 'required': True,
                 'default': 'No, do not email program chairs about received rebuttals',
                 'order': 6
+            },
+            'email_area_chairs_about_rebuttals': {
+                'description': 'Should Area Chairs (if applicable) be emailed when each rebuttal is received? Leave this field empty if your venue does not use Area Chairs.',
+                'value-radio': [
+                    'Yes, email area chairs for each rebuttal received',
+                    'No, do not email area chairs about received rebuttals'],
+                'required': False,
+                'order': 6
             }
         }
 

--- a/openreview/venue_request/venue_request.py
+++ b/openreview/venue_request/venue_request.py
@@ -283,7 +283,7 @@ class VenueStages():
                 'order': 2
             },
             'number_of_rebuttals': {
-                'description': "Select how many rebuttals the authors will be able to post.",
+                'description': "Select how many rebuttals the authors will be able to post. Note that changing this option after the rebuttal stage has started will overwrite the current rebuttal settings.",
                 'value-radio': [
                     'One author rebuttal per paper',
                     'One author rebuttal per posted review',

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -2116,7 +2116,8 @@ Please note that responding to this email will direct your reply to pc@neurips.c
                         }
                     }
                 },
-                'email_program_chairs_about_rebuttals': 'No, do not email program chairs about received rebuttals'
+                'email_program_chairs_about_rebuttals': 'No, do not email program chairs about received rebuttals',
+                'email_area_chairs_about_rebuttals': 'No, do not email area chairs about received rebuttals'
             },
             forum=request_form.forum,
             invitation=f'openreview.net/Support/-/Request{request_form.number}/Rebuttal_Stage',
@@ -2140,6 +2141,10 @@ Please note that responding to this email will direct your reply to pc@neurips.c
         assert invitation.maxReplies == 1
         assert invitation.edit['note']['replyto'] == review.id
 
+        super_invitation = openreview_client.get_invitation('NeurIPS.cc/2023/Conference/-/Rebuttal')
+        assert not super_invitation.content['rebuttal_email_pcs']['value']
+        assert not super_invitation.content['rebuttal_email_acs']['value']
+
         test_client = openreview.api.OpenReviewClient(username='test@mail.com', password=helpers.strong_password)
 
         rebuttal_edit = test_client.post_note_edit(
@@ -2162,6 +2167,9 @@ Please note that responding to this email will direct your reply to pc@neurips.c
             'NeurIPS.cc/2023/Conference/Submission1/Area_Chairs',
             'NeurIPS.cc/2023/Conference/Submission1/Authors'
         ]
+
+        messages = openreview_client.get_messages(to='ac2@gmail.com', subject='[NeurIPS 2023] An author rebuttal was posted on Submission Number: 1, Submission Title: "Paper title 1"')
+        assert not messages
 
         with pytest.raises(openreview.OpenReviewException, match=r'.*You have reached the maximum number \(1\) of replies for this Invitation.*'):
             rebuttal_edit = test_client.post_note_edit(


### PR DESCRIPTION
1. Add an option to the request form and the rebuttal stage for PCs to choose whether ACs should get emails for rebuttals.
2. Save email_pcs and email_acs in the super invitation instead of the domain content, in case there are multiple rebuttals invitations
3. Fix the issue when multiple rebuttal stages are run from the request form. 
   - one fix is what Melisa suggested: deleting any invitations that were not re-posted
   - the other fix is passing `replacement=True` in case the id of the invitation is not changing