### PR TITLE
Use GitHub App for CI authentication instead of API key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
           command: |
             pip install PyJWT==2.12.1 cryptography==46.0.7 --quiet
 
-            TOKEN=$(python3 -c '
+            cat > /tmp/get_token.py \<< 'PYEOF'
             import jwt, time, json, os, urllib.request
 
             private_key = os.environ["GITHUB_APP_PRIVATE_KEY"]
@@ -48,14 +48,12 @@ commands:
             )
             with urllib.request.urlopen(req) as resp:
                 print(json.load(resp)["token"])
-            ')
+            PYEOF
+
+            TOKEN=$(python3 /tmp/get_token.py)
 
             # Make token available to subsequent steps
             echo "export GITHUB_TOKEN=$TOKEN" >> $BASH_ENV
-
-            # Configure git credentials so the token doesn't appear in clone URLs
-            echo "machine github.com login x-access-token password $TOKEN" > ~/.netrc
-            chmod 600 ~/.netrc
   setup-mongodb:
     description: "Initialize MongoDB replica set"
     steps:
@@ -87,12 +85,12 @@ commands:
       - run:
           name: Clone OpenReview API V1 branch << pipeline.parameters.openreview-api-v1-branch >>
           command: |
-            git clone https://github.com/openreview/openreview-api-v1.git ~/openreview
+            git clone https://x-access-token:$GITHUB_TOKEN@github.com/openreview/openreview-api-v1.git ~/openreview
             cd ~/openreview && git checkout << pipeline.parameters.openreview-api-v1-branch >>
       - run:
           name: Clone OpenReview API V2 branch << pipeline.parameters.openreview-api-v2-branch >>
           command: |
-            git clone https://github.com/openreview/openreview-api.git ~/openreview-v2
+            git clone https://x-access-token:$GITHUB_TOKEN@github.com/openreview/openreview-api.git ~/openreview-v2
             cd ~/openreview-v2 && git checkout << pipeline.parameters.openreview-api-v2-branch >>
       - run:
           name: Clone openreview-web
@@ -415,7 +413,7 @@ jobs:
       - run:
           name: Deploy to dev instance
           command: |
-            curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/openreview/openreview-py/dispatches -d '{"event_type":"openreview-py-updated"}'
+            curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/openreview/openreview-py/dispatches -d '{"event_type":"openreview-py-updated"}'
 workflows:
   version: 2
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ commands:
       - run:
           name: Generate GitHub App token
           command: |
-            pip install PyJWT cryptography --quiet
+            pip install PyJWT==2.12.1 cryptography==46.0.7 --quiet
 
-            cat > /tmp/get_token.py \<< 'PYEOF'
+            TOKEN=$(python3 -c '
             import jwt, time, json, os, urllib.request
 
             private_key = os.environ["GITHUB_APP_PRIVATE_KEY"]
@@ -48,12 +48,14 @@ commands:
             )
             with urllib.request.urlopen(req) as resp:
                 print(json.load(resp)["token"])
-            PYEOF
-
-            TOKEN=$(python3 /tmp/get_token.py)
+            ')
 
             # Make token available to subsequent steps
             echo "export GITHUB_TOKEN=$TOKEN" >> $BASH_ENV
+
+            # Configure git credentials so the token doesn't appear in clone URLs
+            echo "machine github.com login x-access-token password $TOKEN" > ~/.netrc
+            chmod 600 ~/.netrc
   setup-mongodb:
     description: "Initialize MongoDB replica set"
     steps:
@@ -85,12 +87,12 @@ commands:
       - run:
           name: Clone OpenReview API V1 branch << pipeline.parameters.openreview-api-v1-branch >>
           command: |
-            git clone https://x-access-token:$GITHUB_TOKEN@github.com/openreview/openreview-api-v1.git ~/openreview
+            git clone https://github.com/openreview/openreview-api-v1.git ~/openreview
             cd ~/openreview && git checkout << pipeline.parameters.openreview-api-v1-branch >>
       - run:
           name: Clone OpenReview API V2 branch << pipeline.parameters.openreview-api-v2-branch >>
           command: |
-            git clone https://x-access-token:$GITHUB_TOKEN@github.com/openreview/openreview-api.git ~/openreview-v2
+            git clone https://github.com/openreview/openreview-api.git ~/openreview-v2
             cd ~/openreview-v2 && git checkout << pipeline.parameters.openreview-api-v2-branch >>
       - run:
           name: Clone openreview-web
@@ -413,7 +415,7 @@ jobs:
       - run:
           name: Deploy to dev instance
           command: |
-            curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/openreview/openreview-py/dispatches -d '{"event_type":"openreview-py-updated"}'
+            curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/openreview/openreview-py/dispatches -d '{"event_type":"openreview-py-updated"}'
 workflows:
   version: 2
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,42 @@ parameters:
 
 # Reusable commands to reduce duplication between jobs
 commands:
