### PR TITLE
allow to set instructions in venue.content

### DIFF
--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -152,7 +152,7 @@ def get_conference(client, request_form_id, support_user='OpenReview.net/Support
         venue.reviewers_name = venue.reviewer_roles[0]
         venue.allow_gurobi_solver = venue_content.get('allow_gurobi_solver', {}).get('value', False)
         venue.submission_license = note.content.get('submission_license', ['CC BY 4.0'])
-        set_homepage_options(note, venue)
+        set_homepage_options(note, venue, venue_content)
         venue.reviewer_identity_readers = get_identity_readers(note, 'reviewer_identity')
         venue.area_chair_identity_readers = get_identity_readers(note, 'area_chair_identity')
         venue.senior_area_chair_identity_readers = get_identity_readers(note, 'senior_area_chair_identity')
@@ -437,14 +437,14 @@ def get_conference_builder(client, request_form_id, support_user='OpenReview.net
 
     return builder
 
-def set_homepage_options(request_forum, venue):
+def set_homepage_options(request_forum, venue, venue_content):
     homepage_override = request_forum.content.get('homepage_override', {})
     venue.name = homepage_override.get('title', request_forum.content.get('Official Venue Name'))  
     venue.short_name = homepage_override.get('subtitle', request_forum.content.get('Abbreviated Venue Name'))
     venue.website = homepage_override.get('website', request_forum.content.get('Official Website URL'))
     venue.contact = homepage_override.get('contact', request_forum.content.get('contact_email'))
     venue.location = homepage_override.get('location', request_forum.content.get('Location'))
-    venue.instructions = homepage_override.get('instructions', '')
+    venue.instructions = homepage_override.get('instructions', venue_content.get('instructions', {}).get('value', ''))
 
     venue_start_date_str = 'TBD'
     venue_start_date = None

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -179,7 +179,7 @@ class TestWorkshopV2():
         instructions = selenium.find_element(By.CLASS_NAME, 'description')
         assert 'Custom Instructions' in instructions.text
 
-        ## try editing the instruction though the venue.content
+        ## try editing the instruction through the venue.content
         edit = pc_client_v2.get_group_edit(id=edit['id'])
         edit.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         pc_client_v2.post_edit(edit)

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -120,9 +120,9 @@ class TestWorkshopV2():
     
     def test_venue_info(self, client, openreview_client, helpers, selenium, request_page):
 
-        pc_client=openreview.Client(username='pc@icaps.cc', password=helpers.strong_password)
-        pc_client_v2=openreview.api.OpenReviewClient(username='pc@icaps.cc', password=helpers.strong_password)
-        request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+        pc_client = openreview.Client(username='pc@icaps.cc', password=helpers.strong_password)
+        pc_client_v2 = openreview.api.OpenReviewClient(username='pc@icaps.cc', password=helpers.strong_password)
+        request_form = pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
         venue_group = pc_client_v2.get_group('PRL/2023/ICAPS')
 


### PR DESCRIPTION
Venues can set home page instructions using any of the following options:

1. Venue request form (homepage override)
2. Venue content (instructions field)
3. Venue web

Option 1 has priority. If option 3 is used then option 1 and 2 no longe work.