### PR TITLE
Fix: Avoid relying on count returned by API

### DIFF
--- a/openreview/venue/process/assignment_pre_process.js
+++ b/openreview/venue/process/assignment_pre_process.js
@@ -45,15 +45,15 @@ async function process(client, edge, invitation) {
   }
 
   if (reviewersAnonName) {
-    const { groups: anonGroups, count: groupCount } = await client.getGroups({ prefix: `${submissionGroupId}/${reviewersAnonName}`, signatory: edge.tail })
+    const { groups: anonGroups } = await client.getGroups({ prefix: `${submissionGroupId}/${reviewersAnonName}`, signatory: edge.tail })
 
-    if (groupCount === 0) { 
+    if (!anonGroups?.length) { 
       return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can remove assignment, signatory groups not found for ${edge.tail}` }))
     }
 
-    const { count: noteCount } = await client.getNotes({ invitation: `${submissionGroupId}/-/` + reviewName, signatures: anonGroups[0].id })
+    const { notes } = await client.getNotes({ invitation: `${submissionGroupId}/-/` + reviewName, signatures: anonGroups[0].id, limit: 1 })
 
-    if (noteCount > 0) {
+    if (notes?.length > 0) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not remove assignment, the user ${edge.tail} already posted a ${reviewName.replace('_', ' ')}` }))
     }
   }


### PR DESCRIPTION
This pull request refines the logic for processing reviewer assignments in the `assignment_pre_process.js` file. The changes focus on improving error handling and simplifying API responses by removing unused fields and enhancing conditional checks.

Enhancements to error handling and API usage:

* Removed the `count` field from the `getGroups` and `getNotes` API calls, replacing it with direct checks on the length of returned arrays (`anonGroups` and `notes`). This ensures more efficient and clear handling of results.
* Updated conditional checks to use `?.length` for safer access to array lengths, avoiding potential issues with undefined or null values.