### PR TITLE
Add description support to CustomStage

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1629,6 +1629,7 @@ class CustomStage(object):
                  notify_readers=False, 
                  email_template=None, 
                  allow_de_anonymization=False,
+                 description=None,
                  child_invitations_name=None):
         self.name = name
         self.child_invitations_name = child_invitations_name if child_invitations_name else self.name
@@ -1647,6 +1648,7 @@ class CustomStage(object):
         self.notify_readers = notify_readers
         self.email_template = email_template
         self.allow_de_anonymization = allow_de_anonymization
+        self.description = description
         self.process_path = None
         self.preprocess_path = None
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -3193,6 +3193,11 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
         if custom_stage.preprocess_path:
             invitation.edit['invitation']['preprocess'] = self.get_process_content(custom_stage.preprocess_path)
 
+        if custom_stage.description:
+            invitation.edit['invitation']['description'] = custom_stage.description
+        else:
+            invitation.edit['invitation']['description'] = { 'param': { 'const': { 'delete': True } } }
+
         self.save_invitation(invitation, replacement=False)
         return invitation
 

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -4734,7 +4734,8 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
                 }
             },
             notify_readers=True,
-            email_sacs=False)
+            email_sacs=False,
+            description='Please acknowledge that you have read the rebuttal.')
 
         venue.create_custom_stage()
 
@@ -4742,6 +4743,8 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         ack_invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Rebuttal_Acknowledgement')
         assert len(ack_invitations) == 2
+        assert ack_invitations[0].description == 'Please acknowledge that you have read the rebuttal.'
+        assert ack_invitations[1].description == 'Please acknowledge that you have read the rebuttal.'
 
 
         ## Ask reviewers to comment the rebuttals
@@ -4776,7 +4779,10 @@ Please note that responding to this email will direct your reply to pc@icml.cc.
 
         helpers.await_queue_edit(openreview_client, 'ICML.cc/2023/Conference/-/Rebuttal_Comment-0-1', count=1)        
 
-        assert len(openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Rebuttal_Comment')) == 2
+        comment_invitations = openreview_client.get_invitations(invitation='ICML.cc/2023/Conference/-/Rebuttal_Comment')
+        assert len(comment_invitations) == 2
+        assert comment_invitations[0].description is None
+        assert comment_invitations[1].description is None
 
         rebuttals = pc_client_v2.get_notes(invitation='ICML.cc/2023/Conference/Submission1/-/Rebuttal')
         assert len(rebuttals) == 2


### PR DESCRIPTION
Fixes #2724

CustomStage had no description parameter, requiring PCs to run the stage and then manually edit the invitation to set one. ReviewStage and MetaReviewStage already supported this — this PR adds the same support to CustomStage.

- Added description=None param to CustomStage.__init__
- Wired it into set_custom_stage_invitation() following the same pattern as set_review_stage_invitation() and set_meta_review_stage_invitation()