### PR TITLE
Add client method to delete a scheduled date-process job

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -256,6 +256,11 @@ class OpenReviewClient(object):
         response = self.session.post(self.baseurl + '/invitations/dateprocesses', json = { 'ids': [invitation_id]}, headers = self.headers)
         response = self.__handle_response(response)
         return response.json()
+
+    def delete_invitation_date_process_scheduler(self, job_id):
+        response = self.session.delete(self.baseurl + '/jobs/queues/pyDateProcessQueueMQ/schedulers/' + job_id.replace('/', '%2F'), headers = self.headers)
+        response = self.__handle_response(response)
+        return response.json()
     
     ## PUBLIC FUNCTIONS
     def impersonate(self, group_id):


### PR DESCRIPTION
### Summary
Adds `delete_invitation_date_process_scheduler(job_id)` to the V2 client
(`openreview.api.OpenReviewClient`), exposing the API endpoint that removes a
scheduler from the `pyDateProcessQueueMQ` queue.

### Motivation
Previously this could only be done with a raw request:

```bash
curl -X DELETE https://api2.openreview.net/jobs/queues/pyDateProcessQueueMQ/schedulers/<job_id> \
  -H "Authorization: Bearer <super user token>"
