### PR TITLE
Add weight param to request_expertise

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -2503,7 +2503,7 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return response.json()
 
-    def request_expertise(self, name, group_id, venue_id, submission_content=None, alternate_match_group = None, expertise_selection_id=None, model=None, baseurl=None):
+    def request_expertise(self, name, group_id, venue_id, submission_content=None, alternate_match_group = None, expertise_selection_id=None, model=None, baseurl=None, weight=None):
 
         # Build entityA from group_id
         entityA = {
@@ -2538,6 +2538,11 @@ class OpenReviewClient(object):
                 'name': model
             }
         }
+
+        if weight:
+            expertise_request['dataset'] = {
+                'weightSpecification': weight
+            }
 
         base_url = baseurl if baseurl else self.baseurl
         response = self.session.post(base_url + '/expertise', json = expertise_request, headers = self.headers)


### PR DESCRIPTION
This PR adds a weight param to request_expertise to support the expertise changes made here: https://github.com/openreview/openreview-expertise/pull/241

Which allows you to specify weights for certain publications. It expects a list of JSON objects, e.g.:

```
[
    {
        "prefix": "NeurIPS.cc",
        "weight": 2
    }
]
```

The expertise changes should be deployed first.