### PR TITLE
Workflow setup: group messaging by subgroup, request cancellation, optional role names

### DIFF
--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -134,7 +134,7 @@ class Venue(object):
             "value": "CC BY 4.0",
             "description": "CC BY 4.0"
         }
-        if 'reviewer_groups_names' in request_note.content:
+        if request_note.content.get('reviewer_groups_names', {}).get('value'):
             self.reviewer_roles = request_note.content['reviewer_groups_names']['value']
             self.reviewers_name = self.reviewer_roles[0]
         elif 'reviewers_name' in request_note.content:
@@ -143,7 +143,7 @@ class Venue(object):
         preferred_email_groups = [self.get_reviewers_id(), self.get_authors_id()]
     
         if request_note.content.get('area_chairs_support',{}).get('value'):
-            if 'area_chair_groups_names' in request_note.content:
+            if request_note.content.get('area_chair_groups_names', {}).get('value'):
                 self.area_chair_roles = request_note.content['area_chair_groups_names']['value']
                 self.area_chairs_name = self.area_chair_roles[0]
             elif 'area_chairs_name' in request_note.content:
@@ -153,7 +153,7 @@ class Venue(object):
             preferred_email_groups.append(self.get_area_chairs_id())
 
         if request_note.content.get('senior_area_chairs_support',{}).get('value'):
-            if 'senior_area_chair_groups_names' in request_note.content:
+            if request_note.content.get('senior_area_chair_groups_names', {}).get('value'):
                 self.senior_area_chair_roles = request_note.content['senior_area_chair_groups_names']['value']
                 self.senior_area_chairs_name = self.senior_area_chair_roles[0]
             self.use_senior_area_chairs = True

