### PR TITLE
Add `pytest-files` parameter to CircleCI for debug runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,7 @@ jobs:
         environment:
           xpack.security.enabled: false
           transport.host: localhost
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     steps:
       - checkout
       - run:
@@ -364,6 +365,7 @@ jobs:
         environment:
           xpack.security.enabled: false
           transport.host: localhost
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     steps:
       - checkout
       - get-github-token
@@ -424,6 +426,7 @@ jobs:
         environment:
           xpack.security.enabled: false
           transport.host: localhost
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     steps:
       - checkout
       - get-github-token

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ commands:
           name: Start API V2
           command: |
             cd ~/openreview-v2
-            npm run cleanStart
+            NODE_OPTIONS="--max-old-space-size=4096" npm run cleanStart
           background: true
       - run:
           name: Wait for API V2 to start

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ parameters:
   python-version:
     type: string
     default: "3.13.1"
+  pytest-files:
+    type: string
+    default: ""
 
 # Reusable commands to reduce duplication between jobs
 commands:
@@ -274,38 +277,46 @@ jobs:
       - run:
           name: Detect modified test files
           command: |
-            # Get the base branch for comparison
-            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-              # Extract PR number from URL
-              PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | grep -oE '[0-9]+$')
-              # Fetch the base branch (usually main or master)
-              git fetch origin master:refs/remotes/origin/master 2>/dev/null || git fetch origin main:refs/remotes/origin/main 2>/dev/null || true
-              
-              # Get modified/added test files compared to master/main
-              MODIFIED_TESTS=$(git diff --name-only --diff-filter=AM origin/master...HEAD -- 'tests/test_*.py' 2>/dev/null || \
-                               git diff --name-only --diff-filter=AM origin/main...HEAD -- 'tests/test_*.py' 2>/dev/null || \
-                               echo "")
-            else
-              # For non-PR builds (e.g., master branch), skip this job
-              MODIFIED_TESTS=""
-            fi
-            
-            # Write the modified tests to a file for subsequent steps
-            echo "$MODIFIED_TESTS" > /tmp/modified_tests.txt
-            
-            FILE_COUNT=$(echo "$MODIFIED_TESTS" | grep -c . || true)
+            PYTEST_FILES="<< pipeline.parameters.pytest-files >>"
 
-            if [ -z "$MODIFIED_TESTS" ]; then
-              echo "No test files were modified in this PR. Skipping PR-specific tests."
-              echo "skip" > /tmp/skip_pr_tests.txt
-            elif [ "$FILE_COUNT" -gt 3 ]; then
-              echo "Too many modified test files ($FILE_COUNT). Deferring to full build job."
-              echo "$MODIFIED_TESTS"
-              echo "skip" > /tmp/skip_pr_tests.txt
-            else
-              echo "Modified test files found:"
-              echo "$MODIFIED_TESTS"
+            if [ -n "$PYTEST_FILES" ]; then
+              echo "Manual override via pytest-files parameter: $PYTEST_FILES"
+              echo "$PYTEST_FILES" > /tmp/modified_tests.txt
               echo "run" > /tmp/skip_pr_tests.txt
+            else
+              # Get the base branch for comparison
+              if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+                # Extract PR number from URL
+                PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | grep -oE '[0-9]+$')
+                # Fetch the base branch (usually main or master)
+                git fetch origin master:refs/remotes/origin/master 2>/dev/null || git fetch origin main:refs/remotes/origin/main 2>/dev/null || true
+
+                # Get modified/added test files compared to master/main
+                MODIFIED_TESTS=$(git diff --name-only --diff-filter=AM origin/master...HEAD -- 'tests/test_*.py' 2>/dev/null || \
+                                 git diff --name-only --diff-filter=AM origin/main...HEAD -- 'tests/test_*.py' 2>/dev/null || \
+                                 echo "")
+              else
+                # For non-PR builds (e.g., master branch), skip this job
+                MODIFIED_TESTS=""
+              fi
+
+              # Write the modified tests to a file for subsequent steps
+              echo "$MODIFIED_TESTS" > /tmp/modified_tests.txt
+
+              FILE_COUNT=$(echo "$MODIFIED_TESTS" | grep -c . || true)
+
+              if [ -z "$MODIFIED_TESTS" ]; then
+                echo "No test files were modified in this PR. Skipping PR-specific tests."
+                echo "skip" > /tmp/skip_pr_tests.txt
+              elif [ "$FILE_COUNT" -gt 3 ]; then
+                echo "Too many modified test files ($FILE_COUNT). Deferring to full build job."
+                echo "$MODIFIED_TESTS"
+                echo "skip" > /tmp/skip_pr_tests.txt
+              else
+                echo "Modified test files found:"
+                echo "$MODIFIED_TESTS"
+                echo "run" > /tmp/skip_pr_tests.txt
+              fi
             fi
       - run:
           name: Check if tests should run
