### PR TITLE
Chore: Remove API 1 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,7 @@ pip install -e .
 Usage
 -----
 
-The openreview-py library can be used to easily access and modify any data stored in the OpenReview system. For example, to get all the papers submitted to ICLR 2019 and print their titles:
-
-```python
-import openreview
-
-client = openreview.Client(baseurl='https://api.openreview.net', username='<your username>', password='<your password>')
-notes = openreview.tools.iterget_notes(client, invitation='ICLR.cc/2019/Conference/-/Blind_Submission')
-for note in notes:
-    print(note.content['title'])
-```
+The openreview-py library can be used to easily access and modify any data stored in the OpenReview system.
 
 For more information, see [the official reference](https://openreview-py.readthedocs.io/en/latest/).
 You can also check the [OpenReview docs](https://docs.openreview.net/getting-started/using-the-api/installing-and-instantiating-the-python-client) for examples and How-To Guides


### PR DESCRIPTION
Since the README already contains links to the docs, there is no need to show an example here