### PR TITLE
Fix/ New Venue UI: force profiles in authorids by default

### DIFF
--- a/openreview/workflows/workflow_process/deploy_reviewers_only_process.py
+++ b/openreview/workflows/workflow_process/deploy_reviewers_only_process.py
@@ -18,7 +18,8 @@ def process(client, edit, invitation):
     venue.submission_stage =  openreview.stages.SubmissionStage(
         start_date=submission_cdate,
         due_date=submission_duedate,
-        double_blind=True
+        double_blind=True,
+        force_profiles=True
     )
 
     venue.bid_stages = [

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -560,14 +560,18 @@ For more details, please check the following links:
         test_client = openreview.api.OpenReviewClient(token=test_client.token)
 
         domains = ['umass.edu', 'amazon.com', 'fb.com', 'cs.umass.edu', 'google.com', 'mit.edu', 'deepmind.com', 'co.ux', 'apple.com', 'nvidia.com']
+        for domain in domains:
+            helpers.create_user(f'andrew@{domain}', 'Andrew', f'{domain.split(".")[0].capitalize()}')
+
         for i in range(1,11):
+
             note = openreview.api.Note(
                 license = 'CC BY-NC-SA 4.0',
                 content = {
                     'title': { 'value': 'Paper title ' + str(i) },
                     'abstract': { 'value': 'This is an abstract ' + str(i) },
-                    'authorids': { 'value': ['~SomeFirstName_User1', 'andrew@' + domains[i % 10]] },
-                    'authors': { 'value': ['SomeFirstName User', 'Andrew Mc'] },
+                    'authorids': { 'value': ['~SomeFirstName_User1', '~Andrew_' + domains[i % 10].split('.')[0].capitalize() + '1'] },
+                    'authors': { 'value': ['SomeFirstName User', 'Andrew ' + domains[i % 10].split('.')[0].capitalize()] },
                     'subject_area': { 'value': '3D from multi-view and sensors' },
                     'pdf': {'value': '/pdf/' + 'p' * 40 +'.pdf' },
                     'email_sharing': { 'value': 'We authorize the sharing of all author emails with Program Chairs.' },
@@ -587,7 +591,7 @@ For more details, please check the following links:
 
         submissions = openreview_client.get_notes(invitation='ABCD.cc/2025/Conference/-/Submission', sort='number:asc')
         assert len(submissions) == 10
-        assert submissions[-1].readers == ['ABCD.cc/2025/Conference', '~SomeFirstName_User1', 'andrew@umass.edu']
+        assert submissions[-1].readers == ['ABCD.cc/2025/Conference', '~SomeFirstName_User1', '~Andrew_Umass1']
 
         messages = openreview_client.get_messages(to='test@mail.com', subject='ABCD 2025 has received your submission titled Paper title .*')
         assert messages and len(messages) == 10


### PR DESCRIPTION
This PR forces authorids to be profiles by default for the new venue UI. 

Two questions:
- should it be mentioned anywhere so that the PCs know this is the default?
- should we write documentation for PCs on how to change the authors/authorids fields if they want to allow emails? I think this won't be clear to them

@melisabok 