### PR TITLE
Comment Stage: use inGroup to select anon reviewers

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -4816,7 +4816,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                     'signatures': ['${3/signatures}'],
                     'readers': {
                         'param': {
-                            'enum': self.journal.get_official_comment_readers('${7/content/noteNumber/value}')
+                            'items': [ { 'inGroup': r.replace('_.*', 's'), 'optional': True } if '.*' in r else { 'value': r, 'optional': True } for r in self.journal.get_official_comment_readers('${8/content/noteNumber/value}')]
                         }
                     },
                     'writers': ['${3/writers}'],

--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1033,7 +1033,7 @@ class CommentStage(object):
                 readers.append({ 'value': conference.get_reviewers_id(number) + '/Submitted', 'optional': True })
 
             if self.Readers.REVIEWERS_ASSIGNED in self.readers or self.Readers.REVIEWERS_SUBMITTED in self.readers:
-                readers.append({ 'prefix': conference.get_anon_reviewer_id(number=number, anon_id='.*'), 'optional': True })
+                readers.append({ 'inGroup': conference.get_reviewers_id(number), 'optional': True })
 
             if self.Readers.AUTHORS in self.readers:
                 readers.append({ 'value': conference.get_authors_id(number), 'optional': True })                

--- a/tests/test_dmlr_journal.py
+++ b/tests/test_dmlr_journal.py
@@ -583,13 +583,31 @@ Please note that responding to this email will direct your reply to andrew@dmlrz
         assert "DMLR/Paper1/-/Official_Recommendation" in [i.id for i in invitations]
 
         official_comment_invitation = openreview_client.get_invitation("DMLR/Paper1/-/Official_Comment")
-        assert official_comment_invitation.edit['note']['readers']['param']['enum'] == [
-            "DMLR/Editors_In_Chief",
-            "DMLR/Action_Editors",
-            "DMLR/Paper1/Action_Editors",
-            "DMLR/Paper1/Reviewers",
-            "DMLR/Paper1/Reviewer_.*",
-            "DMLR/Paper1/Authors"
+        assert official_comment_invitation.edit['note']['readers']['param']['items'] == [
+            {
+                "value": "DMLR/Editors_In_Chief",
+                "optional": True
+            },
+            {
+                "value": "DMLR/Action_Editors",
+                "optional": True
+            },
+            {
+                "value": "DMLR/Paper1/Action_Editors",
+                "optional": True
+            },
+            {
+                "value": "DMLR/Paper1/Reviewers",
+                "optional": True
+            },
+            {
+                "inGroup": "DMLR/Paper1/Reviewers",
+                "optional": True
+            },
+            {
+                "value": "DMLR/Paper1/Authors",
+                "optional": True
+            }
         ]
 
         ## Make a comment before approving the submission to be under review

--- a/tests/test_iclr_conference_v2.py
+++ b/tests/test_iclr_conference_v2.py
@@ -636,7 +636,7 @@ class TestICLRConference():
                 "optional": True
             },
             {
-                "prefix": "ICLR.cc/2024/Conference/Submission1/Reviewer_.*",
+                "inGroup": "ICLR.cc/2024/Conference/Submission1/Reviewers",
                 "optional": True
             }
         ]
