### PR TITLE
ARR: Add custom withdrawal options

### DIFF
--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -1,7 +1,6 @@
 import csv
 import json
 import os
-from copy import deepcopy
 from json import tool
 import datetime
 from io import StringIO
@@ -470,7 +469,7 @@ class ARR(object):
         withdrawal_invitation = self.client.get_invitation(self.get_withdrawal_id())
         invitation_details = withdrawal_invitation.edit['invitation']
         note_edit = invitation_details['edit']['note']
-        note_edit['content'] = deepcopy(arr_withdrawal_content)
+        note_edit['content'] = arr_withdrawal_content
         self.client.post_invitation_edit(
             invitations=self.venue.get_meta_invitation_id(),
             readers=[self.venue_id],

--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import os
+from copy import deepcopy
 from json import tool
 import datetime
 from io import StringIO
@@ -19,7 +20,7 @@ from openreview.venue.recruitment import Recruitment
 from openreview.arr.helpers import (
     setup_arr_invitations
 )
-from openreview.stages.arr_content import hide_fields
+from openreview.stages.arr_content import hide_fields, arr_withdrawal_content
 
 SHORT_BUFFER_MIN = 30
 LONG_BUFFER_DAYS = 10
@@ -464,6 +465,19 @@ class ARR(object):
             signatures=[self.venue_id],
             replacement=False,
             invitation=invitation
+        )
+
+        withdrawal_invitation = self.client.get_invitation(self.get_withdrawal_id())
+        invitation_details = withdrawal_invitation.edit['invitation']
+        note_edit = invitation_details['edit']['note']
+        note_edit['content'] = deepcopy(arr_withdrawal_content)
+        self.client.post_invitation_edit(
+            invitations=self.venue.get_meta_invitation_id(),
+            readers=[self.venue_id],
+            writers=[self.venue_id],
+            signatures=[self.venue_id],
+            replacement=False,
+            invitation=withdrawal_invitation
         )
         return stage_value
 

--- a/openreview/stages/arr_content.py
+++ b/openreview/stages/arr_content.py
@@ -3327,3 +3327,47 @@ arr_submitted_author_content = {
         "order": 22
     }
 }
+
+arr_withdrawal_content = {
+    "withdrawal_confirmation": {
+        "order": 1,
+        "description": "Please confirm to withdraw.",
+        "value": {
+            "param": {
+                "type": "string",
+                "enum": [
+                    "I have read and agree with the venue's withdrawal policy on behalf of myself and my co-authors."
+                ],
+                "input": "checkbox"
+            }
+        }
+    },
+    "comment": {
+        "order": 2,
+        "description": "Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.",
+        "value": {
+            "param": {
+                "type": "string",
+                "maxLength": 200000,
+                "input": "textarea",
+                "optional": True,
+                "deletable": True,
+                "markdown": True
+            }
+        }
+    },
+    "arr_comment": {
+        "order": 2,
+        "description": "Add formatting using Markdown and formulas using LaTeX. For more information see https://openreview.net/faq.",
+        "value": {
+            "param": {
+                "type": "string",
+                "maxLength": 200000,
+                "input": "textarea",
+                "optional": True,
+                "deletable": True,
+                "markdown": True
+            }
+        }
+    }
+}

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -15,6 +15,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from openreview.venue import matching
 from openreview.stages.arr_content import (
     arr_submission_content,
+    arr_withdrawal_content,
     hide_fields,
     hide_fields_from_public,
     arr_registration_task_forum,
@@ -2623,6 +2624,10 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         helpers.await_queue()
         helpers.await_queue_edit(openreview_client, 'aclweb.org/ACL/ARR/2023/August/-/Post_Submission-0-1', count=2)
         pc_client_v2=openreview.api.OpenReviewClient(username='pc@aclrollingreview.org', password=helpers.strong_password)
+
+        withdrawal_invitation = pc_client_v2.get_invitation('aclweb.org/ACL/ARR/2023/August/-/Withdrawal')
+        assert withdrawal_invitation.edit['invitation']['edit']['note']['content'] == arr_withdrawal_content
+        assert 'arr_comment' in withdrawal_invitation.edit['invitation']['edit']['note']['content']
 
         assert len(pc_client_v2.get_all_invitations(invitation='aclweb.org/ACL/ARR/2023/August/-/Withdrawal')) == 101
         assert len(pc_client_v2.get_all_invitations(invitation='aclweb.org/ACL/ARR/2023/August/-/Desk_Rejection')) == 101


### PR DESCRIPTION
This PR allows ARR to input custom fields into the per-submission withdrawal invitations