### PR TITLE
Refine venue management feedback form based on all-hands feedback

### DIFF
--- a/openreview/workflows/workflows.py
+++ b/openreview/workflows/workflows.py
@@ -784,40 +784,23 @@ class Workflows():
                             'content': {
                                 'overall_rating': {
                                     'order': 1,
-                                    'description': 'How would you rate your overall experience with managing your venue? (1 = very poor, 5 = excellent)',
+                                    'description': 'How would you rate your overall experience with managing your venue? (5 = excellent, 1 = very poor)',
                                     'value': {
                                         'param': {
                                             'type': 'integer',
                                             'enum': [
-                                                { 'value': 1, 'description': '1: Very poor - Could not navigate the UI; documentation did not help; needed OpenReview support for basic tasks'},
-                                                { 'value': 2, 'description': '2: Poor - Struggled to navigate the UI, but documentation helped; some OpenReview support needed'},
-                                                { 'value': 3, 'description': '3: Fair - Some features were confusing, but figured out navigation over time'},
+                                                { 'value': 5, 'description': '5: Excellent - Intuitive and easy to understand'},
                                                 { 'value': 4, 'description': '4: Good - Mostly able to run the conference with little assistance'},
-                                                { 'value': 5, 'description': '5: Excellent - Intuitive and easy to understand'}
-                                            ],
-                                            'input': 'radio'
-                                        }
-                                    }
-                                },
-                                'recommendation_likelihood': {
-                                    'order': 2,
-                                    'description': 'How likely are you to recommend OpenReview to colleagues based on this experience? (1 = very unlikely, 5 = very likely)',
-                                    'value': {
-                                        'param': {
-                                            'type': 'integer',
-                                            'enum': [
-                                                { 'value': 1, 'description': '1: Very unlikely'},
-                                                { 'value': 2, 'description': '2: Unlikely'},
-                                                { 'value': 3, 'description': '3: Neutral'},
-                                                { 'value': 4, 'description': '4: Likely'},
-                                                { 'value': 5, 'description': '5: Very likely'}
+                                                { 'value': 3, 'description': '3: Fair - Some features were confusing, but figured out navigation over time'},
+                                                { 'value': 2, 'description': '2: Poor - Struggled to navigate the UI, but documentation helped; some OpenReview support needed'},
+                                                { 'value': 1, 'description': '1: Very poor - Could not navigate the UI; documentation did not help; needed OpenReview support for basic tasks'}
                                             ],
                                             'input': 'radio'
                                         }
                                     }
                                 },
                                 'support_resources_accessed': {
-                                    'order': 3,
+                                    'order': 2,
                                     'description': 'Which forms of support did you access while managing your venue? Select all that apply.',
                                     'value': {
                                         'param': {
@@ -827,7 +810,9 @@ class Workflows():
                                                 'OpenReview documentation site',
                                                 'OpenReview GitHub',
                                                 'Workflow step timeline descriptions',
-                                                'External sources (LLM, colleagues, etc)',
+                                                'LLM (ChatGPT, Claude, etc)',
+                                                'Colleagues',
+                                                'Other external sources',
                                                 'None of the above'
                                             ],
                                             'input': 'checkbox'
@@ -835,7 +820,7 @@ class Workflows():
                                     }
                                 },
                                 'positives': {
-                                    'order': 4,
+                                    'order': 3,
                                     'description': 'What went well with your experience with the OpenReview platform? Please describe any features you found particularly helpful, or anything that went smoothly during your experience.',
                                     'value': {
                                         'param': {
@@ -847,7 +832,7 @@ class Workflows():
                                     }
                                 },
                                 'pain_points': {
-                                    'order': 5,
+                                    'order': 4,
                                     'description': 'What parts of the experience were unclear, frustrating, or blocking? For example the venue editing, submission, recruitment, assignments, or decision process. Specific examples will help us improve the tool. Please describe any bugs, unclear labels, or unexpected behavior you encountered.',
                                     'value': {
                                         'param': {
@@ -858,15 +843,29 @@ class Workflows():
                                         }
                                     }
                                 },
-                                'other_comments': {
-                                    'order': 6,
-                                    'description': 'Use this space to share any other feedback that is not reflected in the questions above. We are especially interested in any features you wish had been available, or any support resources you wish had been available, during your experience managing your venue.',
+                                'new_feature_requests': {
+                                    'order': 5,
+                                    'description': 'Are there any new features you would like to see in OpenReview? Please describe any features you wish had been available during your experience managing your venue.',
                                     'value': {
                                         'param': {
                                             'type': 'string',
                                             'maxLength': 200000,
                                             'markdown': True,
-                                            'input': 'textarea'
+                                            'input': 'textarea',
+                                            'optional': True
+                                        }
+                                    }
+                                },
+                                'other_comments': {
+                                    'order': 6,
+                                    'description': 'Use this space to share any other feedback that is not reflected in the questions above. We are especially interested in any support resources you wish had been available during your experience managing your venue.',
+                                    'value': {
+                                        'param': {
+                                            'type': 'string',
+                                            'maxLength': 200000,
+                                            'markdown': True,
+                                            'input': 'textarea',
+                                            'optional': True
                                         }
                                     }
                                 }

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -173,10 +173,10 @@ class TestTasks():
                 replyto=request.id,
                 content={
                     'overall_rating': { 'value': 4 },
-                    'recommendation_likelihood': { 'value': 4 },
                     'support_resources_accessed': { 'value': ['OpenReview support team', 'OpenReview documentation site', 'Workflow step timeline descriptions'] },
                     'positives': { 'value': 'The new dashboard makes it easy to find the actions I need.' },
                     'pain_points': { 'value': 'Configuring reviewer assignments took longer than expected.' },
+                    'new_feature_requests': { 'value': 'Bulk reviewer assignment from a CSV file.' },
                     'other_comments': { 'value': 'Looking forward to continued improvements.' }
                 }
             )
@@ -186,7 +186,6 @@ class TestTasks():
 
         feedback_note = openreview_client.get_note(feedback_edit['note']['id'])
         assert feedback_note.content['overall_rating']['value'] == 4
-        assert feedback_note.content['recommendation_likelihood']['value'] == 4
         assert feedback_note.content['support_resources_accessed']['value'] == ['OpenReview support team', 'OpenReview documentation site', 'Workflow step timeline descriptions']
         assert feedback_note.forum == request.id
         assert feedback_note.readers == ['openreview.net/Support', 'Tasks.cc/2025/Conference']
@@ -207,13 +206,13 @@ To view the feedback, click here: https://openreview.net/forum?id={request.id}&n
 
 **Overall rating:** 4
 
-**Recommendation likelihood:** 4
-
 **Support resources accessed:** OpenReview support team, OpenReview documentation site, Workflow step timeline descriptions
 
 **Positives:** The new dashboard makes it easy to find the actions I need.
 
 **Pain points:** Configuring reviewer assignments took longer than expected.
+
+**New feature requests:** Bulk reviewer assignment from a CSV file.
 
 **Other comments:** Looking forward to continued improvements.
 


### PR DESCRIPTION

## Summary

Updates the feedback form (`/-/Feedback` invitation) that program chairs fill out after using the new venue management UI. Drops one field, adds another, splits a compound option into separate choices, and reorders the rating scale so positive answers appear first.

## Motivation

Feedback collected at the all-hands surfaced several issues with the form:

- The `recommendation_likelihood` ("how likely are you to recommend OpenReview?") question is better asked in a separate, broader survey rather than mixed in with venue-management-specific feedback.
- The `support_resources_accessed` checkbox bundled "LLM, colleagues, etc" into one option, hiding whether respondents are leaning on LLMs — which is information we specifically want to track.
- The `overall_rating` scale showed `1: Very poor` first, biasing the visual toward the negative end before the positive options were even visible.
- There was no dedicated place to capture feature requests — they were getting buried inside the free-text `other_comments` field, so the description of that field was overloaded.

## Changes

### [openreview/workflows/workflows.py](openreview/workflows/workflows.py)

- **`overall_rating`** — reversed the enum order so `5: Excellent` appears first and `1: Very poor` last. Description updated from `(1 = very poor, 5 = excellent)` to `(5 = excellent, 1 = very poor)` to match.
- **`recommendation_likelihood`** — removed. Will be asked elsewhere.
- **`support_resources_accessed`** — replaced `'External sources (LLM, colleagues, etc)'` with three separate options: `'LLM (ChatGPT, Claude, etc)'`, `'Colleagues'`, `'Other external sources'`. We specifically want LLM usage broken out.
- **`new_feature_requests`** — new optional markdown textarea field (order 5) asking what features the respondent would like to see. Optional because not every PC has a request.
- **`other_comments`** — now optional. Description trimmed to remove the mention of feature requests (now covered by the dedicated field).
- Renumbered `order` on remaining fields: `support_resources_accessed` → 2, `positives` → 3, `pain_points` → 4, `new_feature_requests` → 5, `other_comments` → 6.

### [tests/test_tasks.py](tests/test_tasks.py)

- Removed `recommendation_likelihood` from the feedback payload and from the `feedback_note.content` assertion.
- Added `new_feature_requests` to the feedback payload (placed before `other_comments` to match the order the support-notification email renders).
- Updated the expected support notification email body: removed the `**Recommendation likelihood:** 4` line, added a `**New feature requests:** Bulk reviewer assignment from a CSV file.` line in the correct position.

## Test plan

- [x] `tests/test_tasks.py` — both tests pass locally via Docker (`docker/run.py tests/test_tasks.py`), 81s.
- [ ] Manual: open the feedback form in the UI for a venue and confirm `5: Excellent` is shown first, the LLM/Colleagues/Other options are split out, the new-feature-requests field renders as optional, and submitting without `new_feature_requests` or `other_comments` is accepted.
- [ ] Manual: post a feedback note and check the support notification email — confirm no `Recommendation likelihood` line, and the `New feature requests` line appears between `Pain points` and `Other comments`.