@@ -720,7 +720,7 @@ class TestICLRConference():
                 "optional": True
             },
             {
-                "prefix": "ICLR.cc/2024/Conference/Submission1/Reviewer_.*",
+                "inGroup": "ICLR.cc/2024/Conference/Submission1/Reviewers",
                 "optional": True
             },
             {

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -422,13 +422,13 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert note.content['venueid']['value'] == 'TMLR/Submitted'
 
         invitation = openreview_client.get_invitation(f"{venue_id}/Paper1/-/Official_Comment")
-        assert invitation.edit['note']['readers']['param']['enum'] == [
-            "everyone",
-            "TMLR/Editors_In_Chief",
-            "TMLR/Paper1/Action_Editors",
-            "TMLR/Paper1/Reviewers",
-            "TMLR/Paper1/Reviewer_.*",
-            "TMLR/Paper1/Authors"
+        assert invitation.edit['note']['readers']['param']['items'] == [
+            { "value": "everyone", "optional": True },
+            { "value": "TMLR/Editors_In_Chief", "optional": True },
+            { "value": "TMLR/Paper1/Action_Editors", "optional": True },
+            { "value": "TMLR/Paper1/Reviewers", "optional": True },
+            { "inGroup": "TMLR/Paper1/Reviewers", "optional": True },
+            { "value": "TMLR/Paper1/Authors", "optional": True }
         ]
 
         invitations = openreview_client.get_invitations(replyForum=note_id_1)

--- a/tests/test_tacl_journal.py
+++ b/tests/test_tacl_journal.py
@@ -404,7 +404,8 @@ Please note that responding to this email will direct your reply to graham@mails
         assert "TACL/Paper1/-/Official_Recommendation" in [i.id for i in invitations]
 
         official_comment_invitation = openreview_client.get_invitation("TACL/Paper1/-/Official_Comment")
-        assert 'everyone' not in official_comment_invitation.edit['note']['readers']['param']['enum']
+        readers = [item.get('value', item.get('inGroup')) for item in official_comment_invitation.edit['note']['readers']['param']['items']]
+        assert 'everyone' not in readers
 
 
     def test_official_recommendation(self, journal, openreview_client, helpers):

--- a/tests/test_venue_request_v2.py
+++ b/tests/test_venue_request_v2.py
@@ -2898,13 +2898,41 @@ Please refer to the documentation for instructions on how to run the matcher: ht
 
         paper_official_comment_invitation = openreview.tools.get_invitation(openreview_client, '{}/Submission1/-/Official_Comment'.format(venue['venue_id']))
         assert paper_official_comment_invitation
-        readers = [item.get('value', item.get('prefix')) for item in paper_official_comment_invitation.edit['note']['readers']['param']['items']]
+        readers = [item.get('value', item.get('inGroup')) for item in paper_official_comment_invitation.edit['note']['readers']['param']['items']]
         assert 'V2.cc/2030/Conference/Program_Chairs' in readers
-        assert 'V2.cc/2030/Conference/Submission1/Reviewer_.*' in readers
+        assert 'V2.cc/2030/Conference/Submission1/Reviewer_.*' not in readers
         assert 'V2.cc/2030/Conference/Submission1/Senior_Area_Chairs' in readers
         assert 'V2.cc/2030/Conference/Submission1/Area_Chairs' in readers
         assert 'V2.cc/2030/Conference/Submission1/Reviewers' in readers
         assert 'V2.cc/2030/Conference/Submission1/Authors' in readers
+
+        assert paper_official_comment_invitation.edit['note']['readers']['param']['items'] == [
+            {
+                "value": "V2.cc/2030/Conference/Program_Chairs",
+                "optional": False
+            },
+            {
+                "value": "V2.cc/2030/Conference/Submission1/Senior_Area_Chairs",
+                "optional": False
+            },
+            {
+                "value": "V2.cc/2030/Conference/Submission1/Area_Chairs",
+                "optional": True
+            },
+            {
+                "value": "V2.cc/2030/Conference/Submission1/Reviewers",
+                "optional": True
+            },
+            {
+                "inGroup": "V2.cc/2030/Conference/Submission1/Reviewers",
+                "optional": True
+            },
+            {
+                "value": "V2.cc/2030/Conference/Submission1/Authors",
+                "optional": True
+            }
+        ]
+        
 
         author_client = OpenReviewClient(username='venue_author_v2@mail.com', password=helpers.strong_password)
         # Assert that an official comment can be posted by the paper author


### PR DESCRIPTION
Fixes https://github.com/openreview/openreview-web/issues/2273

When reviewers are unassigned, they won't showup as available readers because they are not part of the reviewers group anymore.