### PR TITLE
Chore: Update env variable of the base url

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -44,7 +44,7 @@ class LogRetry(Retry):
 
 class OpenReviewClient(object):
     """
-    :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL`
+    :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL_V2`
     :type baseurl: str, optional
     :param username: OpenReview username. If none is provided, it defaults to the environment variable `OPENREVIEW_USERNAME`
     :type username: str, optional
@@ -56,7 +56,7 @@ class OpenReviewClient(object):
     :type expiresIn: number, optional
     """
     def __init__(self, baseurl = None, username = None, password = None, token= None, tokenExpiresIn=None):
-        self.baseurl = baseurl if baseurl is not None else os.environ.get('OPENREVIEW_API_BASEURL', 'http://localhost:3001')
+        self.baseurl = baseurl if baseurl is not None else os.environ.get('OPENREVIEW_API_BASEURL_V2', 'http://localhost:3001')
         if 'https://api.openreview.net' in self.baseurl or 'https://devapi.openreview.net' in self.baseurl:
             correct_baseurl = self.baseurl.replace('api', 'api2')
             raise OpenReviewException(f'Please use "{correct_baseurl}" as the baseurl for the OpenReview API or use the old client openreview.Client')
@@ -2655,7 +2655,7 @@ class OpenReviewClient(object):
         :type alternate_invitation: str, optional
         :param model: model used to compute scores, e.g. "specter2+scincl"
         :type model: str, optional
-        :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL`
+        :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL_V2`
         :type baseurl: str, optional
 
         :return: Dictionary containing the job id
@@ -2723,7 +2723,7 @@ class OpenReviewClient(object):
         :type model: str, optional
         :param weight: list of dictionaries that specify weights for publications
         :type weight: list[dict], optional
-        :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL`
+        :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL_V2`
         :type baseurl: str, optional
 
         :return: Dictionary containing the job id
@@ -2795,7 +2795,7 @@ class OpenReviewClient(object):
         :type model: str, optional
         :param weight: list of dictionaries that specify weights for publications
         :type weight: list[dict], optional
-        :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL`
+        :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL_V2`
         :type baseurl: str, optional
 
         :return: Dictionary containing the job id

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -33,7 +33,7 @@ class LogRetry(Retry):
         return super().increment(method=method, url=url, response=response, error=error, _pool=_pool, _stacktrace=_stacktrace)
 class Client(object):
     """
-    :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_BASEURL`
+    :param baseurl: URL to the host, example: https://api.openreview.net (should be replaced by 'host' name). If none is provided, it defaults to the environment variable `OPENREVIEW_API_BASEURL`
     :type baseurl: str, optional
     :param username: OpenReview username. If none is provided, it defaults to the environment variable `OPENREVIEW_USERNAME`
     :type username: str, optional
@@ -45,7 +45,7 @@ class Client(object):
     :type expiresIn: number, optional
     """
     def __init__(self, baseurl = None, username = None, password = None, token= None, tokenExpiresIn=None):
-        self.baseurl = baseurl if baseurl is not None else os.environ.get('OPENREVIEW_BASEURL', 'http://localhost:3000')
+        self.baseurl = baseurl if baseurl is not None else os.environ.get('OPENREVIEW_API_BASEURL', 'http://localhost:3000')
         if 'https://api2.openreview.net' in self.baseurl or 'https://devapi2.openreview.net' in self.baseurl:
             correct_baseurl = self.baseurl.replace('api2', 'api')
             raise OpenReviewException(f'Please use "{correct_baseurl}" as the baseurl for the OpenReview API or use the new client openreview.api.OpenReviewClient')


### PR DESCRIPTION
This pull request updates the environment variable used for specifying the API base URL in the `OpenReviewClient` and related method docstrings. The main change is switching from `OPENREVIEW_BASEURL` to `OPENREVIEW_API_BASEURL` to improve clarity and consistency across the codebase.

**API base URL environment variable update:**

* Updated the docstring for the `OpenReviewClient` class and several methods (`request_paper_similarity`, `request_paper_subset_expertise`, `request_user_subset_expertise`) to reference `OPENREVIEW_API_BASEURL` instead of `OPENREVIEW_BASEURL`. [[1]](diffhunk://#diff-f5d3f10e7a5ff1e9ba8f8f2073dca77d0c33d357533329eb2d8c002cb671bc7cL47-R47) [[2]](diffhunk://#diff-f5d3f10e7a5ff1e9ba8f8f2073dca77d0c33d357533329eb2d8c002cb671bc7cL2658-R2658) [[3]](diffhunk://#diff-f5d3f10e7a5ff1e9ba8f8f2073dca77d0c33d357533329eb2d8c002cb671bc7cL2726-R2726) [[4]](diffhunk://#diff-f5d3f10e7a5ff1e9ba8f8f2073dca77d0c33d357533329eb2d8c002cb671bc7cL2798-R2798)
* Changed the initialization logic in the `OpenReviewClient` constructor to use `OPENREVIEW_API_BASEURL` when a base URL is not provided.