### PR TITLE
ARR: Set reviewers group to see checklists

### DIFF
--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -369,7 +369,7 @@ class ARRWorkflow(object):
                         venue.id + "/Program_Chairs",
                         venue.id + "/Submission{number}/Senior_Area_Chairs",
                         venue.id + "/Submission{number}/Area_Chairs",
-                        venue.id + "/Submission{number}/Reviewers/Submitted"
+                        venue.id + "/Submission{number}/Reviewers"
                     ]
                 }
             },
@@ -427,7 +427,7 @@ class ARRWorkflow(object):
                         venue.id + "/Program_Chairs",
                         venue.id + "/Submission{number}/Senior_Area_Chairs",
                         venue.id + "/Submission{number}/Area_Chairs",
-                        venue.id + "/Submission{number}/Reviewers/Submitted"
+                        venue.id + "/Submission{number}/Reviewers"
                     ]
                 }
             },

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3829,6 +3829,10 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         assert 'flagged_for_ethics_review' not in test_submission.content
         assert 'flagged_for_desk_reject_verification' not in test_submission.content
         assert test_submission.content['number_of_reviewer_checklists']['value'] == 1
+
+        # Assert that the checklist is visible to the user
+        assert 'aclweb.org/ACL/ARR/2023/August/Submission2/Reviewers' in edit['note']['readers']
+
         _, test_submission = post_checklist(user_client, checklist_inv, user, ddate=now(), existing_note=edit['note'])
         assert test_submission.content['number_of_reviewer_checklists']['value'] == 0
         assert 'aclweb.org/ACL/ARR/2023/August/Ethics_Chairs' not in test_submission.readers


### PR DESCRIPTION
This PR solves an issue where reviewer checklists aren't visible to reviewers who submit them