### PR TITLE
Feat: Include openreview-py and python version in the user-agent

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -7,6 +7,8 @@ if sys.version_info[0] < 3:
 else:
     string_types = [str]
 
+from importlib.metadata import version as get_package_version, PackageNotFoundError
+
 from .. import tools
 import requests
 from requests.adapters import HTTPAdapter
@@ -98,9 +100,14 @@ class OpenReviewClient(object):
         self.activatelink_url = self.baseurl + '/activatelink'
         self.domains_rename = self.baseurl + '/domains/rename'
         self.groups_members_cache_url = self.baseurl + '/groups/members/cache'
-        self.user_agent = 'OpenReviewPy/v' + str(sys.version_info[0])
 
-        
+        # Build User-Agent string: openreview-py/{package_version} (Python/{python_version})
+        try:
+            package_version = get_package_version('openreview-py')
+        except PackageNotFoundError:
+            package_version = 'unknown'
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        self.user_agent = f"openreview-py/{package_version} (Python/{python_version})"
 
         self.limit = 1000
         self.token = token.replace('Bearer ', '') if token else None

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -6,6 +6,8 @@ if sys.version_info[0] < 3:
 else:
     string_types = [str]
 
+from importlib.metadata import version as get_package_version, PackageNotFoundError
+
 from . import tools
 import requests
 from requests.adapters import HTTPAdapter
@@ -78,8 +80,15 @@ class Client(object):
         self.note_edits_url = self.baseurl + '/notes/edits'
         self.invitation_edits_url = self.baseurl + '/invitations/edits'
         self.infer_notes_url = self.baseurl + '/notes/infer'
-        self.user_agent = 'OpenReviewPy/v' + str(sys.version_info[0])
         self.domains_rename = self.baseurl + '/domains/rename'
+
+        # Build User-Agent string: openreview-py/{package_version} (Python/{python_version})
+        try:
+            package_version = get_package_version('openreview-py')
+        except PackageNotFoundError:
+            package_version = 'unknown'
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        self.user_agent = f"openreview-py/{package_version} (Python/{python_version})"
 
         self.limit = 1000
         self.token = token.replace('Bearer ', '') if token else None


### PR DESCRIPTION
This pull request updates the construction of the `User-Agent` string in both the `openreview/api/client.py` and `openreview/openreview.py` modules to include the actual package version and Python version. This is so that openreview-api can validate that the version connecting to it is up to date.

**User-Agent String Improvements:**

* Replaced the old `User-Agent` format with a new format that includes the actual `openreview-py` package version and Python version, e.g., `openreview-py/{package_version} (Python/{python_version})`, in both `openreview/api/client.py` and `openreview/openreview.py`. If the package version cannot be determined, it defaults to `'unknown'`. [[1]](diffhunk://#diff-f5d3f10e7a5ff1e9ba8f8f2073dca77d0c33d357533329eb2d8c002cb671bc7cL101-R110) [[2]](diffhunk://#diff-1979f558782e2b59efbfa7ec712171111204d7dfea68a8b404b46c432c0e55bdL81-R92)

**Dependency Imports:**

* Added imports for `version` and `PackageNotFoundError` from `importlib.metadata` to support dynamic retrieval of the package version in both modules. [[1]](diffhunk://#diff-f5d3f10e7a5ff1e9ba8f8f2073dca77d0c33d357533329eb2d8c002cb671bc7cR10-R11) [[2]](diffhunk://#diff-1979f558782e2b59efbfa7ec712171111204d7dfea68a8b404b46c432c0e55bdR9-R10)