### PR TITLE
use replacement=True to replace old invitations

### DIFF
--- a/openreview/profile/management.py
+++ b/openreview/profile/management.py
@@ -934,6 +934,7 @@ return {
         self.client.post_invitation_edit(
             invitations = self.public_article_meta_invitation_id,
             signatures = [self.dblp_group_id],
+            replacement=True,
             invitation = openreview.api.Invitation(
                 id=record_invitation_id,
                 readers=['everyone'],
@@ -1109,6 +1110,7 @@ return {
         self.client.post_invitation_edit(
             invitations = self.public_article_meta_invitation_id,
             signatures = [self.arxiv_group_id],
+            replacement=True,
             invitation = openreview.api.Invitation(
                 id=record_invitation_id,
                 readers=['everyone'],
@@ -1291,6 +1293,7 @@ return {
         self.client.post_invitation_edit(
             invitations = self.public_article_meta_invitation_id,
             signatures = [self.orcid_group_id],
+            replacement=True,
             invitation = openreview.api.Invitation(
                 id=record_invitation_id,
                 readers=['everyone'],


### PR DESCRIPTION
We need to use `replacement=True` at least for the following invitations:
- OpenReview.net/Public_Article/DBLP.org/-/Record
- OpenReview.net/Public_Article/arXiv.org/-/Record
- OpenReview.net/Public_Article/ORCID.org/-/Record

Right now the invitations still have `authorids` because of this.