### PR TITLE
do not get the profile if the reviewer doesn't see the AC identity

### DIFF
--- a/openreview/venue/process/invite_assignment_post_process.py
+++ b/openreview/venue/process/invite_assignment_post_process.py
@@ -19,6 +19,13 @@ def process_update(client, edge, invitation, existing_edge):
         action_string = 'to serve as ethics reviewer for'
     print(edge.id)
 
+    should_get_inviter_profile = True
+    if is_reviewer:
+        signature_group = client.get_group(edge.signatures[0])
+        reviewers_name = domain.content['reviewers_name']['value']
+        reviewer_readers = [r for r in signature_group.readers if r.endswith(f'/{reviewers_name}')]   
+        should_get_inviter_profile = len(reviewer_readers) > 0
+
     if edge.ddate is None and edge.label == invite_label and not existing_edge:
 
         ## Get the submission
@@ -32,7 +39,7 @@ def process_update(client, edge, invitation, existing_edge):
         print(f'Get profile for {user}')
         user_profile=openreview.tools.get_profile(client, user)
         inviter_id=openreview.tools.pretty_id(edge.signatures[0])
-        inviter_profile=openreview.tools.get_profile(client, edge.tauthor)
+        inviter_profile=openreview.tools.get_profile(client, edge.tauthor) if should_get_inviter_profile else None
         inviter_preferred_name=inviter_profile.get_preferred_name(pretty=True) if inviter_profile else edge.signatures[0]
 
         if not user_profile:
@@ -52,7 +59,7 @@ def process_update(client, edge, invitation, existing_edge):
         baseurl = 'https://openreview.net' #Always pointing to the live site so we don't send more invitations with localhost
 
         # build the URL to send in the message
