### PR TITLE
Feat: Be less conservative with max_workers

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -88,7 +88,7 @@ def format_params(params):
 
     return params
 
-def concurrent_requests(request_func, params, desc='Gathering Responses'):
+def concurrent_requests(request_func, params, desc='Gathering Responses', max_workers=None):
     """
     Returns a list of results given for each request_func param execution. It shows a progress bar to know the progress of the task.
 
@@ -96,13 +96,17 @@ def concurrent_requests(request_func, params, desc='Gathering Responses'):
     :type request_func: function
     :param params: a list of values to be executed by request_func.
     :type params: list
-    :param max_workers: number of workers to use in the multiprocessing tool, default value is 6.
+    :param desc: description to show in the progress bar.
+    :type desc: str
+    :param max_workers: number of workers to use in the ThreadPoolExecutor, default value is min(16, cpu_count() * 5).
     :type max_workers: int
 
     :return: A list of results given for each func value execution
     :rtype: list
     """
-    max_workers = cpu_count() - 1
+    if max_workers is None:
+        max_workers = min(16, (cpu_count() or 1) * 5)
+
     futures = []
     gathering_responses = tqdm(total=len(params), desc=desc)
     results = []
@@ -702,7 +706,7 @@ def concurrent_get(client, get_function, **params):
     :return: List of results
     :rtype: list
     """
-    max_workers = min(cpu_count() - 1, 6)
+    max_workers = min(16, (cpu_count() or 1) * 5)
 
     if (params.get('limit') or float('inf')) <= client.limit:
         docs = get_function(**params)


### PR DESCRIPTION
This pull request updates the logic for determining the number of worker threads in concurrent request functions within `openreview/tools.py`. The changes ensure more robust and scalable defaults for thread pool sizing, improving performance and reliability when executing multiple requests concurrently.

**Concurrency and performance improvements:**

* Updated the default calculation for `max_workers` in both `concurrent_requests` and `concurrent_get` to use `min(16, (cpu_count() or 1) * 5)`, allowing for better scaling across different environments and preventing excessive thread creation. [[1]](diffhunk://#diff-a0a408fd57af11c3a81cfd044e307e78e5b96b29d4ec2f55a62cd5667b12b45dL91-R109) [[2]](diffhunk://#diff-a0a408fd57af11c3a81cfd044e307e78e5b96b29d4ec2f55a62cd5667b12b45dL705-R709)
* Improved the handling of the `max_workers` parameter in `concurrent_requests` by setting it to a sensible default only if not provided, and clarified the docstring to match the new logic.