### PR TITLE
ARR: Fix super invitation ID

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -2579,29 +2579,9 @@ class OpenReviewClient(object):
         expertise_request = {
             'name': name,
             'entityA': entityA,
-            "entityB": { 
-                'type': "Note",
-                'submissions': [
-                    {
-                        "id": "medical_paper_1",
-                        "title": "Self-Supervised Learning for Early Detection of Rare Diseases in Multi-Institutional Electronic Health Records",
-                        "abstract": "Early identification of rare diseases remains a significant challenge due to data scarcity, delayed diagnosis, and heterogeneity in clinical presentations. In this study, we propose a self-supervised contrastive learning framework that leverages unlabeled electronic health records (EHRs) from multiple institutions to learn generalized patient embeddings. Our approach utilizes masked temporal modeling and inter-patient contrastive objectives to pre-train on 1.2 million EHR sequences, followed by fine-tuning on a curated rare disease dataset with fewer than 500 labeled cases. We demonstrate substantial improvements in diagnostic accuracy (AUC +9.4%) compared to baseline supervised models, with consistent generalization across three external hospital systems. These results suggest self-supervised pretraining can enable scalable, privacy-preserving rare disease screening across diverse healthcare environments.",
-                    },
-                    {
-                        "id": "medical_paper_2",
-                        "title": "Multi-Modal Generative Modeling for Personalized Cancer Prognosis Using Histopathology and Genomic Data",
-                        "abstract": "Precision oncology requires integrating diverse data modalities to capture the complex interplay between tumor morphology and molecular alterations. We introduce a multi-modal variational autoencoder (MM-VAE) that jointly learns latent representations from whole-slide histopathology images and matched somatic mutation profiles. Using a cohort of 3,812 cancer patients from The Cancer Genome Atlas (TCGA), our model generates patient-specific prognostic embeddings that outperform uni-modal baselines in survival prediction (C-index +0.11). Furthermore, the learned latent space enables counterfactual prognosis simulations by perturbing genomic or morphological features. We validate clinical relevance via correlation with known prognostic biomarkers and oncologist panel review. This work highlights the potential of generative models to support interpretable, patient-tailored decision-making in oncology.",
-                    },
-                    {
-                        "id": "robotics_paper_1",
-                        "title": "Skill Transfer via World Model Distillation in Low-Resource Robot Learning",
-                        "abstract": "Robots operating in real-world environments often lack the large-scale data required for end-to-end reinforcement learning. We present a novel method for skill transfer in low-resource settings using world model distillation. First, a high-capacity world model is trained in simulation across a broad distribution of tasks using model-based reinforcement learning. Then, this model is distilled into a compact latent dynamics representation, enabling fast adaptation on real-world robots using only a few trajectories per task. Our approach outperforms existing sim-to-real transfer methods by up to 38% in task success across four manipulation benchmarks. Notably, the system requires no real-world reward supervision and is robust to domain shift in sensor noise and actuation latency. This work demonstrates a scalable path toward efficient and generalizable robot skill learning under constrained data regimes.",
-                    }
-                ]
-            },
+            'entityB': entityB,
             'model': {
-                'name': model,
-                'sparseValue': 650
+                'name': model
             }
         }
 

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -2571,9 +2571,29 @@ class OpenReviewClient(object):
         expertise_request = {
             'name': name,
             'entityA': entityA,
-            'entityB': entityB,
+            "entityB": { 
+                'type': "Note",
+                'submissions': [
+                    {
+                        "id": "medical_paper_1",
+                        "title": "Self-Supervised Learning for Early Detection of Rare Diseases in Multi-Institutional Electronic Health Records",
+                        "abstract": "Early identification of rare diseases remains a significant challenge due to data scarcity, delayed diagnosis, and heterogeneity in clinical presentations. In this study, we propose a self-supervised contrastive learning framework that leverages unlabeled electronic health records (EHRs) from multiple institutions to learn generalized patient embeddings. Our approach utilizes masked temporal modeling and inter-patient contrastive objectives to pre-train on 1.2 million EHR sequences, followed by fine-tuning on a curated rare disease dataset with fewer than 500 labeled cases. We demonstrate substantial improvements in diagnostic accuracy (AUC +9.4%) compared to baseline supervised models, with consistent generalization across three external hospital systems. These results suggest self-supervised pretraining can enable scalable, privacy-preserving rare disease screening across diverse healthcare environments.",
+                    },
+                    {
+                        "id": "medical_paper_2",
+                        "title": "Multi-Modal Generative Modeling for Personalized Cancer Prognosis Using Histopathology and Genomic Data",
+                        "abstract": "Precision oncology requires integrating diverse data modalities to capture the complex interplay between tumor morphology and molecular alterations. We introduce a multi-modal variational autoencoder (MM-VAE) that jointly learns latent representations from whole-slide histopathology images and matched somatic mutation profiles. Using a cohort of 3,812 cancer patients from The Cancer Genome Atlas (TCGA), our model generates patient-specific prognostic embeddings that outperform uni-modal baselines in survival prediction (C-index +0.11). Furthermore, the learned latent space enables counterfactual prognosis simulations by perturbing genomic or morphological features. We validate clinical relevance via correlation with known prognostic biomarkers and oncologist panel review. This work highlights the potential of generative models to support interpretable, patient-tailored decision-making in oncology.",
+                    },
+                    {
+                        "id": "robotics_paper_1",
+                        "title": "Skill Transfer via World Model Distillation in Low-Resource Robot Learning",
+                        "abstract": "Robots operating in real-world environments often lack the large-scale data required for end-to-end reinforcement learning. We present a novel method for skill transfer in low-resource settings using world model distillation. First, a high-capacity world model is trained in simulation across a broad distribution of tasks using model-based reinforcement learning. Then, this model is distilled into a compact latent dynamics representation, enabling fast adaptation on real-world robots using only a few trajectories per task. Our approach outperforms existing sim-to-real transfer methods by up to 38% in task success across four manipulation benchmarks. Notably, the system requires no real-world reward supervision and is robust to domain shift in sensor noise and actuation latency. This work demonstrates a scalable path toward efficient and generalizable robot skill learning under constrained data regimes.",
+                    }
+                ]
+            },
             'model': {
-                'name': model
+                'name': model,
+                'sparseValue': 650
             }
         }
 

