### PR TITLE
Fix: Validate that no variable is None

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1798,7 +1798,9 @@ def get_own_reviews(client):
         if domain_to_reviewer_invitation_suffix.get(note.domain) is None:
             domain = note.domain
             group = client_v2.get_group(domain)
-            reviewer_invitation_suffix = getattr(group, 'content', {}).get('review_name', {}).get('value', None)
+            reviewer_invitation_suffix = getattr(group, 'content', None)
+            if group and getattr(group, 'content', None):
+                reviewer_invitation_suffix = group.content.get('review_name', {}).get('value', None)
             if reviewer_invitation_suffix is None:
                 continue
             domain_to_reviewer_invitation_suffix[domain] = '/-/' + reviewer_invitation_suffix

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1799,7 +1799,7 @@ def get_own_reviews(client):
             domain = note.domain
             group = client_v2.get_group(domain)
             reviewer_invitation_suffix = getattr(group, 'content', None)
-            if group and getattr(group, 'content', None):
+            if group and reviewer_invitation_suffix:
                 reviewer_invitation_suffix = group.content.get('review_name', {}).get('value', None)
             if reviewer_invitation_suffix is None:
                 continue


### PR DESCRIPTION
Sometimes some groups like the OpenReview Archive will return None for some fields as it is not like other conferences.

This pull request refines the logic for extracting the `reviewer_invitation_suffix` in the `get_own_reviews` function to improve robustness when handling `group.content`. The changes ensure that the code gracefully handles cases where `group` or `group.content` is `None`.

### Improvements to error handling:

* [`openreview/tools.py`](diffhunk://#diff-a0a408fd57af11c3a81cfd044e307e78e5b96b29d4ec2f55a62cd5667b12b45dL1801-R1803): Updated the logic in `get_own_reviews` to check for the existence of `group` and `group.content` before attempting to access `review_name`. This prevents potential `AttributeError` exceptions when `group.content` is `None`.