### PR TITLE
Post Decision Stage: do not change the venueid for submission that don't have a decision posted

### DIFF
--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -429,8 +429,14 @@ class Venue(object):
 
         if venueid:
             return self.client.get_all_notes(content={ 'venueid': venueid}, sort=sort, details=details)
+        
+        venueids = [
+            self.get_submission_venue_id(),
+            self.venue_id,
+            self.get_rejected_submission_venue_id()
+        ]
 
-        return self.client.get_all_notes(invitation=self.get_submission_id(), sort=sort, details=details)
+        return self.client.get_all_notes(content={ 'venueid': ','.join(venueids)}, sort=sort, details=details)
 
     #use to expire revision invitations from request form
     def expire_invitation(self, invitation_id):

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -415,7 +415,7 @@ class Venue(object):
 
     def get_submissions(self, venueid=None, accepted=False, sort='tmdate', details=None):
         if accepted:
-            accepted_notes = self.client.get_all_notes(content={ 'venueid': self.venue_id}, sort=sort)
+            accepted_notes = self.client.get_all_notes(content={ 'venueid': self.venue_id}, sort=sort, details=details)
             if len(accepted_notes) == 0:
                 accepted_notes = []
                 notes = self.client.get_all_notes(content={ 'venueid': f'{self.get_submission_venue_id()}'}, sort=sort, details='directReplies')
@@ -426,14 +426,11 @@ class Venue(object):
                             if openreview.tools.is_accept_decision(decision, self.decision_stage.accept_options):
                                 accepted_notes.append(note)
             return accepted_notes
-        else:
-            notes = self.client.get_all_notes(content={ 'venueid': venueid if venueid else f'{self.get_submission_venue_id()}'}, sort=sort, details=details)
-            if len(notes) == 0:
-                notes = self.client.get_all_notes(content={ 'venueid': self.venue_id}, sort=sort, details=details)
-                rejected = self.client.get_all_notes(content={ 'venueid': self.get_rejected_submission_venue_id()}, sort=sort, details=details)
-                if rejected:
-                    notes.extend(rejected)
-            return notes
+
+        if venueid:
+            return self.client.get_all_notes(content={ 'venueid': venueid}, sort=sort, details=details)
+
+        return self.client.get_all_notes(invitation=self.get_submission_id(), sort=sort, details=details)
 
     #use to expire revision invitations from request form
     def expire_invitation(self, invitation_id):
@@ -761,6 +758,14 @@ Total Errors: {len(errors)}
 
             api1_client.post_note(status_note)
 
+    def get_decision_note(self, submission):
+
+        if submission.details:
+            for reply in submission.details.get('directReplies', submission.details.get('replies', [])):
+                if self.get_invitation_id(name = self.decision_stage.name, number = submission.number) in reply['invitations']:
+                    return Note.from_json(reply)
+    
+    
     def post_decision_stage(self, reveal_all_authors=False, reveal_authors_accepted=False, decision_heading_map=None, submission_readers=None, hide_fields=[]):
 
         venue_id = self.venue_id
@@ -779,19 +784,18 @@ Total Errors: {len(errors)}
             self.submission_stage.readers = submission_readers
 
         def update_note(submission):
-            decision_note = None
-            if submission.details:
-                for reply in submission.details['directReplies']:
-                    if f'{self.venue_id}/{self.submission_stage.name}{submission.number}/-/{self.decision_stage.name}' in reply['invitations']:
-                        decision_note = reply
-                        break
-            note_accepted = decision_note and openreview.tools.is_accept_decision(decision_note['content']['decision']['value'], self.decision_stage.accept_options)
-            submission_readers = self.submission_stage.get_readers(self, submission.number, decision_note['content']['decision']['value'] if decision_note else None, self.decision_stage.accept_options)
+
+            decision_note = self.get_decision_note(submission)
+            if not decision_note:
+                return
+
+            submission_decision_value = decision_note.content.get('decision', {}).get('value')
+            note_accepted = openreview.tools.is_accept_decision(submission_decision_value, self.decision_stage.accept_options)
+            submission_readers = self.submission_stage.get_readers(self, submission.number, submission_decision_value, self.decision_stage.accept_options)
 
             venue = self.short_name
