### PR TITLE
Fix/add request expertise param

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -2551,11 +2551,7 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return response.json()
 
-    def request_expertise(self, name, group_id, venue_id=None, submission_content=None, alternate_match_group = None, alternate_expertise_selection_id=None, expertise_selection_id=None, model='specter2+scincl', baseurl=None, weight=None, top_recent_pubs=None):
-
-        # Check entity B params
-        if bool(venue_id) == bool(alternate_match_group):
-            raise OpenReviewException('Provide exactly one of the following: venue_id, alternate_match_group')
+    def request_expertise(self, name, group_id, venue_id, submission_content=None, alternate_match_group = None, alternate_expertise_selection_id=None, expertise_selection_id=None, model='specter2+scincl', baseurl=None, weight=None, top_recent_pubs=None):
 
         # Build entityA from group_id
         entityA = {

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -2551,7 +2551,11 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return response.json()
 
-    def request_expertise(self, name, group_id, venue_id, submission_content=None, alternate_match_group = None, expertise_selection_id=None, model=None, baseurl=None, weight=None, top_recent_pubs=None):
+    def request_expertise(self, name, group_id, venue_id=None, submission_content=None, alternate_match_group = None, alternate_expertise_selection_id=None, expertise_selection_id=None, model='specter2+scincl', baseurl=None, weight=None, top_recent_pubs=None):
+
+        # Check entity B params
+        if bool(venue_id) == bool(alternate_match_group):
+            raise OpenReviewException('Provide exactly one of the following: venue_id, alternate_match_group')
 
         # Build entityA from group_id
         entityA = {
@@ -2562,14 +2566,14 @@ class OpenReviewClient(object):
             expertise = { 'invitation': expertise_selection_id }
             entityA['expertise'] = expertise
 
-        # Build entityB from alternate_match_group or paper_invitation
+        # Build entityB from alternate_match_group or venue_id
         if alternate_match_group:
             entityB = {
                 'type': 'Group',
                 'memberOf': alternate_match_group
             }
-            if expertise_selection_id:
-                expertise = { 'invitation': expertise_selection_id }
+            if alternate_expertise_selection_id and tools.get_invitation(self, alternate_expertise_selection_id):
+                expertise = { 'invitation': alternate_expertise_selection_id }
                 entityB['expertise'] = expertise
         else:
             entityB = {

--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -586,6 +586,7 @@ class Matching(object):
                 submission_content=self.submission_content,
                 alternate_match_group=self.alternate_matching_group,
                 expertise_selection_id=venue.get_expertise_selection_id(self.match_group.id),
+                alternate_expertise_selection_id=venue.get_expertise_selection_id(self.alternate_matching_group),
                 model=model
             )
             status = ''

--- a/openreview/venue/matching.py
+++ b/openreview/venue/matching.py
@@ -587,7 +587,7 @@ class Matching(object):
                 alternate_match_group=self.alternate_matching_group,
                 expertise_selection_id=venue.get_expertise_selection_id(self.match_group.id),
                 alternate_expertise_selection_id=venue.get_expertise_selection_id(self.alternate_matching_group),
-                model=model
+                model=model,
                 percentile_selection=percentile_selection
             )
             status = ''


### PR DESCRIPTION
This PR adds the param `alternate_expertise_selection_id` to the `request_expertise` function. This allows you to set the expertise selection invitation of the alternate match group if you are computing scores between 2 different groups, e.g. SACs -> ACs.