### PR TITLE
ARR July - Updates to author registration based on issues in May

### DIFF
--- a/openreview/stages/arr_content.py
+++ b/openreview/stages/arr_content.py
@@ -3001,54 +3001,60 @@ arr_metareview_rating_content = {
 
 arr_submitted_author_forum = {
     'title': 'Submitted Author Profile Form',
-    'instructions': 'This form is required for all authors. Failure to complete it will lead to desk rejection.',
+    'instructions': 'This form is required for all authors. Failure to complete it will lead to desk rejection. If any of your co-authors are unable to complete the form (e.g., they are unable to access it), please provide their OpenReview IDs in the first question below.',
 }
 
 arr_submitted_author_content = {
-    "confirm_you_are_willing_to_serve_as_reviewer": {
+    "coauthor_issues": {
+        "order": 1,
         "value": {
             "param": {
-                "input": "radio",
-                "enum": [
-                    "I will serve as a reviewer if asked.",
-                    "I am already serving in ARR in another capacity, e.g., as an AC.",
-                    "No, I cannot serve. My paper should not be desk rejected because I have provided sufficient justification in the next two questions."
-                ],
-                "optional": False,
-                "type": "string"
+                "type": "string[]",
+                "regex": "[^;,\\n]+(,[^,\\n]+)*",
+                "hidden": True
             }
         },
-        "description": "ARR now requires all authors to review if asked. If you answer 'no' without sufficient justification, your paper will be desk rejected. If you are serving in another capacity, e.g., as an ARR AC, you should select the second option above and complete your availability form (we will confirm these and you will not be asked to review).",
         "order": 1
     },
-    "your_reason_for_being_unavailable_to_serve": {
+    "coauthor_issueids": {
+        "value": {
+            "param": {
+                "type": "profile[]",
+                "regex": "^~\\S+$|([a-z0-9_\\-\\.]{1,}@[a-z0-9_\\-\\.]{2,}\\.[a-z]{2,},){0,}([a-z0-9_\\-\\.]{1,}@[a-z0-9_\\-\\.]{2,}\\.[a-z]{2,})"
+            }
+        },
+        "description": "If any of your co-authors are unable to complete this form, please provide their Openreview IDs in this question. Search for the author profile by first, middle and last name or email address. If the profile is not found, you can add the author by completing first, middle, and last names as well as author email address.",
+        "order": 2
+    },
+    "confirm_you_are_willing_to_serve_as_a_reviewer_or_ac": {
         "value": {
             "param": {
                 "input": "radio",
                 "enum": [
-                    "N/A, I am able to review if asked.",
-                    "I am on parental leave.",
-                    "I have a medical emergency.",
-                    "Other, which I have specified in the next question."
+                    "I will serve as a reviewer or area chair (AC) in this cycle if ARR considers me qualified.",
+                    "I will serve as a reviewer in this cycle if ARR considers me qualified, but I do not wish to be an AC.",
+                    "I am already serving in ARR as an SAC, ethics reviewer, ethics chair, or as part of the ARR team.",
+                    "No, I cannot serve because I am on parental leave.",
+                    "No, I cannot serve because I have a medical emergency.",
+                    "No, I cannot serve for another reason. My paper should not be desk rejected because I have provided sufficient justification in the next question."
                 ],
                 "optional": False,
                 "type": "string"
             }
         },
-        "description": "If you answered 'No' in the previous question, please provide your justification here. Otherwise please leave this blank.",
-        "order": 2
+        "description": "ARR now requires all authors to contribute to the review process if asked. Serving as either a reviewer or an AC is sufficient to satisfy this requirement. If you are already a reviewer or AC in ARR, please select one of the first two options to confirm you are willing to serve in this cycle. If you are unable to serve please select 'No...' and note that you must provide sufficient justification in the next question or otherwise your paper will be desk rejected.",
+        "order": 3
     },
     "other_reason_for_being_unavailable_to_serve": {
         "value": {
             "param": {
-                "minLength": 1,
                 "optional": True,
                 "type": "string",
                 "input": "textarea"
             }
         },
-        "description": "If you answered 'Other' in the previous question, please provide your justification here. Otherwise please leave this blank.",
-        "order": 3
+        "description": "If you answered 'No, I cannot serve for another reason' in the previous question, please provide your justification here. Otherwise please leave this blank. If you believe you are not qualified, do not write that here, use the question below. If you are already serving, please use one of the first three options in the previous question.",
+        "order": 4
     },
     "confirm_you_are_qualified_to_review": {
         "value": {
@@ -3063,7 +3069,7 @@ arr_submitted_author_content = {
             }
         },
         "description": "The ARR requirements for reviewers are: (a) at least two papers in main ACL events or Findings, plus (b) at least one more paper in the ACL Anthology or a major AI venue. Venues considered 'main ACL' are: ACL, CL, CoLing, CoNLL, EACL, EMNLP, HLT, IJCNLP / AACL, LREC, NAACL, TACL, *SEM. Major AI venues we consider are: AAAI, CVPR, ECCV, FAccT, ICCV, ICLR, ICML, IJCAI, JAIR, JMLR, NeurIPS, TMLR, TPAMI. Note, we will check that your response matches data online. Having your self-reported status helps us identify issues with available data.",
-        "order": 4
+        "order": 6
     },
     "are_you_a_student": {
         "value": {
@@ -3080,7 +3086,7 @@ arr_submitted_author_content = {
             }
         },
         "description": "We collect this information because sometimes it is unclear from OpenReview profiles.",
-        "order": 5
+        "order": 7
     },
     "what_is_your_highest_level_of_completed_education": {
         "value": {
@@ -3096,62 +3102,63 @@ arr_submitted_author_content = {
             }
         },
         "description": "We collect this information because sometimes it is unclear from OpenReview profiles.",
-        "order": 6
+        "order": 8
     },
-    "serving_as_a_regular_or_emergency_reviewer": {
+    "serving_as_a_regular_or_emergency_reviewer_or_ac": {
         "value": {
             "param": {
                 "input": "radio",
                 "enum": [
-                    "I am willing to serve either as a regular reviewer or as an emergency reviewer.",
-                    "I prefer to serve as a regular reviewer, but may be assigned as an emergency reviewer if needed.",
-                    "I prefer to serve as an emergency reviewer, but may be assigned as a regular reviewer if needed.",
-                    "I only wish to serve as a regular reviewer."
+                    "Yes, I am willing to serve as an emergency reviewer or AC.",
+                    "No, I am not willing to serve as an emergency reviewer or AC.",
                 ],
                 "optional": False,
                 "type": "string"
             }
         },
-        "description": "If you are asked to review, there are two times you may be asked: (1) the normal review process, and (2) at the end of the review period when we have emergency reviewers quickly review (in 1-2 days) papers that are missing reviews.",
-        "order": 7
+        "description": "Some reviewers and ACs will be needed to quickly review (in 1-2 days) papers that are missing reviews at the end of the review period. Please indicate if you are willing to serve in this way.",
+        "order": 9
     },
-    "confirm_load_for_emergency_reviewing": {
+    "indicate_emergency_reviewer_load": {
         "value": {
             "param": {
-                "optional": True,
-                "type": "integer"
+                "input": "radio",
+                "enum": [
+                    "N/A, in the previous question I indicated I do not wish to be an emergency reviewer or AC.",
+                    "1",
+                    "2",
+                    "3"
+                ],
+                "optional": False,
+                "type": "string"
             }
         },
-        "description": "If you are selected as a reviewer and you have indicated that you are willing to help with emergency reviews, please enter your maximum emergency reviewing load here.",
-        "order": 8
+        "description": "Please indicate how many papers you would be willing to do emergency reviews for if asked.",
+        "order": 10
     },
     "confirm_your_profile_has_past_domains": {
-        "order": 9,
-        "description": "I confirm that I have specified in my OpenReview profile the full history of domains I am and previously was affiliated with.",
+        "description": "I confirm that I have specified in my OpenReview profile the full history of domains I am now and previously was affiliated with.",
         "value": {
             "param": {
                 "type": "string",
-                "enum": [
-                    "Yes"
-                ],
+                "enum": ["Yes"],
                 "input": "checkbox",
                 "optional": False
             }
-        }
+        },
+        "order": 11
     },
     "confirm_your_profile_has_all_email_addresses": {
-        "order": 10,
-        "description": "I confirm that I have specified in my OpenReview profile all (professional) email addresses I use and used before.",
+        "description": "I confirm that I have specified in my OpenReview profile all (professional) email addresses I now use and have used before.",
         "value": {
             "param": {
                 "type": "string",
-                "enum": [
-                    "Yes"
-                ],
+                "enum": ["Yes"],
                 "input": "checkbox",
                 "optional": False
             }
-        }
+        },
+        "order": 12
     },
     "meta_data_donation": {
         "value": {
@@ -3161,11 +3168,11 @@ arr_submitted_author_content = {
                     "Yes, If selected as a reviewer, I consent to donating anonymous metadata of my review for research.",
                     "No, I do not consent to donating anonymous metadata of my review for research."
                 ],
-                "type": "string"
+                "type": "string",
             }
         },
         "description": "If selected as reviewer, do you agree for the anonymized metadata associated with your reviews produced in this cycle to be included in a publicly available dataset? This dataset WILL include scores, anonymized paper and reviewer IDs that allow grouping the reviews by paper and by reviewer, as well as meta-review decisions and other numerical and categorical metadata. This dataset WILL NOT include any textual or uniquely attributable data like names, submission titles and texts, review texts, author responses, etc.",
-        "order": 11
+        "order": 13
     },
     "indicate_your_research_areas": {
         "value": {
@@ -3203,7 +3210,7 @@ arr_submitted_author_content = {
             }
         },
         "description": "If you are selected as a reviewer, we will need to know the research areas / tracks you are qualified to review for. Please select the most relevant research areas / tracks for your expertise",
-        "order": 12
+        "order": 14
     },
     "indicate_languages_you_study": {
         "value": {
@@ -3213,10 +3220,10 @@ arr_submitted_author_content = {
                 "type": "string"
             }
         },
-        "description": "Please list the languages that fall under your expertise, separated by commas.",
-        "order": 13
+        "description": "Please list the languages that fall udner your expertise, separated by commas.",
+        "order": 15
     },
-    "confirm_your_openreview_profile_contains_a_dblp_link": {
+    "confirm_your_openreview_profile_contains_dblp_link": {
         "value": {
             "param": {
                 "input": "radio",
@@ -3229,57 +3236,37 @@ arr_submitted_author_content = {
                 "type": "string"
             }
         },
-        "description": "If there is a valid DBLP profile for you, your OpenReview profile must contain a link to it. If the profile is invalid, you must either import your papers to OpenReview or provide a valid ACL Anthology profile link.",
-        "order": 14
+        "order": 16
     },
     "provide_your_dblp_url": {
         "description": "If there is a valid DBLP profile for you, please provide it here. If the profile is invalid, e.g., because it has other people's papers in it, please leave this blank.",
         "value": {
             "param": {
-                "minLength": 1,
-                "optional": True,
-                "type": "string"
-            }
-        },
-        "order": 15
-    },
-    "confirm_your_openreview_profile_contains_a_semantic_scholar_link": {
-        "value": {
-            "param": {
-                "input": "radio",
-                "enum": [
-                    "Yes, my OpenReview profile contains a link to a Semantic Scholar profile with just my papers.",
-                    "No, the Semantic Scholar profile for my name contains other peoples' publications.",
-                    "No, I have no Semantic Scholar listed publications."
-                ],
-                "optional": False,
-                "type": "string"
-            }
-        },
-        "description": "If there is a valid Semantic Scholar profile for you, your OpenReview profile must contain a link to it. If the profile is invalid, you must either import your papers to OpenReview or provide a valid ACL Anthology profile link.",
-        "order": 16
-    },
-    "provide_your_semantic_scholar_url": {
-        "description": "If there is a valid Semantic Scholar profile for you, please provide it here. If the profile is invalid, e.g., because it has other people's papers in it, please leave this blank.",
-        "value": {
-            "param": {
-                "minLength": 1,
                 "optional": True,
                 "type": "string"
             }
         },
         "order": 17
     },
-    "provide_your_acl_anthology_url": {
-        "description": "If there is a valid ACL Anthology profile for you, please provide it here. If the profile is invalid, e.g., because it has a other people's papers in it, please leave this blank.",
+    "provide_your_semantic_scholar_url": {
+        "description": "If there is a valid Semantic Scholar profile for you, please provide it here. If the profile is invalid, e.g., because it has other people's papers in it, please leave this blank.",
         "value": {
             "param": {
-                "minLength": 1,
                 "optional": True,
                 "type": "string"
             }
         },
         "order": 18
+    },
+    "provide_your_acl_anthology_url": {
+        "description": "If there is a valid ACL Anthology profile for you, please provide it here. If the profile is invalid, e.g., because it has a other people's papers in it, please leave this blank.",
+        "value": {
+            "param": {
+                "optional": True,
+                "type": "string"
+            }
+        },
+        "order": 19
     },
     "attribution": {
         "description": "Please read and decide whether to transfer the license to your reviewing data for this iteration of ARR if you are selected as a reviewer.\n\n***DISCLAIMER***\n\nYour participation is strictly voluntary. By transferring this license you grant ACL the right to distribute the text of your review. In particular, we may include your review text and scores in research datasets without revealing the OpenReview identifier that produced the review. Keep in mind that as with any text, your identity might be approximated using author profiling techniques. Only reviews for accepted papers will be eventually made publicly available. The authors of the papers will have to agree to the release of the textual review data associated with their papers.\n\nName of the ACL Conference: previous ARR cycle\n\n**Introduction**\nThis Peer Reviewer Content License Agreement (\u201cAgreement\u201d) is entered into between the Association for Computational Linguistics (\u201cACL\u201d) and the Peer Reviewer listed above in connection with content developed and contributed by Peer Reviewer during the peer review process (referred as \u201cPeer Review Content\u201d). In exchange of adequate consideration, ACL and the Peer Reviewer agree as follows:\n\n**Section 1: Grant of License**\nPeer Reviewer grants ACL a worldwide, irrevocable, and royalty-free license to use the Peer Review Content developed and prepared by Peer Reviewer in connection with the peer review process for the ACL Conference listed above, including but not limited to text, review form scores and metadata, charts, graphics, spreadsheets, and any other materials according to the following terms: A. For Peer Review Content associated with papers accepted for publication, and subject to the Authors permission, ACL may reproduce, publish, distribute, prepare derivative work, and otherwise make use of the Peer Review Content, and to sub-license the Peer Review Content to the public according to terms of the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. B. For Peer Review Content associated with papers not accepted for publication, ACL may use the Peer Review Content for internal research, program analysis, and record- keeping purposes. Notwithstanding the foregoing, the Parties acknowledge and agree that this Agreement does not transfer to ACL the ownership of any proprietary rights pertaining to the Peer Review Content, and that Peer Review retains respective ownership in and to the Peer Review Content.\n\n**Section 2: Attribution and Public Access License**\nA.The Parties agree that for purpose of administering the public access license, ACL will be identified as the licensor of the Content with the following copyright notice: Copyright \u00a9 2022 administered by the Association for Computational Linguistics (ACL) on behalf of ACL content contributors: ______________ (list names of peer reviewers who wish to be attributed), and other contributors who wish to remain anonymous. Content displayed on this webpage is made available under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. B.In the event Peer Reviewer intends to modify the attribution displayed in connection with the copyright notice above, ACL will use reasonable efforts to modify the copyright notice after receipt of Peer Reviewer\u2019s written request. Notwithstanding the foregoing, Peer Reviewer acknowledges and agrees that any modification in connection with attribution will not be retroactively applied. C.The Parties understand and acknowledge that the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License is irrevocable once granted unless the licensee breaches the public access license terms.\n\n**Section 3: Warranty**\nPeer Reviewer represents and warrants that the Content is Peer Reviewer\u2019s original work and does not infringe on the proprietary rights of others. Peer Reviewer further warrants that he or she has obtained all necessary permissions from any persons or organizations whose materials are included in the Content, and that the Content includes appropriate citations that give credit to the original sources.\n\n**Section 4: Legal Relationship**\nThe Parties agree that this Agreement is not intended to create any joint venture, partnership, or agency relationship of any kind; and both agree not to contract any obligations in the name of the other.\n\nUnless the peer reviewer elects to be attributed according to Section 2, the peer reviewer\u2019s name will not be identified in connection with publication of the Peer Review Content. If you wish to be attributed, please check the box below. ATTENTION: this will allow you to get credit for your reviews, but it will also DEANONYMIZE your reviews. Please select after careful consideration.",
@@ -3293,7 +3280,7 @@ arr_submitted_author_content = {
                 "optional": True
             }
         },
-        "order": 19
+        "order": 20
     },
     "agreement": {
         "description": "By selecting 'I agree' below you confirm that you agree to this license agreement if you are selected to review.",
@@ -3309,6 +3296,6 @@ arr_submitted_author_content = {
                 "optional": False
             }
         },
-        "order": 20
+        "order": 21
     }
 }


### PR DESCRIPTION
Based on the experience with the new author registration form in May (and in consultation with the EICs), I've drafted some changes to the form for July. In particular:

- Added a question for people to provide OpenReview IDs of co-authors who were unable to complete the form for some reason (e.g., on leave)
- Simplifying some questions
- Being clearer about how ACs fit in

I realise this is a late change, but it's needed for the July instance.