### PR TITLE
Update CI to Node.js 24 and optimize resource usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
     default: "master"
   openreview-api-v2-branch:
     type: string
-    default: "main"
+    default: "chore/update-nodejs-v2"
   python-version:
     type: string
     default: "3.13.1"


### PR DESCRIPTION
Upgrade Node.js from 22 to 24, add memory limits for API servers (NODE_OPTIONS), cap MongoDB WiredTiger cache to 0.5GB, and limit Elasticsearch JVM heap to 512MB to reduce CI resource pressure.