### PR TITLE
ARR: Revert Seniority condition

### DIFF
--- a/openreview/arr/management/setup_reviewer_matching.py
+++ b/openreview/arr/management/setup_reviewer_matching.py
@@ -13,6 +13,11 @@ def process(client, invitation):
     from openreview.arr.arr import SENIORITY_PUBLICATION_COUNT
     from collections import defaultdict
 
+    def get_title(profile):
+        d = profile.content.get('history', [{}])
+        if len(d) > 0:
+            return d[0].get('position', 'Student')
+
     def is_main_venue(link, pub):
         venueid = pub.content.get('venueid')
         if venueid is not None:
@@ -426,7 +431,7 @@ def process(client, invitation):
     seniority_edges = []
     seniority_inv = f"{reviewers_id}/-/{seniority_name}"
     for profile in reviewer_profiles:
-        if collect_pub_stats(profile.content.get('publications', [])) >= SENIORITY_PUBLICATION_COUNT:
+        if 'student' not in get_title(profile).lower():
             seniority_edges.append(
                 openreview.api.Edge(
                     invitation=seniority_inv,

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -54,7 +54,7 @@ class TestARRVenueV2():
         helpers.create_user('reviewerna@aclrollingreview.com', 'Reviewer', 'ARRNA') ## User for unavailability with N/A
         helpers.create_user('reviewerethics@aclrollingreview.com', 'EthicsReviewer', 'ARROne')
 
-        # Manually create Reviewer ARROne as having more than 5 *CL main publications
+        # Manually create Reviewer ARROne as having more than 5 *CL main publications and full professor
         fullname = f'Reviewer ARROne'
         res = openreview_client.register_user(email = 'reviewer1@aclrollingreview.com', fullname = fullname, password = helpers.strong_password)
         username = res.get('id')
@@ -75,7 +75,7 @@ class TestARRVenueV2():
             'homepage': f"https://{fullname.replace(' ', '')}{int(time.time())}.openreview.net",
         }
         profile_content['history'] = [{
-            'position': 'Student',
+            'position': 'Full Professor',
             'start': 2017,
             'end': None,
             'institution': {


### PR DESCRIPTION
This PR reverts the seniority condition from using *CL publications back to career titles. This is because the publication count condition does not create enough senior reviewers for the reviewer matching