@@ -429,6 +440,8 @@ workflows:
       - build:
           requires:
             - build-pr-tests
+          when:
+            equal: [ "", << pipeline.parameters.pytest-files >> ]
           python-version: "3.10"
       - deploy-dev:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,46 +277,38 @@ jobs:
       - run:
           name: Detect modified test files
           command: |
-            PYTEST_FILES="<< pipeline.parameters.pytest-files >>"
+            # Get the base branch for comparison
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+              # Extract PR number from URL
+              PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | grep -oE '[0-9]+$')
+              # Fetch the base branch (usually main or master)
+              git fetch origin master:refs/remotes/origin/master 2>/dev/null || git fetch origin main:refs/remotes/origin/main 2>/dev/null || true
 
-            if [ -n "$PYTEST_FILES" ]; then
-              echo "Manual override via pytest-files parameter: $PYTEST_FILES"
-              echo "$PYTEST_FILES" > /tmp/modified_tests.txt
-              echo "run" > /tmp/skip_pr_tests.txt
+              # Get modified/added test files compared to master/main
+              MODIFIED_TESTS=$(git diff --name-only --diff-filter=AM origin/master...HEAD -- 'tests/test_*.py' 2>/dev/null || \
+                               git diff --name-only --diff-filter=AM origin/main...HEAD -- 'tests/test_*.py' 2>/dev/null || \
+                               echo "")
             else
-              # Get the base branch for comparison
-              if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-                # Extract PR number from URL
-                PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | grep -oE '[0-9]+$')
-                # Fetch the base branch (usually main or master)
-                git fetch origin master:refs/remotes/origin/master 2>/dev/null || git fetch origin main:refs/remotes/origin/main 2>/dev/null || true
+              # For non-PR builds (e.g., master branch), skip this job
+              MODIFIED_TESTS=""
+            fi
 
-                # Get modified/added test files compared to master/main
-                MODIFIED_TESTS=$(git diff --name-only --diff-filter=AM origin/master...HEAD -- 'tests/test_*.py' 2>/dev/null || \
-                                 git diff --name-only --diff-filter=AM origin/main...HEAD -- 'tests/test_*.py' 2>/dev/null || \
-                                 echo "")
-              else
-                # For non-PR builds (e.g., master branch), skip this job
-                MODIFIED_TESTS=""
-              fi
+            # Write the modified tests to a file for subsequent steps
+            echo "$MODIFIED_TESTS" > /tmp/modified_tests.txt
 
-              # Write the modified tests to a file for subsequent steps
-              echo "$MODIFIED_TESTS" > /tmp/modified_tests.txt
+            FILE_COUNT=$(echo "$MODIFIED_TESTS" | grep -c . || true)
 
