### PR TITLE
AC Invite_Assignment config invitation for addressing #2721

### DIFF
--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -458,6 +458,33 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         custom_load_edges = openreview_client.get_edges_count(invitation='TestVenue.cc/Reviewers/-/Custom_Max_Papers')
         assert custom_load_edges == 1
 
+    def test_ac_invite_assignment_via_invitation(self, venue, openreview_client, helpers):
+
+        ac_invite_inv = openreview_client.get_invitation('TestVenue.cc/-/AC_Invite_Assignment')
+        assert 'TestVenue.cc/Program_Chairs' in ac_invite_inv.invitees
+        assert 'enabled' in ac_invite_inv.edit['content']
+
+        assert openreview.tools.get_invitation(
+            openreview_client, 'TestVenue.cc/Area_Chairs/-/Invite_Assignment'
+        ) is None
+
+        pc_client = OpenReviewClient(username='venue_pc@mail.com', password=helpers.strong_password)
+        pc_client.post_invitation_edit(
+            invitations='TestVenue.cc/-/AC_Invite_Assignment',
+            signatures=['TestVenue.cc/Program_Chairs'],
+            invitation=Invitation(
+                id='TestVenue.cc/-/AC_Invite_Assignment',
+                content={'enabled': {'value': True}},
+            ),
+        )
+        helpers.await_queue_edit(openreview_client, invitation='TestVenue.cc/-/AC_Invite_Assignment')
+
+        invite_assignment_inv = openreview_client.get_invitation(
+            'TestVenue.cc/Area_Chairs/-/Invite_Assignment'
+        )
+        assert invite_assignment_inv.content.get('hash_seed')
+        assert invite_assignment_inv.content.get('match_group', {}).get('value') == 'TestVenue.cc/Area_Chairs'
+
     def test_review_stage(self, venue, openreview_client, helpers):
 
         assert openreview_client.get_invitation('TestVenue.cc/-/Official_Review')


### PR DESCRIPTION
Refs #2721.

Adds a failing test (`test_ac_invite_assignment_via_invitation`) that demonstrates the intended behavior: a PC-posted `enabled: true` on `<venue>/-/AC_Invite_Assignment` should trigger `setup_invite_assignment()` for `Area_Chairs` and create the downstream `<venue>/Area_Chairs/-/Invite_Assignment` edge invitation.

The test is currently the only CI failure (see CircleCI `build` job), failing at the first assertion with:

```
NotFoundError: The Invitation TestVenue.cc/-/AC_Invite_Assignment was not found
```

This confirms the config invitation is not created by `venue.setup()` yet.