### PR TITLE
ARR Commitment: get previous url and allow identity visibility

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -93,8 +93,10 @@ class OpenReviewClient(object):
         self.note_edits_url = self.baseurl + '/notes/edits'
         self.invitation_edits_url = self.baseurl + '/invitations/edits'
         self.group_edits_url = self.baseurl + '/groups/edits'
+        self.activatelink_url = self.baseurl + '/activatelink'
         self.domains_rename = self.baseurl + '/domains/rename'
         self.user_agent = 'OpenReviewPy/v' + str(sys.version_info[0])
+
         
 
         self.limit = 1000
@@ -747,28 +749,31 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return Profile.from_json(response.json())
 
-    def rename_domain(self, old_domain, new_domain):
+    def rename_domain(self, old_domain, new_domain, request_form, additional_renames=None):
         """
         Updates the domain for an entire venue
 
         :param old_domain: Current domain
-        :type profile: str
         :param new_domain: New domain
-        :type profile: str
 
         :return: Status of the request. The process can be tracked in the queue.
         :rtype: dict
         """
+        json = {
+                'oldDomain': old_domain,
+                'newDomain': new_domain,
+                'requestForm': request_form
+            }
+        if additional_renames:
+            json['additionalRenames'] = additional_renames
         response = self.session.post(
             self.domains_rename,
-            json = {
-                'oldDomain': old_domain,
-                'newDomain': new_domain
-            },
+            json = json,
             headers = self.headers)
 
+
         response = self.__handle_response(response)
