### PR TITLE
Add `reviewer_to_reviewer_anonymity` journal setting

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -496,9 +496,12 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
 
         reviewers_group=openreview.tools.get_group(self.client, reviewers_group_id)
         if not reviewers_group:
+            reviewer_deanonymizers = [venue_id, action_editors_group_id]
+            if not self.journal.is_reviewer_to_reviewer_anonymous():
+                reviewer_deanonymizers.append(reviewers_group_id)
             reviewers_group=self.post_group(Group(id=reviewers_group_id,
                 readers=[venue_id, action_editors_group_id, reviewers_group_id],
-                deanonymizers=[venue_id, action_editors_group_id] if self.journal.is_reviewer_to_reviewer_anonymous() else [venue_id, action_editors_group_id, reviewers_group_id],
+                deanonymizers=reviewer_deanonymizers,
                 nonreaders=[authors_group_id],
                 writers=[venue_id, action_editors_group_id],
                 signatures=[venue_id],

--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -498,7 +498,7 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
         if not reviewers_group:
             reviewers_group=self.post_group(Group(id=reviewers_group_id,
                 readers=[venue_id, action_editors_group_id, reviewers_group_id],
-                deanonymizers=[venue_id, action_editors_group_id, reviewers_group_id],
+                deanonymizers=[venue_id, action_editors_group_id] if self.journal.is_reviewer_to_reviewer_anonymous() else [venue_id, action_editors_group_id, reviewers_group_id],
                 nonreaders=[authors_group_id],
                 writers=[venue_id, action_editors_group_id],
                 signatures=[venue_id],

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -664,7 +664,12 @@ class Journal(object):
         return self.settings.get('author_anonymity', True)
     
     def is_action_editor_anonymous(self):
-        return self.settings.get('AE_anonymity', False)    
+        return self.settings.get('AE_anonymity', False)
+
+    def is_reviewer_to_reviewer_anonymous(self):
+        ## Whether reviewers are anonymous to each other. Defaults to False to preserve
+        ## the TMLR behavior where assigned reviewers can see one another's identities.
+        return self.settings.get('reviewer_to_reviewer_anonymity', False)
 
     def release_submission_after_acceptance(self):
         """Return whether submission content is made public after acceptance.

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -704,7 +704,10 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         author_group=openreview_client.get_group(f"{venue_id}/Paper1/Authors")
         assert author_group
         assert author_group.members == ['~SomeFirstName_User1', '~Melissa_Eight1', '~Andrew_McCallumm1']
-        assert openreview_client.get_group(f"{venue_id}/Paper1/Reviewers")
+        reviewers_group = openreview_client.get_group(f"{venue_id}/Paper1/Reviewers")
+        assert reviewers_group
+        ## reviewer_to_reviewer_anonymity defaults to False in TMLR, so reviewers remain visible to each other
+        assert reviewers_group.deanonymizers == [venue_id, f"{venue_id}/Paper1/Action_Editors", f"{venue_id}/Paper1/Reviewers"]
         assert openreview_client.get_group(f"{venue_id}/Paper1/Action_Editors")
 
         note = openreview_client.get_note(note_id_1)

--- a/tests/test_slads_journal.py
+++ b/tests/test_slads_journal.py
@@ -51,6 +51,7 @@ class TestSLADSJournal():
                             "author_anonymity": True,
                             "eic_submission_notification": True,
                             "AE_anonymity": True,
+                            "reviewer_to_reviewer_anonymity": True,
                             "assignment_delay": 5,
                             "submission_name": "Submission",
                             "issn": "3051-3901",
@@ -193,7 +194,11 @@ Thanks,
         author_group=openreview_client.get_group("SLADS/Paper1/Authors")
         assert author_group
         assert author_group.members == ['~SomeFirstName_User1', '~Melisa_Amex1']
-        assert openreview_client.get_group("SLADS/Paper1/Reviewers")
+        reviewers_group = openreview_client.get_group("SLADS/Paper1/Reviewers")
+        assert reviewers_group
+        ## reviewer_to_reviewer_anonymity is enabled, so reviewers must NOT be able to deanonymize each other
+        assert reviewers_group.readers == ['SLADS', 'SLADS/Paper1/Action_Editors', 'SLADS/Paper1/Reviewers']
+        assert reviewers_group.deanonymizers == ['SLADS', 'SLADS/Paper1/Action_Editors']
         ae_group = openreview_client.get_group("SLADS/Paper1/Action_Editors")
         assert ae_group.readers == ['SLADS', 'SLADS/Paper1/Action_Editors', 'SLADS/Paper1/Reviewers']
 


### PR DESCRIPTION
Request from SLADS journal.

## Summary

Adds an optional journal setting that hides reviewer identities from other
assigned reviewers. By default the setting is `False`, preserving the current
TMLR behavior where assigned reviewers can see one another's identities.

When enabled, the per-paper `Reviewers` group no longer lists itself as a
deanonymizer, so reviewers see co-reviewers only as anonymized IDs
(e.g. `Reviewer_xYz`). Author–reviewer double-blind anonymity is unchanged.

## Changes

- `journal.py`: new `is_reviewer_to_reviewer_anonymous()` reader (defaults to `False`).
- `group.py`: per-paper reviewers group excludes the reviewers group from
  `deanonymizers` when the setting is enabled.

## Tests

- `test_slads_journal.py`: enables `reviewer_to_reviewer_anonymity` and asserts
  reviewers are excluded from the reviewers group `deanonymizers`.
- `test_journal.py`: asserts TMLR keeps reviewers mutually visible by default.