### PR TITLE
Feat/ TMLR: changes to decision form

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -4060,7 +4060,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         if self.journal.get_certifications():
             invitation['edit']['note']['content']['certification_recommendations'] = {
                 'order': 4,
-                'description': f'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE, however you are asked to submit your recommendation. See certification details here: {self.journal.get_website_url("editorial_policies")}',
+                'description': f'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE, however you are asked to submit your recommendation. See certification details here: {self.journal.get_website_url("certifications_criteria")}',
                 'value': {
                     'param': {
                         'type': 'string[]',
@@ -5160,7 +5160,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
         if self.journal.get_certifications():
             invitation['edit']['note']['content']['certifications'] = {
                 'order': 8,
-                'description': f'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE and will be reviewed by the Editors-in-Chief. See certification details here: {self.journal.get_website_url("editorial_policies")}.',
+                'description': f'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE and will be reviewed by the Editors-in-Chief. See certification details here: {self.journal.get_website_url("certifications_criteria")}.',
                 'value': {
                     'param': {
                         'type': 'string[]',

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -5085,21 +5085,9 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     'content': {
                         'claims_and_evidence': {
                             'order': 2,
-                            'value': {
-                                'param': {
-                                    'fieldName': f'Are the claims made in the submission supported by accurate, convincing and clear evidence?',
-                                    'type': 'string',
-                                    'enum': ['Yes', 'No'],
-                                    'input': 'radio'
-                                }
-                            }
-                        },
-                        'claims_explanation': {
-                            'order': 3,
                             'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? If not why? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
-                                    'fieldName': 'Explain answer above',
                                     'type': 'string',
                                     'maxLength': 200000,
                                     'input': 'textarea',
@@ -5108,22 +5096,10 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                             }
                         },
                         'audience': {
-                            'order': 4,
-                            'value': {
-                                'param': {
-                                    'fieldName': 'Would at least some individuals in TMLR\'s audience be interested in knowing the findings of this paper?',
-                                    'type': 'string',
-                                    'enum': ['Yes', 'No'],
-                                    'input': 'radio'
-                                }
-                            }
-                        },
-                        'audience_explanation': {
-                            'order': 5,
+                            'order': 3,
                             'description': f'Would at least some individuals in {self.journal.short_name}\'s audience be interested in knowing the findings of this paper? If not, why? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
-                                    'fieldName': 'Explain answer above',
                                     'type': 'string',
                                     'maxLength': 200000,
                                     'input': 'textarea',
@@ -5145,8 +5121,21 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                                 }
                             }
                         },
-                        'resubmission_of_major_revision': {
+                        'comment': {
                             'order': 7,
+                            'description': 'Provide details of the reasoning behind your decision, including for any certification recommendation (if applicable). Also consider summarizing the discussion and recommendations of the reviewers, since these are not visible to the authors. (max 200000 characters). Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.',
+                            'value': {
+                                'param': {
+                                    'type': 'string',
+                                    'maxLength': 200000,
+                                    'input': 'textarea',
+                                    'markdown': True,
+                                    'optional': True
+                                }
+                            }
+                        },
+                        'resubmission_of_major_revision': {
+                            'order': 8,
                             'description': 'Optional and only if decision is Reject.',
                             'value': {
                                 'param': {
@@ -5157,19 +5146,6 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                                     'input': 'checkbox',
                                     'optional': True,
                                     'deletable': True
-                                }
-                            }
-                        },
-                        'additional_comments': {
-                            'order': 10,
-                            'description': 'If you request revisions, provide details on the expected changes. If you recommend a certification, explain the reasons for why the submission deserves this recognition (max 200000 characters). Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.',
-                            'value': {
-                                'param': {
-                                    'type': 'string',
-                                    'maxLength': 200000,
-                                    'input': 'textarea',
-                                    'markdown': True,
-                                    'optional': True
                                 }
                             }
                         }

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -5085,9 +5085,21 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     'content': {
                         'claims_and_evidence': {
                             'order': 2,
+                            'value': {
+                                'param': {
+                                    'fieldName': f'Are the claims made in the submission supported by accurate, convincing and clear evidence?',
+                                    'type': 'string',
+                                    'enum': ['Yes', 'No'],
+                                    'input': 'radio'
+                                }
+                            }
+                        },
+                        'claims_explanation': {
+                            'order': 3,
                             'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? If not why? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
+                                    'fieldName': 'Explain answer above',
                                     'type': 'string',
                                     'maxLength': 200000,
                                     'input': 'textarea',
@@ -5096,10 +5108,22 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                             }
                         },
                         'audience': {
-                            'order': 3,
+                            'order': 4,
+                            'value': {
+                                'param': {
+                                    'fieldName': 'Would at least some individuals in TMLR\'s audience be interested in knowing the findings of this paper?',
+                                    'type': 'string',
+                                    'enum': ['Yes', 'No'],
+                                    'input': 'radio'
+                                }
+                            }
+                        },
+                        'audience_explanation': {
+                            'order': 5,
                             'description': f'Would at least some individuals in {self.journal.short_name}\'s audience be interested in knowing the findings of this paper? If not, why? (see {self.journal.short_name}\'s evaluation criteria at {self.journal.get_website_url("evaluation_criteria")})',
                             'value': {
                                 'param': {
+                                    'fieldName': 'Explain answer above',
                                     'type': 'string',
                                     'maxLength': 200000,
                                     'input': 'textarea',
@@ -5108,7 +5132,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                             }
                         },
                         'recommendation': {
-                            'order': 4,
+                            'order': 6,
                             'value': {
                                 'param': {
                                     'type': 'string',
@@ -5121,20 +5145,8 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                                 }
                             }
                         },
-                        'comment': {
-                            'order': 5,
-                            'description': 'Provide details of the reasoning behind your decision, including for any certification recommendation (if applicable). Also consider summarizing the discussion and recommendations of the reviewers, since these are not visible to the authors. (max 200000 characters). Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.',
-                            'value': {
-                                'param': {
-                                    'type': 'string',
-                                    'maxLength': 200000,
-                                    'input': 'textarea',
-                                    'markdown': True
-                                }
-                            }
-                        },
                         'resubmission_of_major_revision': {
-                            'order': 6,
+                            'order': 7,
                             'description': 'Optional and only if decision is Reject.',
                             'value': {
                                 'param': {
@@ -5145,6 +5157,19 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                                     'input': 'checkbox',
                                     'optional': True,
                                     'deletable': True
+                                }
+                            }
+                        },
+                        'additional_comments': {
+                            'order': 10,
+                            'description': 'If you request revisions, provide details on the expected changes. If you recommend a certification, explain the reasons for why the submission deserves this recognition (max 200000 characters). Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.',
+                            'value': {
+                                'param': {
+                                    'type': 'string',
+                                    'maxLength': 200000,
+                                    'input': 'textarea',
+                                    'markdown': True,
+                                    'optional': True
                                 }
                             }
                         }
@@ -5158,7 +5183,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
 
         if self.journal.get_certifications():
             invitation['edit']['note']['content']['certifications'] = {
-                'order': 6,
+                'order': 8,
                 'description': f'Certifications are meant to highlight particularly notable accepted submissions. Notably, it is through certifications that we make room for more speculative/editorial judgement on the significance and potential for impact of accepted submissions. Certification selection is the responsibility of the AE and will be reviewed by the Editors-in-Chief. See certification details here: {self.journal.get_website_url("editorial_policies")}.',
                 'value': {
                     'param': {

--- a/openreview/journal/process/submission_decision_pre_process.py
+++ b/openreview/journal/process/submission_decision_pre_process.py
@@ -3,3 +3,10 @@ def process(client, edit, invitation):
     if edit.note.content.get('recommendation', {}).get('value') == 'Reject' and edit.note.content.get('certifications', {}).get('value', []):
         raise openreview.OpenReviewException(f'Decision Reject can not have certifications')
 
+    if edit.note.content.get('claims_and_evidence', {}).get('value') == 'Yes' and edit.note.content.get('audience', {}).get('value') == 'Yes':
+        if edit.note.content.get('recommendation', {}).get('value') == 'Reject':
+            raise openreview.OpenReviewException('Decision should be "Accept as is" or "Accept with minor revision" if you answered "Yes" to both TMLR criteria')
+
+    if edit.note.content.get('claims_and_evidence', {}).get('value') == 'No' or edit.note.content.get('audience', {}).get('value') == 'No':
+        if edit.note.content.get('recommendation', {}).get('value') == 'Accept as is':
+            raise openreview.OpenReviewException('Decision should not be "Accept as is" if you answered "No" to either of the two TMLR criteria')

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -169,7 +169,7 @@ class TestJournal():
                                 },
                                 'claims_explanation': {
                                     'order': 3,
-                                    'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? If not why? (see TMLRS\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                                    'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? If not why? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
                                     'value': {
                                         'param': {
                                             'fieldName': 'Explain answer above',
@@ -204,9 +204,7 @@ class TestJournal():
                                         }
                                     }
                                 },
-                                'comment': {
-                                    'delete': True
-                                },
+                                'comment': False,
                                 'additional_comments': {
                                     'order': 10,
                                     'description': 'If you request revisions, provide details on the expected changes. If you recommend a certification, explain the reasons for why the submission deserves this recognition (max 200000 characters). Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.',

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -106,7 +106,8 @@ class TestJournal():
                                 'reviewer_guide': 'https://jmlr.org/tmlr/reviewer-guide.html',
                                 'editorial_policies': 'https://jmlr.org/tmlr/editorial-policies.html',
                                 'faq': 'https://jmlr.org/tmlr/contact.html',
-                                'videos': 'https://tmlr.infinite-conf.org'                
+                                'videos': 'https://tmlr.infinite-conf.org',
+                                'certifications_criteria': 'https://jmlr.org/tmlr/editorial-policies.html#certifications'
                             },
                             'editors_email': 'tmlr-editors@jmlr.org',
                             'skip_ac_recommendation': False,
@@ -127,12 +128,14 @@ class TestJournal():
                             'external_reviewers': True,
                             'expertise_model': 'specter+mfr',
                             'official_recommendation_additional_fields': {
-                                'pilot_recommendation_to_iclr_track': {
+                                'pilot_recommendation_to_iclr_track': False,
+                                'pilot_explain_recommendation_to_iclr_track': False,
+                                'recommendation_to_iclr_track': {
                                     'order': 98,
                                     'description': 'Would you recommend this work be invited for presentation at the ICLR Journal-to-Conference Track? Recall that TMLR\'s acceptance criteria are that a work must be sound and of interest to the TMLR audience. Above these requirements, a paper in the ICLR Journal-to-Conference Track should also stand out in novelty or predicted significance for the field (i.e., comparable to the level of a paper in ICLR\'s regular conference track). **Your anonymized response will be shared with ICLR**',
                                     'value': {
                                         'param': {
-                                            'fieldName': '[Pilot] Recommendation to ICLR Journal-to-Conference Track',
+                                            'fieldName': 'Recommendation to ICLR Journal-to-Conference Track',
                                             'type': 'string',
                                             'enum': ['Strongly Recommend', 'Weakly Recommend', 'Weakly Oppose', 'Strongly Oppose'],
                                             'input': 'radio',
@@ -140,12 +143,12 @@ class TestJournal():
                                     },
                                     'readers': ['TMLR', 'TMLR/Paper${7/content/noteNumber/value}/Action_Editors', '${5/signatures}']
                                 },
-                                'pilot_explain_recommendation_to_iclr_track': {
+                                'explain_recommendation_to_iclr_track': {
                                     'order': 98,
                                     'description': '**Your anonymized response will be shared with ICLR**',
                                     'value': {
                                         'param': {
-                                            'fieldName': '[Pilot] Explain your recommendation to the ICLR Journal-to-Conference Track',
+                                            'fieldName': 'Explain your recommendation to the ICLR Journal-to-Conference Track',
                                             'type': 'string',
                                             'maxLength': 50000,
                                             'markdown': True,
@@ -158,6 +161,7 @@ class TestJournal():
                             'decision_additional_fields': {
                                 'claims_and_evidence': {
                                     'order': 2,
+                                    'description': 'Learn more about TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation.',
                                     'value': {
                                         'param': {
                                             'fieldName': f'Are the claims made in the submission supported by accurate, convincing and clear evidence?',
@@ -169,10 +173,10 @@ class TestJournal():
                                 },
                                 'claims_explanation': {
                                     'order': 3,
-                                    'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? If not why? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                                    'description': 'Learn more about TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation.',
                                     'value': {
                                         'param': {
-                                            'fieldName': 'Explain answer above',
+                                            'fieldName': 'Explain your/the answer above',
                                             'type': 'string',
                                             'maxLength': 200000,
                                             'input': 'textarea',
@@ -182,6 +186,7 @@ class TestJournal():
                                 },
                                 'audience': {
                                     'order': 4,
+                                    'description': 'Learn more about TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation.',
                                     'value': {
                                         'param': {
                                             'fieldName': 'Would at least some individuals in TMLR\'s audience be interested in knowing the findings of this paper?',
@@ -193,10 +198,10 @@ class TestJournal():
                                 },
                                 'audience_explanation': {
                                     'order': 5,
-                                    'description': f'Would at least some individuals in TMLR\'s audience be interested in knowing the findings of this paper? If not, why? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                                    'description': 'Learn more about TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation.',
                                     'value': {
                                         'param': {
-                                            'fieldName': 'Explain answer above',
+                                            'fieldName': 'Explain your/the answer above',
                                             'type': 'string',
                                             'maxLength': 200000,
                                             'input': 'textarea',
@@ -207,7 +212,7 @@ class TestJournal():
                                 'comment': False,
                                 'additional_comments': {
                                     'order': 10,
-                                    'description': 'If you request revisions, provide details on the expected changes. If you recommend a certification, explain the reasons for why the submission deserves this recognition (max 200000 characters). Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.',
+                                    'description': 'If you request revisions, provide details on the expected changes. If you recommend a certification, explain the reasons for why the submission deserves this recognition.',
                                     'value': {
                                         'param': {
                                             'type': 'string',
@@ -218,12 +223,14 @@ class TestJournal():
                                         }
                                     }
                                 },
-                                'pilot_recommendation_to_iclr_track': {
+                                'pilot_recommendation_to_iclr_track': False,
+                                'pilot_explain_recommendation_to_iclr_track': False,
+                                'recommendation_to_iclr_track': {
                                     'order': 98,
                                     'description': 'Would you recommend this work be invited for presentation at the ICLR Journal-to-Conference Track? Recall that TMLR\'s acceptance criteria are that a work must be sound and of interest to the TMLR audience. Above these requirements, a paper in the ICLR Journal-to-Conference Track should also stand out in novelty or predicted significance for the field (i.e., comparable to the level of a paper in ICLR\'s regular conference track. **Your response will be shared with ICLR**',
                                     'value': {
                                         'param': {
-                                            'fieldName': '[Pilot] Recommendation to ICLR Journal-to-Conference Track',
+                                            'fieldName': 'Recommendation to ICLR Journal-to-Conference Track',
                                             'type': 'string',
                                             'enum': ['Strongly Recommend', 'Weakly Recommend', 'Weakly Oppose', 'Strongly Oppose'],
                                             'input': 'radio',
@@ -231,12 +238,12 @@ class TestJournal():
                                     },
                                     'readers': ['TMLR', 'TMLR/Paper${7/content/noteNumber/value}/Action_Editors']
                                 },
-                                'pilot_explain_recommendation_to_iclr_track': {
+                                'explain_recommendation_to_iclr_track': {
                                     'order': 98,
                                     'description': '**Your response will be shared with ICLR**',
                                     'value': {
                                         'param': {
-                                            'fieldName': '[Pilot] Explain your recommendation to the ICLR Journal-to-Conference Track',
+                                            'fieldName': 'Explain your recommendation to the ICLR Journal-to-Conference Track',
                                             'type': 'string',
                                             'maxLength': 50000,
                                             'markdown': True,
@@ -2253,8 +2260,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                         'decision_recommendation': { 'value': 'Leaning Accept' },
                         'claims_and_evidence': { 'value': 'Yes' },
                         'audience': { 'value': 'Yes' },
-                        'pilot_recommendation_to_iclr_track': { 'value': 'Weakly Recommend' },
-                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because I like it.' }
+                        'recommendation_to_iclr_track': { 'value': 'Weakly Recommend' },
+                        'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because I like it.' }
                     }
                 )
             )
@@ -2284,8 +2291,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                     'certification_recommendations': { 'value': ['Featured Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2312,8 +2319,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                     'certification_recommendations': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2340,8 +2347,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                     'certification_recommendations': { 'value': ['Survey Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2356,8 +2363,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                     'certification_recommendations': { 'value': ['Survey Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2421,8 +2428,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                     'certification_recommendations': { 'value': ['Survey Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -2514,8 +2521,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                         'recommendation': { 'value': 'Accept as is' },
                         'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                         'additional_comments': { 'value': 'This is a nice paper!' },
-                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                        'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                     }
                 )
             )
@@ -2530,8 +2537,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                         'audience': { 'value': 'Yes' },
                         'audience_explanation': { 'value': 'Reject' },
                         'recommendation': { 'value': 'Reject' },
-                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                        'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                     }
                 )
             )
@@ -2548,8 +2555,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                         'recommendation': { 'value': 'Accept as is' },
                         'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                         'additional_comments': { 'value': 'Great paper!' },
-                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                        'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                     }
                 )
             )
@@ -2576,8 +2583,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                         'recommendation': { 'value': 'Accept as is' },
                         'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                         'additional_comments': { 'value': 'Great paper!' },
-                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                        'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                     }
                 )
             )
@@ -3495,8 +3502,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3511,8 +3518,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3557,8 +3564,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                         'recommendation': { 'value': 'Reject' },
                         'additional_comments': { 'value': 'This is not a good paper' },
                         'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
-                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                        'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                     }
                 )
             )
@@ -3574,8 +3581,8 @@ Please note that responding to this email will direct your reply to joelle@mails
                     'recommendation': { 'value': 'Reject' },
                     'additional_comments': { 'value': 'This is not a good paper' },
                     'resubmission_of_major_revision': { 'value': 'The authors may consider submitting a major revision at a later time.' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }                   
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }                   
                 }
             )
         )
@@ -3933,8 +3940,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3949,8 +3956,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3965,8 +3972,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -3997,8 +4004,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                     'audience_explanation': { 'value': 'Accept with minor revision' },
                     'recommendation': { 'value': 'Accept with minor revision' },
                     'additional_comments': { 'value': 'This is a good paper' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -4256,8 +4263,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -4272,8 +4279,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -4288,8 +4295,8 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                     'decision_recommendation': { 'value': 'Reject' },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -5334,8 +5341,8 @@ note={Under review}
                     'certification_recommendations': { 'value': ['Featured Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -5350,8 +5357,8 @@ note={Under review}
                     'certification_recommendations': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -5366,8 +5373,8 @@ note={Under review}
                     'certification_recommendations': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                     'claims_and_evidence': { 'value': 'Yes' },
                     'audience': { 'value': 'Yes' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )
@@ -5401,8 +5408,8 @@ note={Under review}
                     'audience_explanation': { 'value': 'No' },
                     'recommendation': { 'value': 'Accept with minor revision' },
                     'additional_comments': { 'value': 'This is a good paper' },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    'recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                    'explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
             )
         )

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -2440,20 +2440,57 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert invitation.duedate == last_rating_invitation.duedate
         assert not invitation.expdate
 
-        decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Decision',
-            signatures=[joelle_paper1_anon_group.id],
-            note=Note(
-                content={
-                    'claims_and_evidence': { 'value': 'Accept as is' },
-                    'audience': { 'value': 'Accept as is' },
-                    'recommendation': { 'value': 'Accept as is' },
-                    'comment': { 'value': 'This is a nice paper!' },
-                    'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
-                    'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
-                    'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
-                }
+        with pytest.raises(openreview.OpenReviewException, match=r'Decision should not be "Accept as is" if you answered "No" to either of the two TMLR criteria'):
+            decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Decision',
+                signatures=[joelle_paper1_anon_group.id],
+                note=Note(
+                    content={
+                        'claims_and_evidence': { 'value': 'No' },
+                        'claims_explanation': { 'value': 'Accept as is' },
+                        'audience': { 'value': 'Yes' },
+                        'audience_explanation': { 'value': 'Accept as is' },
+                        'recommendation': { 'value': 'Accept as is' },
+                        'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
+                        'additional_comments': { 'value': 'This is a nice paper!' },
+                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    }
+                )
             )
-        )
+
+        with pytest.raises(openreview.OpenReviewException, match=r'Decision should be "Accept as is" or "Accept with minor revision" if you answered "Yes" to both TMLR criteria'):
+            decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Decision',
+                signatures=[joelle_paper1_anon_group.id],
+                note=Note(
+                    content={
+                        'claims_and_evidence': { 'value': 'Yes' },
+                        'claims_explanation': { 'value': 'Reject' },
+                        'audience': { 'value': 'Yes' },
+                        'audience_explanation': { 'value': 'Reject' },
+                        'recommendation': { 'value': 'Reject' },
+                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    }
+                )
+            )
+
+        # post 'Accept as is' decision
+        decision_note = joelle_client.post_note_edit(invitation=f'{venue_id}/Paper1/-/Decision',
+                signatures=[joelle_paper1_anon_group.id],
+                note=Note(
+                    content={
+                        'claims_and_evidence': { 'value': 'Yes' },
+                        'claims_explanation': { 'value': 'Accept as is' },
+                        'audience': { 'value': 'Yes' },
+                        'audience_explanation': { 'value': 'Accept as is' },
+                        'recommendation': { 'value': 'Accept as is' },
+                        'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
+                        'additional_comments': { 'value': 'Great paper!' },
+                        'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
+                        'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
+                    }
+                )
+            )
 
         helpers.await_queue_edit(openreview_client, edit_id=decision_note['id'])
 
@@ -2470,11 +2507,13 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
                 signatures=[joelle_paper1_anon_group.id],
                 note=Note(
                     content={
-                        'claims_and_evidence': { 'value': 'Accept as is' },
-                        'audience': { 'value': 'Accept as is' },
+                        'claims_and_evidence': { 'value': 'Yes' },
+                        'claims_explanation': { 'value': 'Accept as is' },
+                        'audience': { 'value': 'Yes' },
+                        'audience_explanation': { 'value': 'Accept as is' },
                         'recommendation': { 'value': 'Accept as is' },
-                        'comment': { 'value': 'This is a nice paper!' },
                         'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
+                        'additional_comments': { 'value': 'Great paper!' },
                         'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
                         'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                     }
@@ -3449,10 +3488,12 @@ Please note that responding to this email will direct your reply to joelle@mails
                 signatures=[joelle_paper4_anon_group.id],
                 note=Note(
                     content={
-                        'claims_and_evidence': { 'value': 'Accept as is' },
-                        'audience': { 'value': 'Accept as is' },
+                        'claims_and_evidence': { 'value': 'No' },
+                        'claims_explanation': { 'value': 'Accept as is' },
+                        'audience': { 'value': 'No' },
+                        'audience_explanation': { 'value': 'Accept as is' },
                         'recommendation': { 'value': 'Reject' },
-                        'comment': { 'value': 'This is not a good paper' },
+                        'additional_comments': { 'value': 'This is not a good paper' },
                         'certifications': { 'value': ['Featured Certification', 'Reproducibility Certification'] },
                         'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
                         'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
@@ -3464,10 +3505,12 @@ Please note that responding to this email will direct your reply to joelle@mails
             signatures=[joelle_paper4_anon_group.id],
             note=Note(
                 content={
-                    'claims_and_evidence': { 'value': 'Accept as is' },
-                    'audience': { 'value': 'Accept as is' },
+                    'claims_and_evidence': { 'value': 'No' },
+                    'claims_explanation': { 'value': 'Reject' },
+                    'audience': { 'value': 'No' },
+                    'audience_explanation': { 'value': 'Reject' },
                     'recommendation': { 'value': 'Reject' },
-                    'comment': { 'value': 'This is not a good paper' },
+                    'additional_comments': { 'value': 'This is not a good paper' },
                     'resubmission_of_major_revision': { 'value': 'The authors may consider submitting a major revision at a later time.' },
                     'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
                     'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }                   
@@ -3886,10 +3929,12 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
             signatures=[joelle_paper5_anon_group.id],
             note=Note(
                 content={
-                    'claims_and_evidence': { 'value': 'Accept as is' },
-                    'audience': { 'value': 'Accept as is' },
+                    'claims_and_evidence': { 'value': 'Yes' },
+                    'claims_explanation': { 'value': 'Accept with minor revision' },
+                    'audience': { 'value': 'No' },
+                    'audience_explanation': { 'value': 'Accept with minor revision' },
                     'recommendation': { 'value': 'Accept with minor revision' },
-                    'comment': { 'value': 'This is a good paper' },
+                    'additional_comments': { 'value': 'This is a good paper' },
                     'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
                     'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }
@@ -5288,10 +5333,12 @@ note={Under review}
             signatures=[joelle_paper13_anon_group.id],
             note=Note(
                 content={
-                    'claims_and_evidence': { 'value': 'Accept as is' },
-                    'audience': { 'value': 'Accept as is' },
+                    'claims_and_evidence': { 'value': 'Yes' },
+                    'claims_explanation': { 'value': 'Accept' },
+                    'audience': { 'value': 'Yes' },
+                    'audience_explanation': { 'value': 'No' },
                     'recommendation': { 'value': 'Accept with minor revision' },
-                    'comment': { 'value': 'This is a good paper' },
+                    'additional_comments': { 'value': 'This is a good paper' },
                     'pilot_recommendation_to_iclr_track': { 'value': 'Strongly Recommend' },
                     'pilot_explain_recommendation_to_iclr_track': { 'value': 'I recommend this paper to be published in the ICLR track because...' }
                 }

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -176,7 +176,7 @@ class TestJournal():
                                     'description': 'Learn more about TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation.',
                                     'value': {
                                         'param': {
-                                            'fieldName': 'Explain your/the answer above',
+                                            'fieldName': 'Explain your answer above',
                                             'type': 'string',
                                             'maxLength': 200000,
                                             'input': 'textarea',
@@ -201,7 +201,7 @@ class TestJournal():
                                     'description': 'Learn more about TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation.',
                                     'value': {
                                         'param': {
-                                            'fieldName': 'Explain your/the answer above',
+                                            'fieldName': 'Explain your answer above',
                                             'type': 'string',
                                             'maxLength': 200000,
                                             'input': 'textarea',

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -156,6 +156,70 @@ class TestJournal():
                                 }                                
                             },
                             'decision_additional_fields': {
+                                'claims_and_evidence': {
+                                    'order': 2,
+                                    'value': {
+                                        'param': {
+                                            'fieldName': f'Are the claims made in the submission supported by accurate, convincing and clear evidence?',
+                                            'type': 'string',
+                                            'enum': ['Yes', 'No'],
+                                            'input': 'radio'
+                                        }
+                                    }
+                                },
+                                'claims_explanation': {
+                                    'order': 3,
+                                    'description': f'Are the claims made in the submission supported by accurate, convincing and clear evidence? If not why? (see TMLRS\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                                    'value': {
+                                        'param': {
+                                            'fieldName': 'Explain answer above',
+                                            'type': 'string',
+                                            'maxLength': 200000,
+                                            'input': 'textarea',
+                                            'markdown': True
+                                        }
+                                    }
+                                },
+                                'audience': {
+                                    'order': 4,
+                                    'value': {
+                                        'param': {
+                                            'fieldName': 'Would at least some individuals in TMLR\'s audience be interested in knowing the findings of this paper?',
+                                            'type': 'string',
+                                            'enum': ['Yes', 'No'],
+                                            'input': 'radio'
+                                        }
+                                    }
+                                },
+                                'audience_explanation': {
+                                    'order': 5,
+                                    'description': f'Would at least some individuals in TMLR\'s audience be interested in knowing the findings of this paper? If not, why? (see TMLR\'s evaluation criteria at https://jmlr.org/tmlr/editorial-policies.html#evaluation)',
+                                    'value': {
+                                        'param': {
+                                            'fieldName': 'Explain answer above',
+                                            'type': 'string',
+                                            'maxLength': 200000,
+                                            'input': 'textarea',
+                                            'markdown': True
+                                        }
+                                    }
+                                },
+                                'comment': {
+                                    'delete': True
+                                },
+                                'additional_comments': {
+                                    'order': 10,
+                                    'description': 'If you request revisions, provide details on the expected changes. If you recommend a certification, explain the reasons for why the submission deserves this recognition (max 200000 characters). Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.',
+                                    'value': {
+                                        'param': {
+                                            'type': 'string',
+                                            'maxLength': 200000,
+                                            'input': 'textarea',
+                                            'markdown': True,
+                                            'optional': True
+                                        }
+                                    }
+                                },
                                 'pilot_recommendation_to_iclr_track': {
                                     'order': 98,
                                     'description': 'Would you recommend this work be invited for presentation at the ICLR Journal-to-Conference Track? Recall that TMLR\'s acceptance criteria are that a work must be sound and of interest to the TMLR audience. Above these requirements, a paper in the ICLR Journal-to-Conference Track should also stand out in novelty or predicted significance for the field (i.e., comparable to the level of a paper in ICLR\'s regular conference track. **Your response will be shared with ICLR**',


### PR DESCRIPTION
TMLR asked for some changes to the AE decision form. 

This is what the form looks like:
![Screenshot 2025-04-28 at 3 04 33 PM](https://github.com/user-attachments/assets/8de319eb-25cf-496c-9323-55334cbb3f32)

and how the form is stored:
![Screenshot 2025-04-28 at 3 05 35 PM](https://github.com/user-attachments/assets/247aad72-6fb2-4926-a901-0e7512f16782)

Also, added some code to the preprocess.