### PR TITLE
Fix affinity score model selection

### DIFF
--- a/openreview/venue_request/process/matchingProcess.py
+++ b/openreview/venue_request/process/matchingProcess.py
@@ -29,7 +29,7 @@ def process(client, note, invitation):
 
     try:
         matching_status = conference.setup_committee_matching(
-            matching_group, None if compute_affinity_scores == 'No' else { 'name': compute_affinity_scores, 'percentile_selection': percentile_selection } if compute_affinity_scores in models else compute_affinity_scores, 
+            matching_group, None if compute_affinity_scores == 'No' else { 'model': compute_affinity_scores, 'percentile_selection': percentile_selection } if compute_affinity_scores in models else compute_affinity_scores,
             None if compute_conflicts == 'No' else compute_conflicts,
             int(compute_conflicts_N_years) if compute_conflicts_N_years else None,
             alternate_matching_group=alternate_group,


### PR DESCRIPTION
the Paper Matching Setup form is not passing the model name correctly to the setup_committee_matching. 

I discovered this by selecting specter+mfr and the vertex AI is not downloading the expected models. 