### PR TITLE
Test: Update some tests validation

### DIFF
--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -69,9 +69,8 @@ class TestEdges:
     
     def test_rename_edges(self, client, openreview_client, helpers):
         guest = openreview.api.OpenReviewClient()
-        to_profile = guest.register_user(email = 'nadia@mail.com', fullname = 'Nadia L', password = helpers.strong_password)
-        assert to_profile
-        assert to_profile['id'] == '~Nadia_L1'
+        registration = guest.register_user(email = 'nadia@mail.com', fullname = 'Nadia L', password = helpers.strong_password)
+        assert registration['status'] == 'ok'
         super_user_edges = list(openreview.tools.iterget_edges(openreview_client, tail="~Super_User1"))
         openreview_client.rename_edges('~Super_User1', '~Nadia_L1')
         nadias_edges = list(openreview.tools.iterget_edges(openreview_client, tail="~Nadia_L1"))

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -3724,7 +3724,7 @@ The OpenReview Team.
 
         profile = openreview_client.get_profile(email_or_id='~Lionel_Messi1')
         assert len(profile.content['emails']) == 2
-        assert len(profile.content['emailsConfirmed']) == 2
+        assert len(profile.content['emailsConfirmed']) == 1
 
         profile_content={
             'names': [


### PR DESCRIPTION
This pull request contains minor updates to the test suite, specifically fixing test assertions for user registration and profile email confirmation. The changes help ensure that the tests accurately reflect the intended behavior of the registration and profile management processes.

Requires: https://github.com/openreview/openreview-api/pull/929

Test improvements:

* Updated the user registration test in `test_edges.py` to assert the `'status'` field of the registration result instead of relying on the returned profile ID. This makes the test more robust and explicit about the expected outcome.
* Adjusted the profile email confirmation test in `test_profile_management.py` to expect only one confirmed email instead of two, aligning the test with the actual behavior of the email confirmation logic.