### PR TITLE
Fix ORCID Authorship_Claim apostrophe mismatch

### DIFF
--- a/openreview/profile/process/author_coreference_pre_process.js
+++ b/openreview/profile/process/author_coreference_pre_process.js
@@ -1,6 +1,9 @@
 async function process(client, edit, invitation) {
   client.throwErrors = true;
-  
+
+  const normalizeName = (s) =>
+    typeof s === 'string' ? s.normalize('NFKC').replace(/[’ʼʹ]/g, "'") : s;
+
   const authorIndex = edit.content.author_index.value;
   const authorId = edit.content.author_id.value;
   const authorName = edit.content.author_name.value;
@@ -8,7 +11,7 @@ async function process(client, edit, invitation) {
   if (Tools.prettyId(authorId) !== authorName) {
     return Promise.reject(new OpenReviewError({ name: 'Error', message: `The author id ${authorId} doesn't match with the author name ${authorName}` }));
   }
-  
+
   const { notes } = await client.getNotes({ id: edit.note.id });
   const publication = notes[0];
 
@@ -24,7 +27,7 @@ async function process(client, edit, invitation) {
   const userProfile = profiles[0];
 
   const usernames = userProfile.content.names.map(name => name.username).filter(username => !!username);
-  const names = userProfile.content.names.map(name => name.fullname);
+  const names = userProfile.content.names.map(name => normalizeName(name.fullname));
 
   const usernameIndex = usernames.indexOf(authorId);
 
@@ -33,7 +36,7 @@ async function process(client, edit, invitation) {
   }
 
   const publicationAuthorName = publication.content.authors.value[authorIndex]?.fullname;
-  const nameIndex = names.indexOf(publicationAuthorName);
+  const nameIndex = names.indexOf(normalizeName(publicationAuthorName));
   if (nameIndex === -1) {
     return Promise.reject(new OpenReviewError({ name: 'Error', message: `The author name ${publicationAuthorName} from index ${authorIndex} doesn't match with the names listed in your profile` }));
   }

--- a/openreview/profile/process/deprecated_dblp_author_coreference_pre_process.js
+++ b/openreview/profile/process/deprecated_dblp_author_coreference_pre_process.js
@@ -1,6 +1,9 @@
 async function process(client, edit, invitation) {
   client.throwErrors = true;
-  
+
+  const normalizeName = (s) =>
+    typeof s === 'string' ? s.normalize('NFKC').replace(/[’ʼʹ]/g, "'") : s;
+
   const authorIndex = edit.content.author_index.value;
   const authorId = edit.content.author_id.value;
 
@@ -17,9 +20,9 @@ async function process(client, edit, invitation) {
 
   const { profiles } = await client.getProfiles({ id: edit.signatures[0] });
   const userProfile = profiles[0];
-  
+
   const usernames = userProfile.content.names.map(name => name.username).filter(username => !!username);
-  const names = userProfile.content.names.map(name => name.fullname);
+  const names = userProfile.content.names.map(name => normalizeName(name.fullname));
 
   if (authorId === '') {
     const authorName = publication.content.authorids.value[authorIndex];
@@ -34,9 +37,9 @@ async function process(client, edit, invitation) {
   if (usernameIndex === -1) {
     return Promise.reject(new OpenReviewError({ name: 'Error', message: `The author id ${authorId} doesn't match with the names listed in your profile` }));
   }
-  
+
   const authorName = publication.content.authors.value[authorIndex];
-  const nameIndex = names.indexOf(authorName);
+  const nameIndex = names.indexOf(normalizeName(authorName));
   if (nameIndex === -1) {
     return Promise.reject(new OpenReviewError({ name: 'Error', message: `The author name ${authorName} from index ${authorIndex} doesn't match with the names listed in your profile` }));
   }

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -1675,6 +1675,181 @@ computation and memory.
         assert note.content['authors']['value'][2] == {'fullname': 'Sarah Racz', 'username': '~Sarah_Racz1'}
 
 
+    def test_orcid_authorship_claim_unicode_apostrophe(self, client, openreview_client, test_client, helpers):
+        # Crossref deposits ORCID credit-name values with U+2019 (RIGHT SINGLE
+        # QUOTATION MARK), but OpenReview profile names use U+0027 (straight
+        # apostrophe). The Authorship_Claim preprocess must normalize both sides
+        # before comparison so legitimate authors of Crossref-sourced publications
+        # can successfully claim authorship.
+
+        poster_client = helpers.create_user('apostrophe_poster@profile.org', 'Apostrophe', 'Poster')
+
+        edit = poster_client.post_note_edit(
+            invitation = 'openreview.net/Public_Article/ORCID.org/-/Record',
+            signatures = ['~Apostrophe_Poster1'],
+            content = {
+                'json': {
+                    'value': {
+                        'created-date': {'value': 1708964039610},
+                        'last-modified-date': {'value': 1708964039610},
+                        'source': {
+                            'source-orcid': None,
+                            'source-client-id': {
+                                'uri': 'https://orcid.org/client/0000-0001-8607-8906',
+                                'path': '0000-0001-8607-8906',
+                                'host': 'orcid.org',
+                            },
+                            'source-name': {'value': 'INSPIRE-HEP'},
+                            'assertion-origin-orcid': None,
+                            'assertion-origin-client-id': None,
+                            'assertion-origin-name': None,
+                        },
+                        'put-code': 154061861,
+                        'path': '/0000-0002-7416-5859/work/154061861',
+                        'title': {
+                            'title': {'value': 'Apostrophe normalization in author name matching'},
+                            'subtitle': None,
+                            'translated-title': None,
+                        },
+                        'journal-title': {'value': 'Test Journal'},
+                        'short-description': None,
+                        'citation': {
+                            'citation-type': 'bibtex',
+                            'citation-value': '@article{Test:2024,\n  author = "Poster, Apostrophe and O’Connor, Luke and Other, Bob"\n}\n',
+                        },
+                        'type': 'journal-article',
+                        'publication-date': {
+                            'year': {'value': '2024'},
+                            'month': {'value': '03'},
+                            'day': {'value': '01'},
+                        },
+                        'external-ids': {
+                            'external-id': [{
+                                'external-id-type': 'doi',
+                                'external-id-value': '10.1038/test-unicode-apostrophe',
+                                'external-id-normalized': {
+                                    'value': '10.1038/test-unicode-apostrophe',
+                                    'transient': True,
+                                },
+                                'external-id-normalized-error': None,
+                                'external-id-url': {
+                                    'value': 'http://dx.doi.org/10.1038/test-unicode-apostrophe',
+                                },
+                                'external-id-relationship': 'self',
+                            }],
+                        },
+                        'url': {'value': 'http://example.com/test-apostrophe-paper'},
+                        'contributors': {
+                            'contributor': [
+                                {
+                                    'contributor-orcid': None,
+                                    'credit-name': {'value': 'Poster, Apostrophe'},
+                                    'contributor-email': None,
+                                    'contributor-attributes': {
+                                        'contributor-sequence': 'first',
+                                        'contributor-role': 'author',
+                                    },
+                                },
+                                {
+                                    'contributor-orcid': None,
+                                    'credit-name': {'value': 'O’Connor, Luke'},
+                                    'contributor-email': None,
+                                    'contributor-attributes': {
+                                        'contributor-sequence': 'additional',
+                                        'contributor-role': 'author',
+                                    },
+                                },
+                                {
+                                    'contributor-orcid': None,
+                                    'credit-name': {'value': 'Other, Bob'},
+                                    'contributor-email': None,
+                                    'contributor-attributes': {
+                                        'contributor-sequence': 'additional',
+                                        'contributor-role': 'author',
+                                    },
+                                },
+                            ],
+                        },
+                        'language-code': None,
+                        'country': None,
+                        'visibility': 'public',
+                    }
+                }
+            },
+            note = openreview.api.Note(
+                external_id = 'doi:10.1038/test-unicode-apostrophe',
+                content={
+                    'title': {
+                        'value': 'Apostrophe normalization in author name matching',
+                    },
+                    'authors': {
+                        'value': [
+                            {'fullname': 'Apostrophe Poster', 'username': '~Apostrophe_Poster1'},
+                            {'fullname': 'Luke O’Connor', 'username': ''},
+                            {'fullname': 'Bob Other', 'username': ''},
+                        ],
+                    },
+                    'venue': {
+                        'value': 'Test Journal',
+                    }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'], process_index=0)
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'], process_index=1)
+
+        note = poster_client.get_note(edit['note']['id'])
+        # Precondition: the publication note kept U+2019 in author 1's fullname.
+        # Without that, the bug wouldn't reproduce and the test would be vacuous.
+        assert note.content['authors']['value'][1]['fullname'] == 'Luke O’Connor'
+
+        # Positive case: profile fullname uses U+0027, publication uses U+2019.
+        # With the normalizeName fix, the indexOf check succeeds and the claim
+        # is accepted.
+        luke_client = helpers.create_user('luke_oconnor@profile.org', 'Luke', "O'Connor")
+        luke_profile = openreview_client.get_profile('luke_oconnor@profile.org')
+        luke_id = luke_profile.id
+        luke_pretty = openreview.tools.pretty_id(luke_id)
+
+        edit = luke_client.post_note_edit(
+            invitation = 'openreview.net/Public_Article/-/Authorship_Claim',
+            signatures = [luke_id],
+            content = {
+                'author_index': { 'value': 1 },
+                'author_id': { 'value': luke_id },
+                'author_name': { 'value': luke_pretty },
+            },
+            note = openreview.api.Note(
+                id = note.id
+            )
+        )
+
+        note = poster_client.get_note(note.id)
+        assert note.content['authors']['value'][1]['username'] == luke_id
+
+        # Negative case: a genuinely different name still rejects, and the error
+        # message preserves the un-normalized publication name so the user sees
+        # what was actually compared.
+        bob_other_client = helpers.create_user('bob_different@profile.org', 'Bob', 'Different')
+        bob_id = openreview_client.get_profile('bob_different@profile.org').id
+        bob_pretty = openreview.tools.pretty_id(bob_id)
+
+        with pytest.raises(openreview.OpenReviewException, match=r"The author name Bob Other from index 2 doesn\'t match with the names listed in your profile"):
+            bob_other_client.post_note_edit(
+                invitation = 'openreview.net/Public_Article/-/Authorship_Claim',
+                signatures = [bob_id],
+                content = {
+                    'author_index': { 'value': 2 },
+                    'author_id': { 'value': bob_id },
+                    'author_name': { 'value': bob_pretty },
+                },
+                note = openreview.api.Note(
+                    id = note.id
+                )
+            )
+
+
     def test_remove_alternate_name(self, openreview_client, support_client, helpers):
 
         john_client = helpers.create_user('john@profile.org', 'John', 'Last', alternates=[], institution='google.com')


### PR DESCRIPTION
Fixes openreview/openreview#415

## Summary
Crossref deposits ORCID `credit-name` values with U+2019 (right single quote), but OpenReview profile names use U+0027 (straight apostrophe). The `Authorship_Claim` preprocess did a strict byte-for-byte `indexOf`, so legitimate authors of papers like `O'Connor` were unable to claim Crossref-sourced publications — the UI surfaced this as disabled "claim authorship" checkboxes.

The fix normalizes both sides of the comparison (NFKC + fold U+2019 / U+02BC / U+02B9 → U+0027) before `indexOf`. The un-normalized publication name is preserved in the error message so users see what was actually compared.

## Changes
- **`openreview/profile/process/author_coreference_pre_process.js`**: added a `normalizeName` helper; applied it to the user's profile names and to the publication's author name before the `indexOf` lookup.
- **`openreview/profile/process/deprecated_dblp_author_coreference_pre_process.js`**: same fix — this file is still wired up via `ProfileManagement.set_deprecated_dblp_ivitations()` and attached to `DBLP.org/-/Author_Coreference`.

## Tests
- **`tests/test_profile_management.py::test_orcid_authorship_claim_unicode_apostrophe`**: verifies that a profile whose `fullname` uses U+0027 can claim an ORCID-imported publication whose author name uses U+2019; and that a genuinely different name still rejects with the un-normalized publication name preserved in the error message.

## Deployment
The preprocess JS is stored on the `Authorship_Claim` invitation (and the deprecated `DBLP.org/-/Author_Coreference` invitation). This change only takes effect after `ProfileManagement.setup()` is re-run so the invitation's `preprocess` field is refreshed with the new code.

## Out of scope (deliberate)
- \`openreview-api\`'s profile-name validator — the U+0027-only canonical-apostrophe policy stays as-is.
- Profile-name storage canonicalization — no migration needed; existing U+0027 profile names will match U+2019 Crossref records after this fix.