### PR TITLE
Fix/ TMLR Fixes

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -65,7 +65,12 @@ class InvitationBuilder(object):
         self.eic_reminder_process = {
             'dates': ["#{4/duedate} + " + str(week), "#{4/duedate} + " + str(one_month)],
             'script': self.get_super_dateprocess_content('eic_reminder_script', self.journal.get_meta_invitation_id(), { 0: 'one week', 1: 'one month' })
-        }        
+        }
+
+        self.responsibility_ACK_reminder_process = {
+            'dates': ["#{4/duedate} + " + str(day), "#{4/duedate} + " + str(week),  "#{4/duedate} + " + str(one_month)],
+            'script': self.get_super_dateprocess_content('responsibility_ACK_reminder_script', self.journal.get_meta_invitation_id(), { 0: '1', 1: 'one week', 3: 'one month' })
+        }
 
     def set_invitations(self, assignment_delay):
         self.set_ae_recruitment_invitation()
@@ -277,6 +282,9 @@ class InvitationBuilder(object):
                     },
                     'eic_reminder_script': {
                         'value': self.get_process_content('process/eic_reminder_process.py')
+                    },
+                    'responsibility_ACK_reminder_script': {
+                        'value': self.get_process_content('process/reviewer_responsibility_ack_process.py')
                     }
                 },
                 edit=True
@@ -568,7 +576,7 @@ If you have questions after reviewing the points below that are not answered on 
                     'signatures': [editors_in_chief_id],
                     'maxReplies': 1,
                     'duedate': '${2/content/duedate/value}',
-                    'dateprocesses': [self.reviewer_reminder_process],
+                    'dateprocesses': [self.responsibility_ACK_reminder_process],
                     'edit': {
                         'signatures': { 
                             'param': { 

--- a/openreview/journal/process/reviewer_responsibility_ack_process.py
+++ b/openreview/journal/process/reviewer_responsibility_ack_process.py
@@ -32,7 +32,7 @@ def process(client, invitation):
         subject=f'''[{journal.short_name}] You are late in performing a task: {task}''',
         message=f'''Hi {{{{fullname}}}},
 
-Our records show that you are late on the current reviewing task:
+Our records show that you are late on the current task:
 
 Task: {task}
 Number of days late: {days_late}

--- a/openreview/journal/process/reviewer_responsibility_ack_process.py
+++ b/openreview/journal/process/reviewer_responsibility_ack_process.py
@@ -1,0 +1,50 @@
+def process(client, invitation):
+
+    journal = openreview.journal.Journal()
+
+    forum = client.get_note(invitation.edit['note']['forum'])
+    duedate = datetime.datetime.fromtimestamp(invitation.duedate/1000)
+    now = datetime.datetime.now()
+    task = invitation.pretty_id()
+
+    late_invitees = journal.get_late_invitees(invitation.id)
+
+    if len(late_invitees) == 0:
+      return
+
+    if days_late_map:
+        days_late = days_late_map.get(str(date_index), abs((now - duedate).days))
+    else:
+        days_late = abs((now - duedate).days)
+
+    invitee = late_invitees[0]
+    official_reviewer = client.get_groups(member=invitee, id=journal.get_reviewers_id())
+
+    if not official_reviewer:
+        print('Reviewer is no longer an official reviewer')
+        return
+    
+    ## send email to reviewers
+    print('send email to reviewers', late_invitees)
+    client.post_message(
+        invitation=journal.get_meta_invitation_id(),
+        recipients=late_invitees,
+        subject=f'''[{journal.short_name}] You are late in performing a task: {task}''',
+        message=f'''Hi {{{{fullname}}}},
+
+Our records show that you are late on the current reviewing task:
+
+Task: {task}
+Number of days late: {days_late}
+Link: https://openreview.net/forum?id={forum.id}
+
+Please follow the provided link and complete your task ASAP.
+
+We thank you for your cooperation.
+
+The {journal.short_name} Editors-in-Chief
+''',
+        replyTo=journal.contact_info,
+        signature=journal.venue_id,
+        sender=journal.get_message_sender()
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openreview-py"
-version = "1.48.0"
+version = "1.48.1"
 description = "OpenReview API Python client library"
 authors = [{name = "OpenReview Team", email = "info@openreview.net"}]
 license = {text = "MIT"}

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1175,6 +1175,44 @@ note: replies to this email will go to the AE, Joelle Pineau.
 
 Please note that responding to this email will direct your reply to joelle@mailseven.com.
 '''
+        
+        ack_invitation = openreview_client.get_invitation(id=f'{venue_id}/Reviewers/-/~David_Belanger1/Responsibility/Acknowledgement')
+        forum_id = ack_invitation.edit['note']['forum']
+
+ ## Check responsibility ackowledgement reminder
+        raia_client.post_invitation_edit(
+            invitations='TMLR/-/Edit',
+            readers=[venue_id],
+            writers=[venue_id],
+            signatures=[venue_id],
+            invitation=openreview.api.Invitation(id=ack_invitation.id,
+                cdate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 10)),
+                duedate=openreview.tools.datetime_millis(datetime.datetime.now() - datetime.timedelta(days = 1)) + 2000,
+                signatures=['TMLR/Editors_In_Chief']
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, 'TMLR/Reviewers/-/~David_Belanger1/Responsibility/Acknowledgement-0-0')
+
+        messages = journal.client.get_messages(subject = '[TMLR] You are late in performing a task: Responsibility Acknowledgement')
+        assert len(messages) == 1
+        assert messages[0]['content']['text'] == f'''Hi David Belanger,
+
+Our records show that you are late on the current task:
+
+Task: Responsibility Acknowledgement
+Number of days late: 1
+Link: https://openreview.net/forum?id={forum_id}
+
+Please follow the provided link and complete your task ASAP.
+
+We thank you for your cooperation.
+
+The TMLR Editors-in-Chief
+
+
+Please note that responding to this email will direct your reply to tmlr@jmlr.org.
+'''
 
         ## Check reviewer assignment reminders
         raia_client.post_invitation_edit(


### PR DESCRIPTION
1. Looks like Responsibility Acknowledgement reminders are being sent to archived reviewers. I have separated the reminder for this task from `reviewer_reminder_process.py` since there is no submission in this case and added a check to see if the reviewer is archived. 

This is what the email used to look like:
<img width="1188" alt="Screenshot 2025-04-11 at 3 06 40 PM" src="https://github.com/user-attachments/assets/5bfa6fba-ce56-4f2b-9f8f-d4d087b89a60" />

This is the new template (I removed the submission text)
<img width="840" alt="Screenshot 2025-04-11 at 2 10 28 PM" src="https://github.com/user-attachments/assets/c4e92471-1f02-4216-97fc-5d63d3c96703" />

