### PR TITLE
ARR: Remove Checklist Preprocess for field

### DIFF
--- a/openreview/arr/process/checklist_preprocess.py
+++ b/openreview/arr/process/checklist_preprocess.py
@@ -12,12 +12,6 @@ def process(client, edit, invitation):
     'responsible_checklist': 'Responsible Checklist',
     'limitations': 'Limitations'
   }
-  if False in [note.content.get(field, {}).get('value', 'Yes') == 'Yes' for field in violation_fields]:
-    violated_fields = [format_field[field] for field in violation_fields if note.content.get(field, {}).get('value', 'Yes') == 'No']
-    potential_violation_justification = str(note.content.get('potential_violation_justification', {}).get('value', 'N/A')).strip()
-    if potential_violation_justification.lower().startswith('n/a') or len(potential_violation_justification) <= 0:
-      exception_string = f"You have indicated a potential violation with the following fields: {', '.join(violated_fields)}. Please enter a brief explanation under \"Potential Violation Justification\""
-      raise openreview.OpenReviewException(exception_string)
     
   needs_ethics_review = edit.note.content.get('need_ethics_review', {}).get('value', 'No') == 'Yes'
   if needs_ethics_review and 'N/A' in edit.note.content.get('ethics_review_justification', {}).get('value', 'N/A'):

--- a/openreview/arr/process/checklist_preprocess.py
+++ b/openreview/arr/process/checklist_preprocess.py
@@ -3,16 +3,6 @@ def process(client, edit, invitation):
   note = edit.note
   forum = client.get_note(note.forum)
 
-  violation_fields = ['appropriateness', 'formatting', 'length', 'anonymity', 'responsible_checklist', 'limitations']
-  format_field = {
-    'appropriateness': 'Appropriateness',
-    'formatting': 'Formatting',
-    'length': 'Length',
-    'anonymity': 'Anonymity',
-    'responsible_checklist': 'Responsible Checklist',
-    'limitations': 'Limitations'
-  }
-    
   needs_ethics_review = edit.note.content.get('need_ethics_review', {}).get('value', 'No') == 'Yes'
   if needs_ethics_review and 'N/A' in edit.note.content.get('ethics_review_justification', {}).get('value', 'N/A'):
     raise openreview.OpenReviewException("You have indicated that this submission needs an ethics review. Please enter a brief justification for your flagging.")

--- a/openreview/stages/arr_content.py
+++ b/openreview/stages/arr_content.py
@@ -2277,18 +2277,6 @@ arr_ae_checklist = {
         "description": "Have the authors completed the responsible NLP research checklist appropriately?",
         "order": 13
     },