-              FILE_COUNT=$(echo "$MODIFIED_TESTS" | grep -c . || true)
-
-              if [ -z "$MODIFIED_TESTS" ]; then
-                echo "No test files were modified in this PR. Skipping PR-specific tests."
-                echo "skip" > /tmp/skip_pr_tests.txt
-              elif [ "$FILE_COUNT" -gt 3 ]; then
-                echo "Too many modified test files ($FILE_COUNT). Deferring to full build job."
-                echo "$MODIFIED_TESTS"
-                echo "skip" > /tmp/skip_pr_tests.txt
-              else
-                echo "Modified test files found:"
-                echo "$MODIFIED_TESTS"
-                echo "run" > /tmp/skip_pr_tests.txt
-              fi
+            if [ -z "$MODIFIED_TESTS" ]; then
+              echo "No test files were modified in this PR. Skipping PR-specific tests."
+              echo "skip" > /tmp/skip_pr_tests.txt
+            elif [ "$FILE_COUNT" -gt 3 ]; then
+              echo "Too many modified test files ($FILE_COUNT). Deferring to full build job."
+              echo "$MODIFIED_TESTS"
+              echo "skip" > /tmp/skip_pr_tests.txt
+            else
+              echo "Modified test files found:"
+              echo "$MODIFIED_TESTS"
+              echo "run" > /tmp/skip_pr_tests.txt
             fi
       - run:
           name: Check if tests should run
@@ -374,13 +366,6 @@ jobs:
           transport.host: localhost
     steps:
       - checkout
-      - run:
-          name: Skip full build when pytest-files override is set
-          command: |
-            if [ -n "<< pipeline.parameters.pytest-files >>" ]; then
-              echo "pytest-files override is set; skipping full build job."
-              circleci-agent step halt
-            fi
       - get-github-token
       - install-nodejs
       - setup-mongodb
@@ -421,6 +406,49 @@ jobs:
             fi
       - copy-logs-on-failure
       - store-test-artifacts
+  debug-tests:
+    # Run an explicit set of tests against custom openreview-api / openreview-api-v1
+    # branches. Triggered by passing a non-empty `pytest-files` pipeline parameter
+    # from the CircleCI UI; bypasses install-package + build-pr-tests + build.
+    resource_class: large
+    working_directory: ~/openreview-py-repo
+    parameters:
+      python-version:
+        type: string
+    docker:
+      - image: cimg/python:<<parameters.python-version>>
+      - image: cimg/redis:7.2
+      - image: mongo:8.0
+        command: [ --replSet, rs0 ]
+      - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
+        environment:
+          xpack.security.enabled: false
+          transport.host: localhost
+    steps:
+      - checkout
+      - get-github-token
+      - install-nodejs
+      - setup-mongodb
+      - clone-repos
+      - create-directories
+      - install-firefox
+      - start-apis
+      - setup-openreview-web
+      - install-geckodriver
+      - install-pytest
+      - run:
+          name: Run pytest-files
+          environment:
+            PYTHONUNBUFFERED: "1"
+          command: |
+            cd ~/openreview-py-repo
+            PYTEST_FILES="<< pipeline.parameters.pytest-files >>"
+            echo "Running tests from pytest-files parameter: $PYTEST_FILES"
+            pytest $PYTEST_FILES --durations=0 -v -o junit_family=legacy \
+              --junitxml=test-reports/junit-debug.xml \
+              --driver Firefox --driver-path tests/drivers/geckodriver
+      - copy-logs-on-failure
+      - store-test-artifacts
   deploy-dev:
     working_directory: ~/openreview-py-repo
     docker:
@@ -435,6 +463,8 @@ jobs:
 workflows:
   version: 2
   build-deploy:
+    when:
+      equal: [ "", << pipeline.parameters.pytest-files >> ]
     jobs:
       - install-package:
           matrix:
@@ -454,3 +484,9 @@ workflows:
           filters:
             branches:
               only: master
+  debug:
+    unless:
+      equal: [ "", << pipeline.parameters.pytest-files >> ]
+    jobs:
+      - debug-tests:
+          python-version: "3.10"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,6 +374,13 @@ jobs:
           transport.host: localhost
     steps:
       - checkout
+      - run:
+          name: Skip full build when pytest-files override is set
+          command: |
+            if [ -n "<< pipeline.parameters.pytest-files >>" ]; then
+              echo "pytest-files override is set; skipping full build job."
+              circleci-agent step halt
+            fi
       - get-github-token
       - install-nodejs
       - setup-mongodb
@@ -440,8 +447,6 @@ workflows:
       - build:
           requires:
             - build-pr-tests
-          when:
-            equal: [ "", << pipeline.parameters.pytest-files >> ]
           python-version: "3.10"
       - deploy-dev:
           requires:


### PR DESCRIPTION
## Summary
CI infra changes that came out of debugging the recent `Run tests` failures on master. Three independent changes bundled because they share the same investigation and edit the same file:

1. **`pytest-files` pipeline parameter + new `debug` workflow** — lets us trigger CI from the UI against a specific `openreview-api-v2-branch` SHA and run only the tests we care about, for bisection / one-off debug runs.
2. **Raise `openreview-api-v2` Node heap to 4 GiB** — fixes the actual cause of the recent master `Run tests` failures, which were `FATAL ERROR: Reached heap limit / Allocation failed - JavaScript heap out of memory` aborts (exit 134) in the API V2 sidecar.
3. **Cap Elasticsearch heap at 512 MiB** — gives back ~500 MiB to the cgroup budget that already hosts api-v2's 4 GiB heap, the `next build`, mongo, and the test process. Mirrors the analogous change in #3080 for the two pre-existing test jobs and extends it to the new `debug-tests` job so debug runs don't drift from normal CI.

## Why
Job 53467 (parallel run 9, master, 2026-06-10) failed with API V2 V8 OOM at ~2046 MiB / 2070 MiB — Node 22's auto-sized `--max-old-space-size` default on a CircleCI `large` (8 GiB) container. The OOM took `localhost:3001` down mid-test, which surfaced as a misleading `ConnectionError` from `test_LLM_PDF_response_stage`. There was no API regression in `openreview-api/main`; the heap ceiling was the root cause.

Capping ES and bumping api-v2 explicitly removes the auto-sizing surprise and leaves enough cgroup headroom that the cgroup OOM-killer isn't a risk either.

## Changes in `.circleci/config.yml`

- New `pytest-files` pipeline parameter (default `""`).
- New `debug-tests` job that reuses the existing setup commands (clone-repos, install-nodejs, setup-mongodb, install-firefox, start-apis, setup-openreview-web, install-geckodriver, install-pytest) and runs `pytest $PYTEST_FILES ...`.
- Workflow split via workflow-level `when:` / `unless:`:
  - `build-deploy` — runs when `pytest-files` is empty. Unchanged normal CI: `install-package` → `build-pr-tests` (git-diff detection) → `build` → `deploy-dev`.
  - `debug` — runs when `pytest-files` is non-empty. Schedules only `debug-tests`; `install-package`, `build-pr-tests`, and `build` are not scheduled at all.
- `start-apis` command: `NODE_OPTIONS="--max-old-space-size=4096"` on `npm run cleanStart` for openreview-api-v2.
- Elasticsearch sidecar in `build-pr-tests`, `build`, and `debug-tests`: `ES_JAVA_OPTS: "-Xms512m -Xmx512m"`.

## Usage of the debug mode
Trigger Pipeline from the CircleCI UI on the desired `openreview-py` branch with, e.g.:
- `openreview-api-v2-branch` = `<SHA on openreview/openreview-api/main>`
- `pytest-files` = `tests/test_foo.py::test_bar` (space-separated values and pytest selectors both work — the parameter is passed verbatim to pytest)

Only `debug-tests` runs; nothing else is scheduled.

## Verification
- **Pipeline #15791** (`debug` workflow, `pytest-files=tests/test_reviewers_only.py`): green — confirms the workflow split and the heap bump fix the previously OOMing test.
- **Pipeline #15793 rerun** (`build-deploy`, heap bump only): green — full 10-container suite passes.
- **Pipeline #15794 rerun** (`build-deploy`, heap bump + ES cap): green — full suite passes with the ES cap applied.

Each first-attempt failure we hit during verification was a different, pre-existing flaky test (`TokenExpiredError` on container 4, then edge-count `21==11` on container 9), both green on retry — independent of the changes in this PR.

## Coordination with #3080
PR #3080 also adds `ES_JAVA_OPTS` to `build-pr-tests` and `build`. Whichever lands second will need a trivial conflict resolution. #3080 also `@pytest.mark.skip`s `test_LLM_PDF_response_stage`; once this PR's heap bump lands, that skip becomes unnecessary and should be removed in a follow-up.