-        return Profile.from_json(response.json())
+        return response.json()
 
     def rename_profile(self, current_id, new_id):
         """

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -93,9 +93,9 @@ class OpenReviewClient(object):
         self.note_edits_url = self.baseurl + '/notes/edits'
         self.invitation_edits_url = self.baseurl + '/invitations/edits'
         self.group_edits_url = self.baseurl + '/groups/edits'
-        self.activatelink_url = self.baseurl + '/activatelink'
         self.domains_rename = self.baseurl + '/domains/rename'
         self.user_agent = 'OpenReviewPy/v' + str(sys.version_info[0])
+        
 
         self.limit = 1000
         self.token = token.replace('Bearer ', '') if token else None
@@ -742,6 +742,29 @@ class OpenReviewClient(object):
         response = self.session.post(
             self.profiles_url,
             json = profile.to_json(),
+            headers = self.headers)
+
+        response = self.__handle_response(response)
+        return Profile.from_json(response.json())
+
+    def rename_domain(self, old_domain, new_domain):
+        """
+        Updates the domain for an entire venue
+
+        :param old_domain: Current domain
+        :type profile: str
+        :param new_domain: New domain
+        :type profile: str
+
+        :return: Status of the request. The process can be tracked in the queue.
+        :rtype: dict
+        """
+        response = self.session.post(
+            self.domains_rename,
+            json = {
+                'oldDomain': old_domain,
+                'newDomain': new_domain
+            },
             headers = self.headers)
 
         response = self.__handle_response(response)

--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -579,7 +579,7 @@ class ARR(object):
         return self.venue.get_preferred_emails_invitation_id()
     
     @classmethod
-    def process_commitment_venue(ARR, client, venue_id, invitation_reply_ids=['Official_Review', 'Meta_Review'], additional_readers=[]):
+    def process_commitment_venue(ARR, client, venue_id, invitation_reply_ids=['Official_Review', 'Meta_Review'], additional_readers=[], get_previous_url_submission=False):
 
         def add_readers_to_note(note, readers):
             if readers[0] in note.readers:
@@ -643,7 +643,19 @@ class ARR(object):
                 for invitation_reply_id in invitation_reply_ids:
                     if invitation_reply_id in reply.invitations[0]:
                         add_readers_to_note(reply, [commitment_readers_group_id])
-        
+
+        def process_previous_url(arr_submission):
+            previous_url = arr_submission.content.get('previous_URL', {}).get('value')
+            if previous_url:
+                try:
+                    previous_url_id = previous_url.split('=')[-1]
+                    previous_url_submission = openreview.tools.get_note(client, previous_url_id)
+                    if previous_url_submission:
+                        create_readers_group(previous_url_submission, arr_submission)
+                        add_readers_to_arr_submission(previous_url_submission)
+                except openreview.OpenReviewException as e:
+                    print(f"Error retrieving note for previous_URL: {e}. This note may not be an API 2 note or may not exist.")
+
         venue_group = client.get_group(venue_id)
 
         is_commitment_venue = venue_group.content.get('commitments_venue', {}).get('value', False)
@@ -663,6 +675,8 @@ class ARR(object):
                 if arr_submission and 'aclweb.org/ACL/ARR/' in arr_submission.invitations[0]:
                     create_readers_group(arr_submission, note)
                     add_readers_to_arr_submission(arr_submission)
+                    if get_previous_url_submission:  # Trigger process_previous_url if the parameter is True
+                        process_previous_url(arr_submission)
                     return True
             return False
 

--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -579,7 +579,7 @@ class ARR(object):
         return self.venue.get_preferred_emails_invitation_id()
     
     @classmethod
-    def process_commitment_venue(ARR, client, venue_id, invitation_reply_ids=['Official_Review', 'Meta_Review'], additional_readers=[], get_previous_url_submission=False):
+    def process_commitment_venue(ARR, client, venue_id, invitation_reply_ids=['Official_Review', 'Meta_Review'], additional_readers=[], get_previous_url_submission=False, identity_visibility=False):
 
         def add_readers_to_note(note, readers):
             if readers[0] in note.readers:
@@ -629,6 +629,21 @@ class ARR(object):
                 )
             )
 
+        def update_deanonymizers(group, group_id, commitment_readers_group_id):
+            if group:
+                deanonymizers = getattr(group, 'deanonymizers', [])
+                client.post_group_edit(
+                    invitation=f'{group_id}/-/Edit',
+                    signatures=[group_id],
+                    group=openreview.api.Group(
+                        id=group.id,
+                        signatures=[group_id],
+                        writers=[group_id],
+                        readers=[group_id],
+                        deanonymizers=[commitment_readers_group_id] + deanonymizers
+                    )
+                )
+
         def add_readers_to_arr_submission(submission):
 
             domain = submission.domain
@@ -643,6 +658,15 @@ class ARR(object):
                 for invitation_reply_id in invitation_reply_ids:
                     if invitation_reply_id in reply.invitations[0]:
                         add_readers_to_note(reply, [commitment_readers_group_id])
+
+            # This adds the Commitment readers group to the deanonymizer for the assigned AC and reviewers group of the ARR submission so the commitment ACs can see the identities of the reviewers and ACs
+            if identity_visibility:
+                # Update Area Chairs group
+                arr_ac_group = client.get_group(f'{domain}/Submission{submission.number}/Area_Chairs')
+                update_deanonymizers(arr_ac_group, domain, commitment_readers_group_id)
+                # Update Reviewers group
+                arr_reviewers_group = client.get_group(f'{domain}/Submission{submission.number}/Reviewers')
+                update_deanonymizers(arr_reviewers_group, domain, commitment_readers_group_id)
 
         def process_previous_url(arr_submission):
             previous_url = arr_submission.content.get('previous_URL', {}).get('value')

--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -581,6 +581,16 @@ class ARR(object):
     @classmethod
     def process_commitment_venue(ARR, client, venue_id, invitation_reply_ids=['Official_Review', 'Meta_Review'], additional_readers=[], get_previous_url_submission=False, identity_visibility=False):
 
+        """
+        This function processes the commitment venue by providing read access to the original ARR submission if the submission is API2.
+        
+        invitation_reply_ids: list of invitation names for notes commitment readers will be added to so the PCs of assigned ACs can read the contents. The default is Official_Review and Meta_Review. Add Official_Comment for the review discussion.
+        additional_readers: list of additional readers to add to the commitment readers group. The default is empty, which means only the venue_id is added to the commitment readers group, so PCs can access the notes. Add Area_Chairs if you want the Area Chairs to be able to read the notes.
+        get_previous_url_submission: boolean indicating whether to process the previous URL submission. The default is False. It will only process API 2 notes.
+        identity_visibility: boolean indicating whether to add the commitment readers group to the deanonymizers of the assigned AC and reviewers group of the ARR submission allowing the assigned committee to see those identities. The default is False. If True and get_previous_url_submission is True, it will add the commitment readers group to the deanonymizers of the assigned AC and reviewers group of the previous_URL ARR submission.
+
+        """
+
         def add_readers_to_note(note, readers):
             if readers[0] in note.readers:
                 return

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -79,6 +79,7 @@ class Client(object):
         self.invitation_edits_url = self.baseurl + '/invitations/edits'
         self.infer_notes_url = self.baseurl + '/notes/infer'
         self.user_agent = 'OpenReviewPy/v' + str(sys.version_info[0])
+        self.domains_rename = self.baseurl + '/domains/rename'
 
         self.limit = 1000
         self.token = token.replace('Bearer ', '') if token else None
@@ -592,6 +593,29 @@ class Client(object):
         response = self.__handle_response(response)
         return Profile.from_json(response.json())
 
+    def rename_domain(self, old_domain, new_domain):
+        """
+        Updates the domain for an entire venue
+
+        :param old_domain: Current domain
+        :type profile: str
+        :param new_domain: New domain
+        :type profile: str
+
+        :return: Status of the request. The process can be tracked in the queue.
+        :rtype: dict
+        """
+        response = self.session.post(
+            self.domains_rename,
+            json = {
+                'oldDomain': old_domain,
+                'newDomain': new_domain
+            },
+            headers = self.headers)
+
+        response = self.__handle_response(response)
+        return Profile.from_json(response.json())
+    
     def rename_profile(self, current_id, new_id):
         """
         Updates a Profile

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -5955,7 +5955,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         notes = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', number=3)
         assert len(notes) == 0
 
