### PR TITLE
Feat: Pass domain to request if invitation is provided

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1812,7 +1812,7 @@ class OpenReviewClient(object):
 
         return tools.concurrent_get(self, self.get_edges, **params)
 
-    def get_edges_count(self, id = None, invitation = None, head = None, tail = None, label = None):
+    def get_edges_count(self, id=None, invitation=None, head=None, tail=None, label=None, domain=None):
         """
         Returns a list of Edge objects based on the filters provided.
 
@@ -1821,6 +1821,7 @@ class OpenReviewClient(object):
         :arg head: Profile ID of the Profile that is connected to the Note ID in tail
         :arg tail: Note ID of the Note that is connected to the Profile ID in head
         :arg label: Label ID of the match
+        :arg domain: If provided, and the user has the domain as transitive member (venue organizer), it makes the request more efficient.
         """
         params = {}
 
@@ -1829,6 +1830,12 @@ class OpenReviewClient(object):
         params['head'] = head
         params['tail'] = tail
         params['label'] = label
+
+        if domain is not None:
+            params['domain'] = domain
+        elif invitation is not None:
+            edges_invitation = self.get_invitation(invitation)
+            params['domain'] = edges_invitation.domain
 
         response = self.session.get(self.edges_count_url, params=tools.format_params(params), headers = self.headers)
         response = self.__handle_response(response)

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1838,7 +1838,7 @@ class OpenReviewClient(object):
                 edges_invitation = self.get_invitation(invitation)
                 params['domain'] = edges_invitation.domain
             except:
-                return 0
+                pass
 
         response = self.session.get(self.edges_count_url, params=tools.format_params(params), headers = self.headers)
         response = self.__handle_response(response)

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1834,8 +1834,11 @@ class OpenReviewClient(object):
         if domain is not None:
             params['domain'] = domain
         elif invitation is not None:
-            edges_invitation = self.get_invitation(invitation)
-            params['domain'] = edges_invitation.domain
+            try:
+                edges_invitation = self.get_invitation(invitation)
+                params['domain'] = edges_invitation.domain
+            except:
+                return 0
 
         response = self.session.get(self.edges_count_url, params=tools.format_params(params), headers = self.headers)
         response = self.__handle_response(response)


### PR DESCRIPTION
This pull request introduces an improvement to the `get_edges_count` method in the `openreview/api/client.py` file, allowing for more efficient requests when a `domain` parameter is provided. The main changes add support for the `domain` argument and ensure it is included in the request parameters when appropriate.

Enhancements to edge count retrieval efficiency:

* Added a `domain` parameter to the `get_edges_count` method signature and documented its purpose for optimizing requests when the user is a transitive member of the domain. [[1]](diffhunk://#diff-f5d3f10e7a5ff1e9ba8f8f2073dca77d0c33d357533329eb2d8c002cb671bc7cL1815-R1815) [[2]](diffhunk://#diff-f5d3f10e7a5ff1e9ba8f8f2073dca77d0c33d357533329eb2d8c002cb671bc7cR1824)
* Updated logic to include the `domain` in request parameters if provided, or derive it from the invitation when not explicitly set.