### PR TITLE
Feat: New Venue UI: add internal status invitation for support

### DIFF
--- a/openreview/workflows/workflows.py
+++ b/openreview/workflows/workflows.py
@@ -45,6 +45,7 @@ class Workflows():
         self.set_conference_review_deployment()
         self.set_conference_review_comment()
         self.set_conference_review_status_comment()
+        self.set_conference_review_internal_status()
 
     def get_process_content(self, file_path):
         process = None
@@ -614,6 +615,51 @@ class Workflows():
                 }
             },
             process = self.get_process_content('workflow_process/venue_comment_process.py')
+        )
+
+        self.post_invitation_edit(invitation)
+
+    def set_conference_review_internal_status(self):
+
+        support_group_id = self.support_group_id
+        status_invitation_id = f'{support_group_id}/Venue_Request/Conference_Review_Workflow/-/Internal_Status'
+
+        invitation = Invitation(id=status_invitation_id,
+            invitees=[support_group_id],
+            readers=[support_group_id],
+            writers=[support_group_id],
+            signatures=[support_group_id],
+            edit = {
+                'signatures': { 
+                    'param': { 
+                        'items': [ { 'value': support_group_id, 'optional': True } ] 
+                    }
+                },
+                'readers': [support_group_id],
+                'writers': [support_group_id],
+                'note': {
+                    'id': {
+                        'param': {
+                            'withInvitation': f'{support_group_id}/Venue_Request/-/Conference_Review_Workflow',
+                        }
+                    },
+                    'content': {
+                        'status': {
+                            'order': 1,
+                            'description': 'Internal status for this venue. This will not be visible to the PCs. Leave empty to delete a previous status.',
+                            'value': {
+                                'param': {
+                                    'type': 'string',
+                                    'regex': '.{0,500}',
+                                    'optional': True,
+                                    'deletable': True
+                                }
+                            },
+                            'readers': [support_group_id],
+                        }
+                    }
+                }
+            }
         )
 
         self.post_invitation_edit(invitation)

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -133,6 +133,22 @@ class TestReviewersOnly():
 
         helpers.await_queue_edit(openreview_client, edit_id=comment_edit['id'])
 
+        # post an internal status
+        status_edit = openreview_client.post_note_edit(
+            invitation=f'openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Internal_Status',
+            signatures=['openreview.net/Support'],
+            note=openreview.api.Note(
+                id=request.id,
+                content={
+                    'status': { 'value': 'Do not deploy yet, awaiting PC clarification.' }
+                }
+            )
+        )
+
+        request_form = openreview_client.get_note(request.id)
+        assert 'status' in request_form.content and request_form.content['status']['value'] == 'Do not deploy yet, awaiting PC clarification.'
+        assert request_form.content['status']['readers'] == ['openreview.net/Support']
+
         comment = openreview_client.get_note(comment_edit['note']['id'])
         assert comment.readers == ['openreview.net/Support', 'programchair@abcd.cc']
 
@@ -179,6 +195,21 @@ class TestReviewersOnly():
         helpers.await_queue_edit(openreview_client, 'ABCD.cc/2025/Conference/-/Desk_Rejection-0-1', count=1)
         helpers.await_queue_edit(openreview_client, 'ABCD.cc/2025/Conference/Program_Committee/-/Submission_Group-0-1', count=1)
         helpers.await_queue_edit(openreview_client, 'ABCD.cc/2025/Conference/-/Submission_Change_Before_Bidding-0-1', count=1)
+
+        # delete status after it's not needed anymore
+        status_edit = openreview_client.post_note_edit(
+            invitation=f'openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Internal_Status',
+            signatures=['openreview.net/Support'],
+            note=openreview.api.Note(
+                id=request.id,
+                content={
+                    'status': { 'value': { 'delete': True } }
+                }
+            )
+        )
+
+        request_form = openreview_client.get_note(request.id)
+        assert not request_form.content.get('status', {}).get('value')
 
         venue_group = openreview.tools.get_group(openreview_client, 'ABCD.cc/2025/Conference')
         assert venue_group and venue_group.content['reviewers_recruitment_id']['value'] == 'ABCD.cc/2025/Conference/Program_Committee/-/Recruitment_Response'


### PR DESCRIPTION
This PR adds a `status` field to venue requests, readable only by Support, to keep track of the status of the venue. It will appear below the title of the venue request and can be deleted once the status is no longer needed. 

<img width="2490" height="514" alt="image" src="https://github.com/user-attachments/assets/52764580-72d0-4816-ac70-75a08d923469" />
