### PR TITLE
ARR: Add custom max papers invitation to SAC Console

### DIFF
--- a/openreview/arr/webfield/seniorAreaChairsWebfield.js
+++ b/openreview/arr/webfield/seniorAreaChairsWebfield.js
@@ -43,6 +43,7 @@ const browseReviewerInvitations = [
 ].join(';')
 
 const headBrowseInvitations = [
+  domain.content.reviewers_custom_max_papers_id?.value,
   `${reviewersId}/-/Registered_Load`,
   `${reviewersId}/-/Emergency_Load`,
   `${reviewersId}/-/Emergency_Area`,


### PR DESCRIPTION
- Resolves #2760

Adds the missing custom max papers invitation for the per-submission reviewer edge browser in the SAC console