### PR TITLE
Check custom max papers in assignment preprocess

### DIFF
--- a/openreview/venue/process/assignment_pre_process.js
+++ b/openreview/venue/process/assignment_pre_process.js
@@ -11,6 +11,7 @@ async function process(client, edge, invitation) {
   const committeeRole = invitation.content.committee_role?.value
   const quota = domain.content?.[`submission_assignment_max_${committeeRole}`]?.value
   const inviteAssignmentId = domain.content?.[`${committeeRole}_invite_assignment_id`]?.value
+  const customMaxPapersId = domain.content?.[`${committeeRole}_custom_max_papers_id`]?.value
 
   const { notes } = await client.getNotes({ id: edge.head })
   const submission = notes[0]
@@ -51,6 +52,31 @@ async function process(client, edge, invitation) {
     if (!bypassQuota && quota && filteredInviteAssignmentEdges.length + filteredAssignmentEdges.length >= quota) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not make assignment, total assignments and invitations must not exceed ${quota}; invite edges=${filteredInviteAssignmentEdges.length} assignment edges=${filteredAssignmentEdges.length}` }))
     }
+
+    // Check if assignment respects user's custom max papers for direct assignments
+    const hasAcceptedInvite = inviteAssignmentEdges.some(e => {
+      return e.tail === edge.tail && acceptLabel && e?.label === acceptLabel
+    })
+
+    if (!hasAcceptedInvite && customMaxPapersId) {
+      const [{ edges: customMaxPapersEdges }, userAssignmentsResponse] = await Promise.all([
+        client.getEdges({ invitation: customMaxPapersId, tail: edge.tail }),
+        client.getEdges({ invitation: edge.invitation, tail: edge.tail })
+      ])
+      const userAssignmentCount = userAssignmentsResponse.count ?? userAssignmentsResponse.edges.length
+
+      let userPaperQuota = customMaxPapersEdges.length > 0 ? customMaxPapersEdges[0].weight : 0
+
+      if (!userPaperQuota) {
+        const { invitations: cmpInvitations } = await client.getInvitations({ id: customMaxPapersId })
+        userPaperQuota = cmpInvitations[0]?.edge?.weight?.param?.default
+      }
+
+      if (userPaperQuota && userAssignmentCount >= userPaperQuota) {
+        return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not make assignment, quota of ${userPaperQuota} has been reached for ${edge.tail}` }))
+      }
+    }
+
     const { count } = await client.getGroups({ id: `${submissionGroupId}/${committeeName}` })
     if ( count === 0) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not make assignment, submission ${committeeName} group not found.` }))

--- a/openreview/venue/process/assignment_pre_process.js
+++ b/openreview/venue/process/assignment_pre_process.js
@@ -65,14 +65,14 @@ async function process(client, edge, invitation) {
       ])
       const userAssignmentCount = userAssignmentsResponse.count ?? userAssignmentsResponse.edges.length
 
-      let userPaperQuota = customMaxPapersEdges.length > 0 ? customMaxPapersEdges[0].weight : 0
+      let userPaperQuota = customMaxPapersEdges.length > 0 ? customMaxPapersEdges[0].weight : null
 
-      if (!userPaperQuota) {
+      if (userPaperQuota == null) {
         const { invitations: cmpInvitations } = await client.getInvitations({ id: customMaxPapersId })
-        userPaperQuota = cmpInvitations[0]?.edge?.weight?.param?.default
+        userPaperQuota = cmpInvitations[0]?.edge?.weight?.param?.default ?? null
       }
 
-      if (userPaperQuota && userAssignmentCount >= userPaperQuota) {
+      if (userPaperQuota != null && userAssignmentCount >= userPaperQuota) {
         return Promise.reject(new OpenReviewError({ name: 'Error', message: `Can not make assignment, quota of ${userPaperQuota} has been reached for ${edge.tail}` }))
       }
     }

--- a/openreview/venue/process/assignment_pre_process.js
+++ b/openreview/venue/process/assignment_pre_process.js
@@ -63,7 +63,15 @@ async function process(client, edge, invitation) {
         client.getEdges({ invitation: customMaxPapersId, tail: edge.tail }),
         client.getEdges({ invitation: edge.invitation, tail: edge.tail })
       ])
-      const userAssignmentCount = userAssignmentsResponse.count ?? userAssignmentsResponse.edges.length
+
+      // Exclude current assignment in case of edge update
+      const filteredUserAssignments = userAssignmentsResponse.edges.filter(e => e.id !== edge.id)
+      const isExistingEdge = filteredUserAssignments.length < userAssignmentsResponse.edges.length
+
+      // If updating an existing edge, subtract 1 so it is not counted against the quota
+      const userAssignmentCount = userAssignmentsResponse.count != null
+        ? userAssignmentsResponse.count - (isExistingEdge ? 1 : 0)
+        : filteredUserAssignments.length
 
       let userPaperQuota = customMaxPapersEdges.length > 0 ? customMaxPapersEdges[0].weight : null
 

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -4195,6 +4195,14 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
 
         helpers.await_queue_edit(openreview_client, invitation='aclweb.org/ACL/ARR/2023/August/Area_Chairs/-/Assignment')
 
+        # ~AC_ARROne1 has CMP=0 from June migration, update quota to allow assignment in August
+        ac_cmp_edge = openreview_client.get_edges(
+            invitation='aclweb.org/ACL/ARR/2023/August/Area_Chairs/-/Custom_Max_Papers',
+            tail='~AC_ARROne1'
+        )[0]
+        ac_cmp_edge.weight = 2
+        openreview_client.post_edge(ac_cmp_edge)
+
         edge = openreview_client.post_edge(openreview.api.Edge(
             invitation = 'aclweb.org/ACL/ARR/2023/August/Area_Chairs/-/Assignment',
             head = submissions[1].id,
@@ -4348,6 +4356,14 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         reviewer_two_edge = client.get_all_edges(invitation='aclweb.org/ACL/ARR/2023/August/Reviewers/-/Invite_Assignment', tail='~Reviewer_ARRTwo1', head=submissions[1].id)
         assert reviewer_two_edge[0].label == 'Declined: I am too busy.'
 
+        # Update quota to allow assignment
+        rev_cmp_edge = openreview_client.get_all_edges(
+            invitation='aclweb.org/ACL/ARR/2023/August/Reviewers/-/Custom_Max_Papers',
+            tail='~Reviewer_ARRFour1'
+        )[0]
+        rev_cmp_edge.weight = 2
+        openreview_client.post_edge(rev_cmp_edge)
+        
         # Assignment for reviewer 4 should post
         existing_edges.append(
             openreview_client.post_edge(openreview.api.Edge(

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -549,6 +549,62 @@ class TestWorkshopV2():
         )
         assert len(assignment_edges) == 1
 
+        # Test 5: Quota of 0 - Rejected
+        cmp_edge = openreview_client.post_edge(openreview.api.Edge(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Custom_Max_Papers',
+            head='PRL/2023/ICAPS/Reviewers',
+            tail='~Reviewer_ICAPSThree1',
+            signatures=['PRL/2023/ICAPS/Program_Chairs'],
+            weight=0
+        ))
+
+        with pytest.raises(openreview.OpenReviewException, match=r'Can not make assignment, quota of 0 has been reached for ~Reviewer_ICAPSThree1'):
+            openreview_client.post_edge(openreview.api.Edge(
+                invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+                head=submissions[0].id,
+                tail='~Reviewer_ICAPSThree1',
+                signatures=['PRL/2023/ICAPS/Program_Chairs'],
+                weight=1
+            ))
+
+        openreview_client.delete_edges(invitation='PRL/2023/ICAPS/Reviewers/-/Custom_Max_Papers', head='PRL/2023/ICAPS/Reviewers', tail='~Reviewer_ICAPSThree1')
+
+        # Test 5: Read quota from invitation
+        cmp_edges = openreview_client.get_all_edges(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+            head='PRL/2023/ICAPS/Reviewers',
+            tail='Reviewer_ICAPSThree1'
+        )
+        assert len(cmp_edges) == 0
+
+        cmp_invitation = openreview_client.get_invitation('PRL/2023/ICAPS/Reviewers/-/Custom_Max_Papers')
+        cmp_invitation.edit['weight']['param']['default'] = 1
+        openreview_client.post_invitation_edit(
+            invitations='PRL/2023/ICAPS/-/Edit',
+            readers=['PRL/2023/ICAPS'],
+            writers=['PRL/2023/ICAPS'],
+            signatures=['PRL/2023/ICAPS'],
+            invitation=cmp_invitation
+        )
+
+        assignment_edge = openreview_client.post_edge(openreview.api.Edge(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+            head=submissions[0].id,
+            tail='~Reviewer_ICAPSThree1',
+            signatures=['PRL/2023/ICAPS/Program_Chairs'],
+            weight=1
+        ))
+        helpers.await_queue_edit(openreview_client, edit_id=assignment_edge.id)
+
+        with pytest.raises(openreview.OpenReviewException, match=r'Can not make assignment, quota of 1 has been reached for ~Reviewer_ICAPSThree1'):
+            openreview_client.post_edge(openreview.api.Edge(
+                invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+                head=submissions[1].id,
+                tail='~Reviewer_ICAPSThree1',
+                signatures=['PRL/2023/ICAPS/Program_Chairs'],
+                weight=1
+            ))
+
     def test_review_stage(self, client, openreview_client, helpers, request_page, selenium):
 
 

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -478,6 +478,87 @@ class TestWorkshopV2():
         assert messages[0]['content']['text'].startswith('Hi External Reviewer Adobe,\n\nYou were invited to review the paper number: 12, title: "Paper title No Abstract Version 2".\n\nPlease respond the invitation clicking the following link:')
         assert messages[0]['content']['replyTo'] == 'pc@icaps.cc'
 
+    def test_custom_max_papers_assignment_preprocess(self, client, openreview_client, helpers):
+
+        pc_client_v2=openreview.api.OpenReviewClient(username='pc@icaps.cc', password=helpers.strong_password)
+        submissions = pc_client_v2.get_notes(invitation='PRL/2023/ICAPS/-/Submission', sort='number:asc')
+
+        # Set user's quota to 1
+        cmp_edge = openreview_client.post_edge(openreview.api.Edge(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Custom_Max_Papers',
+            head='PRL/2023/ICAPS/Reviewers',
+            tail='~Reviewer_ICAPSTwo1',
+            signatures=['PRL/2023/ICAPS/Program_Chairs'],
+            weight=1
+        ))
+
+        # Test 1: User below quota - Allow
+        # 0 current assignments < 1 quota
+        assignment1 = openreview_client.post_edge(openreview.api.Edge(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+            head=submissions[0].id,
+            tail='~Reviewer_ICAPSTwo1',
+            signatures=['PRL/2023/ICAPS/Program_Chairs'],
+            weight=1
+        ))
+        helpers.await_queue_edit(openreview_client, edit_id=assignment1.id)
+
+        # Test 2: Exceeding quota - Reject
+        with pytest.raises(openreview.OpenReviewException, match=r'Can not make assignment, quota of 1 has been reached for ~Reviewer_ICAPSTwo1'):
+            openreview_client.post_edge(openreview.api.Edge(
+                invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+                head=submissions[2].id,
+                tail='~Reviewer_ICAPSTwo1',
+                signatures=['PRL/2023/ICAPS/Program_Chairs'],
+                weight=1
+            ))
+
+        # Test 3: "Invitation Sent" - Reject
+        # User hasn't accepted, still enforce quota
+        invite_edge = openreview_client.post_edge(openreview.api.Edge(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Invite_Assignment',
+            head=submissions[2].id,
+            tail='~Reviewer_ICAPSTwo1',
+            signatures=['PRL/2023/ICAPS/Program_Chairs'],
+            weight=0,
+            label='Invitation Sent'
+        ))
+        helpers.await_queue_edit(openreview_client, edit_id=invite_edge.id)
+
+        with pytest.raises(openreview.OpenReviewException, match=r'Can not make assignment, quota of 1 has been reached for ~Reviewer_ICAPSTwo1'):
+            openreview_client.post_edge(openreview.api.Edge(
+                invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+                head=submissions[2].id,
+                tail='~Reviewer_ICAPSTwo1',
+                signatures=['PRL/2023/ICAPS/Program_Chairs'],
+                weight=1
+            ))
+
+        # Test 4: Accepted Invite Assignment - Allow
+        messages = openreview_client.get_messages(
+            to='reviewer2@icaps.cc',
+            subject='[PRL ICAPS 2023] Invitation to review paper titled "Paper title 3"'
+        )
+        assert messages and len(messages) == 1
+
+        invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+        helpers.respond_invitation_fast(invitation_url, accept=True)
+
+        invite_edges = openreview_client.get_all_edges(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Invite_Assignment',
+            head=submissions[2].id,
+            tail='~Reviewer_ICAPSTwo1'
+        )
+        assert len(invite_edges) == 1
+        assert invite_edges[0].label == 'Accepted'
+
+        assignment_edges = openreview_client.get_all_edges(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+            head=submissions[2].id,
+            tail='~Reviewer_ICAPSTwo1'
+        )
+        assert len(assignment_edges) == 1
+
     def test_review_stage(self, client, openreview_client, helpers, request_page, selenium):
 
 

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -503,7 +503,25 @@ class TestWorkshopV2():
                 weight=1
             ))
 
-        # Test 3: "Invitation Sent" - Reject
+        # Test 3: Update existing assignment edge - Allow
+        updated_edge = openreview_client.post_edge(openreview.api.Edge(
+            id=assignment1.id,
+            invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+            head=submissions[0].id,
+            tail='~Reviewer_ICAPSTwo1',
+            signatures=['PRL/2023/ICAPS/Program_Chairs'],
+            weight=2
+        ))
+        helpers.await_queue_edit(openreview_client, edit_id=updated_edge.id)
+
+        updated_edges = openreview_client.get_all_edges(
+            invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+            tail='~Reviewer_ICAPSTwo1'
+        )
+        assert len(updated_edges) == 1
+        assert updated_edges[0].weight == 2
+
+        # Test 4: "Invitation Sent" - Reject
         # User hasn't accepted, still enforce quota
         invite_edge = openreview_client.post_edge(openreview.api.Edge(
             invitation='PRL/2023/ICAPS/Reviewers/-/Invite_Assignment',
@@ -524,7 +542,7 @@ class TestWorkshopV2():
                 weight=1
             ))
 
-        # Test 4: Accepted Invite Assignment - Allow
+        # Test 5: Accepted Invite Assignment - Allow
         messages = openreview_client.get_messages(
             to='reviewer2@icaps.cc',
             subject='[PRL ICAPS 2023] Invitation to review paper titled "Paper title 3"'
@@ -549,7 +567,7 @@ class TestWorkshopV2():
         )
         assert len(assignment_edges) == 1
 
-        # Test 5: Quota of 0 - Rejected
+        # Test 6: Quota of 0 - Rejected
         cmp_edge = openreview_client.post_edge(openreview.api.Edge(
             invitation='PRL/2023/ICAPS/Reviewers/-/Custom_Max_Papers',
             head='PRL/2023/ICAPS/Reviewers',
@@ -569,11 +587,11 @@ class TestWorkshopV2():
 
         openreview_client.delete_edges(invitation='PRL/2023/ICAPS/Reviewers/-/Custom_Max_Papers', head='PRL/2023/ICAPS/Reviewers', tail='~Reviewer_ICAPSThree1')
 
-        # Test 5: Read quota from invitation
+        # Test 7: Read quota from invitation
         cmp_edges = openreview_client.get_all_edges(
-            invitation='PRL/2023/ICAPS/Reviewers/-/Assignment',
+            invitation='PRL/2023/ICAPS/Reviewers/-/Custom_Max_Papers',
             head='PRL/2023/ICAPS/Reviewers',
-            tail='Reviewer_ICAPSThree1'
+            tail='~Reviewer_ICAPSThree1'
         )
         assert len(cmp_edges) == 0
 


### PR DESCRIPTION
- Fixes https://github.com/openreview/openreview-py/issues/2982

Since the edge browser will cache browse edges, the assignment preprocess will need to check that custom max papers is respected for direct assignments. Assignment edges coming from the invite assignment assignment will be ignored.