### PR TITLE
functions needed to schedule date process functions

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -181,9 +181,9 @@ class OpenReviewClient(object):
         raise OpenReviewException("Process timed out")    
 
     def get_invitation_date_process_job(self, job_id):
-        response = self.session.get(self.baseurl + '/queue/api/queues/Python Date Processes MQ/' + job_id.replace('/', '%2F'), params = {}, headers = self.headers)
+        response = self.session.get(self.baseurl + '/jobs/queues/pyDateProcessQueueMQ/' + job_id.replace('/', '%2F'), params = {}, headers = self.headers)
         response = self.__handle_response(response)
-        return response.json()['job']
+        return response.json()
     
     def reschedule_date_process_jobs(self, invitation_id):
         response = self.session.post(self.baseurl + '/invitations/dateprocesses', json = { 'ids': [invitation_id]}, headers = self.headers)

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -180,6 +180,16 @@ class OpenReviewClient(object):
 
         raise OpenReviewException("Process timed out")    
 
+    def get_invitation_date_process_job(self, job_id):
+        response = self.session.get(self.baseurl + '/queue/api/queues/Python Date Processes MQ/' + job_id.replace('/', '%2F'), params = {}, headers = self.headers)
+        response = self.__handle_response(response)
+        return response.json()['job']
+    
+    def reschedule_date_process_jobs(self, invitation_id):
+        response = self.session.post(self.baseurl + '/invitations/dateprocesses', json = { 'ids': [invitation_id]}, headers = self.headers)
+        response = self.__handle_response(response)
+        return response.json()
+    
     ## PUBLIC FUNCTIONS
     def impersonate(self, group_id):
         response = self.session.post(self.baseurl + '/impersonate', json={ 'groupId': group_id }, headers=self.headers)


### PR DESCRIPTION
This is the script used to schedule date process functions that disappeared after redis restart:

```
review_invitations = client.get_all_invitations(prefix='DMLR/')
for review_invitation in tqdm(review_invitations, desc='Rescheduling jobs'):
    logs = client.get_process_logs(invitation=review_invitation.id, status='queued')
    for log in logs:
        job_id = log['id']
        if job_id.startswith(review_invitation.id):
            try:
                job = client.get_invitation_date_process_job(job_id)
            except openreview.OpenReviewException as e:
                print(f'Error retrieving job {job_id}, try scheduling')
                client.reschedule_date_process_jobs(review_invitation.id)
```

I didn't add this script to the Journal class because I don't think this will happen again but let's keep it here in case we need it in the future.