--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -730,7 +730,7 @@ class ARRWorkflow(object):
             ),
             ARRStage(
                 type=ARRStage.Type.REGISTRATION_STAGE,
-                group_id=venue.get_reviewers_id(),
+                group_id=venue.get_ethics_reviewers_id(),
                 required_fields=['maximum_load_due_date', 'maximum_load_exp_date'],
                 super_invitation_id=f"{venue.get_ethics_reviewers_id()}/-/{self.invitation_builder.MAX_LOAD_AND_UNAVAILABILITY_NAME}",
                 stage_arguments={
@@ -842,7 +842,7 @@ class ARRWorkflow(object):
                 type=ARRStage.Type.REGISTRATION_STAGE,
                 group_id=venue.get_authors_id(),
                 required_fields=['reviewer_nomination_start_date', 'reviewer_nomination_end_date'],
-                super_invitation_id=f"{self.venue_id}/-/{self.invitation_builder.SUBMITTED_AUTHORS_NAME}",
+                super_invitation_id=f"{venue.get_authors_id()}/-/{self.invitation_builder.SUBMITTED_AUTHORS_NAME}",
                 stage_arguments={   
                     'committee_id': venue.get_authors_id(),
                     'name': self.invitation_builder.SUBMITTED_AUTHORS_NAME,
@@ -852,7 +852,8 @@ class ARRWorkflow(object):
                     'remove_fields': ['profile_confirmed', 'expertise_confirmed']
                 },
                 start_date=self.configuration_note.content.get('reviewer_nomination_start_date'),
-                due_date=self.configuration_note.content.get('reviewer_nomination_end_date')
+                due_date=self.configuration_note.content.get('reviewer_nomination_end_date'),
+                exp_date=self.configuration_note.content.get('reviewer_nomination_end_date')
             ),
             ARRStage(
                 type=ARRStage.Type.CUSTOM_STAGE,

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -2452,7 +2452,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                         'confirm_you_are_willing_to_serve_as_a_reviewer_or_ac': {'value': "I will serve as a reviewer or area chair (AC) in this cycle if ARR considers me qualified."},
                         'details_of_reason_for_being_unavailable_to_serve': {'value': ""},
                         'serving_as_a_regular_or_emergency_reviewer_or_ac': {'value': "Yes, I am willing to serve as an emergency reviewer or AC."},
-                        'indicate_emergency_reviewer_load': {'value': 3},
+                        'indicate_emergency_reviewer_load': {'value': '3'},
                         'confirm_you_are_qualified_to_review': {'value': "Yes, I meet the ARR requirements to be a reviewer."},
                         'are_you_a_student': {'value': "Yes, I am a Masters student."},
                         'what_is_your_highest_level_of_completed_education': {'value': "Doctorate"},
@@ -2517,6 +2517,58 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                     ddate=openreview.tools.datetime_millis(datetime.datetime.now())
                 )
             )
+
+        # Manually add new field
+        openreview_client.post_invitation_edit(
+            invitations='aclweb.org/ACL/ARR/2023/August/-/Edit',
+            readers=['aclweb.org/ACL/ARR/2023/August'],
+            writers=['aclweb.org/ACL/ARR/2023/August'],
+            signatures=['aclweb.org/ACL/ARR/2023/August'],
+            invitation=openreview.api.Invitation(
+                id = f"aclweb.org/ACL/ARR/2023/August/Authors/-/Submitted_Author_Form",
+                edit = {
+                    'note': {
+                        'content': {
+                            "paper_type": {
+                                "value": {
+                                    "param": {
+                                        "input": "radio",
+                                        "enum": [
+                                            "Long",
+                                            "Short"
+                                        ],
+                                        "optional": False,
+                                        "type": "string"
+                                    }
+                                },
+                                "description": "Long or short. See the CFP for the requirements for long and short papers.",
+                                "order": 11
+                            }
+                        }
+                    }
+                }
+            )
+        )
+        # Change dates and check that field is in invitation
+        pc_client.post_note(
+            openreview.Note(
+                content={
+                    'reviewer_nomination_start_date': (now).strftime('%Y/%m/%d %H:%M'),
+                    'reviewer_nomination_end_date': (due_date).strftime('%Y/%m/%d %H:%M')
+                },
+                invitation=f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration',
+                forum=request_form.id,
+                readers=['aclweb.org/ACL/ARR/2023/August/Program_Chairs', 'openreview.net/Support'],
+                referent=request_form.id,
+                replyto=request_form.id,
+                signatures=['~Program_ARRChair1'],
+                writers=[],
+            )
+        )
+        helpers.await_queue()
+
+        invitation = openreview_client.get_invitation(f"aclweb.org/ACL/ARR/2023/August/Authors/-/Submitted_Author_Form")
+        assert 'paper_type' in invitation.edit['note']['content']
 
     def test_post_submission(self, client, openreview_client, helpers, test_client, request_page, selenium):
 


### PR DESCRIPTION
This PR fixes an issue with some ARR stages where the the information for each stages was inconsistent.

The submitted author form didn't point to the correct invitation, causing manual changes to be overwritten by the ARR configuration process function because it always looked for an invitation that never existsed