### PR TITLE
Fix/ Journal Decision Dates Constraints

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -5027,6 +5027,13 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     }
                 }
             },
+            'cdate': {
+                'value': {
+                    'param': {
+                        'type': 'integer'
+                    }
+                }
+            },
             'duedate': { 
                 'value': {
                     'param': {
@@ -5038,6 +5045,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
 
         invitation = {
             'id': self.journal.get_ae_decision_id(number='${2/content/noteNumber/value}'),  
+            'cdate': '${2/content/cdate/value}',
             'duedate': '${2/content/duedate/value}',
             'invitees': [venue_id, self.journal.get_action_editors_id(number='${3/content/noteNumber/value}')],
             'readers': ['everyone'],
@@ -5169,11 +5177,12 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
 
         self.save_super_invitation(self.journal.get_ae_decision_id(), invitation_content, edit_content, invitation)
 
-    def set_note_decision_invitation(self, note, duedate):
+    def set_note_decision_invitation(self, note, cdate, duedate):
         return self.client.post_invitation_edit(invitations=self.journal.get_ae_decision_id(),
             content={ 
                 'noteId': { 'value': note.id }, 
                 'noteNumber': { 'value': note.number },
+                'cdate': { 'value': openreview.tools.datetime_millis(cdate)},
                 'duedate': { 'value': openreview.tools.datetime_millis(duedate)}
             },
             readers=[self.journal.venue_id],

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -951,7 +951,7 @@ Your {lower_formatted_invitation} on a submission has been {action}
                     self.invitation_builder.set_note_release_comment_invitation(submission)
 
                 elif invitation.id == self.get_ae_decision_id(number=note_number):
-                    self.invitation_builder.set_note_decision_invitation(submission, duedate=datetime.datetime.fromtimestamp(int(invitation.duedate/1000)))
+                    self.invitation_builder.set_note_decision_invitation(submission, cdate=datetime.datetime.fromtimestamp(int(invitation.cdate/1000)), duedate=datetime.datetime.fromtimestamp(int(invitation.duedate/1000)))
 
                 elif invitation.id == self.get_release_decision_id(number=note_number):
                     self.invitation_builder.set_note_decision_release_invitation(submission)

--- a/openreview/journal/process/review_rating_process.py
+++ b/openreview/journal/process/review_rating_process.py
@@ -11,4 +11,4 @@ def process(client, edit, invitation):
     reviews = [r for r in submission.details['replies'] if r['invitations'][0] == journal.get_review_id(number=submission.number)]
     ratings = [r for r in submission.details['replies'] if r['invitations'][0].endswith('Rating')]
     if len(reviews) == len(ratings):
-        journal.invitation_builder.set_note_decision_invitation(submission,  invitation.duedate)
+        journal.invitation_builder.set_note_decision_invitation(submission,  invitation.cdate, invitation.duedate)

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -2397,6 +2397,17 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         reviews=openreview_client.get_notes(forum=note_id_1, invitation=f'{venue_id}/Paper1/-/Review', sort= 'number:asc')
         for review in reviews:
             signature=review.signatures[0]
+
+            openreview_client.post_invitation_edit(
+                invitations='TMLR/-/Edit',
+                signatures=['TMLR'],
+                invitation=openreview.api.Invitation(
+                    id=f'{signature}/-/Rating',
+                    cdate=openreview.tools.datetime_millis(datetime.datetime.now()-datetime.timedelta(days=1)),
+                    duedate=openreview.tools.datetime_millis(datetime.datetime.now()-datetime.timedelta(minutes=30)) #set duedate in the past
+                )
+            )
+
             rating_note=joelle_client.post_note_edit(invitation=f'{signature}/-/Rating',
                 signatures=[joelle_paper1_anon_group.id],
                 note=Note(
@@ -2421,9 +2432,13 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             )
         )
 
+        last_rating_invitation = openreview_client.get_invitation(rating_note['invitation'])
 
         invitation = raia_client.get_invitation(f'{venue_id}/Paper1/-/Decision')
         assert invitation.edit['note']['content']['certifications']['value']['param']['enum'] == ['Featured Certification', 'Reproducibility Certification', 'Survey Certification']
+        assert invitation.cdate == last_rating_invitation.cdate
+        assert invitation.duedate == last_rating_invitation.duedate
+        assert not invitation.expdate
 
         decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Decision',
             signatures=[joelle_paper1_anon_group.id],

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -1587,6 +1587,7 @@ Please refer to the documentation for instructions on how to run the matcher: ht
         ))
 
         helpers.await_queue()
+        helpers.await_queue_edit(openreview_client, 'V2.cc/2030/Conference/Reviewers/-/Submission_Group-0-1', count=4)
 
         # Post a review stage note
         now = datetime.datetime.now()


### PR DESCRIPTION
This fixes the issue with the decision invitation for the journal. 

The issue is as follows:
- The last review rating is submitted when the Rating invitation's duedate already passed
- We create the decision invitation with the same duedate as the Rating invitation. In this case, this means that cdate > duedate since the duedate is already in the past

To fix this, I am creating the Decision invitation with both the cdate and duedate of the Rating invitation, this way we ensure cdate < duedate. I do not want to change the duedate of this invitation because the AEs have a limited amount of time to submit their decisions as outlined in the email that is sent to them. These invitations have no expdate anyway so they can still submit the decision even if the duedate has passed. 