### PR TITLE
update venues and active_venues group with the renamed domain

### DIFF
--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -6302,4 +6302,15 @@ Best,
         assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Chat')
         assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Chat_Reaction')
         assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Official_Review')
-        assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Meta_Review')        
+        assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Meta_Review')
+
+        assert 'ICML.cc/2023/Conference' in openreview_client.get_group('venues').members        
+        assert 'ICML.cc/2023/Conference' in openreview_client.get_group('active_venues').members
+
+        openreview_client.remove_members_from_group('venues', 'ICML.cc/2023/Conference')
+        openreview_client.remove_members_from_group('active_venues', 'ICML.cc/2023/Conference')
+        openreview_client.add_members_to_group('venues', 'ICML.org/2023/Conference')
+        openreview_client.add_members_to_group('active_venues', 'ICML.org/2023/Conference')
+        
+        assert 'ICML.org/2023/Conference' in openreview_client.get_group('venues').members
+        assert 'ICML.org/2023/Conference' in openreview_client.get_group('active_venues').members        


### PR DESCRIPTION
if CircleCI runs the tests in this order, it fails:

`pytest tests/test_icml_conference.py tests/test_venue_with_tracks.py`

the first tests renames a domain and the second test runs the script to check new profiles for each venues. The script iterates through all the members of active venues and the old domain is not being replaced in the active venues group.