### PR TITLE
Fix/ Journal: fix comment note writers

### DIFF
--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -4819,7 +4819,7 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
                             'items': [ { 'inGroup': r.replace('_.*', 's'), 'optional': True } if '.*' in r else { 'value': r, 'optional': True } for r in self.journal.get_official_comment_readers('${8/content/noteNumber/value}')]
                         }
                     },
-                    'writers': ['${3/writers}'],
+                    'writers': [venue_id, '${3/signatures}'],
                     'content': {
                         'title': {
                             'order': 1,


### PR DESCRIPTION
TMLR asked not to allow users to edit the revisions to comments, so I had removed `signatures` from the edit.writers. This also removed `signatures` from note.writers, which means users are not allow to edit their comments. 