### PR TITLE
Fix: Set readers to everyone for Review Count always

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -4760,12 +4760,12 @@ class InvitationBuilder(object):
 
         self.save_invitation(invitation)           
 
-    def create_metric_invitation(self, metric_name):
+    def create_metric_invitation(self, metric_name, readers=None):
         
         venue_id = self.venue_id
         reviewers_id = self.venue.get_reviewers_id()
         invitation_id = f'{reviewers_id}/-/{metric_name}'
-        readers = f'{reviewers_id}/{metric_name}/Readers'
+        readers_group = f'{reviewers_id}/{metric_name}/Readers'
         nonreaders = f'{reviewers_id}/{metric_name}/NonReaders'
         invitation = openreview.api.Invitation(
             id=invitation_id,
@@ -4775,7 +4775,7 @@ class InvitationBuilder(object):
             signatures=['~Super_User1'],
             minReplies=1,
             maxReplies=1,
-            type='Tag',            
+            type='Tag',
             edit={
                 'id': {
                     'param': {
@@ -4797,11 +4797,7 @@ class InvitationBuilder(object):
                         'deletable': True
                     }
                 },
-                'readers': [
-                    venue_id,
-                    readers,
-                    '${2/tail}'
-                ],
+                'readers': readers if readers else [venue_id, readers_group, '${2/profile}'],
                 'nonreaders': [nonreaders],
                 'writers': [venue_id],
                 'signature': venue_id,

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -1440,7 +1440,7 @@ Total Errors: {len(errors)}
     def compute_reviewers_stats(self):
 
         self.invitation_builder.create_metric_invitation('Review_Assignment_Count')
-        self.invitation_builder.create_metric_invitation('Review_Count')
+        self.invitation_builder.create_metric_invitation('Review_Count', ['everyone'])
         self.invitation_builder.create_metric_invitation('Review_Days_Late_Sum')
         self.invitation_builder.create_metric_invitation('Discussion_Reply_Sum')
 
@@ -1525,36 +1525,36 @@ Total Errors: {len(errors)}
                         review_days_late.append(np.maximum((review_tcdate - review_duedate).days, 0))
 
             review_assignment_count_tags.append(openreview.api.Tag(
-                invitation= f'{reviewers_id}/-/Review_Assignment_Count',
-                profile= reviewer_id,
-                weight= num_assigned,
-                readers= [venue_id, f'{reviewers_id}/Review_Assignment_Count/Readers', reviewer_id],
-                writers= [venue_id],
-                nonreaders= [f'{reviewers_id}/Review_Assignment_Count/NonReaders'],
+                invitation = f'{reviewers_id}/-/Review_Assignment_Count',
+                profile = reviewer_id,
+                weight = num_assigned,
+                readers = [venue_id, f'{reviewers_id}/Review_Assignment_Count/Readers', reviewer_id],
+                writers = [venue_id],
+                nonreaders = [f'{reviewers_id}/Review_Assignment_Count/NonReaders'],
             ))
             review_count_tags.append(openreview.api.Tag(
-                invitation= f'{reviewers_id}/-/Review_Count',
-                profile= reviewer_id,
-                weight= num_reviews,
-                readers= [venue_id, f'{reviewers_id}/Review_Count/Readers', reviewer_id],
-                writers= [venue_id],
-                nonreaders= [f'{reviewers_id}/Review_Count/NonReaders'],
+                invitation = f'{reviewers_id}/-/Review_Count',
+                profile = reviewer_id,
+                weight = num_reviews,
+                readers = ['everyone'],
+                writers = [venue_id],
+                nonreaders = [f'{reviewers_id}/Review_Count/NonReaders'],
             ))
             comment_count_tags.append(openreview.api.Tag(
-                invitation= f'{reviewers_id}/-/Discussion_Reply_Sum',
-                profile= reviewer_id,
-                weight= num_comments,
-                readers= [venue_id, f'{reviewers_id}/Discussion_Reply_Sum/Readers', reviewer_id],
-                writers= [venue_id],
-                nonreaders= [f'{reviewers_id}/Discussion_Reply_Sum/NonReaders'],
+                invitation = f'{reviewers_id}/-/Discussion_Reply_Sum',
+                profile = reviewer_id,
+                weight = num_comments,
+                readers = [venue_id, f'{reviewers_id}/Discussion_Reply_Sum/Readers', reviewer_id],
+                writers = [venue_id],
+                nonreaders = [f'{reviewers_id}/Discussion_Reply_Sum/NonReaders'],
             ))
             review_days_late_tags.append(openreview.api.Tag(
-                invitation= f'{reviewers_id}/-/Review_Days_Late_Sum',
-                profile= reviewer_id,
-                weight= int(np.sum(review_days_late)),
-                readers= [venue_id, f'{reviewers_id}/Review_Days_Late_Sum/Readers', reviewer_id],
-                writers= [venue_id],
-                nonreaders= [f'{reviewers_id}/Review_Days_Late_Sum/NonReaders'],
+                invitation = f'{reviewers_id}/-/Review_Days_Late_Sum',
+                profile = reviewer_id,
+                weight = int(np.sum(review_days_late)),
+                readers = [venue_id, f'{reviewers_id}/Review_Days_Late_Sum/Readers', reviewer_id],
+                writers = [venue_id],
+                nonreaders = [f'{reviewers_id}/Review_Days_Late_Sum/NonReaders'],
             ))
             print(reviewer_id,
             num_assigned,


### PR DESCRIPTION
This pull request introduces changes to the `openreview` codebase to enhance flexibility in defining readers for metric invitations and updates the default readers for specific metrics. The most important changes include modifying the `create_metric_invitation` method to accept custom readers, updating the `Review_Count` metric to use `['everyone']` as its readers, and adjusting related logic to accommodate these changes.

### Enhancements to `create_metric_invitation` method:

* [`openreview/venue/invitation.py`](diffhunk://#diff-5f630aad45619aab75cba46ea1daed6ab09bee6cde761b0a8399ec3e33cfe334L4763-R4768): Updated the `create_metric_invitation` method to include an optional `readers` parameter, allowing custom reader groups to be specified. The default behavior now uses `readers_group` when no `readers` are provided. [[1]](diffhunk://#diff-5f630aad45619aab75cba46ea1daed6ab09bee6cde761b0a8399ec3e33cfe334L4763-R4768) [[2]](diffhunk://#diff-5f630aad45619aab75cba46ea1daed6ab09bee6cde761b0a8399ec3e33cfe334L4800-R4800)

### Updates to `Review_Count` metric:

* [`openreview/venue/venue.py`](diffhunk://#diff-5c665402c72755d200aacca88c81ebdc52c1adfbda71343f8bfd09a1eb5be0bdL1443-R1443): Modified calls to `create_metric_invitation` for the `Review_Count` metric to explicitly set `['everyone']` as the readers. This ensures the metric is accessible to all users.
* [`openreview/venue/venue.py`](diffhunk://#diff-5c665402c72755d200aacca88c81ebdc52c1adfbda71343f8bfd09a1eb5be0bdL1539-R1539): Adjusted the `readers` field for the `Review_Count` metric to use `['everyone']`, replacing the previous logic that included specific reader groups.