### PR TITLE
Reviewer Recommendation: let SACs of assigned submissions to recommend reviewers

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -4198,9 +4198,10 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
             cdate=tools.datetime_millis(start_date) if start_date else None,
             duedate=tools.datetime_millis(due_date) if due_date else None,
             expdate=tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)) if due_date else None,
-            invitees=[venue.get_area_chairs_id()],
+            responseArchiveDate = venue.get_edges_archive_date(),
+            invitees=[venue.get_area_chairs_id()] + ([venue.get_senior_area_chairs_id()] if venue.use_senior_area_chairs else []),
             signatures = [venue_id],
-            readers = [venue_id, venue.get_area_chairs_id()],
+            readers = [venue_id, venue.get_area_chairs_id()] + ([venue.get_senior_area_chairs_id()] if venue.use_senior_area_chairs else []),
             writers = [venue_id],
             minReplies = total_recommendations,
             web = webfield_content,
@@ -4230,15 +4231,19 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
                         'deletable': True
                     }
                 },
-                'readers':  [venue_id, '${2/signatures}', venue.get_senior_area_chairs_id(number='${{2/head}/number}')] if venue.use_senior_area_chairs else [venue_id, '${2/signatures}'],
+                'readers':  [venue_id, venue.get_area_chairs_id(number='${{2/head}/number}'), venue.get_senior_area_chairs_id(number='${{2/head}/number}')] if venue.use_senior_area_chairs else [venue_id, venue.get_area_chairs_id(number='${{2/head}/number}')],
                 'nonreaders': [venue.get_authors_id(number='${{2/head}/number}')],
-                'writers': [ venue_id, '${2/signatures}' ],
+                'writers': [venue_id, venue.get_area_chairs_id(number='${{2/head}/number}'), venue.get_senior_area_chairs_id(number='${{2/head}/number}')] if venue.use_senior_area_chairs else [venue_id, venue.get_area_chairs_id(number='${{2/head}/number}')],
                 'signatures': {
-                    'param': {
-                        'items': [
-                            { 'prefix': '~.*', 'optional': True },
-                            { 'value': venue_id, 'optional': True }
-                        ] 
+                    'param': { 
+                        'items': [ 
+                            { 'prefix': venue.get_area_chairs_id(number='${{3/head}/number}', anon=True), 'optional': True },
+                            { 'value': venue.get_senior_area_chairs_id(number='${{3/head}/number}'), 'optional': True },
+                            { 'value': venue_id, 'optional': True },
+                            { 'value': venue.get_program_chairs_id(), 'optional': True }
+                            
+                        ], 
+                        'default': [venue.get_program_chairs_id()]
                     }
                 },
                 'head': {

--- a/tests/test_cvpr_conference_v2.py
+++ b/tests/test_cvpr_conference_v2.py
@@ -392,12 +392,16 @@ class TestCVPRConference():
         invitation = openreview_client.get_invitation('thecvf.com/CVPR/2024/Conference/Reviewers/-/Recommendation')
         assert invitation
         assert 'thecvf.com/CVPR/2024/Conference/Area_Chairs' in invitation.invitees
+        assert 'thecvf.com/CVPR/2024/Conference/Senior_Area_Chairs' in invitation.invitees
 
         ac_client = openreview.api.OpenReviewClient(username='ac1@cvpr.cc', password=helpers.strong_password)
+        anon_groups = ac_client.get_groups(prefix='thecvf.com/CVPR/2024/Conference/Submission1/Area_Chair_', signatory='~AC_CVPROne1')
+        anon_group_id = anon_groups[0].id          
+
         ac_client.post_edge(openreview.Edge(invitation = venue.get_recommendation_id(),
-            readers = [venue.id, '~AC_CVPROne1', 'thecvf.com/CVPR/2024/Conference/Submission1/Senior_Area_Chairs'],
-            writers = ['thecvf.com/CVPR/2024/Conference', '~AC_CVPROne1'],
-            signatures = ['~AC_CVPROne1'],
+            readers = [venue.id, 'thecvf.com/CVPR/2024/Conference/Submission1/Area_Chairs', 'thecvf.com/CVPR/2024/Conference/Submission1/Senior_Area_Chairs'],
+            writers = ['thecvf.com/CVPR/2024/Conference', 'thecvf.com/CVPR/2024/Conference/Submission1/Area_Chairs', 'thecvf.com/CVPR/2024/Conference/Submission1/Senior_Area_Chairs'],
+            signatures = [anon_group_id],
             head = submissions[0].id,
             tail = '~Reviewer_CVPROne1',
             weight = 1))
@@ -415,6 +419,15 @@ class TestCVPRConference():
         recommendation_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
         ac_client.post_edge(recommendation_edge)
         assert not ac_client.get_edges(invitation=venue.get_recommendation_id(), tail='~Reviewer_CVPROne1')
+
+        sac_client = openreview.api.OpenReviewClient(username='sac1@cvpr.cc', password=helpers.strong_password)
+        sac_client.post_edge(openreview.Edge(invitation = venue.get_recommendation_id(),
+            readers = [venue.id, 'thecvf.com/CVPR/2024/Conference/Submission1/Area_Chairs', 'thecvf.com/CVPR/2024/Conference/Submission1/Senior_Area_Chairs'],
+            writers = ['thecvf.com/CVPR/2024/Conference', 'thecvf.com/CVPR/2024/Conference/Submission1/Area_Chairs', 'thecvf.com/CVPR/2024/Conference/Submission1/Senior_Area_Chairs'],
+            signatures = ['thecvf.com/CVPR/2024/Conference/Submission1/Senior_Area_Chairs'],
+            head = submissions[0].id,
+            tail = '~Reviewer_CVPRTwo1',
+            weight = 5))        
         
         ## Go to edge browser to recommend reviewers
         start = 'thecvf.com/CVPR/2024/Conference/Area_Chairs/-/Assignment,tail:~AC_CVPROne1'


### PR DESCRIPTION
This PR fixes the Recommendation invitation to include the SACs as readers, invitees, signatures, edge readers and writers. 

The invitation configuration is the same than the Assignment invitation where SACs can change the assigned reviewers of a submission.

There is one thing missing that could be manually adjusted for CVPR: SACs need to have access to the edge browser link to recommend reviewers. 

Option 1: Remove the `start` parameter of the button link so the first column in the edge browser show the submission visible to the logged in users instead of their assigned papers because this doesn't apply to SACs.
<img width="946" height="603" alt="Screenshot 2025-11-24 at 1 44 30 PM" src="https://github.com/user-attachments/assets/bb37ac4d-4fcf-494d-af32-15d4dea2bf71" />

Option 2: Modify the edge browser url in the "Area Chair Status" tab to go to the recommendation browser instead of assignment browser. This is very easy to change in the webfield config
<img width="247" height="132" alt="Screenshot 2025-11-24 at 1 45 57 PM" src="https://github.com/user-attachments/assets/b58940f8-8d41-49bd-bb4b-bc437810eb9d" />

Option 3: Show the edge browser url in the SAC console header, this as option 1 will rely on the readers permission of the submission to load the first column causing that SACs can see their own submissions.

I think the best approach is option 2. 
