### PR TITLE
 Ignore `independent-researcher.org` domain in conflict-of-interest computation

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1473,7 +1473,8 @@ def get_all_venues(client):
 def info_function_builder(policy_function):
     def inner(profile, n_years=None, submission_venueid=None):
         common_domains = ['gmail.com', 'qq.com', '126.com', '163.com',
-                    'outlook.com', 'hotmail.com', 'yahoo.com', 'foxmail.com', 'aol.com', 'msn.com', 'ymail.com', 'googlemail.com', 'live.com']
+                    'outlook.com', 'hotmail.com', 'yahoo.com', 'foxmail.com', 'aol.com', 'msn.com', 'ymail.com', 'googlemail.com', 'live.com',
+                    'independent-researcher.org']
         argspec = inspect.getfullargspec(policy_function)
         if 'submission_venueid' in argspec.args:
             result = policy_function(profile, n_years, submission_venueid)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -720,6 +720,84 @@ class TestTools():
         assert len(conflicts) == 1
         assert 'umass.edu' in conflicts
 
+    def test_independent_researcher_conflicts(self):
+
+        ## Two profiles that both declare to be independent researchers should not
+        ## conflict with each other through the independent-researcher.org domain
+        independent1 = openreview.Profile(
+            id='~Independent_One1',
+            content={
+                'emails': ['independent_one@gmail.com'],
+                'history': [{
+                    'institution': {
+                        'domain': 'independent-researcher.org'
+                    }
+                }]
+            }
+        )
+
+        independent2 = openreview.Profile(
+            id='~Independent_Two1',
+            content={
+                'emails': ['independent_two@gmail.com'],
+                'history': [{
+                    'institution': {
+                        'domain': 'independent-researcher.org'
+                    }
+                }]
+            }
+        )
+
+        conflicts = openreview.tools.get_conflicts([independent1], independent2)
+        assert len(conflicts) == 0
+
+        conflicts = openreview.tools.get_conflicts([independent1], independent2, policy='NeurIPS')
+        assert len(conflicts) == 0
+
+        conflicts = openreview.tools.get_conflicts([independent1], independent2, policy='Comprehensive')
+        assert len(conflicts) == 0
+
+        ## A real shared institution domain should still be detected as a conflict
+        independent_and_affiliated = openreview.Profile(
+            id='~Independent_Three1',
+            content={
+                'emails': ['independent_three@gmail.com'],
+                'history': [
+                    {
+                        'institution': {
+                            'domain': 'independent-researcher.org'
+                        }
+                    },
+                    {
+                        'institution': {
+                            'domain': 'cmu.edu'
+                        }
+                    }
+                ]
+            }
+        )
+
+        affiliated = openreview.Profile(
+            id='~Affiliated_One1',
+            content={
+                'emails': ['affiliated_one@gmail.com'],
+                'history': [{
+                    'institution': {
+                        'domain': 'cmu.edu'
+                    }
+                }]
+            }
+        )
+
+        conflicts = openreview.tools.get_conflicts([independent_and_affiliated], affiliated)
+        assert len(conflicts) == 1
+        assert 'cmu.edu' in conflicts
+
+        ## The independent researcher domain should still be ignored even when another
+        ## institution is shared
+        conflicts = openreview.tools.get_conflicts([independent_and_affiliated], independent1)
+        assert len(conflicts) == 0
+
     def test_group(self, client):
 
         assert openreview.tools.get_group(client, '~Super_User1')


### PR DESCRIPTION

## Summary

We introduced the domain `independent-researcher.org` as the institution domain for users who declare themselves as independent researchers in their profile history. Because this is a shared placeholder domain rather than a real shared affiliation, it should **not** create conflicts of interest between users.

This PR ensures the conflict-of-interest computation ignores the `independent-researcher.org` domain, so two independent researchers are no longer flagged as conflicted with each other through their history domain.

## Changes

- **`openreview/tools.py`**: Added `independent-researcher.org` to the `common_domains` list in `info_function_builder`. This list is the single point that every conflict policy (`default`, `NeurIPS`, `Comprehensive`, and custom callables) flows through, so the domain is discarded from the conflict domain set after subdomain expansion — across all policies.

- **`tests/test_tools.py`**: Added `test_independent_researcher_conflicts` covering:
  - Two independent researchers (both with `independent-researcher.org` in history) produce **no conflict**, under the `default`, `NeurIPS`, and `Comprehensive` policies.
  - A genuinely shared institution domain (e.g. `cmu.edu`) is **still** detected as a conflict, even when one profile also declares `independent-researcher.org`.
  - The independent-researcher domain remains ignored even when present alongside another institution.

## Notes

`subdomains('independent-researcher.org')` returns just `['independent-researcher.org']` (since `.org` is a TLD), so discarding that single entry fully removes it from the conflict domain set without affecting any other domain.

## Testing

```
tests/test_tools.py::TestTools::test_independent_researcher_conflicts PASSED
============================== 1 passed in 0.10s ===============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
