### PR TITLE
Fix/ New UI Recruitment

### DIFF
--- a/openreview/workflows/process/committee_recruitment_request_process.py
+++ b/openreview/workflows/process/committee_recruitment_request_process.py
@@ -82,16 +82,16 @@ def process(client, edit, invitation):
             if 'profile_not_found' not in recruitment_status['errors']:
                 recruitment_status['errors']['profile_not_found'] = []
             recruitment_status['errors']['profile_not_found'].append(email)
-        elif invited_group_ids:
-            invited_group_id=invited_group_ids[0]
-            if invited_group_id not in recruitment_status['already_invited']:
-                recruitment_status['already_invited'][invited_group_id] = [] 
-            recruitment_status['already_invited'][invited_group_id].append(email)
         elif member_group_ids:
             member_group_id = member_group_ids[0]
             if member_group_id not in recruitment_status['already_member']:
                 recruitment_status['already_member'][member_group_id] = []
             recruitment_status['already_member'][member_group_id].append(email)
+        elif invited_group_ids:
+            invited_group_id=invited_group_ids[0]
+            if invited_group_id not in recruitment_status['already_invited']:
+                recruitment_status['already_invited'][invited_group_id] = [] 
+            recruitment_status['already_invited'][invited_group_id].append(email)
         else:
             name = invitee_names[index] if (invitee_names and index < len(invitee_names)) else None
             if not name and not is_profile_id:
@@ -161,8 +161,8 @@ def process(client, edit, invitation):
     message = f'''The recruitment request process for the {committee_role.capitalize()} Committee has been completed.
 
 Invited: {recruitment_status["invited"]}
-Already invited: {len(recruitment_status["already_invited"])}
-Already member: {len(recruitment_status["already_member"])}
+Already invited: {len(recruitment_status["already_invited"].get(invited_group.id, []))}
+Already member: {len(recruitment_status["already_member"].get(group_id, []))}
 Errors: {len(recruitment_status["errors"])}
 
 For more details, please check the following links:

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -540,6 +540,21 @@ For more details, please check the following links:
         helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
         helpers.await_queue_edit(openreview_client, edit_id=edit['id'], process_index=1)
 
+        messages = openreview_client.get_messages(to='programchair@abcd.cc', subject = 'Recruitment request status for ABCD 2025 Reviewers Committee')
+        assert len(messages) == 3
+        assert messages[-1]['content']['text'] == f'''The recruitment request process for the Reviewers Committee has been completed.
+
+Invited: 0
+Already invited: 2
+Already member: 1
+Errors: 0
+
+For more details, please check the following links:
+
+- [recruitment request details](https://openreview.net/group/revisions?id=ABCD.cc/2025/Conference/Program_Committee&editId={edit['id']})
+
+- [all invited list](https://openreview.net/group/edit?id=ABCD.cc/2025/Conference/Program_Committee/Invited)'''
+
     def test_post_submissions(self, openreview_client, test_client, helpers):
 
         test_client = openreview.api.OpenReviewClient(token=test_client.token)


### PR DESCRIPTION
There is an error in the recruitment process when check valid_invitees is empty. I am checking if any users where invited when posting the recruitment status note and when sending an email to PCs. The recruitment status note instead says "No users invited"

<img width="869" height="325" alt="Screenshot 2025-12-17 at 12 09 10 PM" src="https://github.com/user-attachments/assets/5cac0987-3262-4d06-95f1-2a188deb0683" />
