### PR TITLE
Small adjustment related to ARR author registration

### DIFF
--- a/openreview/stages/arr_content.py
+++ b/openreview/stages/arr_content.py
@@ -1917,7 +1917,7 @@ arr_max_load_task = {
                 "type": "integer",
             }
         },
-        "description": "Enter your maximum reviewing load for papers in this cycle. This refers only to the specific role mentioned at the top of this page. A load of '0' indicates you are unable to review new submissions.",
+        "description": "Enter your maximum reviewing load for papers in this cycle. This refers only to the specific role mentioned at the top of this page. A load of '0' indicates you are unable to review new submissions. Note: if you are an author this cycle then you are required to contribute to the review process if asked. If you indicate you are unavailable here then that will be ignored and overwritten to indicate you are available. If you believe you should be exempt you must provide a suitable reason in the author registration form. For details of suitable reasons for exemption see: https://aclrollingreview.org/exemptions2025",
         "order": 1,
     },
     "maximum_load_this_cycle_for_resubmissions": {
@@ -3014,6 +3014,21 @@ arr_submitted_author_content = {
             }
         },
         "description": "If any of your co-authors are unable to complete this form, please provide their Openreview IDs in this question. Search for the author profile by first, middle and last name or email address. If the profile is not found, you can add the author by completing first, middle, and last names as well as author email address.",
+        "order": 1
+    },
+    "confirm_you_are_qualified_to_review": {
+        "value": {
+            "param": {
+                "input": "radio",
+                "enum": [
+                    "Yes, I meet the ARR requirements to be a reviewer.",
+                    "No, I do not meet the ARR requirements to be a reviewer."
+                ],
+                "optional": False,
+                "type": "string"
+            }
+        },
+        "description": "The ARR requirements for reviewers are: (a) at least two papers in main ACL events or Findings, plus (b) at least one more paper in the ACL Anthology or a major AI venue. Venues considered 'main ACL' are: ACL, CL, CoLing, CoNLL, EACL, EMNLP, HLT, IJCNLP / AACL, LREC, NAACL, TACL, *SEM. Major AI venues we consider are: AAAI, CVPR, ECCV, FAccT, ICCV, ICLR, ICML, IJCAI, JAIR, JMLR, NeurIPS, TMLR, TPAMI. Note, we will check that your response matches data online. Having your self-reported status helps us identify issues with available data.",
         "order": 2
     },
     "confirm_you_are_willing_to_serve_as_a_reviewer_or_ac": {
@@ -3023,20 +3038,21 @@ arr_submitted_author_content = {
                 "enum": [
                     "I will serve as a reviewer or area chair (AC) in this cycle if ARR considers me qualified.",
                     "I will serve as a reviewer in this cycle if ARR considers me qualified, but I do not wish to be an AC.",
-                    "I am already serving in ARR as either an SAC, ethics reviewer, ethics chair, EIC, technical staff, support team, or editorial staff.",
+                    "I am either an editor, senior area chair, ethics reviewer, ethics chair, technical staff, support staff, or editorial staff for ARR.",
+                    "No, I cannot serve because I am unqualified (we will check this and if you are qualified you will be required to review).",
                     "No, I cannot serve because I am on parental leave.",
                     "No, I cannot serve because I am on family medical leave.",
                     "No, I cannot serve because I have a medical emergency.",
                     "No, I cannot serve because of another form of emergency beyond my control.",
-                    "No, I cannot serve because I am an AC / SAC / PC / General Chair / Local Chair for a related venue.",
-                    "No, I cannot serve because I am editor-in-chief of a major related journal.",
-                    "No, I cannot serve for another reason (this choice is very rare)."
+                    "No, I cannot serve because I am an AC / SAC / PC / General Chair / Local Chair for a related venue, which I will specify in the next question.",
+                    "No, I cannot serve because I am editor-in-chief of a major related journal, which I will specify in the next question.",
+                    "No, I cannot serve for another reason, which I will specify in the next question (this choice is very rare)."
                 ],
                 "optional": False,
                 "type": "string"
             }
         },
-        "description": "ARR now requires all authors to contribute to the review process if asked. For details see: https://aclrollingreview.org/exemptions2025 Serving as either a reviewer or an AC is sufficient to satisfy this requirement. If you are already a reviewer or AC in ARR, please select one of the first two options to confirm you are willing to serve in this cycle. If you are unable to serve please select 'No...' and note that you must provide sufficient justification in the next question or otherwise your paper will be desk rejected.",
+        "description": "ARR now requires all authors to contribute to the review process if asked. For details see: https://aclrollingreview.org/exemptions2025 Serving as either a reviewer or an AC is sufficient to satisfy this requirement. If you are unable to serve please select the most appropriate option that starts with 'No'. Note that for the last three options you must provide sufficient justification in the next question or your paper will be desk rejected. If you are already a reviewer or AC in ARR, please select one of the first two options to confirm you are willing to serve in this cycle. Note: if you indicate you are unavailable in the unavailability form, we will overwrite your response based on your answers here. ",
         "order": 3
     },
     "details_of_reason_for_being_unavailable_to_serve": {
@@ -3047,7 +3063,7 @@ arr_submitted_author_content = {
                 "input": "textarea"
             }
         },
-        "description": "If you answered 'No, I cannot serve ...' in the previous question, please provide details here, e.g., the name of the conference you are a PC for. Otherwise please leave this blank. If you believe you are not qualified, do not write that here, use the question below. If you are already serving in ARR, please use one of the first three options in the previous question. For details of what are and are not suitable reasons, see: https://aclrollingreview.org/exemptions2025",
+        "description": "If you chose 'No, I cannot serve ... which I will specify in the next question' above, please provide details here, e.g., the name of the conference you are a PC for. Otherwise please leave this blank. If you believe you are not qualified, do *not* write that here. If you are already serving in ARR, please use one of the first three options in the previous question. For details of what are and are not suitable reasons, see: https://aclrollingreview.org/exemptions2025",
         "order": 4
     },
     "serving_as_a_regular_or_emergency_reviewer_or_ac": {
@@ -3081,21 +3097,6 @@ arr_submitted_author_content = {
         },
         "description": "Please indicate how many papers you would be willing to do emergency reviews for if asked.",
         "order": 6
-    },
-    "confirm_you_are_qualified_to_review": {
-        "value": {
-            "param": {
-                "input": "radio",
-                "enum": [
-                    "Yes, I meet the ARR requirements to be a reviewer.",
-                    "No, I do not meet the ARR requirements to be a reviewer."
-                ],
-                "optional": False,
-                "type": "string"
-            }
-        },
-        "description": "The ARR requirements for reviewers are: (a) at least two papers in main ACL events or Findings, plus (b) at least one more paper in the ACL Anthology or a major AI venue. Venues considered 'main ACL' are: ACL, CL, CoLing, CoNLL, EACL, EMNLP, HLT, IJCNLP / AACL, LREC, NAACL, TACL, *SEM. Major AI venues we consider are: AAAI, CVPR, ECCV, FAccT, ICCV, ICLR, ICML, IJCAI, JAIR, JMLR, NeurIPS, TMLR, TPAMI. Note, we will check that your response matches data online. Having your self-reported status helps us identify issues with available data.",
-        "order": 7
     },
     "are_you_a_student": {
         "value": {


### PR DESCRIPTION
This makes some small tweaks to the ARR author registration form and the unavailability form to make it clearer to authors that they must serve as reviewers and the registration form will override the unavailability form.

I had a look and don't believe this impacts any of the tests.