-        openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment', get_previous_url_submission=True, identity_visibility=True)
+        openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment', get_previous_url_submission=True, identity_visibility=False)
         
         august_submissions = openreview_client.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', sort='number:asc')
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -5955,7 +5955,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         notes = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', number=3)
         assert len(notes) == 0
 
-        openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment', get_previous_url_submission=True)
+        openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment', get_previous_url_submission=True, identity_visibility=True)
         
         august_submissions = openreview_client.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', sort='number:asc')
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -5955,7 +5955,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         notes = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', number=3)
         assert len(notes) == 0
 
-        openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment', get_previous_url_submission=True, identity_visibility=False)
+        openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment', get_previous_url_submission=True, identity_visibility=True)
         
         august_submissions = openreview_client.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', sort='number:asc')
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -5955,7 +5955,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         notes = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', number=3)
         assert len(notes) == 0
 
-        openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment')
+        openreview.arr.ARR.process_commitment_venue(openreview_client, 'aclweb.org/ACL/2024/Workshop/C3NLP_ARR_Commitment', get_previous_url_submission=True)
         
         august_submissions = openreview_client.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', sort='number:asc')
 


### PR DESCRIPTION
update_deanonymizers() and process_previous_url() were added to process_commitment_venue().

update_deanonymizers is triggered if identity_visibility is True and it's executed when readers are added to arr submissions in add_readers_to_arr_submission().

process_previous_url() is triggered in process_commitment_submission if get_previous_url_submission is True.

I've also added a description to process_commitment_venue().

I want to test it a more extensively, but I would like feedback before spending more time on it.