-        invitation_url = f'{baseurl}/invitation?id={recruitment_invitation_id}&user={user_profile.id}&key={hashkey}&submission_id={submission.id}&inviter={inviter_profile.id}'
+        invitation_url = f'{baseurl}/invitation?id={recruitment_invitation_id}&user={user_profile.id}&key={hashkey}&submission_id={submission.id}&inviter={inviter_profile.id if inviter_profile else edge.signatures[0]}'
 
         invitation_links = f'''Please respond the invitation clicking the following link:
 
@@ -119,7 +126,7 @@ Thanks,
         print(f'Get profile for {user}')
         user_profile=openreview.tools.get_profile(client, user)
         inviter_id=openreview.tools.pretty_id(edge.signatures[0])
-        inviter_profile=openreview.tools.get_profile(client, edge.tauthor)
+        inviter_profile=openreview.tools.get_profile(client, edge.tauthor) if should_get_inviter_profile else None
         inviter_preferred_name=inviter_profile.get_preferred_name(pretty=True) if inviter_profile else edge.signatures[0]
 
         if not user_profile:

--- a/tests/test_cvpr_conference_v2.py
+++ b/tests/test_cvpr_conference_v2.py
@@ -7,6 +7,7 @@ import csv
 import os
 import random
 import time
+import re
 
 class TestCVPRConference():
 
@@ -29,7 +30,8 @@ class TestCVPRConference():
         helpers.create_user('reviewer3@cvpr.cc', 'Reviewer', 'CVPRThree')
         helpers.create_user('reviewer4@cvpr.cc', 'Reviewer', 'CVPRFour')
         helpers.create_user('reviewer5@cvpr.cc', 'Reviewer', 'CVPRFive')
-        helpers.create_user('reviewer6@cvpr.cc', 'Reviewer', 'CVPRSix')    
+        helpers.create_user('reviewer6@cvpr.cc', 'Reviewer', 'CVPRSix')
+        helpers.create_user('reviewer7@gmail.com', 'Reviewer', 'CVPRSeven')    
 
         request_form_note = pc_client.post_note(openreview.Note(
             invitation='openreview.net/Support/-/Request_Form',
@@ -58,7 +60,7 @@ class TestCVPRConference():
                 'submission_reviewer_assignment': 'Automatic',
                 'Author and Reviewer Anonymity': 'Double-blind',
                 'reviewer_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair', 'Assigned Reviewers'],
-                'area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair', 'Assigned Reviewers'],
+                'area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair'],
                 'senior_area_chair_identity': ['Program Chairs', 'Assigned Senior Area Chair', 'Assigned Area Chair', 'Assigned Reviewers'],
                 'Open Reviewing Policy': 'Submissions and reviews should both be private.',
                 'submission_readers': 'Program chairs and paper authors only',
@@ -238,7 +240,7 @@ class TestCVPRConference():
 
         openreview_client.add_members_to_group('thecvf.com/CVPR/2024/Conference/Senior_Area_Chairs', members=['~SAC_CVPROne1'])
         openreview_client.add_members_to_group('thecvf.com/CVPR/2024/Conference/Area_Chairs', members=['~AC_CVPROne1', '~AC_CVPRTwo1', '~AC_CVPRThree1'])
-        openreview_client.add_members_to_group('thecvf.com/CVPR/2024/Conference/Reviewers', members=['~Reviewer_CVPROne1', '~Reviewer_CVPRTwo1', '~Reviewer_CVPRThree1', '~Reviewer_CVPRFour1', '~Reviewer_CVPRFive1', '~Reviewer_CVPRSix1'])
+        openreview_client.add_members_to_group('thecvf.com/CVPR/2024/Conference/Reviewers', members=['~Reviewer_CVPROne1', '~Reviewer_CVPRTwo1', '~Reviewer_CVPRThree1', '~Reviewer_CVPRFour1', '~Reviewer_CVPRFive1', '~Reviewer_CVPRSix1', '~Reviewer_CVPRSeven1'])
 
         submissions = pc_client_v2.get_notes(invitation='thecvf.com/CVPR/2024/Conference/-/Submission', sort='number:asc')
 
@@ -437,11 +439,107 @@ class TestCVPRConference():
         assert len(links) == 1
         assert url == links[0].get_attribute("href")
 
-    def test_review_rating_stage(self, client, openreview_client, helpers, test_client):
+        ## Set and deploy reviewer assignments
+        edge = pc_client_v2.post_edge(openreview.api.Edge(
+            invitation = 'thecvf.com/CVPR/2024/Conference/Reviewers/-/Proposed_Assignment',
+            head = submissions[0].id,
+            tail = '~Reviewer_CVPROne1',
+            signatures = ['thecvf.com/CVPR/2024/Conference/Program_Chairs'],
+            weight = 1,
+            label = 'reviewers-matching'
+        ))         
 
-        # enable review stage first
-        openreview_client.add_members_to_group('thecvf.com/CVPR/2024/Conference/Submission1/Reviewers', members=['~Reviewer_CVPROne1', '~Reviewer_CVPRTwo1', '~Reviewer_CVPRThree1'])
-        openreview_client.add_members_to_group('thecvf.com/CVPR/2024/Conference/Submission2/Reviewers', members=['~Reviewer_CVPRFour1', '~Reviewer_CVPRFive1', '~Reviewer_CVPRSix1'])
+        edge = pc_client_v2.post_edge(openreview.api.Edge(
+            invitation = 'thecvf.com/CVPR/2024/Conference/Reviewers/-/Proposed_Assignment',
+            head = submissions[0].id,
+            tail = '~Reviewer_CVPRTwo1',
+            signatures = ['thecvf.com/CVPR/2024/Conference/Program_Chairs'],
+            weight = 1,
+            label = 'reviewers-matching'
+        ))         
+
+        edge = pc_client_v2.post_edge(openreview.api.Edge(
+            invitation = 'thecvf.com/CVPR/2024/Conference/Reviewers/-/Proposed_Assignment',
+            head = submissions[0].id,
+            tail = '~Reviewer_CVPRThree1',
+            signatures = ['thecvf.com/CVPR/2024/Conference/Program_Chairs'],
+            weight = 1,
+            label = 'reviewers-matching'
+        ))         
+
+        edge = pc_client_v2.post_edge(openreview.api.Edge(
+            invitation = 'thecvf.com/CVPR/2024/Conference/Reviewers/-/Proposed_Assignment',
+            head = submissions[1].id,
+            tail = '~Reviewer_CVPRFour1',
+            signatures = ['thecvf.com/CVPR/2024/Conference/Program_Chairs'],
+            weight = 1,
+            label = 'reviewers-matching'
+        ))         
+
+        edge = pc_client_v2.post_edge(openreview.api.Edge(
+            invitation = 'thecvf.com/CVPR/2024/Conference/Reviewers/-/Proposed_Assignment',
+            head = submissions[1].id,
+            tail = '~Reviewer_CVPRFive1',
+            signatures = ['thecvf.com/CVPR/2024/Conference/Program_Chairs'],
+            weight = 1,
+            label = 'reviewers-matching'
+        ))         
+
+        edge = pc_client_v2.post_edge(openreview.api.Edge(
+            invitation = 'thecvf.com/CVPR/2024/Conference/Reviewers/-/Proposed_Assignment',
+            head = submissions[1].id,
+            tail = '~Reviewer_CVPRSix1',
+            signatures = ['thecvf.com/CVPR/2024/Conference/Program_Chairs'],
+            weight = 1,
+            label = 'reviewers-matching'
+        ))         
+
+        venue.set_assignments(assignment_title='reviewers-matching', committee_id='thecvf.com/CVPR/2024/Conference/Reviewers', enable_reviewer_reassignment=True)
+
+        assert '~Reviewer_CVPROne1' in openreview_client.get_group('thecvf.com/CVPR/2024/Conference/Submission1/Reviewers').members
+        assert '~Reviewer_CVPRFour1' in openreview_client.get_group('thecvf.com/CVPR/2024/Conference/Submission2/Reviewers').members
+
+    def test_invite_reviewers(self, client, openreview_client, helpers, test_client):
+
+        pc_client_v2=openreview.api.OpenReviewClient(username='pc@cvpr.cc', password=helpers.strong_password)
+
+        submissions = pc_client_v2.get_notes(invitation='thecvf.com/CVPR/2024/Conference/-/Submission', sort='number:asc')
+
+        ac_client = openreview.api.OpenReviewClient(username='ac1@cvpr.cc', password=helpers.strong_password)
+        anon_groups = ac_client.get_groups(prefix='thecvf.com/CVPR/2024/Conference/Submission1/Area_Chair_', signatory='~AC_CVPROne1')
+        anon_group_id = anon_groups[0].id        
+        edge = ac_client.post_edge(
+            openreview.api.Edge(invitation='thecvf.com/CVPR/2024/Conference/Reviewers/-/Invite_Assignment',
+                signatures=[anon_group_id],
+                head=submissions[0].id,
+                tail='~Reviewer_CVPRSeven1',
+                label='Invitation Sent',
+                weight=1
+        ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=edge.id, count=1)
+
+        messages = openreview_client.get_messages(to='reviewer7@gmail.com', subject='[CVPR 2024] Invitation to review paper titled "Paper title 1"')
+        assert messages and len(messages) == 1
+        assert '~AC_CVPROne1' not in messages[0]['content']['text']
+        assert 'AC CVPROne' not in messages[0]['content']['text']
+
+        invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+        helpers.respond_invitation_fast(invitation_url, accept=True)
+
+        assert '~Reviewer_CVPRSeven1' in openreview_client.get_group('thecvf.com/CVPR/2024/Conference/Submission1/Reviewers').members
+
+        messages = openreview_client.get_messages(to='reviewer7@gmail.com', subject='[CVPR 2024] Reviewer Invitation accepted for paper 1')
+        assert messages and len(messages) == 1
+        assert '~AC_CVPROne1' not in messages[0]['content']['text']
+        assert 'AC CVPROne' not in messages[0]['content']['text'] 
+
+        messages = openreview_client.get_messages(to='reviewer7@gmail.com', subject='[CVPR 2024] You have been assigned as a Reviewer for paper number 1')
+        assert messages and len(messages) == 1
+        assert '~AC_CVPROne1' not in messages[0]['content']['text']
+        assert 'AC CVPROne' not in messages[0]['content']['text']                      
+
+    def test_review_rating_stage(self, client, openreview_client, helpers, test_client):
 
         pc_client=openreview.Client(username='pc@cvpr.cc', password=helpers.strong_password)
         request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]


### PR DESCRIPTION
Fixes: https://github.com/openreview/openreview-py/issues/2656

The fix is only for the scenario when the invite assignment is to recruit reviewers