-            decision_option = decision_note['content']['decision']['value'] if decision_note else ''
-            venue = tools.decision_to_venue(venue, decision_option, self.decision_stage.accept_options)
-            venueid = decision_to_venueid(decision_option)
+            venue = tools.decision_to_venue(venue, submission_decision_value, self.decision_stage.accept_options)
+            venueid = decision_to_venueid(submission_decision_value)
 
             content = {
                 'venueid': {
@@ -850,21 +854,23 @@ Total Errors: {len(errors)}
         tools.concurrent_requests(update_note, submissions)
 
     def send_decision_notifications(self, decision_options, messages):
+        print('send_decision_notifications')
         paper_notes = self.get_submissions(details='directReplies')
 
         def send_notification(note):
-            decision_note = None
-            for reply in note.details['directReplies']:
-                if f'{self.venue_id}/{self.submission_stage.name}{note.number}/-/{self.decision_stage.name}' in reply['invitations']:
-                    decision_note = reply
-                    break
+            
+            decision_note = self.get_decision_note(note)
+            print(f'send_notification: {note.number} {note.content["title"]["value"]} {decision_note}')
+            if not decision_note:
+                return
+
             subject = "[{SHORT_NAME}] Decision notification for your submission {submission_number}: {submission_title}".format(
                 SHORT_NAME=self.short_name,
                 submission_number=note.number,
                 submission_title=note.content['title']['value']
             )
-            if decision_note and not self.client.get_messages(subject=subject):
-                message = messages[decision_note['content']['decision']['value']]
+            if not self.client.get_messages(subject=subject):
+                message = messages[decision_note.content['decision']['value']]
                 final_message = message.replace("{{submission_title}}", note.content['title']['value'])
                 final_message = final_message.replace("{{forum_url}}", f'https://openreview.net/forum?id={note.id}')
                 self.client.post_message(subject, 

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -442,7 +442,7 @@ class TestWorkshopV2():
         assert len(submissions) == 12
 
         decisions = ['Accept', 'Invite to Venue', 'Reject']
-        for idx in range(len(submissions)):
+        for idx in range(len(submissions[:10])):
             decision = pc_client_v2.post_note_edit(
                 invitation=f'PRL/2023/ICAPS/Submission{submissions[idx].number}/-/Decision',
                     signatures=['PRL/2023/ICAPS/Program_Chairs'],
@@ -552,15 +552,15 @@ Best,
         submissions = openreview_client.get_notes(invitation='PRL/2023/ICAPS/-/Submission', sort='number:asc')
         assert len(submissions) == 12
 
-        for idx in range(len(submissions)):
+        for idx in range(len(submissions[:10])):
             if idx % 3 <= 1:
-                submissions[idx].readers = [
+                assert submissions[idx].readers == [
                     'PRL/2023/ICAPS',
                     'PRL/2023/ICAPS/Reviewers',
                     'PRL/2023/ICAPS/Publication_Chairs',
                     f'PRL/2023/ICAPS/Submission{submissions[idx].number}/Authors'
                 ]
-                submissions[idx].content['authors']['readers'] = [
+                assert submissions[idx].content['authors']['readers'] == [
                     'PRL/2023/ICAPS',
                     f'PRL/2023/ICAPS/Submission{submissions[idx].number}/Authors',
                     'PRL/2023/ICAPS/Publication_Chairs'
@@ -569,24 +569,45 @@ Best,
                 submission_venue = 'PRL ICAPS 2023' if idx % 3 == 0 else 'PRL ICAPS 2023 InvitetoVenue'
                 assert submissions[idx].content['venue']['value'] == submission_venue
             else:
-                submissions[idx].readers = [
+                assert submissions[idx].readers == [
                     'PRL/2023/ICAPS',
                     'PRL/2023/ICAPS/Reviewers',
                     f'PRL/2023/ICAPS/Submission{submissions[idx].number}/Authors'
                 ]
-                submissions[idx].content['authors']['readers'] = [
+                assert submissions[idx].content['authors']['readers'] == [
                     'PRL/2023/ICAPS',
                     f'PRL/2023/ICAPS/Submission{submissions[idx].number}/Authors'
                 ]
                 assert submissions[idx].content['venueid']['value'] == 'PRL/2023/ICAPS/Rejected_Submission'
                 assert submissions[idx].content['venue']['value'] == 'Submitted to PRL ICAPS 2023'
 
+        assert submissions[10].content['venueid']['value'] == 'PRL/2023/ICAPS/Submission'
+        assert submissions[10].content['venue']['value'] == 'PRL 2023 ICAPS Submission'
+        assert submissions[10].readers == [
+            'PRL/2023/ICAPS',
+            'PRL/2023/ICAPS/Submission11/Authors'
+        ]
+        assert submissions[10].content['authors']['readers'] == [
+            'PRL/2023/ICAPS',
+            'PRL/2023/ICAPS/Submission11/Authors'
+        ]        
+        assert submissions[11].content['venueid']['value'] == 'PRL/2023/ICAPS/Submission'
+        assert submissions[11].content['venue']['value'] == 'PRL 2023 ICAPS Submission'
+        assert submissions[11].readers == [
+            'PRL/2023/ICAPS',
+            'PRL/2023/ICAPS/Submission12/Authors'
+        ]
+        assert submissions[11].content['authors']['readers'] == [
+            'PRL/2023/ICAPS',
+            'PRL/2023/ICAPS/Submission12/Authors'
+        ]
+
         helpers.create_user('publicationchair@mail.com', 'Publication', 'ICAPSChair')
         publication_chair_client_v2=openreview.api.OpenReviewClient(username='publicationchair@mail.com', password=helpers.strong_password)
 
         assert publication_chair_client_v2.get_group('PRL/2023/ICAPS/Authors/Accepted')
         submissions = publication_chair_client_v2.get_notes(invitation='PRL/2023/ICAPS/-/Submission', sort='number:asc')
-        assert len(submissions) == 8
+        assert len(submissions) == 7
 
         # Check messages
         messages = openreview_client.get_messages(subject=f'[PRL ICAPS 2023] Decision notification for your submission 1:.*')
@@ -614,13 +635,13 @@ Best,
 
         request_page(selenium, f'{url}#tab-invite-to-venue', token=openreview_client.token, wait_for_element='header')
         notes = selenium.find_element(By.ID, 'invite-to-venue').find_elements(By.CLASS_NAME, 'note')
-        assert len(notes) == 4
-        assert notes[0].find_element(By.TAG_NAME, 'h4').text == 'Paper title 11'
+        assert len(notes) == 3
+        assert notes[0].find_element(By.TAG_NAME, 'h4').text == 'Paper title 8'
 
         request_page(selenium, f'{url}#tab-submitted', token=openreview_client.token, wait_for_element='header')
         notes = selenium.find_element(By.ID, 'submitted').find_elements(By.CLASS_NAME, 'note')
-        assert len(notes) == 4
-        assert notes[0].find_element(By.TAG_NAME, 'h4').text == 'Paper title No Abstract Version 2'
+        assert len(notes) == 3
+        assert notes[0].find_element(By.TAG_NAME, 'h4').text == 'Paper title 9'
 
     def test_enable_camera_ready_revisions(self, client, openreview_client, helpers, selenium, request_page):
 
@@ -675,7 +696,7 @@ Best,
         assert process_logs[0]['status'] == 'ok'
 
         invitations = openreview_client.get_invitations(invitation='PRL/2023/ICAPS/-/Camera_Ready_Revision')
-        assert len(invitations) == 8
+        assert len(invitations) == 7
         invitation = openreview_client.get_invitation(id='PRL/2023/ICAPS/Submission1/-/Camera_Ready_Revision')
         assert 'authors' not in invitation.edit['note']['content']
         assert 'authorids' not in invitation.edit['note']['content']

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -619,6 +619,12 @@ Best,
         messages = openreview_client.get_messages(subject=f'[PRL ICAPS 2023] Decision notification for your submission 3:.*')
         assert 'We regret to inform you that your submission was not accepted.' in messages[0]['content']['text']
 
+        messages = openreview_client.get_messages(subject=f'[PRL ICAPS 2023] Decision notification for your submission 11:.*')
+        assert len(messages) == 0
+
+        messages = openreview_client.get_messages(subject=f'[PRL ICAPS 2023] Decision notification for your submission 12:.*')
+        assert len(messages) == 0
+
         # Check homepage tabs
         url = 'http://localhost:3030/group?id=PRL/2023/ICAPS'
         request_page(selenium, f'{url}', token=openreview_client.token, wait_for_element='header')


### PR DESCRIPTION
Currently submissions that don't have a decision posted are being treated as rejected submission when the post decision stage runs.

This PR ignores these submissions and it doesn't change the venueid, readers not send any notification.