### PR TITLE
ARR: Add SACs to resubmission readers

### DIFF
--- a/openreview/arr/management/setup_sae_matching.py
+++ b/openreview/arr/management/setup_sae_matching.py
@@ -39,6 +39,7 @@ def process(client, invitation):
     support_group = request_form.invitation.split('/-/')[0]
     venue = openreview.helpers.get_conference(client_v1, request_form_id, support_group)
     submissions = venue.get_submissions()
+    resubmissions = get_resubmissions(submissions, previous_url_field)
 
     skip_scores = defaultdict(list)
 
@@ -94,6 +95,28 @@ def process(client, invitation):
     track_edge_readers = {
         senior_area_chairs_id: [venue_id]
     }
+
+    # Grant current-cycle SACs read access to previous-cycle submissions.
+    for submission in resubmissions:
+        previous_id = submission.content[previous_url_field]['value'].split('?id=')[1].split('&')[0]
+        try:
+            previous_submission = client_v1.get_note(previous_id)
+            previous_venue_id = previous_submission.invitation.split('/-/')[0]
+            previous_sac = openreview.tools.get_group(client_v1, f"{previous_venue_id}/Paper{previous_submission.number}/Senior_Area_Chairs")
+            current_client = client_v1
+        except:
+            previous_submission = client.get_note(previous_id)
+            previous_venue_id = previous_submission.domain
+            previous_sac = openreview.tools.get_group(client, f"{previous_venue_id}/Submission{previous_submission.number}/Senior_Area_Chairs")
+            current_client = client
+
+        if previous_sac is None:
+            print(f"no previous SAC for {submission.id}")
+            continue
+
+        current_sac_group = venue.get_senior_area_chairs_id(number=submission.number)
+        if current_sac_group not in previous_sac.members:
+            current_client.add_members_to_group(previous_sac, current_sac_group)
 
     # 3) Post track edges
     for role_id, track_to_members in track_to_ids.items():

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -3866,6 +3866,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         assert ac_scores['~AC_ARROne1']['weight'] == 3
         assert rev_scores['~Reviewer_ARROne1']['weight'] == 3
         assert 'aclweb.org/ACL/ARR/2023/August/Submission2/Area_Chairs' in pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission2/Area_Chairs').members
+        assert 'aclweb.org/ACL/ARR/2023/August/Submission2/Senior_Area_Chairs' in pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission2/Senior_Area_Chairs').members
         assert 'aclweb.org/ACL/ARR/2023/August/Submission2/Reviewers' in pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission2/Reviewers/Submitted').members
 
         # For 2, assert that the affinity scores on June reviewers/aes is 0
@@ -3880,6 +3881,7 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         assert ac_scores['~AC_ARRTwo1']['weight'] == 0
         assert rev_scores['~Reviewer_ARRTwo1']['weight'] == 0
         assert 'aclweb.org/ACL/ARR/2023/August/Submission3/Area_Chairs' in pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission3/Area_Chairs').members
+        assert 'aclweb.org/ACL/ARR/2023/August/Submission3/Senior_Area_Chairs' in pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission3/Senior_Area_Chairs').members
         assert 'aclweb.org/ACL/ARR/2023/August/Submission3/Reviewers/Submitted' in pc_client_v2.get_group('aclweb.org/ACL/ARR/2023/June/Submission3/Reviewers/Submitted').members
 
         # Check for existence of track information


### PR DESCRIPTION
This PR adds the current cycle's SACs to the previous submission's SACs in the setup matching data script