### PR TITLE
ARR emergency-load optimization + venue rename cleanup

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -867,15 +867,20 @@ class OpenReviewClient(object):
 
         response = self.__handle_response(response)
 
-        ## The old venue id no longer exists after the rename, make sure it is not left
-        ## behind in the active_venues/venues groups as a stale member.
+        ## The old venue id no longer exists after the rename. Replace it with the new venue
+        ## id in the active_venues/venues groups so the renamed venue stays registered and no
+        ## stale member is left behind (which would break jobs that iterate these groups).
         for group_id in ['active_venues', 'venues']:
             try:
-                self.remove_members_from_group(group_id, old_venue_id)
+                group = self.get_group(group_id)
             except OpenReviewException as e:
                 error = e.args[0]
-                if error.get('name') != 'NotFoundError' and not error.get('message', '').startswith('Group Not Found'):
-                    raise e
+                if error.get('name') == 'NotFoundError' or error.get('message', '').startswith('Group Not Found'):
+                    continue
+                raise e
+            if old_venue_id in (group.members or []):
+                self.remove_members_from_group(group_id, old_venue_id)
+                self.add_members_to_group(group_id, new_venue_id)
 
         return response.json()
 

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -866,6 +866,17 @@ class OpenReviewClient(object):
 
 
         response = self.__handle_response(response)
+
+        ## The old venue id no longer exists after the rename, make sure it is not left
+        ## behind in the active_venues/venues groups as a stale member.
+        for group_id in ['active_venues', 'venues']:
+            try:
+                self.remove_members_from_group(group_id, old_venue_id)
+            except OpenReviewException as e:
+                error = e.args[0]
+                if error.get('name') != 'NotFoundError' and not error.get('message', '').startswith('Group Not Found'):
+                    raise e
+
         return response.json()
 
     def put_attachment(self, file_path, invitation, name):

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -867,6 +867,21 @@ class OpenReviewClient(object):
 
         response = self.__handle_response(response)
 
+        ## The rename is processed asynchronously through the internalQueueMQStatus queue.
+        ## Wait for it to finish before doing any post-processing so we don't race with the
+        ## server-side rename (which would otherwise leave the venue in a half-renamed state).
+        wait_time = 0.5
+        max_iterations = int(600 / wait_time)
+        for _ in range(max_iterations):
+            jobs = self.get_jobs_status()
+            job_count = sum(
+                job.get('waiting', 0) + job.get('active', 0) + job.get('delayed', 0)
+                for job_name, job in jobs.items() if job_name == 'internalQueueMQStatus'
+            )
+            if job_count == 0 and tools.get_group(self, new_venue_id) is not None:
+                break
+            time.sleep(wait_time)
+
         ## Make sure the parent groups for the new venue id exist (e.g. ICML.org and
         ## ICML.org/2023 for ICML.org/2023/Conference), creating any that are missing the
         ## same way the venue group builder does.

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -866,21 +866,28 @@ class OpenReviewClient(object):
 
 
         response = self.__handle_response(response)
+        result = response.json()
 
-        ## The rename is processed asynchronously through the internalQueueMQStatus queue.
-        ## Wait for it to finish before doing any post-processing so we don't race with the
-        ## server-side rename (which would otherwise leave the venue in a half-renamed state).
-        wait_time = 0.5
-        max_iterations = int(600 / wait_time)
-        for _ in range(max_iterations):
-            jobs = self.get_jobs_status()
-            job_count = sum(
-                job.get('waiting', 0) + job.get('active', 0) + job.get('delayed', 0)
-                for job_name, job in jobs.items() if job_name == 'internalQueueMQStatus'
-            )
-            if job_count == 0 and tools.get_group(self, new_venue_id) is not None:
-                break
-            time.sleep(wait_time)
+        ## The rename is processed asynchronously. Wait for the specific rename job to finish
+        ## (its id is returned in the response) before doing any post-processing, so we don't
+        ## race with the server-side rename (which would leave the venue half-renamed).
+        job_id = result.get('jobId')
+        if job_id:
+            wait_time = 0.5
+            max_iterations = int(600 / wait_time)
+            for _ in range(max_iterations):
+                try:
+                    job = self.get_job('internalQueueMQ', job_id)
+                except OpenReviewException as e:
+                    error = e.args[0] if e.args else {}
+                    message = error.get('message', '') if isinstance(error, dict) else str(error)
+                    ## the job finished and was removed from the queue
+                    if error.get('name') == 'NotFoundError' or 'not found' in message.lower():
+                        break
+                    raise
+                if not job or job.get('finishedOn'):
+                    break
+                time.sleep(wait_time)
 
         ## Make sure the parent groups for the new venue id exist (e.g. ICML.org and
         ## ICML.org/2023 for ICML.org/2023/Conference), creating any that are missing the