-    "potential_violation_justification": {
-        "value": {
-            "param": {
-                "regex": ".{1,250}",
-                "optional": False,
-                "default": "N/A - the authors filled in the responsible NLP checklist appropriately.",
-                "type": "string"
-            }
-        },
-        "description": "If the authors provided incorrect, incomplete or misleading information in this checklist, please give a brief explanation of the issue",
-        "order": 14
-    },
     "need_ethics_review": {
         "value": {
             "param": {
@@ -2586,18 +2574,6 @@ arr_reviewer_checklist = {
         },
         "description": "Have the authors completed the responsible NLP research checklist appropriately?",
         "order": 13
-    },
-    "potential_violation_justification": {
-        "value": {
-            "param": {
-                "regex": ".{1,250}",
-                "optional": False,
-                "default": "N/A - the authors filled in the responsible NLP checklist appropriately.",
-                "type": "string"
-            }
-        },
-        "description": "If the authors provided incorrect, incomplete or misleading information in this checklist, please give a brief explanation of the issue",
-        "order": 14
     },
     "need_ethics_review": {
         "value": {

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -4602,14 +4602,6 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         venue = openreview.helpers.get_conference(client, request_form.id, 'openreview.net/Support')
         submissions = pc_client_v2.get_notes(invitation='aclweb.org/ACL/ARR/2023/August/-/Submission', sort='number:asc')
         violation_fields = ['appropriateness', 'formatting', 'length', 'anonymity', 'responsible_checklist', 'limitations'] # TODO: move to domain or somewhere?
-        format_field = {
-            'appropriateness': 'Appropriateness',
-            'formatting': 'Formatting',
-            'length': 'Length',
-            'anonymity': 'Anonymity',
-            'responsible_checklist': 'Responsible Checklist',
-            'limitations': 'Limitations'
-        }
         only_required_fields = ['number_of_assignments', 'diversity']
 
         default_fields = {field: True for field in violation_fields + only_required_fields}
@@ -4706,9 +4698,6 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         }
         with pytest.raises(openreview.OpenReviewException, match=r'You have indicated that this submission needs an ethics review. Please enter a brief justification for your flagging.'):
             post_checklist(user_client, checklist_inv, user, tested_field='need_ethics_review', override_fields=force_justifications)
-        for field in violation_fields:
-            with pytest.raises(openreview.OpenReviewException, match=rf'You have indicated a potential violation with the following fields: {format_field[field]}. Please enter a brief explanation under \"Potential Violation Justification\"'):
-                post_checklist(user_client, checklist_inv, user, tested_field=field, override_fields=force_justifications)
                 
         # Post checklist with no ethics flag and no violation field - check that flags are not there
         edit, test_submission = post_checklist(user_client, checklist_inv, user)

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -4614,7 +4614,6 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             'anonymity_justification': {'value': 'N/A - this paper is properly anonymized.'},
             'limitations_justification': {'value': "N/A - this paper has the 'Limitations' section."},
             'overall_level_justification': {'value': 'N/A - this seems like a good-faith submission worthy of full review.'},
-            'potential_violation_justification': {'value': 'N/A - the authors filled in the responsible NLP checklist appropriately.'},
             'ethics_review_justification': {'value': 'N/A - this paper does not need an ethics review.'}
         }
         test_submission = submissions[1]
@@ -4647,7 +4646,6 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                 if tested_field:
                     ret_content[tested_field] = {'value':'Yes'} if not default_fields[tested_field] else {'value':'No'}
                     ret_content['ethics_review_justification'] = {'value': 'There is an issue'}
-                    ret_content['potential_violation_justification'] = {'value': 'There are violations with this submission'}
 
                 if 'Reviewer' in chk_inv:
                     for field in only_required_fields:
@@ -4662,7 +4660,6 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                 if tested_field:
                     content[tested_field] = {'value':'Yes'} if not default_fields[tested_field] else {'value':'No'}
                     content['ethics_review_justification'] = {'value': 'There is an issue'}
-                    content['potential_violation_justification'] = {'value': 'There are violations with this submission'}
 
             if override_fields:
                 for field in override_fields.keys():
@@ -4693,12 +4690,20 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
 
         # Test checklist pre-process
         force_justifications = {
-                'potential_violation_justification': {'value': 'N/A - the authors filled in the responsible NLP checklist appropriately.'},
                 'ethics_review_justification': {'value': 'N/A - this paper does not need an ethics review.'}
         }
         with pytest.raises(openreview.OpenReviewException, match=r'You have indicated that this submission needs an ethics review. Please enter a brief justification for your flagging.'):
             post_checklist(user_client, checklist_inv, user, tested_field='need_ethics_review', override_fields=force_justifications)
-                
+        with pytest.raises(openreview.OpenReviewException, match=r'The property potential_violation_justification must NOT be present'):
+            post_checklist(
+                user_client,
+                checklist_inv,
+                user,
+                override_fields={
+                    'potential_violation_justification': {'value': 'This deprecated field should be rejected'}
+                }
+            )
+
         # Post checklist with no ethics flag and no violation field - check that flags are not there
         edit, test_submission = post_checklist(user_client, checklist_inv, user)
         assert 'flagged_for_ethics_review' not in test_submission.content
@@ -5166,7 +5171,6 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             "number_of_assignments" : { "value" : "Yes" },
             "diversity" : { "value" : "Yes" },
             "need_ethics_review" : { "value" : "Yes" },
-            "potential_violation_justification" : { "value" : "N/A - the authors filled in the responsible NLP checklist appropriately." },
             "ethics_review_justification" : { "value" : "There is an issue" }
         }
         chk_edit = ac_client.post_note_edit(
@@ -6584,7 +6588,6 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
                     "number_of_assignments" : { "value" : "Yes" },
                     "diversity" : { "value" : "Yes" },
                     "need_ethics_review" : { "value" : "No" },
-                    "potential_violation_justification" : { "value" : "N/A - the authors filled in the responsible NLP checklist appropriately." },
                     "ethics_review_justification" : { "value" : "There is an issue" }
                 }
             )


### PR DESCRIPTION
This PR removes a validation in the ARR checklist preprocess that requires a field to be filled out, since the field is no longer present