### PR TITLE
Chore: Update mongo and redis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
         type: string
     docker:
       - image: cimg/python:<<parameters.python-version>>-node
-      - image: cimg/redis:6.2.6
-      - image: mongo:7.0
+      - image: cimg/redis:7.2
+      - image: mongo:8.0
         command: [ --replSet, rs0 ]
       - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
         environment:
@@ -58,12 +58,12 @@ jobs:
             retry sudo apt-get update
             retry sudo apt-get install -y gnupg curl
 
-            curl -fsSL https://pgp.mongodb.com/server-7.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor
-            echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+            curl -fsSL https://pgp.mongodb.com/server-8.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
+            echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
 
             retry sudo apt-get update
             retry sudo apt-get upgrade -y
-            retry sudo apt-get install -y mongodb-org=7.0.0
+            retry sudo apt-get install -y mongodb-org=8.0.0
 
             mongosh mongodb://localhost:27017 --eval "rs.initiate()"
 


### PR DESCRIPTION
This pull request updates the configuration for our CircleCI jobs to use newer versions of Redis and MongoDB. The main goal is to ensure our CI environment is running the latest supported versions for better security and compatibility.

**Dependency version upgrades:**

* Updated the Redis Docker image from `cimg/redis:6.2.6` to `cimg/redis:7.2` in the `.circleci/config.yml` job configuration.
* Updated the MongoDB Docker image from `mongo:7.0` to `mongo:8.0` in the `.circleci/config.yml` job configuration.

**MongoDB installation script updates:**

* Changed the MongoDB GPG key and repository setup from version 7.0 to 8.0, ensuring the installation script pulls the correct version in `.circleci/config.yml`.
* Updated the MongoDB installation command to install `mongodb-org=8.0.0` instead of `mongodb-org=7.0.0` in the CI setup steps.