@@ -3006,6 +3013,22 @@ class OpenReviewClient(object):
         """
 
         response = self.session.get(self.jobs_status, headers=self.headers)
+        response = self.__handle_response(response)
+        return response.json()
+
+    def get_job(self, queue_name, job_id):
+        """
+        **Only for Super User**. Retrieves a single job from a queue by id.
+
+        :param queue_name: Name of the queue (e.g. ``internalQueueMQ``)
+        :type queue_name: str
+        :param job_id: Id of the job
+        :type job_id: str
+
+        :return: Job object
+        :rtype: dict
+        """
+        response = self.session.get(f'{self.baseurl}/jobs/queues/{queue_name}/{job_id}', headers=self.headers)
         response = self.__handle_response(response)
         return response.json()
 

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -867,6 +867,30 @@ class OpenReviewClient(object):
 
         response = self.__handle_response(response)
 
+        ## Make sure the parent groups for the new venue id exist (e.g. ICML.org and
+        ## ICML.org/2023 for ICML.org/2023/Conference), creating any that are missing the
+        ## same way the venue group builder does.
+        path_components = new_venue_id.split('/')
+        paths = ['/'.join(path_components[0:index + 1]) for index in range(len(path_components))]
+        for path in paths:
+            if tools.get_group(self, path) is None:
+                self.post_group_edit(
+                    invitation = 'openreview.net/-/Edit',
+                    readers = ['everyone'],
+                    writers = ['~Super_User1'],
+                    signatures = ['~Super_User1'],
+                    group = Group(
+                        id = path,
+                        readers = ['everyone'],
+                        nonreaders = [],
+                        writers = [path],
+                        signatories = [path],
+                        signatures = ['~Super_User1'],
+                        members = [],
+                        details = { 'writable': True }
+                    )
+                )
+
         ## The old venue id no longer exists after the rename. Replace it with the new venue
         ## id in the active_venues/venues groups so the renamed venue stays registered and no
         ## stale member is left behind (which would break jobs that iterate these groups).

--- a/openreview/arr/process/emergency_load_process.py
+++ b/openreview/arr/process/emergency_load_process.py
@@ -147,20 +147,24 @@ def process(client, edit, invitation):
                 review_counts[review.forum] = 0
             review_counts[review.forum] += 1
 
-        eligible_submission_ids = []
+        eligible_submission_ids = set()
         for submission in submissions:
             if review_counts.get(submission.id, 0) < 3:
-                eligible_submission_ids.append(submission.id)
+                eligible_submission_ids.add(submission.id)
+
+        ## Get all the user's aggregate score edges in a single call and index them by submission
+        aggregate_score_edges_by_submission = {}
+        for edge in client.get_all_edges(
+            invitation=f"{role}/-/Aggregate_Score",
+            label=deployed_label,
+            tail=user,
+            domain=venue_id
+        ):
+            aggregate_score_edges_by_submission.setdefault(edge.head, []).append(edge)
 
         aggregate_score_edges = []
         for submission_id in eligible_submission_ids:
-            aggregate_score_edges.extend(client.get_all_edges(
-                invitation=f"{role}/-/Aggregate_Score",
-                label=deployed_label,
-                head=submission_id,
-                tail=user,
-                domain=venue_id
-            ))
+            aggregate_score_edges.extend(aggregate_score_edges_by_submission.get(submission_id, []))
 
         edges_to_post = []
         for edge in aggregate_score_edges:

--- a/openreview/arr/process/emergency_load_process.py
+++ b/openreview/arr/process/emergency_load_process.py
@@ -147,10 +147,10 @@ def process(client, edit, invitation):
                 review_counts[review.forum] = 0
             review_counts[review.forum] += 1
 
-        eligible_submission_ids = set()
+        eligible_submission_ids = []
         for submission in submissions:
             if review_counts.get(submission.id, 0) < 3:
-                eligible_submission_ids.add(submission.id)
+                eligible_submission_ids.append(submission.id)
 
         ## Get all the user's aggregate score edges in a single call and index them by submission
         aggregate_score_edges_by_submission = {}

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -2388,8 +2388,11 @@ OpenReview Team'''
 
         for venue_id in active_venues:
 
-            venue_group = client.get_group(venue_id)
-            
+            venue_group = openreview.tools.get_group(client, venue_id)
+
+            if venue_group is None:
+                continue
+
             if hasattr(venue_group, 'domain') and venue_group.content and 'journal_request_id' not in venue_group.content:
                 
                 print(f'Check active venue {venue_group.id}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,19 @@ class Helpers:
         assert not [l for l in super_client.get_process_logs(status='error') if l['executedOn'] == 'openreview-api-1']
 
     @staticmethod
+    def await_venue_processes(super_client, venue_id, timeout=300):
+        # Wait until no process function for this specific venue is running, so renaming the venue
+        # is not rejected with a 409. Filtering by the venue prefix means we only wait on this
+        # venue's jobs and ignore active/scheduled jobs belonging to other venues from previous tests.
+        wait_time = 0.5
+        max_iterations = int(timeout / wait_time)
+        for _ in range(max_iterations):
+            running = super_client.get_process_logs(invitation=f'{venue_id}/.*', status='running')
+            if not running:
+                break
+            time.sleep(wait_time)
+
+    @staticmethod
     def await_queue_edit(super_client, edit_id=None, invitation=None, count=1, error=False, process_index=0, timeout=300):
         super_client = Helpers.get_user('openreview.net')
         expected_status = 'error' if error else 'ok'

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -6559,6 +6559,9 @@ url={https://openreview.net/forum?id='''
 
         request_form=client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
 
+        # the server rejects the rename while a process job for the venue is active, so wait for
+        # this venue's running processes to finish first (jobs from other venues are ignored)
+        helpers.await_venue_processes(openreview_client, 'ICML.cc/2023/Conference')
         openreview_client.rename_venue('ICML.cc/2023/Conference', 'ICML.org/2023/Conference', request_form.id)
 
         assert openreview.tools.get_group(openreview_client, 'ICML.org/2023/Conference')

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -6597,13 +6597,9 @@ url={https://openreview.net/forum?id='''
         assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Official_Review')
         assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Meta_Review')
 
-        assert 'ICML.cc/2023/Conference' in openreview_client.get_group('venues').members        
-        assert 'ICML.cc/2023/Conference' in openreview_client.get_group('active_venues').members
+        ## the rename replaces the old venue id with the new one in the venues/active_venues groups
+        assert 'ICML.cc/2023/Conference' not in openreview_client.get_group('venues').members
+        assert 'ICML.cc/2023/Conference' not in openreview_client.get_group('active_venues').members
 
-        openreview_client.remove_members_from_group('venues', 'ICML.cc/2023/Conference')
-        openreview_client.remove_members_from_group('active_venues', 'ICML.cc/2023/Conference')
-        openreview_client.add_members_to_group('venues', 'ICML.org/2023/Conference')
-        openreview_client.add_members_to_group('active_venues', 'ICML.org/2023/Conference')
-        
         assert 'ICML.org/2023/Conference' in openreview_client.get_group('venues').members
-        assert 'ICML.org/2023/Conference' in openreview_client.get_group('active_venues').members        
+        assert 'ICML.org/2023/Conference' in openreview_client.get_group('active_venues').members

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -6561,8 +6561,6 @@ url={https://openreview.net/forum?id='''
 
         openreview_client.rename_venue('ICML.cc/2023/Conference', 'ICML.org/2023/Conference', request_form.id)
 
-        helpers.await_queue(openreview_client, queue_names=['internalQueueMQStatus'])
-
         assert openreview.tools.get_group(openreview_client, 'ICML.org/2023/Conference')
         assert openreview.tools.get_group(openreview_client, 'ICML.org/2023/Conference/Authors')
         assert openreview.tools.get_group(openreview_client, 'ICML.org/2023/Conference/Authors/Accepted')

--- a/tests/test_icml_conference.py
+++ b/tests/test_icml_conference.py
@@ -6597,6 +6597,10 @@ url={https://openreview.net/forum?id='''
         assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Official_Review')
         assert not openreview.tools.get_invitation(openreview_client, 'ICML.cc/2023/Conference/-/Meta_Review')
 
+        ## the parent groups for the new venue id must exist
+        assert openreview.tools.get_group(openreview_client, 'ICML.org')
+        assert openreview.tools.get_group(openreview_client, 'ICML.org/2023')
+
         ## the rename replaces the old venue id with the new one in the venues/active_venues groups
         assert 'ICML.cc/2023/Conference' not in openreview_client.get_group('venues').members
         assert 'ICML.cc/2023/Conference' not in openreview_client.get_group('active_venues').members

--- a/tests/test_venue_deployment.py
+++ b/tests/test_venue_deployment.py
@@ -388,7 +388,6 @@ class TestVenueDeployment():
 
         # 2. rename the venue to a new domain
         openreview_client.rename_venue(venue_id, renamed_venue_id, request_note.id)
-        helpers.await_queue(openreview_client, queue_names=['internalQueueMQStatus'])
 
         assert openreview.tools.get_group(openreview_client, renamed_venue_id)
 

--- a/tests/test_venue_deployment.py
+++ b/tests/test_venue_deployment.py
@@ -392,9 +392,11 @@ class TestVenueDeployment():
 
         assert openreview.tools.get_group(openreview_client, renamed_venue_id)
 
-        # the old venue id must not be left behind in the active_venues/venues groups
+        # the rename replaces the old venue id with the new one in the active_venues/venues groups
         assert venue_id not in openreview_client.get_group('active_venues').members
         assert venue_id not in openreview_client.get_group('venues').members
+        assert renamed_venue_id in openreview_client.get_group('active_venues').members
+        assert renamed_venue_id in openreview_client.get_group('venues').members
 
         # 3. the date processes must be re-scheduled under the new domain
         helpers.await_queue_edit(openreview_client, edit_id=f'{renamed_venue_id}/-/Withdrawal-0-1', count=1)

--- a/tests/test_venue_deployment.py
+++ b/tests/test_venue_deployment.py
@@ -387,6 +387,10 @@ class TestVenueDeployment():
         ]
 
         # 2. rename the venue to a new domain
+        # the server rejects the rename while a process job for the venue is active, so wait for
+        # this venue's running processes to finish first (the deliberately-delayed Withdrawal-0-0
+        # cdate job stays 'delayed', not 'running', so it does not block this wait)
+        helpers.await_venue_processes(openreview_client, venue_id)
         openreview_client.rename_venue(venue_id, renamed_venue_id, request_note.id)
 
         assert openreview.tools.get_group(openreview_client, renamed_venue_id)

--- a/tests/test_venue_deployment.py
+++ b/tests/test_venue_deployment.py
@@ -392,6 +392,10 @@ class TestVenueDeployment():
 
         assert openreview.tools.get_group(openreview_client, renamed_venue_id)
 
+        # the old venue id must not be left behind in the active_venues/venues groups
+        assert venue_id not in openreview_client.get_group('active_venues').members
+        assert venue_id not in openreview_client.get_group('venues').members
+
         # 3. the date processes must be re-scheduled under the new domain
         helpers.await_queue_edit(openreview_client, edit_id=f'{renamed_venue_id}/-/Withdrawal-0-1', count=1)
 


### PR DESCRIPTION


## Summary

This branch contains two related improvements to venue/ARR management:

1. **Performance:** removes a per-submission API loop in the ARR emergency load process (which took ~8 minutes to run).
2. **Correctness:** makes a venue domain rename fully clean up after itself (waits for the rename job to finish, fixes `active_venues`/`venues` membership, creates parent groups) and makes `check_new_profiles` resilient to deleted venue groups — fixing a `Group Not Found` 404 that broke unrelated tests on CI.

---

## 1. Optimize emergency score edge creation (`openreview/arr/process/emergency_load_process.py`)

### Problem
When creating emergency score edges, the process iterated over every eligible submission (those with fewer than 3 reviews) and made **one `get_all_edges` API call per submission**:

```python
aggregate_score_edges = []
for submission_id in eligible_submission_ids:
    aggregate_score_edges.extend(client.get_all_edges(
        invitation=f"{role}/-/Aggregate_Score",
        label=deployed_label,
        head=submission_id,
        tail=user,
        domain=venue_id
    ))
```

In venues with many submissions under the 3-review threshold, this resulted in hundreds/thousands of sequential API calls — the process took ~8 minutes.

### Change
Fetch all of the user's `Aggregate_Score` edges in a **single** API call (filtered only by `tail=user`), index them by `edge.head`, and look up eligible submissions in memory:

```python
## Get all the user's aggregate score edges in a single call and index them by submission
aggregate_score_edges_by_submission = {}
for edge in client.get_all_edges(
    invitation=f"{role}/-/Aggregate_Score",
    label=deployed_label,
    tail=user,
    domain=venue_id
):
    aggregate_score_edges_by_submission.setdefault(edge.head, []).append(edge)

aggregate_score_edges = []
for submission_id in eligible_submission_ids:
    aggregate_score_edges.extend(aggregate_score_edges_by_submission.get(submission_id, []))
```

The number of `Aggregate_Score` API calls is now **constant (1)** regardless of how many submissions are eligible. The resulting `aggregate_score_edges` — and the downstream `post_bulk_edges` behavior — is functionally identical to before.

---

## 2. Venue rename: wait for the rename job, then clean up (`openreview/api/client.py`)

### `rename_venue`
After issuing the rename, `rename_venue` now:

1. **Waits for the specific rename job to finish.** The rename is processed asynchronously; the request returns a `jobId`. The client polls that single job (`GET /jobs/queues/internalQueueMQ/<jobId>`) until it reports `finishedOn` (or 404s once it ages out of the retained window), instead of polling the whole queue. This avoids racing the in-flight rename (which would otherwise leave the venue half-renamed, e.g. the old group not deleted), and is unaffected by unrelated jobs.
2. **Creates missing parent groups** for the new venue id (e.g. `ICML.org` and `ICML.org/2023` for `ICML.org/2023/Conference`), mirroring the venue group builder.
3. **Replaces the old venue id with the new one** in the `active_venues` and `venues` groups (removes the old, adds the new), so the renamed venue stays registered and no stale member is left behind.

### `get_job`
Added a `get_job(queue_name, job_id)` client method wrapping `GET /jobs/queues/<queue_name>/<jobId>` (super user only), used by `rename_venue` to wait on the rename job.

## 3. Make `check_new_profiles` resilient to deleted venues (`openreview/venue/venue.py`)

`check_new_profiles` iterates the members of `active_venues` and fetched each with `client.get_group(venue_id)`, which raised `Group Not Found` (404) if a member's group had been deleted — aborting the whole job. It now uses `openreview.tools.get_group` and skips venues whose group no longer exists:

```python
venue_group = openreview.tools.get_group(client, venue_id)

if venue_group is None:
    continue
```

This was the root cause of an ICML test failure on CI: a stale `active_venues` member (a venue left behind by the rename test) caused a 404. Change #2 prevents the stale member in the first place; this change is the defensive safety net for any other path that deletes a venue group.

---

## Tests

The server rejects a rename with a 409 while a process job for the venue is **active**. The venue deployment + date-process cascade spawns such jobs, so a rename issued while one is mid-execution randomly 409s (flaky CI).

- **`tests/conftest.py`** — added `await_venue_processes(super_client, venue_id)`, which waits until no process function **for that specific venue** is `running` (`get_process_logs(invitation=f'{venue_id}/.*', status='running')`). It only waits on the venue's own jobs, so active/scheduled jobs from other venues (and this venue's deliberately-delayed cdate, which is `delayed` not `running`) don't block it.
- **`tests/test_venue_deployment.py`** / **`tests/test_icml_conference.py`** — call `helpers.await_venue_processes(...)` immediately before each `rename_venue`. The explicit `await_queue(['internalQueueMQStatus'])` after the rename was removed (the wait now lives inside `rename_venue`). `test_rename_domain` also asserts parent groups exist and the old→new replacement in `active_venues`/`venues`.

All run via Docker:
- `tests/test_venue_deployment.py` — passed, including `test_rename_reschedules_date_processes`.
- `tests/test_icml_conference.py` — passed, including `test_rename_domain`.
