### PR TITLE
store reviewer recommendation id in domain.content

### DIFF
--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -319,6 +319,9 @@ class GroupBuilder(object):
         if venue_group.content.get('enable_reviewers_reassignment'):
             content['enable_reviewers_reassignment'] = venue_group.content.get('enable_reviewers_reassignment')
 
+        if venue_group.content.get('reviewers_recommendation_id'):
+            content['reviewers_recommendation_id'] = venue_group.content.get('reviewers_recommendation_id')            
+
         if venue_group.content.get('reviewers_proposed_assignment_title'):
             content['reviewers_proposed_assignment_title'] = venue_group.content.get('reviewers_proposed_assignment_title')
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -4330,6 +4330,7 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
         )
 
         recommendation_invitation = self.save_invitation(recommendation_invitation, replacement=True)
+        return recommendation_invitation
         
     def set_group_recruitment_invitations(self, committee_name):
         

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -1161,7 +1161,16 @@ Total Errors: {len(errors)}
         self.invitation_builder.set_SAC_ethics_flag_invitation(sac_ethics_flag_duedate)
 
     def open_reviewer_recommendation_stage(self, start_date=None, due_date=None, total_recommendations=7):
-        self.invitation_builder.set_reviewer_recommendation_invitation(start_date, due_date, total_recommendations)
+        recommendation_invitation = self.invitation_builder.set_reviewer_recommendation_invitation(start_date, due_date, total_recommendations)
+        self.client.post_group_edit(invitation=self.get_meta_invitation_id(),
+            signatures = [self.venue_id],
+            group = openreview.api.Group(
+                id = self.venue_id,
+                content = {
+                    'reviewers_recommendation_id': { 'value': recommendation_invitation.id },
+                }
+            )
+        )        
 
     def ithenticate_create_and_upload_submission(self):
         if not self.iThenticate_plagiarism_check:

--- a/openreview/venue/webfield/programChairsWebfield.js
+++ b/openreview/venue/webfield/programChairsWebfield.js
@@ -35,7 +35,9 @@ return {
     paperReviewsCompleteThreshold: 3,
     bidName: domain.content.bid_name?.value,
     recommendationName:
-      domain.content.recommendation_id?.value || "Recommendation",
+      domain.content.recommendation_id?.value || "Recommendation",  //Deprecated: to be removed in favor of reviewersRecommendationId  
+    reviewersRecommendationId:
+      domain.content.reviewers_recommendation_id?.value,
     metaReviewRecommendationName:
       domain.content.meta_review_recommendation?.value || "recommendation",
     submissionId: domain.content.submission_id?.value,


### PR DESCRIPTION
Webfield can read the entire invitation id instead of using invitation name