### PR TITLE
Feat: Update iThenticate params based on iThenticate support

### DIFF
--- a/openreview/api/iThenticate_client.py
+++ b/openreview/api/iThenticate_client.py
@@ -67,7 +67,7 @@ class iThenticateClient:
         submitter_last_name=None,
         submitter_email=None,
         extract_text_only=None,
-        owner_permission_set="LEARNER",
+        owner_permission_set="USER",
         submitter_permission_set="EDITOR",
     ):
         print('Eula version', eula_version)

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -1205,7 +1205,7 @@ Total Errors: {len(errors)}
                         "name": self.name,
                         "owners": [],
                     },
-                    group_type="ASSIGNMENT",
+                    group_type="FOLDER",
                     eula_version=eula_version,
                 )
                 iThenticate_submission_id = res["id"]


### PR DESCRIPTION
This pull request updates the iThenticate integration to improve permission handling and group organization in the submission workflow. The most important changes are:

**Permission and Role Adjustments:**

* The default value for `owner_permission_set` in the `create_submission` function was changed from `"LEARNER"` to `"USER"`, ensuring the correct permission level is set for submission owners.

**Group Organization:**

* The `group_type` parameter in the `ithenticate_create_and_upload_submission` method was changed from `"ASSIGNMENT"` to `"FOLDER"`, aligning submission grouping with iThenticate's folder-based organization.