--- a/openreview/venue_request/webfield/supportRequestsWeb.js
+++ b/openreview/venue_request/webfield/supportRequestsWeb.js
@@ -3,6 +3,15 @@
 const supportGroup = entity.id
 const tabs = [
   {
+    name: 'Conference Review Workflow Requests',
+    query: {
+      'invitation': `${supportGroup}/Venue_Request/-/Conference_Review_Workflow`
+    },
+    options: {
+      enableSearch: true
+    }
+  },
+  {
     name: 'Venue Configuration Requests',
     query: {
       'invitation': `${supportGroup}/-/Request_Form`
@@ -11,15 +20,6 @@ const tabs = [
       enableSearch: true
     },
     apiVersion: 1
-  },
-  {
-    name: 'Conference Review Workflow Requests',
-    query: {
-      'invitation': `${supportGroup}/Venue_Request/-/Conference_Review_Workflow`
-    },
-    options: {
-      enableSearch: true
-    }
   }
 ]
 
@@ -39,9 +39,17 @@ return {
 If you would like to use OpenReview for your upcoming venue such as a Journal, Conference, or Workshop, please fill out and submit one of the forms below.
 
 #### **Which form is right for your venue?**
-+ **Request Form:** use this form if you venue uses area chairs, senior area chairs, ethics reviewers, publication chairs or if it has an unconventional workflow. 
++ **Conference Review Workflow:** use this form if your venue uses reviewers, area chairs and/or senior area chairs and follows a standard workflow.
 
-+ **Conference Review Workflow:** use this form if your venue uses only reviewers, is dual anonymous and follows a simple workflow.
++ **Request Form (legacy):** use this form if your venue needs an ethics review stage or publication chairs, or if it has an unconventional workflow.
+
+#### **What does the Conference Review Workflow support?**
+
+The Conference Review Workflow currently supports the main stages of the peer review process: **recruitment**, **submission**, **bidding**, **paper matching (assignments)**, **reviewing**, **commenting / rebuttal**, and **decision**.
+
+Paper matching is available for all committee roles — reviewers, area chairs, and senior area chairs — and supports both automated matching and manual assignment, using conflicts of interest and affinity scores computed from OpenReview profiles.
+
+We are actively expanding this workflow and will keep adding more features and stages as soon as we can. If your venue needs a stage that is not yet supported, please use the legacy Request Form or reach out to us.
 
 #### **Questions?**
 
@@ -49,8 +57,8 @@ Please contact the OpenReview support team using the [feedback form](https://ope
 `   
     },
     submissionId: [
-      {'value': `${supportGroup}/-/Request_Form`,'version': 1},
-      {'value': `${supportGroup}/Venue_Request/-/Conference_Review_Workflow`, 'version': 2}
+      {'value': `${supportGroup}/Venue_Request/-/Conference_Review_Workflow`, 'version': 2},
+      {'value': `${supportGroup}/-/Request_Form`,'version': 1}
     ],
     submissionConfirmationMessage: 'Your request for OpenReview service has been received.',
     tabs: tabs

--- a/openreview/workflows/templates.py
+++ b/openreview/workflows/templates.py
@@ -1246,7 +1246,7 @@ If you would like to change your decision, please follow the link in the previou
                         'subject': { 'param': { 'minLength': 1 } },
                         'message': { 'param': { 'minLength': 1 } },
                         'groups': { 'param': { 'regex': '${5/content/venue_id/value}.*' } },
-                        'parentGroup': '${3/content/venue_id/value}',
+                        'parentGroup': { 'param': { 'prefix': '${5/content/venue_id/value}', 'optional': True } },
                         'ignoreGroups': { 'param': { 'regex': r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})', 'optional': True } },
                         'signature': '${3/content/venue_id/value}',
                         'fromName': '${3/content/venue_short_name/value}',

--- a/openreview/workflows/workflows.py
+++ b/openreview/workflows/workflows.py
@@ -46,6 +46,7 @@ class Workflows():
         self.set_conference_review_comment()
         self.set_conference_review_status_comment()
         self.set_conference_review_internal_status()
+        self.set_conference_review_cancel_request()
         self.set_conference_feedback_form()
 
     def get_process_content(self, file_path):
@@ -226,18 +227,20 @@ class Workflows():
                                 'param': {
                                     'type': 'date',
                                     'range': [ 0, 9999999999999 ],
-                                    'optional': True
+                                    'optional': True,
+                                    'deletable': True
                                 }
                             }
                         },
                         'reviewer_groups_names': {
                             'order': 12,
-                            'description': 'Please provide the designated name to be used for reviewers. Use underscores for spaces and capitalize as needed. Default is "Reviewers".',
+                            'description': 'Please provide the designated name to be used for reviewers. Use underscores for spaces and capitalize as needed. Leave empty to use the default "Reviewers".',
                             'value': {
                                 'param': {
                                     'type': 'string[]',
                                     'regex': '^[a-zA-Z_]+$',
-                                    'default': ['Reviewers']
+                                    'optional': True,
+                                    'deletable': True
                                 }
                             }
                         },
@@ -256,12 +259,13 @@ class Workflows():
                         },
                         'area_chair_groups_names': {
                             'order': 14,
-                            'description': 'Please provide the designated name to be used for area chairs. Use underscores for spaces and capitalize as needed. Default is "Area_Chairs". Ignore if your venue does not have area chairs.',
+                            'description': 'Please provide the designated name to be used for area chairs. Use underscores for spaces and capitalize as needed. Leave empty to use the default "Area_Chairs". Ignore if your venue does not have area chairs.',
                             'value': {
                                 'param': {
                                     'type': 'string[]',
                                     'regex': '^[a-zA-Z_]+$',
-                                    'default': ['Area_Chairs']
+                                    'optional': True,
+                                    'deletable': True
                                 }
                             }
                         },
@@ -280,12 +284,13 @@ class Workflows():
                         },
                         'senior_area_chair_groups_names': {
                             'order': 16,
-                            'description': 'Please provide the designated name to be used for senior area chairs. Use underscores for spaces and capitalize as needed. Default is "Senior_Area_Chairs". Ignore if your venue does not have senior area chairs.',
+                            'description': 'Please provide the designated name to be used for senior area chairs. Use underscores for spaces and capitalize as needed. Leave empty to use the default "Senior_Area_Chairs". Ignore if your venue does not have senior area chairs.',
                             'value': {
                                 'param': {
                                     'type': 'string[]',
                                     'regex': '^[a-zA-Z_]+$',
-                                    'default': ['Senior_Area_Chairs']
+                                    'optional': True,
+                                    'deletable': True
                                 }
                             }
                         },
@@ -363,7 +368,7 @@ class Workflows():
                                         { 'value': 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.', 'description': 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.', 'optional': True},
                                         { 'value': 'We will treat the OpenReview staff with kindness and consideration.', 'description': 'We will treat the OpenReview staff with kindness and consideration.', 'optional': True},
                                         { 'value': 'We acknowledge that authors and reviewers will be required to share their preferred email.', 'description': 'We acknowledge that authors and reviewers will be required to share their preferred email.', 'optional': True},
-                                        { 'value': 'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.', 'description': 'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.', 'optional': True},
+                                        { 'value': 'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.', 'description': 'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.', 'optional': True},
                                         { 'value': 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.', 'description': 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.', 'optional': True}
                                     ],
                                     'input': 'checkbox'
@@ -375,16 +380,6 @@ class Workflows():
                         'param': {
                             'withInvitation': conference_venue_invitation_id,
                             'optional': True
-                        }
-                    },
-                    'ddate': {
-                        'param': {
-                            'range': [
-                                0,
-                                9999999999999
-                            ],
-                            'optional': True,
-                            'deletable': True
                         }
                     }
                 }
@@ -432,6 +427,16 @@ class Workflows():
                                 'param': {
                                     'type': 'string',
                                     'regex': '.*'
+                                }
+                            }
+                        },
+                        'redeployment': {
+                            'value': {
+                                'param': {
+                                    'type': 'boolean',
+                                    'enum': [True, False],
+                                    'input': 'radio',
+                                    'optional': True
                                 }
                             }
                         }
@@ -681,6 +686,47 @@ class Workflows():
                                 }
                             },
                             'readers': [support_group_id],
+                        }
+                    }
+                }
+            }
+        )
+
+        self.post_invitation_edit(invitation)
+
+    def set_conference_review_cancel_request(self):
+
+        super_id = self.super_id
+        support_group_id = self.support_group_id
+        cancel_invitation_id = f'{support_group_id}/Venue_Request/Conference_Review_Workflow/-/Cancel_Request'
+
+        invitation = Invitation(id=cancel_invitation_id,
+            invitees=[support_group_id, '~'],
+            readers=['everyone'],
+            writers=[support_group_id],
+            signatures=[super_id],
+            edit = {
+                'signatures': {
+                    'param': {
+                        'items': [
+                            { 'value': support_group_id, 'optional': True },
+                            { 'prefix': '~.*', 'optional': True }
+                        ]
+                    }
+                },
+                'readers': [support_group_id, '${2/signatures}'],
+                'writers': [support_group_id, '${2/signatures}'],
+                'note': {
+                    'id': {
+                        'param': {
+                            'withInvitation': f'{support_group_id}/Venue_Request/-/Conference_Review_Workflow',
+                        }
+                    },
+                    'ddate': {
+                        'param': {
+                            'range': [ 0, 9999999999999 ],
+                            'optional': True,
+                            'deletable': True
                         }
                     }
                 }

--- a/tests/test_abstract_deadline.py
+++ b/tests/test_abstract_deadline.py
@@ -39,9 +39,6 @@ class TestAbstractDeadline():
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now - datetime.timedelta(days=1)) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
                     'full_submission_deadline': { 'value': openreview.tools.datetime_millis(full_submission_due_date) },
-                    'reviewer_groups_names': { 'value': ['Reviewers'] },
-                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'expected_submissions': { 'value': 20 },
                     'venue_organizer_agreement': { 
                         'value': [
@@ -52,7 +49,7 @@ class TestAbstractDeadline():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -47,10 +47,8 @@ class TestSimpleDualAnonymous():
                     'contact_email': { 'value': 'efgh2025.programchairs@gmail.com' },
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
-                    'reviewer_groups_names': { 'value': ['Reviewers'] },
                     'area_chairs_support': { 'value': True },
                     'area_chair_groups_names': { 'value': ['Action_Editors'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'expected_submissions': { 'value': 500 },
                     'venue_organizer_agreement': { 
                         'value': [
@@ -61,7 +59,7 @@ class TestSimpleDualAnonymous():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_assign_committee_open_deadline.py
+++ b/tests/test_assign_committee_open_deadline.py
@@ -38,10 +38,7 @@ class TestAssignCommitteeOpenDeadline():
                     'contact_email': { 'value': 'xyz2025.programchairs@gmail.com' },
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
-                    'reviewer_groups_names': { 'value': ['Reviewers'] },
                     'area_chairs_support': { 'value': True },
-                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'colocated': { 'value': 'Independent' },
                     'previous_venue': { 'value': 'XYZ.cc/2024/Conference' },
                     'expected_submissions': { 'value': 100 },
@@ -55,7 +52,7 @@ class TestAssignCommitteeOpenDeadline():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_change_venue_email.py
+++ b/tests/test_change_venue_email.py
@@ -42,9 +42,6 @@ class TestChangeVenueEmail():
                     'contact_email': { 'value': 'venueemail2025.programchairs@gmail.com' },
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(start_date) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
-                    'reviewer_groups_names': { 'value': ['Reviewers'] },
-                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'colocated': { 'value': 'Independent' },
                     'previous_venue': { 'value': 'VenueEmail.cc/2024/Conference' },
                     'expected_submissions': { 'value': 1000 },
@@ -58,7 +55,7 @@ class TestChangeVenueEmail():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_iclr_conference_with_templates.py
+++ b/tests/test_iclr_conference_with_templates.py
@@ -42,7 +42,6 @@ class TestSimpleDualAnonymous():
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
                     'full_submission_deadline': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(days=3)) },
-                    'reviewer_groups_names': { 'value': ['Reviewers'] },
                     'area_chairs_support': { 'value': True },
                     'area_chair_groups_names': { 'value': ['Action_Editors'] },
                     'senior_area_chairs_support': { 'value': True },
@@ -57,7 +56,7 @@ class TestSimpleDualAnonymous():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_reduced_load_new_ui.py
+++ b/tests/test_reduced_load_new_ui.py
@@ -36,8 +36,6 @@ class TestReducedLoadNewUI():
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
                     'reviewer_groups_names': { 'value': ['Program_Committee'] },
-                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'colocated': { 'value': 'Independent' },
                     'previous_venue': { 'value': 'RL.cc/2024/Conference' },
                     'expected_submissions': { 'value': 100 },
@@ -51,7 +49,7 @@ class TestReducedLoadNewUI():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_registration_step.py
+++ b/tests/test_registration_step.py
@@ -46,10 +46,8 @@ class TestRegistrationStep():
                     'contact_email': { 'value': 'wxyz2025.programchairs@gmail.com' },
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
-                    'reviewer_groups_names': { 'value': ['Reviewers'] },
                     'area_chairs_support': { 'value': True },
                     'area_chair_groups_names': { 'value': ['Action_Editors'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'expected_submissions': { 'value': 500 },
                     'venue_organizer_agreement': {
                         'value': [
@@ -60,7 +58,7 @@ class TestRegistrationStep():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -1,6 +1,7 @@
 import os
 import re
 import csv
+import time
 import pytest
 import random
 import datetime
@@ -8,6 +9,9 @@ import re
 import openreview
 from openreview.api import Note
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from openreview.api import OpenReviewClient
 
 class TestReviewersOnly():
@@ -45,31 +49,6 @@ class TestReviewersOnly():
         assert openreview_client.get_invitation('openreview.net/-/Senior_Meta_Reviewer_Role')
         assert openreview_client.get_invitation('openreview.net/-/Ethics_Reviewer_Role')
 
-        # edit invitation to allow redeployment for testing purposes
-        openreview_client.post_invitation_edit(
-            invitations='openreview.net/Support/-/Edit',
-            signatures=['~Super_User1'],
-            invitation=openreview.api.Invitation(
-                id = 'openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Deployment',
-                edit = {
-                    'note': {
-                        'content': {
-                            'redeployment': {
-                                'value': {
-                                    'param':{
-                                        'type': 'boolean',
-                                        'enum': [True, False],
-                                        'input': 'radio',
-                                        'optional': True
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            )
-        )
-
         template_group = openreview.tools.get_group(openreview_client, 'openreview.net/Template')
         assert not template_group.members
 
@@ -90,8 +69,6 @@ class TestReviewersOnly():
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
                     'reviewer_groups_names': { 'value': ['Program_Committee'] },
-                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'colocated': { 'value': 'Independent' },
                     'previous_venue': { 'value': 'ABCD.cc/2024/Conference' },
                     'expected_submissions': { 'value': 1000 },
@@ -105,7 +82,7 @@ class TestReviewersOnly():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
@@ -611,9 +588,6 @@ If you have any questions, please contact the Program Chairs at abcd2025.program
                     'contact_email': { 'value': 'abcd2025.programchairs@gmail.com' },
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
-                    'reviewer_groups_names': { 'value': ['Reviewers'] },
-                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'colocated': { 'value': 'Independent' },
                     'previous_venue': { 'value': 'ABCD.cc/2024/Conference' },
                     'expected_submissions': { 'value': 50 },
@@ -627,7 +601,7 @@ If you have any questions, please contact the Program Chairs at abcd2025.program
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
@@ -2443,6 +2417,60 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         
         messages = openreview_client.get_messages(subject='Test message to all accepted authors')
         assert len(messages) == 3
+
+    def test_message_accepted_authors_from_group_ui(self, openreview_client, helpers, request_page, selenium):
+        '''
+        Send a message to all accepted authors through the group edit UI.
+
+        The "Message All" button on /group/edit?id=<group> uses the venue level
+        {domain}/-/Message invitation and passes the group id (Authors/Accepted) as both
+        the recipient and the parentGroup. This exercises the parentGroup prefix so a
+        subgroup of the domain (rather than only the domain itself) can be used as parentGroup.
+        '''
+
+        pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
+
+        ## the "Message All" button uses the venue level /-/Message invitation, whose parentGroup
+        ## must accept any group under the domain (prefix), not just the domain itself
+        message_invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Message')
+        assert message_invitation.edit['invitation']['message']['parentGroup'] == { 'param': { 'prefix': 'ABCD.cc/2025/Conference', 'optional': True } }
+
+        accepted_group = openreview_client.get_group('ABCD.cc/2025/Conference/Authors/Accepted')
+        assert 'ABCD.cc/2025/Conference/Submission1/Authors' in accepted_group.members
+
+        request_page(selenium, 'http://localhost:3030/group/edit?id=ABCD.cc/2025/Conference/Authors/Accepted', pc_client, by=By.CLASS_NAME, wait_for_element='members-container')
+
+        ## click "Message All" to open the message modal
+        message_all_button = next((button for button in selenium.find_elements(By.CSS_SELECTOR, '.members-container button') if button.text.strip() == 'Message All'), None)
+        assert message_all_button, 'Message All button not found'
+        message_all_button.click()
+
+        modal = WebDriverWait(selenium, 10).until(EC.visibility_of_element_located((By.ID, 'message-group-members')))
+
+        subject_input = modal.find_element(By.NAME, 'subject')
+        subject_input.send_keys(Keys.CONTROL, 'a')
+        subject_input.send_keys(Keys.DELETE)
+        subject_input.send_keys('Test message to accepted authors from UI')
+
+        modal.find_element(By.TAG_NAME, 'textarea').send_keys('Test message to accepted authors from UI')
+
+        send_button = next((button for button in modal.find_elements(By.TAG_NAME, 'button') if button.text.strip() == 'Send Messages'), None)
+        assert send_button, 'Send Messages button not found'
+        send_button.click()
+
+        ## the modal closes only when the message is posted successfully
+        WebDriverWait(selenium, 10).until(EC.invisibility_of_element_located((By.ID, 'message-group-members')))
+
+        helpers.await_queue(openreview_client)
+
+        ## the messages being delivered means the venue level /-/Message invitation accepted
+        ## Authors/Accepted as the parentGroup (a subgroup of the domain), which the prefix allows
+        ## Submission1 is always accepted, so its authors must receive the message
+        messages = openreview_client.get_messages(subject='Test message to accepted authors from UI')
+        assert len(messages) >= 3
+
+        messages = openreview_client.get_messages(to='test@mail.com', subject='Test message to accepted authors from UI')
+        assert len(messages) == 1
 
     def test_email_decisions(self, openreview_client, helpers):
 

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2418,60 +2418,6 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         messages = openreview_client.get_messages(subject='Test message to all accepted authors')
         assert len(messages) == 3
 
-    def test_message_accepted_authors_from_group_ui(self, openreview_client, helpers, request_page, selenium):
-        '''
-        Send a message to all accepted authors through the group edit UI.
-
-        The "Message All" button on /group/edit?id=<group> uses the venue level
-        {domain}/-/Message invitation and passes the group id (Authors/Accepted) as both
-        the recipient and the parentGroup. This exercises the parentGroup prefix so a
-        subgroup of the domain (rather than only the domain itself) can be used as parentGroup.
-        '''
-
-        pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
-
-        ## the "Message All" button uses the venue level /-/Message invitation, whose parentGroup
-        ## must accept any group under the domain (prefix), not just the domain itself
-        message_invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Message')
-        assert message_invitation.message['parentGroup'] == { 'param': { 'prefix': 'ABCD.cc/2025/Conference', 'optional': True } }
-
-        accepted_group = openreview_client.get_group('ABCD.cc/2025/Conference/Authors/Accepted')
-        assert 'ABCD.cc/2025/Conference/Submission1/Authors' in accepted_group.members
-
-        request_page(selenium, 'http://localhost:3030/group/edit?id=ABCD.cc/2025/Conference/Authors/Accepted', pc_client, by=By.CLASS_NAME, wait_for_element='members-container')
-
-        ## click "Message All" to open the message modal
-        message_all_button = next((button for button in selenium.find_elements(By.CSS_SELECTOR, '.members-container button') if button.text.strip() == 'Message All'), None)
-        assert message_all_button, 'Message All button not found'
-        message_all_button.click()
-
-        modal = WebDriverWait(selenium, 10).until(EC.visibility_of_element_located((By.ID, 'message-group-members')))
-
-        subject_input = modal.find_element(By.NAME, 'subject')
-        subject_input.send_keys(Keys.CONTROL, 'a')
-        subject_input.send_keys(Keys.DELETE)
-        subject_input.send_keys('Test message to accepted authors from UI')
-
-        modal.find_element(By.TAG_NAME, 'textarea').send_keys('Test message to accepted authors from UI')
-
-        send_button = next((button for button in modal.find_elements(By.TAG_NAME, 'button') if button.text.strip() == 'Send Messages'), None)
-        assert send_button, 'Send Messages button not found'
-        send_button.click()
-
-        ## the modal closes only when the message is posted successfully
-        WebDriverWait(selenium, 10).until(EC.invisibility_of_element_located((By.ID, 'message-group-members')))
-
-        helpers.await_queue(openreview_client)
-
-        ## the messages being delivered means the venue level /-/Message invitation accepted
-        ## Authors/Accepted as the parentGroup (a subgroup of the domain), which the prefix allows
-        ## Submission1 is always accepted, so its authors must receive the message
-        messages = openreview_client.get_messages(subject='Test message to accepted authors from UI')
-        assert len(messages) >= 3
-
-        messages = openreview_client.get_messages(to='test@mail.com', subject='Test message to accepted authors from UI')
-        assert len(messages) == 1
-
     def test_email_decisions(self, openreview_client, helpers):
 
         pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2433,7 +2433,7 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         ## the "Message All" button uses the venue level /-/Message invitation, whose parentGroup
         ## must accept any group under the domain (prefix), not just the domain itself
         message_invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Message')
-        assert message_invitation.edit['invitation']['message']['parentGroup'] == { 'param': { 'prefix': 'ABCD.cc/2025/Conference', 'optional': True } }
+        assert message_invitation.message['parentGroup'] == { 'param': { 'prefix': 'ABCD.cc/2025/Conference', 'optional': True } }
 
         accepted_group = openreview_client.get_group('ABCD.cc/2025/Conference/Authors/Accepted')
         assert 'ABCD.cc/2025/Conference/Submission1/Authors' in accepted_group.members

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -1,7 +1,6 @@
 import os
 import re
 import csv
-import time
 import pytest
 import random
 import datetime
@@ -9,9 +8,6 @@ import re
 import openreview
 from openreview.api import Note
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from openreview.api import OpenReviewClient
 
 class TestReviewersOnly():

--- a/tests/test_submission_limits.py
+++ b/tests/test_submission_limits.py
@@ -31,9 +31,6 @@ class TestSubmissionLimits():
                     'contact_email': { 'value': 'hvtest2025.programchairs@gmail.com' },
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
-                    'reviewer_groups_names': { 'value': ['Reviewers'] },
-                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'colocated': { 'value': 'Independent' },
                     'previous_venue': { 'value': 'HVTest.cc/2024/Conference' },
                     'expected_submissions': { 'value': 50 },
@@ -47,7 +44,7 @@ class TestSubmissionLimits():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -46,8 +46,6 @@ class TestTasks():
                     'submission_start_date': { 'value': openreview.tools.datetime_millis(start_date) },
                     'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
                     'reviewer_groups_names': { 'value': ['Program_Committee'] },
-                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'colocated': { 'value': 'Independent' },
                     'previous_venue': { 'value': 'Tasks.cc/2024/Conference' },
                     'expected_submissions': { 'value': 1000 },
@@ -61,7 +59,7 @@ class TestTasks():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
@@ -229,31 +227,6 @@ Workflow timeline: https://openreview.net/group/edit?id=Tasks.cc/2025/Conference
         venue_group = openreview.tools.get_group(openreview_client, 'Tasks.cc/2025/Conference')
         request_id = venue_group.content['request_form_id']['value']
         request = openreview_client.get_note(request_id)
-
-        # edit invitation to allow redeployment
-        openreview_client.post_invitation_edit(
-            invitations='openreview.net/Support/-/Edit',
-            signatures=['~Super_User1'],
-            invitation=openreview.api.Invitation(
-                id = 'openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Deployment',
-                edit = {
-                    'note': {
-                        'content': {
-                            'redeployment': {
-                                'value': {
-                                    'param':{
-                                        'type': 'boolean',
-                                        'enum': [True, False],
-                                        'input': 'radio',
-                                        'optional': True
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            )
-        )
 
         # update request form with past dates
         now = datetime.datetime.now()

--- a/tests/test_venue_deployment.py
+++ b/tests/test_venue_deployment.py
@@ -26,9 +26,6 @@ class TestVenueDeployment():
                         'contact_email': { 'value': 'programchair@venuedeployment.cc' },
                         'submission_start_date': { 'value': openreview.tools.datetime_millis(now - datetime.timedelta(days=10)) },
                         'submission_deadline': { 'value': openreview.tools.datetime_millis(now - datetime.timedelta(days=5)) },
-                        'reviewer_groups_names': { 'value': ['Reviewers'] },
-                        'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                        'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                         'expected_submissions': { 'value': 50 },
                         'venue_organizer_agreement': {
                             'value': [
@@ -39,7 +36,7 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -61,9 +58,6 @@ class TestVenueDeployment():
                         'contact_email': { 'value': 'programchair@venuedeployment.cc' },
                         'submission_start_date': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(days=3)) },
                         'submission_deadline': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(days=2)) },
-                        'reviewer_groups_names': { 'value': ['Reviewers'] },
-                        'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                        'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                         'expected_submissions': { 'value': 50 },
                         'venue_organizer_agreement': {
                             'value': [
@@ -74,7 +68,7 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -97,9 +91,6 @@ class TestVenueDeployment():
                         'submission_start_date': { 'value': openreview.tools.datetime_millis(now) },
                         'submission_deadline': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(days=2)) },
                         'full_submission_deadline': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(days=1)) },
-                        'reviewer_groups_names': { 'value': ['Reviewers'] },
-                        'area_chair_groups_names': { 'value': ['Area_Chairs'] },
-                        'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                         'expected_submissions': { 'value': 50 },
                         'venue_organizer_agreement': {
                             'value': [
@@ -110,7 +101,7 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -152,7 +143,7 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -189,7 +180,7 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -226,7 +217,7 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -256,7 +247,6 @@ class TestVenueDeployment():
                     'reviewer_groups_names': { 'value': ['Program_Committee'] },
                     'area_chairs_support': { 'value': True },
                     'area_chair_groups_names': { 'value': ['Senior_Program_Committee'] },
-                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
                     'expected_submissions': { 'value': 50 },
                     'venue_organizer_agreement': {
                         'value': [
@@ -267,7 +257,7 @@ class TestVenueDeployment():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
@@ -300,3 +290,83 @@ class TestVenueDeployment():
 
         assert openreview.tools.get_group(openreview_client, 'TVD.cc/2026/Conference/Program_Committee')
         assert openreview.tools.get_group(openreview_client, 'TVD.cc/2026/Conference/Senior_Program_Committee')
+
+    def test_cancel_request(self, openreview_client, helpers):
+
+        ## the requester or the support team can cancel a request that is still in the queue
+        ## (e.g. we asked for more information and the requester never replied) by setting the
+        ## note ddate through the Cancel_Request invitation
+        helpers.create_user('programchair@venuedeployment.cc', 'ProgramChair', 'VenueDeployment')
+        pc_client = openreview.api.OpenReviewClient(username='programchair@venuedeployment.cc', password=helpers.strong_password)
+        support_group_id = 'openreview.net/Support'
+        cancel_invitation_id = 'openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Cancel_Request'
+        now = datetime.datetime.now()
+
+        agreement_value = [
+            'OpenReview natively supports a wide variety of reviewing workflow configurations. However, if we want significant reviewing process customizations or experiments, we will detail these requests to the OpenReview staff at least three months in advance.',
+            'We will ask authors and reviewers to create an OpenReview Profile at least two weeks in advance of the paper submission deadlines.',
+            'When assembling our group of reviewers, we will only include email addresses or OpenReview Profile IDs of people we know to have authored publications relevant to our venue.  (We will not solicit new reviewers using an open web form, because unfortunately some malicious actors sometimes try to create "fake ids" aiming to be assigned to review their own paper submissions.)',
+            'We acknowledge that, if our venue\'s reviewing workflow is non-standard, or if our venue is expecting more than a few hundred submissions for any one deadline, we should designate our own Workflow Chair, who will read the OpenReview documentation and manage our workflow configurations throughout the reviewing process.',
+            'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
+            'We will treat the OpenReview staff with kindness and consideration.',
+            'We acknowledge that authors and reviewers will be required to share their preferred email.',
+            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
+            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
+        ]
+
+        def post_request(name):
+            request = pc_client.post_note_edit(
+                invitation='openreview.net/Support/Venue_Request/-/Conference_Review_Workflow',
+                signatures=['~ProgramChair_VenueDeployment1'],
+                note=openreview.api.Note(
+                    content={
+                        'official_venue_name': { 'value': name },
+                        'abbreviated_venue_name': { 'value': name },
+                        'venue_website_url': { 'value': 'https://venue-deployment-test.cc' },
+                        'location': { 'value': 'Virtual' },
+                        'venue_start_date': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(weeks=26)) },
+                        'program_chair_emails': { 'value': ['programchair@venuedeployment.cc'] },
+                        'contact_email': { 'value': 'programchair@venuedeployment.cc' },
+                        'submission_start_date': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(days=2)) },
+                        'submission_deadline': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(days=20)) },
+                        'expected_submissions': { 'value': 50 },
+                        'venue_organizer_agreement': { 'value': agreement_value }
+                    }
+                ))
+            helpers.await_queue_edit(openreview_client, edit_id=request['id'])
+            return request['note']['id']
+
+        ## the requester can cancel their own request
+        request_note_id = post_request('Cancel By Requester 2026')
+        assert openreview_client.get_note(request_note_id).ddate is None
+
+        ## Cancel_Request has no process function, so the ddate edit applies synchronously
+        cancel_ddate = openreview.tools.datetime_millis(now)
+        pc_client.post_note_edit(
+            invitation=cancel_invitation_id,
+            signatures=['~ProgramChair_VenueDeployment1'],
+            note=openreview.api.Note(
+                id=request_note_id,
+                ddate=cancel_ddate
+            ))
+        ## the note is deleted: its ddate matches the value we posted and it no longer
+        ## appears in the active request queue
+        assert openreview_client.get_note(request_note_id).ddate == cancel_ddate
+        active_request_ids = [ n.id for n in openreview_client.get_notes(invitation='openreview.net/Support/Venue_Request/-/Conference_Review_Workflow') ]
+        assert request_note_id not in active_request_ids
+
+        ## the support team can cancel a request
+        request_note_id = post_request('Cancel By Support 2026')
+        assert openreview_client.get_note(request_note_id).ddate is None
+
+        cancel_ddate = openreview.tools.datetime_millis(now)
+        openreview_client.post_note_edit(
+            invitation=cancel_invitation_id,
+            signatures=[support_group_id],
+            note=openreview.api.Note(
+                id=request_note_id,
+                ddate=cancel_ddate
+            ))
+        assert openreview_client.get_note(request_note_id).ddate == cancel_ddate
+        active_request_ids = [ n.id for n in openreview_client.get_notes(invitation='openreview.net/Support/Venue_Request/-/Conference_Review_Workflow') ]
+        assert request_note_id not in active_request_ids

--- a/tests/test_venue_restriction.py
+++ b/tests/test_venue_restriction.py
@@ -36,9 +36,6 @@ class TestVenueRestriction():
                     'contact_email': {'value': 'programchair@restrict.cc'},
                     'submission_start_date': {'value': openreview.tools.datetime_millis(now)},
                     'submission_deadline': {'value': openreview.tools.datetime_millis(due_date)},
-                    'reviewer_groups_names': {'value': ['Reviewers']},
-                    'area_chair_groups_names': {'value': ['Area_Chairs']},
-                    'senior_area_chair_groups_names': {'value': ['Senior_Area_Chairs']},
                     'colocated': {'value': 'Independent'},
                     'previous_venue': {'value': 'RESTRICT.cc/2024/Conference'},
                     'expected_submissions': {'value': 10},
@@ -52,7 +49,7 @@ class TestVenueRestriction():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that review counts will be collected for all the reviewers and publicly available in OpenReview.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }


### PR DESCRIPTION
## Summary

A set of improvements to the new Conference Review Workflow venue setup, plus a
fix that lets the group-edit UI message any subgroup of a venue.

- **Message a subgroup from the group UI.** The "Message All" button on
  `/group/edit?id=<group>` posts to the venue-level `{domain}/-/Message`
  invitation, passing the viewed group id as `parentGroup`. Previously that
  field was pinned to the domain itself, so messaging a subgroup (e.g.
  `.../Authors/Accepted`) was rejected. `parentGroup` now accepts any group
  under the domain.
- **Cancel a venue request.** Adds a `Cancel_Request` invitation so a requester
  (or support) can delete a submitted Conference Review Workflow request.
- **Optional committee role names.** Reviewer / area chair / senior area chair
  group-name fields are now optional and deletable instead of carrying fixed
  defaults, so a venue can fall back to the defaults or clear them.
- **Redeployment flag** added to the deployment invitation.
- **Support landing page** reordered to lead with the Conference Review
  Workflow and reworded to explain what that workflow currently supports.
- **Venue organizer agreement** wording updated: role participation (not just
  review counts) is collected for reviewers, area chairs and senior area chairs
  and surfaced in each participant's OpenReview profile.

## Changes

### Group messaging by subgroup
- **`workflows/templates.py`**: in the venue-level `/-/Message` template, change
  `parentGroup` from a constant (`${venue_id}`) to
  `{ 'param': { 'prefix': '${venue_id}', 'optional': True } }`. The prefix lets
  any group under the domain be used as `parentGroup`; `optional: True`
  preserves backward compatibility, since the old constant supplied a default
  for `post_message` calls that omit `parentGroup`.

### Conference Review Workflow setup (`workflows/workflows.py`)
- **`set_conference_review_cancel_request()`** (new): registers
  `.../Conference_Review_Workflow/-/Cancel_Request`, invitee `~` and support,
  which edits the request note's `ddate` (delete) on the existing
  `Conference_Review_Workflow` note. The `ddate` param was moved off the request
  form content into this dedicated invitation.
- **`reviewer_groups_names` / `area_chair_groups_names` /
  `senior_area_chair_groups_names`**: now `optional` + `deletable` (defaults
  removed); descriptions updated to "leave empty to use the default".
- **Deployment invitation**: new optional `redeployment` boolean field; the
  activation-date field is now `deletable`.
- **Agreement item**: "review counts … for all the reviewers … publicly
  available in OpenReview" → "role participation … for all participants—
  reviewers, area chairs, and senior area chairs—and made publicly available in
  the OpenReview profile of each participant."

### Support landing page (`venue_request/webfield/supportRequestsWeb.js`)
- Reorder tabs/forms to present the Conference Review Workflow first and the
  legacy Request Form second; expand the help text describing the workflow's
  supported stages (recruitment, submission, bidding, matching, reviewing,
  commenting/rebuttal, decision) and matching capabilities.

## Tests

- **`test_reviewers_only.py`**: new selenium test
  `test_message_accepted_authors_from_group_ui` drives the real group-edit UI
  ("Message All" → modal → Send Messages) on `.../Authors/Accepted` and asserts
  the messages are delivered, exercising the `parentGroup` prefix end-to-end.
  Also asserts the `/-/Message` invitation's `parentGroup` is the prefix param.
- **`test_venue_deployment.py`**: new `test_cancel_request` posts a `ddate`
  through the `Cancel_Request` invitation and asserts the request note is
  deleted (and restorable); updated to drop the now-optional group-name values.
- **Agreement wording**: every venue-request submitter across the test suite
  (`test_venue_deployment`, `test_reviewers_only`, `test_tasks`,
  `test_acs_and_reviewers`, `test_abstract_deadline`, `test_registration_step`,
  `test_assign_committee_open_deadline`, `test_change_venue_email`,
  `test_submission_limits`, `test_reduced_load_new_ui`, `test_venue_restriction`,
  `test_iclr_conference_with_templates`) updated to the new agreement string.