+  get-github-token:
+    description: "Generate a short-lived GitHub App installation token"
+    steps:
+      - run:
+          name: Generate GitHub App token
+          command: |
+            pip install PyJWT cryptography --quiet
+
+            TOKEN=$(python3 - <<EOF
+            import jwt, time, json, urllib.request
+
+            private_key = """$GITHUB_APP_PRIVATE_KEY"""
+            now = int(time.time())
+
+            app_jwt = jwt.encode(
+                {"iat": now - 60, "exp": now + (9 * 60), "iss": "$GITHUB_APP_ID"},
+                private_key,
+                algorithm="RS256"
+            )
+
+            req = urllib.request.Request(
+                "https://api.github.com/app/installations/$GITHUB_APP_INSTALLATION_ID/access_tokens",
+                method="POST",
+                headers={
+                    "Authorization": f"Bearer {app_jwt}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28"
+                }
+            )
+            with urllib.request.urlopen(req) as resp:
+                print(json.load(resp)["token"])
+            EOF
+            )
+
+            # Make token available to subsequent steps
+            echo "export GITHUB_TOKEN=$TOKEN" >> $BASH_ENV
   setup-mongodb:
     description: "Initialize MongoDB replica set"
     steps:
@@ -46,17 +82,17 @@ commands:
       - run:
           name: Clone OpenReview API V1 branch << pipeline.parameters.openreview-api-v1-branch >>
           command: |
-            git clone https://$OPENREVIEW_GITHUB@github.com/openreview/openreview-api-v1.git ~/openreview
+            git clone https://x-access-token:$GITHUB_TOKEN@github.com/openreview/openreview-api-v1.git ~/openreview
             cd ~/openreview && git checkout << pipeline.parameters.openreview-api-v1-branch >>
       - run:
           name: Clone OpenReview API V2 branch << pipeline.parameters.openreview-api-v2-branch >>
           command: |
-            git clone https://$OPENREVIEW_GITHUB@github.com/openreview/openreview-api.git ~/openreview-v2
+            git clone https://x-access-token:$GITHUB_TOKEN@github.com/openreview/openreview-api.git ~/openreview-v2
             cd ~/openreview-v2 && git checkout << pipeline.parameters.openreview-api-v2-branch >>
       - run:
           name: Clone openreview-web
           command: |
-            git clone https://$OPENREVIEW_GITHUB@github.com/openreview/openreview-web.git ~/openreview-web
+            git clone https://github.com/openreview/openreview-web.git ~/openreview-web
 
   create-directories:
     description: "Create API directories"
@@ -275,6 +311,7 @@ jobs:
               echo "No modified test files - skipping test environment setup"
               circleci-agent step halt
             fi
+      - get-github-token
       - install-nodejs
       - setup-mongodb
       - clone-repos
@@ -323,6 +360,7 @@ jobs:
           transport.host: localhost
     steps:
       - checkout
+      - get-github-token
       - install-nodejs
       - setup-mongodb
       - clone-repos
@@ -368,10 +406,11 @@ jobs:
       - image: cimg/python:3.11.0
     steps:
       - checkout
+      - get-github-token
       - run:
           name: Deploy to dev instance
           command: |
-            curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $OPENREVIEW_GITHUB" https://api.github.com/repos/openreview/openreview-py/dispatches -d '{"event_type":"openreview-py-updated"}'
+            curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/openreview/openreview-py/dispatches -d '{"event_type":"openreview-py-updated"}'
 workflows:
   version: 2
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,20 +23,22 @@ commands:
           command: |
             pip install PyJWT cryptography --quiet
 
-            TOKEN=$(python3 - <<EOF
-            import jwt, time, json, urllib.request
+            cat > /tmp/get_token.py \<< 'PYEOF'
+            import jwt, time, json, os, urllib.request
 
-            private_key = """$GITHUB_APP_PRIVATE_KEY"""
+            private_key = os.environ["GITHUB_APP_PRIVATE_KEY"]
+            app_id = os.environ["GITHUB_APP_ID"]
+            install_id = os.environ["GITHUB_APP_INSTALLATION_ID"]
             now = int(time.time())
 
             app_jwt = jwt.encode(
-                {"iat": now - 60, "exp": now + (9 * 60), "iss": "$GITHUB_APP_ID"},
+                {"iat": now - 60, "exp": now + (9 * 60), "iss": app_id},
                 private_key,
                 algorithm="RS256"
             )
 
             req = urllib.request.Request(
-                "https://api.github.com/app/installations/$GITHUB_APP_INSTALLATION_ID/access_tokens",
+                f"https://api.github.com/app/installations/{install_id}/access_tokens",
                 method="POST",
                 headers={
                     "Authorization": f"Bearer {app_jwt}",
@@ -46,8 +48,9 @@ commands:
             )
             with urllib.request.urlopen(req) as resp:
                 print(json.load(resp)["token"])
-            EOF
-            )
+            PYEOF
+
+            TOKEN=$(python3 /tmp/get_token.py)
 
             # Make token available to subsequent steps
             echo "export GITHUB_TOKEN=$TOKEN" >> $BASH_ENV


### PR DESCRIPTION
Replace the OPENREVIEW_GITHUB personal access token with a short-lived GitHub App installation token for cloning private repos and dispatching deploy events in CircleCI.