### PR TITLE
Feat/decision emails

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -1466,6 +1466,8 @@ class DecisionStage(object):
     def __init__(self, name = 'Decision', options = None, accept_options = None, start_date = None, due_date = None, public = False, release_to_authors = False, release_to_reviewers = False, release_to_area_chairs = False, email_authors = False, additional_fields = {}, decisions_file=None, content=None):
         if not options:
             options = ['Accept (Oral)', 'Accept (Poster)', 'Reject']
+        if not accept_options:
+            accept_options = [option for option in options if 'accept' in option.lower()]
         self.options = options
         self.accept_options = accept_options
         self.start_date = start_date

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -2173,40 +2173,43 @@ def should_match_invitation_source(client, invitation, submission, note=None, do
             if is_accept_decision(decision_value, accept_options) != with_decision_accept:
                 return False
 
-    content_keys = invitation.edit.get('content', {}).keys()
-    
-    if 'withdrawalId' in content_keys:
-        return False
-    
-    if 'deskRejectionId' in content_keys:
-        return False
-    
-    if 'noteReaders' in content_keys:
-        return False
-    
-    if content_keys and 'noteId' not in content_keys:
-        return False
-    
-    if content_keys and 'noteNumber' not in content_keys:
-        return False
+    if invitation.edit:
+        content_keys = invitation.edit.get('content', {}).keys()
 
-    if note and 'replyto' not in content_keys:
-        return False
+        if 'withdrawalId' in content_keys:
+            return False
+
+        if 'deskRejectionId' in content_keys:
+            return False
+
+        if 'noteReaders' in content_keys:
+            return False
+
+        if content_keys and 'noteId' not in content_keys:
+            return False
+
+        if content_keys and 'noteNumber' not in content_keys:
+            return False
+
+        if note and 'replyto' not in content_keys:
+            return False
     
     return True
 
 def is_forum_invitation(invitation):
 
-    content_keys = invitation.edit.get('content', {}).keys()
-    
-    if 'noteId' not in content_keys:
-        return False
-    
-    if 'noteNumber' not in content_keys:
-        return False
-    
-    if 'replyto' in content_keys:
-        return False
+    if invitation.edit:
+
+        content_keys = invitation.edit.get('content', {}).keys()
+
+        if 'noteId' not in content_keys:
+            return False
+
+        if 'noteNumber' not in content_keys:
+            return False
+
+        if 'replyto' in content_keys:
+            return False
 
     return True    
 

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2207,7 +2207,7 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
                     'value': decision_stage.options
                 },
                 'accept_decision_options': {
-                    'value': ['Accept (Oral)', 'Accept (Poster)']
+                    'value': decision_stage.accept_options if decision_stage.accept_options else ['Accept (Oral)', 'Accept (Poster)']
                 },
                 'source': {
                     'value': {

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2207,7 +2207,7 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
                     'value': decision_stage.options
                 },
                 'accept_decision_options': {
-                    'value': decision_stage.accept_options if decision_stage.accept_options else ['Accept (Oral)', 'Accept (Poster)']
+                    'value': decision_stage.accept_options if decision_stage.accept_options else [option for option in decision_stage.options if 'accept' in option.lower()]
                 },
                 'source': {
                     'value': {

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -2215,7 +2215,7 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
                     'value': decision_stage.options
                 },
                 'accept_decision_options': {
-                    'value': decision_stage.accept_options if decision_stage.accept_options else [option for option in decision_stage.options if 'accept' in option.lower()]
+                    'value': decision_stage.accept_options
                 },
                 'source': {
                     'value': {

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1460,7 +1460,7 @@ class EditInvitationsBuilder(object):
             }
 
         invitation_content = {
-            'email_subject': {
+            'subject': {
                 'value': '${4/content/email_subject/value}'
             }
         }
@@ -1473,7 +1473,7 @@ class EditInvitationsBuilder(object):
                 'value': '${4/content/reject_email_content/value}'
             }
         elif is_review_invitation:
-            invitation_content['email_content'] = {
+            invitation_content['message'] = {
                 'value': '${4/content/email_content/value}'
             }
 

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1409,10 +1409,73 @@ class EditInvitationsBuilder(object):
         self.save_invitation(invitation, replacement=True)
         return invitation
 
-    def set_edit_email_template_invitation(self, super_invitation_id):
+    def set_edit_email_template_invitation(self, super_invitation_id, is_review_invitation=False):
 
         venue_id = self.venue_id
-        invitation_id = super_invitation_id + '/Message'
+        invitation_id = super_invitation_id + '/Templates'
+
+        edit_content = {
+            'email_subject': {
+                'description': 'The subject of the email to be sent to authors.  Make sure not to remove the parenthesized tokens.',
+                'value': {
+                    'param': {
+                        'type': 'string',
+                        'regex': '.+',
+                    }
+                }
+            }
+        }
+
+        if not is_review_invitation:
+            edit_content['accept_email_content'] = {
+                'description': 'The content of the email to be sent to authors for accepted submissions.  Make sure not to remove the parenthesized tokens.',
+                'value': {
+                    'param': {
+                        'type': 'string',
+                        'maxLength': 100000,
+                        'input': 'textarea'
+                    }
+                }
+            }
+            edit_content['reject_email_content'] = {
+                'description': 'The content of the email to be sent to authors for rejected submissions.  Make sure not to remove the parenthesized tokens.',
+                'value': {
+                    'param': {
+                        'type': 'string',
+                        'maxLength': 100000,
+                        'input': 'textarea'
+                    }
+                }
+            }
+        elif is_review_invitation:
+            edit_content['email_content'] = {
+                'description': 'The content of the email to be sent to authors.  Make sure not to remove the parenthesized tokens.',
+                'value': {
+                    'param': {
+                        'type': 'string',
+                        'maxLength': 100000,
+                        'input': 'textarea'
+                    }
+                }
+            }
+
+        invitation_content = {
+            'email_subject': {
+                'value': '${4/content/email_subject/value}'
+            }
+        }
+
+        if not is_review_invitation:
+            invitation_content['accept_message'] = {
+                'value': '${4/content/accept_email_content/value}'
+            }
+            invitation_content['reject_message'] = {
+                'value': '${4/content/reject_email_content/value}'
+            }
+        elif is_review_invitation:
+            invitation_content['email_content'] = {
+                'value': '${4/content/email_content/value}'
+            }
 
         invitation = Invitation(
             id = invitation_id,
@@ -1421,41 +1484,14 @@ class EditInvitationsBuilder(object):
             readers = [venue_id],
             writers = [venue_id],
             edit = {
-                'content': {
-                    'email_subject': {
-                        'description': 'The subject of the email to be sent to authors.  Make sure not to remove the parenthesized tokens.',
-                        'value': {
-                            'param': {
-                                'type': 'string',
-                                'regex': '.+',
-                            }
-                        }
-                    },
-                    'email_content': {
-                        'description': 'The content of the email to be sent to authors.  Make sure not to remove the parenthesized tokens.',
-                        'value': {
-                            'param': {
-                                'type': 'string',
-                                'maxLength': 100000,
-                                'input': 'textarea'
-                            }
-                        }
-                    }
-                },
+                'content': edit_content,
                 'signatures': [self.get_content_value('program_chairs_id', f'{venue_id}/Program_Chairs')],
                 'readers': [venue_id],
                 'writers': [venue_id],
                 'invitation': {
                     'id': super_invitation_id,
                     'signatures': [venue_id],
-                    'content': {
-                        'subject': {
-                            'value': '${4/content/email_subject/value}'
-                        },
-                        'message': {
-                            'value': '${4/content/email_content/value}'
-                        }
-                    }
+                    'content': invitation_content
                 }
             }
         )

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1436,32 +1436,8 @@ class EditInvitationsBuilder(object):
                         'regex': '.+',
                     }
                 }
-            }
-        }
-
-        if not is_review_invitation:
-            edit_content['accept_email_content'] = {
-                'description': 'The content of the email to be sent to authors for accepted submissions.  Make sure not to remove the parenthesized tokens.',
-                'value': {
-                    'param': {
-                        'type': 'string',
-                        'maxLength': 100000,
-                        'input': 'textarea'
-                    }
-                }
-            }
-            edit_content['reject_email_content'] = {
-                'description': 'The content of the email to be sent to authors for rejected submissions.  Make sure not to remove the parenthesized tokens.',
-                'value': {
-                    'param': {
-                        'type': 'string',
-                        'maxLength': 100000,
-                        'input': 'textarea'
-                    }
-                }
-            }
-        elif is_review_invitation:
-            edit_content['email_content'] = {
+            },
+            'email_content': {
                 'description': 'The content of the email to be sent to authors.  Make sure not to remove the parenthesized tokens.',
                 'value': {
                     'param': {
@@ -1471,24 +1447,7 @@ class EditInvitationsBuilder(object):
                     }
                 }
             }
-
-        invitation_content = {
-            'subject': {
-                'value': '${4/content/email_subject/value}'
-            }
         }
-
-        if not is_review_invitation:
-            invitation_content['accept_message'] = {
-                'value': '${4/content/accept_email_content/value}'
-            }
-            invitation_content['reject_message'] = {
-                'value': '${4/content/reject_email_content/value}'
-            }
-        elif is_review_invitation:
-            invitation_content['message'] = {
-                'value': '${4/content/email_content/value}'
-            }
 
         invitation = Invitation(
             id = invitation_id,
@@ -1504,7 +1463,14 @@ class EditInvitationsBuilder(object):
                 'invitation': {
                     'id': super_invitation_id,
                     'signatures': [venue_id],
-                    'content': invitation_content
+                    'content': {
+                        'subject': {
+                            'value': '${4/content/email_subject/value}'
+                        },
+                        'message': {
+                            'value': '${4/content/email_content/value}'
+                        }
+                    }
                 }
             }
         )

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1422,7 +1422,7 @@ class EditInvitationsBuilder(object):
         self.save_invitation(invitation, replacement=True)
         return invitation
 
-    def set_edit_email_template_invitation(self, super_invitation_id, is_review_invitation=False):
+    def set_edit_email_template_invitation(self, super_invitation_id):
 
         venue_id = self.venue_id
         invitation_id = super_invitation_id + '/Templates'

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1429,7 +1429,7 @@ class EditInvitationsBuilder(object):
 
         edit_content = {
             'email_subject': {
-                'description': 'The subject of the email to be sent to authors.  Make sure not to remove the parenthesized tokens.',
+                'description': 'The subject of the email to be sent to authors. Make sure not to remove the parenthesized tokens. If an email with this subject has already been sent, it will be skipped — to re-send emails for this decision option, change the subject.',
                 'value': {
                     'param': {
                         'type': 'string',

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1175,8 +1175,8 @@ class EditInvitationsBuilder(object):
                         'value': {
                             'param': {
                                 'type': 'string[]',
-                                'regex': '^[^,;:\/]{1,250}$',
-                                'mismatchError': 'can not contain the following characters: ; : / or ,'
+                                'regex': '^[\w ()]+$',
+                                'mismatchError': 'can only contain letters, numbers, spaces, underscores and parentheses'
                             }
                         }
                     },
@@ -1185,8 +1185,8 @@ class EditInvitationsBuilder(object):
                         'value': {
                             'param': {
                                 'type': 'string[]',
-                                'regex': '^[^,;:\/]{1,250}$',
-                                'mismatchError': 'can not contain the following characters: ; : / or ,'
+                                'regex': '^[\w ()]+$',
+                                'mismatchError': 'can only contain letters, numbers, spaces, underscores and parentheses'
                             }
                         }
                     }

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1171,11 +1171,12 @@ class EditInvitationsBuilder(object):
             edit = {
                 'content': {
                     'decision_options': {
-                        'description': 'List all decision options. Provide comma separated values, e.g. "Accept (Best Paper), Invite to Archive, Reject". Default options are: "Accept (Oral)", "Accept (Poster)", "Reject"',
+                        'description': 'List all decision options. Provide comma separated values, e.g. "Accept (Best Paper), Invite to Archive, Reject". Default options are: "Accept", "Reject"',
                         'value': {
                             'param': {
                                 'type': 'string[]',
-                                'regex': '.+',
+                                'regex': '^[^,;:\/]{1,250}$',
+                                'mismatchError': 'can not contain the following characters: ; : / or ,'
                             }
                         }
                     },
@@ -1184,7 +1185,8 @@ class EditInvitationsBuilder(object):
                         'value': {
                             'param': {
                                 'type': 'string[]',
-                                'regex': '.+',
+                                'regex': '^[^,;:\/]{1,250}$',
+                                'mismatchError': 'can not contain the following characters: ; : / or ,'
                             }
                         }
                     }

--- a/openreview/workflows/process/email_decisions_process.py
+++ b/openreview/workflows/process/email_decisions_process.py
@@ -56,33 +56,36 @@ def process(client, invitation):
             submission_number=submission.number,
             submission_title=submission.content['title']['value']
         )
-        decisions = [openreview.api.Note.from_json(reply) for reply in submission.details['directReplies'] if f'{venue_id}/{submission_name}{submission.number}/-/{decision_name}' in reply['invitations']]
-        if decisions:
-            formatted_decision = ''
-            decision = decisions[0]
-            for key in fields_to_include:
-                value = decision.content.get(key, {}).get('value')
-                if value:
-                    formatted_decision+=f'''**{key}**: {value}\n'''
 
-            decision_value = decision.content.get(decision_field_name, {}).get('value')
+        # if email with this subject has already been sent, skip sending email
+        if not client.get_messages(subject=subject):
+            decisions = [openreview.api.Note.from_json(reply) for reply in submission.details['directReplies'] if f'{venue_id}/{submission_name}{submission.number}/-/{decision_name}' in reply['invitations']]
+            if decisions:
+                formatted_decision = ''
+                decision = decisions[0]
+                for key in fields_to_include:
+                    value = decision.content.get(key, {}).get('value')
+                    if value:
+                        formatted_decision+=f'''**{key}**: {value}\n'''
 
-            # if the decision matches, send email. ## To-do: support this in the submission source instead
-            if decision_value == decision_option:
-                message = email_content.format(
-                    submission_number=submission.number,
-                    submission_title=submission.content['title']['value'],
-                    formatted_decision=formatted_decision,
-                    submission_forum=submission.id
-                )
+                decision_value = decision.content.get(decision_field_name, {}).get('value')
 
-                client.post_message(
-                    subject=subject,
-                    recipients=[f'{venue_id}/{submission_name}{submission.number}/{authors_name}'],
-                    message=message,
-                    invitation=invitation.id,
-                    replyTo=contact_email
-                )
+                # if the decision matches, send email. ## To-do: support this in the submission source instead
+                if decision_value == decision_option:
+                    message = email_content.format(
+                        submission_number=submission.number,
+                        submission_title=submission.content['title']['value'],
+                        formatted_decision=formatted_decision,
+                        submission_forum=submission.id
+                    )
+
+                    client.post_message(
+                        subject=subject,
+                        recipients=[f'{venue_id}/{submission_name}{submission.number}/{authors_name}'],
+                        message=message,
+                        invitation=invitation.id,
+                        replyTo=contact_email
+                    )
 
     openreview.tools.concurrent_requests(send_decision_email, active_submissions)
 

--- a/openreview/workflows/process/email_decisions_process.py
+++ b/openreview/workflows/process/email_decisions_process.py
@@ -20,15 +20,13 @@ def process(client, invitation):
     support_user = invitation.invitations[0].split('Template')[0] + 'Support'
 
     email_subject = invitation.get_content_value('subject')
-    accept_email_content = invitation.get_content_value('accept_message')
-    reject_email_content = invitation.get_content_value('reject_message')
+    email_content = invitation.get_content_value('message')
     decision_invitation = client.get_invitation(f'{venue_id}/-/{decision_name}')
     accept_options = decision_invitation.content.get('accept_decision_options', {}).get('value')
-    print('accept_options', accept_options)
     decision_field_name = domain.content.get('decision_field_name', {}).get('value', 'decision')
-    print('decision_field_name', decision_field_name)
     fields_to_include = invitation.get_content_value('fields_to_include')
     contact_email = domain.get_content_value('contact')
+    decision_option = invitation.get_content_value('decision_option')
 
     status_invitation_id = domain.get_content_value('status_invitation_id')
     request_form_id = domain.get_content_value('request_form_id')
@@ -43,7 +41,7 @@ def process(client, invitation):
                 forum=request_form_id,
                 signatures=[venue_id],
                 content={
-                    'title': { 'value': 'Author Decision Notification Failed' },
+                    'title': { 'value': f'Author {decision_option} Decision Notification Failed' },
                     'comment': { 'value': f'The process "{invitation.id.split("/")[-1].replace("_", " ")}" was scheduled to run, but we found no valid decision fields to include in the email notification. Please re-schedule this process to run at a later time and then select which fields to include.\n1. To re-schedule this process for a later time, go to the [workflow timeline UI](https://openreview.net/group/edit?={venue_id}), find and expand the "Create {invitation.id.split("/")[-1].replace("_", " ")}" invitation, and click on "Edit" next to "Dates". Set the activation date to a later time and click "Submit".\n2. Once the process has been re-scheduled, click "Edit" next to the "Fields To Include" invitation, select the fields to include when emailing decisions to authors and click "Submit".\n\nIf you would like this process to run now, you can skip step 1 and just select a valid fields to include. Once you have selected the fields to include, click "Submit" and the process will automatically be scheduled to run shortly.'}
                 }
             )
@@ -68,30 +66,24 @@ def process(client, invitation):
                     formatted_decision+=f'''**{key}**: {value}\n'''
 
             decision_value = decision.content.get(decision_field_name, {}).get('value')
-            note_accepted = openreview.tools.is_accept_decision(decision_value, accept_options) if decision_value else False
-            if note_accepted:
-                message = accept_email_content.format(
-                    submission_number=submission.number,
-                    submission_title=submission.content['title']['value'],
-                    formatted_decision=formatted_decision,
-                    submission_forum=submission.id
-                )
-            else:
-                message = reject_email_content.format(
+
+            # if the decision matches, send email. ## To-do: support this in the submission source instead
+            if decision_value == decision_option:
+                message = email_content.format(
                     submission_number=submission.number,
                     submission_title=submission.content['title']['value'],
                     formatted_decision=formatted_decision,
                     submission_forum=submission.id
                 )
 
-            client.post_message(
-                subject=subject,
-                recipients=[f'{venue_id}/{submission_name}{submission.number}/{authors_name}'],
-                message=message,
-                invitation=invitation.id,
-                replyTo=contact_email
-            )
+                client.post_message(
+                    subject=subject,
+                    recipients=[f'{venue_id}/{submission_name}{submission.number}/{authors_name}'],
+                    message=message,
+                    invitation=invitation.id,
+                    replyTo=contact_email
+                )
 
     openreview.tools.concurrent_requests(send_decision_email, active_submissions)
 
-    print('Decision emails sent to authors')
+    print(f'{decision_option} decision emails sent to authors')

--- a/openreview/workflows/process/email_decisions_process.py
+++ b/openreview/workflows/process/email_decisions_process.py
@@ -21,8 +21,6 @@ def process(client, invitation):
 
     email_subject = invitation.get_content_value('subject')
     email_content = invitation.get_content_value('message')
-    decision_invitation = client.get_invitation(f'{venue_id}/-/{decision_name}')
-    accept_options = decision_invitation.content.get('accept_decision_options', {}).get('value')
     decision_field_name = domain.content.get('decision_field_name', {}).get('value', 'decision')
     fields_to_include = invitation.get_content_value('fields_to_include')
     contact_email = domain.get_content_value('contact')

--- a/openreview/workflows/process/email_decisions_process.py
+++ b/openreview/workflows/process/email_decisions_process.py
@@ -20,7 +20,13 @@ def process(client, invitation):
     support_user = invitation.invitations[0].split('Template')[0] + 'Support'
 
     email_subject = invitation.get_content_value('subject')
-    email_content = invitation.get_content_value('message')
+    accept_email_content = invitation.get_content_value('accept_message')
+    reject_email_content = invitation.get_content_value('reject_message')
+    decision_invitation = client.get_invitation(f'{venue_id}/-/{decision_name}')
+    accept_options = decision_invitation.content.get('accept_decision_options', {}).get('value')
+    print('accept_options', accept_options)
+    decision_field_name = domain.content.get('decision_field_name', {}).get('value', 'decision')
+    print('decision_field_name', decision_field_name)
     fields_to_include = invitation.get_content_value('fields_to_include')
     contact_email = domain.get_content_value('contact')
 
@@ -53,6 +59,7 @@ def process(client, invitation):
             submission_title=submission.content['title']['value']
         )
         decisions = [openreview.api.Note.from_json(reply) for reply in submission.details['directReplies'] if f'{venue_id}/{submission_name}{submission.number}/-/{decision_name}' in reply['invitations']]
+        print(len(decisions), 'decisions found for submission', submission.number)
         if decisions:
             formatted_decision = ''
             decision = decisions[0]
@@ -61,12 +68,23 @@ def process(client, invitation):
                 if value:
                     formatted_decision+=f'''**{key}**: {value}\n'''
 
-            message = email_content.format(
-                submission_number=submission.number,
-                submission_title=submission.content['title']['value'],
-                formatted_decision=formatted_decision,
-                submission_forum=submission.id
-            )
+            decision_value = decision.content.get(decision_field_name, {}).get('value')
+            note_accepted = openreview.tools.is_accept_decision(decision_value, accept_options) if decision_value else False
+            print('decision_value:', decision_value, 'note_accepted:', note_accepted)
+            if note_accepted:
+                message = accept_email_content.format(
+                    submission_number=submission.number,
+                    submission_title=submission.content['title']['value'],
+                    formatted_decision=formatted_decision,
+                    submission_forum=submission.id
+                )
+            else:
+                message = reject_email_content.format(
+                    submission_number=submission.number,
+                    submission_title=submission.content['title']['value'],
+                    formatted_decision=formatted_decision,
+                    submission_forum=submission.id
+                )
 
             client.post_message(
                 subject=subject,

--- a/openreview/workflows/process/email_decisions_process.py
+++ b/openreview/workflows/process/email_decisions_process.py
@@ -59,7 +59,6 @@ def process(client, invitation):
             submission_title=submission.content['title']['value']
         )
         decisions = [openreview.api.Note.from_json(reply) for reply in submission.details['directReplies'] if f'{venue_id}/{submission_name}{submission.number}/-/{decision_name}' in reply['invitations']]
-        print(len(decisions), 'decisions found for submission', submission.number)
         if decisions:
             formatted_decision = ''
             decision = decisions[0]
@@ -70,7 +69,6 @@ def process(client, invitation):
 
             decision_value = decision.content.get(decision_field_name, {}).get('value')
             note_accepted = openreview.tools.is_accept_decision(decision_value, accept_options) if decision_value else False
-            print('decision_value:', decision_value, 'note_accepted:', note_accepted)
             if note_accepted:
                 message = accept_email_content.format(
                     submission_number=submission.number,

--- a/openreview/workflows/process/email_decisions_process.py
+++ b/openreview/workflows/process/email_decisions_process.py
@@ -70,13 +70,16 @@ def process(client, invitation):
                     submission_forum=submission.id
                 )
 
-                client.post_message(
+                request = client.post_message(
                     subject=subject,
                     recipients=[f'{venue_id}/{submission_name}{submission.number}/{authors_name}'],
                     message=message,
                     invitation=invitation.id,
                     replyTo=contact_email
                 )
+                return request
+
+        return None
 
     all_submissions = client.get_all_notes(invitation=submission_id, sort='number:asc', details='directReplies', domain=venue_id)
     print(f'Total submissions retrieved: {len(all_submissions)}')
@@ -92,6 +95,10 @@ def process(client, invitation):
         print(f'No emails were sent since there are no {decision_option.lower()} submissions')
         return
 
-    openreview.tools.concurrent_requests(send_decision_email, filtered_submissions)
+    messages = openreview.tools.concurrent_requests(send_decision_email, filtered_submissions)
+    len_messages = len([m for m in messages if m is not None])
 
-    print(f'{len(filtered_submissions)} {decision_option} decision emails sent to authors')
+    if len_messages:
+        print(f'{len_messages} {decision_option} decision emails sent to authors')
+    else:
+        print(f'No new {decision_option} decision emails sent to authors')

--- a/openreview/workflows/process/email_decisions_process.py
+++ b/openreview/workflows/process/email_decisions_process.py
@@ -13,7 +13,7 @@ def process(client, invitation):
     
     domain = client.get_group(invitation.domain)
     venue_id = domain.id
-    submission_venue_id = domain.get_content_value('submission_venue_id')
+    submission_id = domain.get_content_value('submission_id')
     decision_name = domain.get_content_value('decision_name')
     submission_name = domain.get_content_value('submission_name')
     authors_name  = domain.get_content_value('authors_name')
@@ -21,7 +21,6 @@ def process(client, invitation):
 
     email_subject = invitation.get_content_value('subject')
     email_content = invitation.get_content_value('message')
-    decision_field_name = domain.content.get('decision_field_name', {}).get('value', 'decision')
     fields_to_include = invitation.get_content_value('fields_to_include')
     contact_email = domain.get_content_value('contact')
     decision_option = invitation.get_content_value('decision_option')
@@ -46,10 +45,9 @@ def process(client, invitation):
         )
         return
 
-    active_submissions = client.get_notes(content={'venueid': submission_venue_id}, details='directReplies')
-    print('# active submissions:', len(active_submissions))
+    def send_decision_email(submission_tuple):
+        submission, decisions = submission_tuple
 
-    def send_decision_email(submission):
         subject = email_subject.format(
             submission_number=submission.number,
             submission_title=submission.content['title']['value']
@@ -57,7 +55,6 @@ def process(client, invitation):
 
         # if email with this subject has already been sent, skip sending email
         if not client.get_messages(subject=subject):
-            decisions = [openreview.api.Note.from_json(reply) for reply in submission.details['directReplies'] if f'{venue_id}/{submission_name}{submission.number}/-/{decision_name}' in reply['invitations']]
             if decisions:
                 formatted_decision = ''
                 decision = decisions[0]
@@ -66,25 +63,35 @@ def process(client, invitation):
                     if value:
                         formatted_decision+=f'''**{key}**: {value}\n'''
 
-                decision_value = decision.content.get(decision_field_name, {}).get('value')
+                message = email_content.format(
+                    submission_number=submission.number,
+                    submission_title=submission.content['title']['value'],
+                    formatted_decision=formatted_decision,
+                    submission_forum=submission.id
+                )
 
-                # if the decision matches, send email. ## To-do: support this in the submission source instead
-                if decision_value == decision_option:
-                    message = email_content.format(
-                        submission_number=submission.number,
-                        submission_title=submission.content['title']['value'],
-                        formatted_decision=formatted_decision,
-                        submission_forum=submission.id
-                    )
+                client.post_message(
+                    subject=subject,
+                    recipients=[f'{venue_id}/{submission_name}{submission.number}/{authors_name}'],
+                    message=message,
+                    invitation=invitation.id,
+                    replyTo=contact_email
+                )
 
-                    client.post_message(
-                        subject=subject,
-                        recipients=[f'{venue_id}/{submission_name}{submission.number}/{authors_name}'],
-                        message=message,
-                        invitation=invitation.id,
-                        replyTo=contact_email
-                    )
+    all_submissions = client.get_all_notes(invitation=submission_id, sort='number:asc', details='directReplies', domain=venue_id)
+    print(f'Total submissions retrieved: {len(all_submissions)}')
 
-    openreview.tools.concurrent_requests(send_decision_email, active_submissions)
+    filtered_submissions = []
+    for submission in all_submissions:
+        if openreview.tools.should_match_invitation_source(client, invitation, submission, domain=domain):
+            filtered_submissions.append((submission, [openreview.api.Note.from_json(reply) for reply in submission.details['directReplies'] if f'{venue_id}/{submission_name}{submission.number}/-/{decision_name}' in reply['invitations']]))
 
-    print(f'{decision_option} decision emails sent to authors')
+    print(f'{len(filtered_submissions)} out of {len(all_submissions)} submissions matched the source criteria')
+
+    if not filtered_submissions:
+        print(f'No emails were sent since there are no {decision_option.lower()} submissions')
+        return
+
+    openreview.tools.concurrent_requests(send_decision_email, filtered_submissions)
+
+    print(f'{len(filtered_submissions)} {decision_option} decision emails sent to authors')

--- a/openreview/workflows/templates.py
+++ b/openreview/workflows/templates.py
@@ -1462,7 +1462,7 @@ If you would like to change your decision, please follow the link in the previou
                     },
                     'name': {
                         'order': 2,
-                        'description': 'Name for this step, use underscores to represent spaces. Default is Author_Decision_Notification.',
+                        'description': 'Name for this step, use underscores to represent spaces.',
                         'value': {
                             'param': {
                                 'type': 'string',

--- a/openreview/workflows/templates.py
+++ b/openreview/workflows/templates.py
@@ -1459,8 +1459,7 @@ If you would like to change your decision, please follow the link in the previou
                             'param': {
                                 'type': 'string',
                                 'maxLength': 100,
-                                'regex': '^[a-zA-Z0-9_]*$',
-                                'default': 'Author_Decision_Notification'
+                                'regex': '^[a-zA-Z0-9_]*$'
                             }
                         }
                     },
@@ -1491,6 +1490,24 @@ If you would like to change your decision, please follow the link in the previou
                                 'regex': '.*'
                             }
                         }
+                    },
+                    'decision': {
+                        'value': {
+                            'param': {
+                                'type': 'string',
+                                'enum': ['Accept', 'Reject']
+                            }
+                        }
+                    },
+                    'message': {
+                        'value': {
+                            'param': {
+                                'type': 'string',
+                                'maxLength': 200000,
+                                'input': 'textarea',
+                                'markdown': True
+                            }
+                        }
                     }
                 },
                 'domain': '${1/content/venue_id/value}',
@@ -1510,11 +1527,11 @@ If you would like to change your decision, please follow the link in the previou
                         'subject': {
                             'value': '[${4/content/short_name/value}] The decision for your submission #{submission_number}, titled "{submission_title}" is now available'
                         },
-                        'accept_message': {
-                            'value': 'Hi {{{{fullname}}}},\n\nWe are delighted to inform you that your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n${4/content/short_name/value} Program Chairs'
+                        'message': {
+                            'value': '${4/content/message/value}'
                         },
-                        'reject_message': {
-                            'value': 'Hi {{{{fullname}}}},\n\nWe regret to inform you that your submission was not accepted. We encourage you to consider the feedback provided and submit to future venues.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n${4/content/short_name/value} Program Chairs'
+                        'decision_option': {
+                            'value': '${4/content/decision/value}'
                         }
                     },
                     'message': {

--- a/openreview/workflows/templates.py
+++ b/openreview/workflows/templates.py
@@ -1510,8 +1510,11 @@ If you would like to change your decision, please follow the link in the previou
                         'subject': {
                             'value': '[${4/content/short_name/value}] The decision for your submission #{submission_number}, titled "{submission_title}" is now available'
                         },
-                        'message': {
-                            'value': 'Hi {{{{fullname}}}},\n\nThis is to inform you that the decision for your submission #{submission_number}, "{submission_title}", to ${4/content/short_name/value} is now available.\n\n{formatted_decision}\n\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}'
+                        'accept_message': {
+                            'value': 'Hi {{{{fullname}}}},\n\nWe are delighted to inform you that your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n${4/content/short_name/value} Program Chairs'
+                        },
+                        'reject_message': {
+                            'value': 'Hi {{{{fullname}}}},\n\nWe regret to inform you that your submission was not accepted. We encourage you to consider the feedback provided and submit to future venues.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n${4/content/short_name/value} Program Chairs'
                         }
                     },
                     'message': {

--- a/openreview/workflows/templates.py
+++ b/openreview/workflows/templates.py
@@ -1428,11 +1428,19 @@ If you would like to change your decision, please follow the link in the previou
             writers=[self.template_domain],
             signatures=[self.template_domain],
             process=self.get_process_content('workflow_process/email_authors_template_process.py'),
+            content={
+                'accept_message': {
+                    'value': 'Hi {{{{fullname}}}},\n\nWe are delighted to inform you that your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n{short_name} Program Chairs'
+                },
+                'reject_message': {
+                    'value': 'Hi {{{{fullname}}}},\n\nWe regret to inform you that your submission was not accepted. We encourage you to consider the feedback provided and submit to future venues.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n{short_name} Program Chairs'
+                }
+            },
             edit = {
                 'signatures' : {
                     'param': {
                         'items': [
-                            { 'prefix': '~.*', 'optional': True },
+                            { 'prefix': '.*', 'optional': True },
                             { 'value': self.template_domain, 'optional': True }
                         ]
                     }
@@ -1495,17 +1503,7 @@ If you would like to change your decision, please follow the link in the previou
                         'value': {
                             'param': {
                                 'type': 'string',
-                                'enum': ['Accept', 'Reject']
-                            }
-                        }
-                    },
-                    'message': {
-                        'value': {
-                            'param': {
-                                'type': 'string',
-                                'maxLength': 200000,
-                                'input': 'textarea',
-                                'markdown': True
+                                'regex': '.*'
                             }
                         }
                     }
@@ -1526,9 +1524,6 @@ If you would like to change your decision, please follow the link in the previou
                     'content': {
                         'subject': {
                             'value': '[${4/content/short_name/value}] The decision for your submission #{submission_number}, titled "{submission_title}" is now available'
-                        },
-                        'message': {
-                            'value': '${4/content/message/value}'
                         },
                         'decision_option': {
                             'value': '${4/content/decision/value}'

--- a/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
+++ b/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
@@ -98,7 +98,8 @@ def process(client, edit, invitation):
     venue.decision_stage = openreview.stages.DecisionStage(
         start_date=submission_deadline_datetime + datetime.timedelta(weeks=6),
         due_date=submission_deadline_datetime + datetime.timedelta(weeks=7),
-        accept_options=['Accept (Oral)', 'Accept (Poster)']
+        options=['Accept', 'Reject'],
+        accept_options=['Accept']
     )
 
     venue.submission_revision_stage = openreview.stages.SubmissionRevisionStage(

--- a/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
+++ b/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
@@ -236,10 +236,26 @@ def process(client, edit, invitation):
         signatures=[invitation_prefix],
         content={
             'venue_id': { 'value': venue_id },
-            'name': { 'value': 'Author_Decision_Notification' },
+            'name': { 'value': 'Author_Accept_Decision_Notification' },
             'activation_date': { 'value': submission_deadline + (60*60*1000*24*7*7) },
             'short_name': { 'value': note.content['abbreviated_venue_name']['value'] },
-            'from_email': { 'value': from_email }
+            'from_email': { 'value': from_email },
+            'decision': { 'value': 'Accept' },
+            'message': { 'value': 'Hi {{{{fullname}}}},\n\nWe are delighted to inform you that your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n${4/content/short_name/value} Program Chairs' }
+        }
+    )
+
+    client.post_invitation_edit(
+        invitations=f'{invitation_prefix}/-/Author_Decision_Notification',
+        signatures=[invitation_prefix],
+        content={
+            'venue_id': { 'value': venue_id },
+            'name': { 'value': 'Author_Reject_Decision_Notification' },
+            'activation_date': { 'value': submission_deadline + (60*60*1000*24*7*7) },
+            'short_name': { 'value': note.content['abbreviated_venue_name']['value'] },
+            'from_email': { 'value': from_email },
+            'decision': { 'value': 'Reject' },
+            'message': { 'value': 'Hi {{{{fullname}}}},\n\nWe regret to inform you that your submission was not accepted. We encourage you to consider the feedback provided and submit to future venues.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n${4/content/short_name/value} Program Chairs' }
         }
     )
 

--- a/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
+++ b/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
@@ -240,8 +240,7 @@ def process(client, edit, invitation):
             'activation_date': { 'value': submission_deadline + (60*60*1000*24*7*7) },
             'short_name': { 'value': note.content['abbreviated_venue_name']['value'] },
             'from_email': { 'value': from_email },
-            'decision': { 'value': 'Accept' },
-            'message': { 'value': 'Hi {{{{fullname}}}},\n\nWe are delighted to inform you that your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n${4/content/short_name/value} Program Chairs' }
+            'decision': { 'value': 'Accept' }
         }
     )
 
@@ -254,8 +253,7 @@ def process(client, edit, invitation):
             'activation_date': { 'value': submission_deadline + (60*60*1000*24*7*7) },
             'short_name': { 'value': note.content['abbreviated_venue_name']['value'] },
             'from_email': { 'value': from_email },
-            'decision': { 'value': 'Reject' },
-            'message': { 'value': 'Hi {{{{fullname}}}},\n\nWe regret to inform you that your submission was not accepted. We encourage you to consider the feedback provided and submit to future venues.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\n${4/content/short_name/value} Program Chairs' }
+            'decision': { 'value': 'Reject' }
         }
     )
 

--- a/openreview/workflows/workflow_process/edit_decision_options_process.py
+++ b/openreview/workflows/workflow_process/edit_decision_options_process.py
@@ -4,6 +4,8 @@ def process(client, edit, invitation):
     venue_id = domain.id
     meta_invitation_id = domain.get_content_value('meta_invitation_id')
     accept_decision_options = edit.content['accept_decision_options']['value']
+    decision_name = domain.get_content_value('decision_name', 'Decision')
+    decision_invitation_id = f'{venue_id}/-/{decision_name}'
 
     client.post_group_edit(
         invitation = meta_invitation_id,
@@ -16,4 +18,60 @@ def process(client, edit, invitation):
                 }
             }
         )
+    )
+
+    # delete the old decision notification invitations and create new ones with the updated decision options
+    invitation_edits = client.get_invitation_edits(invitation_id=decision_invitation_id, invitation=invitation.id, sort='tcdate:asc')
+
+    now = openreview.tools.datetime_millis(datetime.datetime.now())
+
+    if len(invitation_edits) > 1:
+        # delete the previous edit's decision notification invitations
+        previous_edit = invitation_edits[-2]
+        previous_decision_options = previous_edit.content['decision_options']['value']
+    else:
+        #delete the default decision notification invitations
+        previous_decision_options = ['Accept', 'Reject']
+
+    new_decision_options = edit.content['decision_options']['value']
+
+    previous_set = set(previous_decision_options)
+    new_set = set(new_decision_options)
+
+    removed_decision_options = previous_set - new_set
+    added_decision_options = new_set - previous_set
+
+    # delete the decision notification invitations for the removed decision options
+    for decision_option in removed_decision_options:
+        formatted_decision_option = decision_option.replace(' ', '_')
+        client.post_invitation_edit(
+            invitations=meta_invitation_id,
+            readers=[venue_id],
+            writers=[venue_id],
+            signatures=[venue_id],
+            invitation=openreview.api.Invitation(
+                id=f'{venue_id}/-/Author_{formatted_decision_option}_Decision_Notification',
+                ddate=now
+            )
+        )
+
+    # post new decision notification invitations for the added decision options
+    request_form_inv = domain.get_content_value('request_form_invitation')
+    invitation_prefix =request_form_inv.split('Support')[0] + 'Template'
+    short_name = domain.get_content_value('subtitle')
+    from_email = domain.content['message_sender']['value']['fromEmail']
+
+    for decision_option in added_decision_options:
+        formatted_decision_option = decision_option.replace(' ', '_')
+        client.post_invitation_edit(
+        invitations=f'{invitation_prefix}/-/Author_Decision_Notification',
+        signatures=[venue_id],
+        content={
+            'venue_id': { 'value': venue_id },
+            'name': { 'value': f'Author_{formatted_decision_option}_Decision_Notification' },
+            'activation_date': { 'value': now + (60*60*1000*24*7) },
+            'short_name': { 'value': short_name },
+            'from_email': { 'value': from_email },
+            'decision': { 'value': decision_option }
+        }
     )

--- a/openreview/workflows/workflow_process/edit_decision_options_process.py
+++ b/openreview/workflows/workflow_process/edit_decision_options_process.py
@@ -43,7 +43,7 @@ def process(client, edit, invitation):
 
     # delete the decision notification invitations for the removed decision options
     for decision_option in removed_decision_options:
-        formatted_decision_option = decision_option.replace(' ', '_')
+        formatted_decision_option = decision_option.replace(' ', '_').replace('(', '').replace(')', '')
         client.post_invitation_edit(
             invitations=meta_invitation_id,
             readers=[venue_id],
@@ -62,7 +62,7 @@ def process(client, edit, invitation):
     from_email = domain.content['message_sender']['value']['fromEmail']
 
     for decision_option in added_decision_options:
-        formatted_decision_option = decision_option.replace(' ', '_')
+        formatted_decision_option = decision_option.replace(' ', '_').replace('(', '').replace(')', '')
         client.post_invitation_edit(
         invitations=f'{invitation_prefix}/-/Author_Decision_Notification',
         signatures=[venue_id],

--- a/openreview/workflows/workflow_process/edit_decision_options_process.py
+++ b/openreview/workflows/workflow_process/edit_decision_options_process.py
@@ -44,16 +44,20 @@ def process(client, edit, invitation):
     # delete the decision notification invitations for the removed decision options
     for decision_option in removed_decision_options:
         formatted_decision_option = decision_option.replace(' ', '_').replace('(', '').replace(')', '')
-        client.post_invitation_edit(
-            invitations=meta_invitation_id,
-            readers=[venue_id],
-            writers=[venue_id],
-            signatures=[venue_id],
-            invitation=openreview.api.Invitation(
-                id=f'{venue_id}/-/Author_{formatted_decision_option}_Decision_Notification',
-                ddate=now
+        invitation_id = f'{venue_id}/-/Author_{formatted_decision_option}_Decision_Notification'
+        invitations_to_delete = client.get_invitations(prefix=invitation_id)
+
+        for inv in invitations_to_delete:
+            client.post_invitation_edit(
+                invitations=meta_invitation_id,
+                readers=[venue_id],
+                writers=[venue_id],
+                signatures=[venue_id],
+                invitation=openreview.api.Invitation(
+                    id=inv.id,
+                    ddate=now
+                )
             )
-        )
 
     # post new decision notification invitations for the added decision options
     request_form_inv = domain.get_content_value('request_form_invitation')

--- a/openreview/workflows/workflow_process/edit_decision_options_process.py
+++ b/openreview/workflows/workflow_process/edit_decision_options_process.py
@@ -27,10 +27,12 @@ def process(client, edit, invitation):
 
     if len(invitation_edits) > 1:
         # delete the previous edit's decision notification invitations
+        print('Deleting previous decision notification invitations for the old decision options.')
         previous_edit = invitation_edits[-2]
         previous_decision_options = previous_edit.content['decision_options']['value']
     else:
         #delete the default decision notification invitations
+        print('Deleting default decision notification invitations for the old decision options.')
         previous_decision_options = ['Accept', 'Reject']
 
     new_decision_options = edit.content['decision_options']['value']
@@ -48,16 +50,9 @@ def process(client, edit, invitation):
         invitations_to_delete = client.get_invitations(prefix=invitation_id)
 
         for inv in invitations_to_delete:
-            client.post_invitation_edit(
-                invitations=meta_invitation_id,
-                readers=[venue_id],
-                writers=[venue_id],
-                signatures=[venue_id],
-                invitation=openreview.api.Invitation(
-                    id=inv.id,
-                    ddate=now
-                )
-            )
+            print(f'Deleting invitation: {inv.id}')
+            client.delete_invitation(inv.id)
+        cdate = inv.tcdate
 
     # post new decision notification invitations for the added decision options
     request_form_inv = domain.get_content_value('request_form_invitation')
@@ -73,7 +68,7 @@ def process(client, edit, invitation):
         content={
             'venue_id': { 'value': venue_id },
             'name': { 'value': f'Author_{formatted_decision_option}_Decision_Notification' },
-            'activation_date': { 'value': now + (60*60*1000*24*7) },
+            'activation_date': { 'value': cdate },
             'short_name': { 'value': short_name },
             'from_email': { 'value': from_email },
             'decision': { 'value': decision_option }

--- a/openreview/workflows/workflow_process/edit_decision_options_process.py
+++ b/openreview/workflows/workflow_process/edit_decision_options_process.py
@@ -23,7 +23,7 @@ def process(client, edit, invitation):
     # delete the old decision notification invitations and create new ones with the updated decision options
     invitation_edits = client.get_invitation_edits(invitation_id=decision_invitation_id, invitation=invitation.id, sort='tcdate:asc')
 
-    now = openreview.tools.datetime_millis(datetime.datetime.now())
+    now = datetime.datetime.now()
 
     if len(invitation_edits) > 1:
         # delete the previous edit's decision notification invitations
@@ -43,6 +43,8 @@ def process(client, edit, invitation):
     removed_decision_options = previous_set - new_set
     added_decision_options = new_set - previous_set
 
+    cdate = now + datetime.timedelta(weeks=1)
+
     # delete the decision notification invitations for the removed decision options
     for decision_option in removed_decision_options:
         formatted_decision_option = decision_option.replace(' ', '_').replace('(', '').replace(')', '')
@@ -52,7 +54,6 @@ def process(client, edit, invitation):
         for inv in invitations_to_delete:
             print(f'Deleting invitation: {inv.id}')
             client.delete_invitation(inv.id)
-        cdate = inv.tcdate
 
     # post new decision notification invitations for the added decision options
     request_form_inv = domain.get_content_value('request_form_invitation')
@@ -68,7 +69,7 @@ def process(client, edit, invitation):
         content={
             'venue_id': { 'value': venue_id },
             'name': { 'value': f'Author_{formatted_decision_option}_Decision_Notification' },
-            'activation_date': { 'value': cdate },
+            'activation_date': { 'value': openreview.tools.datetime_millis(cdate) },
             'short_name': { 'value': short_name },
             'from_email': { 'value': from_email },
             'decision': { 'value': decision_option }

--- a/openreview/workflows/workflow_process/email_authors_template_process.py
+++ b/openreview/workflows/workflow_process/email_authors_template_process.py
@@ -7,7 +7,7 @@ def process(client, edit, invitation):
 
     edit_invitations_builder = openreview.workflows.EditInvitationsBuilder(client, domain.id)
     invitation_id = f'{domain.id}/-/{stage_name}'
-    edit_invitations_builder.set_edit_email_template_invitation(invitation_id)
     is_review_invitation = True if 'Reviews' in stage_name else False
+    edit_invitations_builder.set_edit_email_template_invitation(invitation_id, is_review_invitation=is_review_invitation)
     edit_invitations_builder.set_edit_fields_email_template_invitation(invitation_id, is_review_invitation=is_review_invitation)
     edit_invitations_builder.set_edit_dates_one_level_invitation(invitation_id)

--- a/openreview/workflows/workflow_process/email_authors_template_process.py
+++ b/openreview/workflows/workflow_process/email_authors_template_process.py
@@ -2,6 +2,7 @@ def process(client, edit, invitation):
 
     domain = client.get_group(edit.domain)
     meta_invitation_id = domain.content.get('meta_invitation_id', {}).get('value')
+    short_name = domain.content['subtitle']['value']
 
     stage_name = edit.content['name']['value']
 
@@ -11,3 +12,22 @@ def process(client, edit, invitation):
     edit_invitations_builder.set_edit_email_template_invitation(invitation_id)
     edit_invitations_builder.set_edit_fields_email_template_invitation(invitation_id, is_review_invitation=is_review_invitation)
     edit_invitations_builder.set_edit_dates_one_level_invitation(invitation_id)
+
+    if not is_review_invitation:
+        decision = edit.content['decision']['value']
+        accept_decision_options = domain.content.get('accept_decision_options', {}).get('value')
+        if decision in accept_decision_options:
+            decision_option = 'accept'
+        else:
+            decision_option = 'reject'
+        message = invitation.content[f'{decision_option}_message']['value'].replace('{short_name}', short_name)
+        client.post_invitation_edit(
+            invitations=meta_invitation_id,
+            signatures=[domain.id],
+            invitation=openreview.api.Invitation(
+                id=edit.invitation.id,
+                content={
+                    'message': { 'value': message }
+                }
+            )
+        )

--- a/openreview/workflows/workflow_process/email_authors_template_process.py
+++ b/openreview/workflows/workflow_process/email_authors_template_process.py
@@ -8,6 +8,6 @@ def process(client, edit, invitation):
     edit_invitations_builder = openreview.workflows.EditInvitationsBuilder(client, domain.id)
     invitation_id = f'{domain.id}/-/{stage_name}'
     is_review_invitation = True if 'Reviews' in stage_name else False
-    edit_invitations_builder.set_edit_email_template_invitation(invitation_id, is_review_invitation=is_review_invitation)
+    edit_invitations_builder.set_edit_email_template_invitation(invitation_id)
     edit_invitations_builder.set_edit_fields_email_template_invitation(invitation_id, is_review_invitation=is_review_invitation)
     edit_invitations_builder.set_edit_dates_one_level_invitation(invitation_id)

--- a/openreview/workflows/workflow_process/email_authors_template_process.py
+++ b/openreview/workflows/workflow_process/email_authors_template_process.py
@@ -15,19 +15,35 @@ def process(client, edit, invitation):
 
     if not is_review_invitation:
         decision = edit.content['decision']['value']
+
+        content = {
+            'source': {
+                'value': {
+                    'venueid': [
+                        f'{domain.get_content_value("submission_venue_id")}',
+                        domain.id,
+                        f'{domain.get_content_value("rejected_venue_id")}'
+                    ],
+                    'decision_options': [decision]
+                }
+            }
+        }
+
         accept_decision_options = domain.content.get('accept_decision_options', {}).get('value')
         if decision in accept_decision_options:
             decision_option = 'accept'
         else:
             decision_option = 'reject'
         message = invitation.content[f'{decision_option}_message']['value'].replace('{short_name}', short_name)
+
+        content['message'] = {
+            'value': message
+        }
         client.post_invitation_edit(
             invitations=meta_invitation_id,
             signatures=[domain.id],
             invitation=openreview.api.Invitation(
                 id=edit.invitation.id,
-                content={
-                    'message': { 'value': message }
-                }
+                content=content
             )
         )

--- a/tests/test_abstract_deadline.py
+++ b/tests/test_abstract_deadline.py
@@ -134,7 +134,8 @@ class TestAbstractDeadline():
         assert openreview_client.get_invitation('ifaamas.org/AAMAS/2026/Workshop/EMAS/Reviewers/-/Bid')
         assert openreview_client.get_invitation('ifaamas.org/AAMAS/2026/Workshop/EMAS/-/Venue_Information')
         assert openreview_client.get_invitation('ifaamas.org/AAMAS/2026/Workshop/EMAS/-/Author_Reviews_Notification')
-        assert openreview_client.get_invitation('ifaamas.org/AAMAS/2026/Workshop/EMAS/-/Author_Decision_Notification')
+        assert openreview_client.get_invitation('ifaamas.org/AAMAS/2026/Workshop/EMAS/-/Author_Accept_Decision_Notification')
+        assert openreview_client.get_invitation('ifaamas.org/AAMAS/2026/Workshop/EMAS/-/Author_Reject_Decision_Notification')
 
     def test_update_submission_deadline(self, openreview_client, helpers):
 

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -1079,6 +1079,15 @@ note={under review}
         assert pc_client.get_invitation('EFGH.cc/2025/Conference/-/Decision_Upload')
         assert pc_client.get_invitation('EFGH.cc/2025/Conference/-/Decision_Upload/Decision_CSV')
 
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification')
+        assert invitation and not invitation.ddate
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Dates')
+        assert invitation and not invitation.ddate
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Fields_to_Include')
+        assert invitation and not invitation.ddate
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Templates')
+        assert invitation and not invitation.ddate
+
         # edit decision options
         edit = pc_client.post_invitation_edit(
             invitations='EFGH.cc/2025/Conference/-/Decision/Decision_Options',
@@ -1090,14 +1099,11 @@ note={under review}
         helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
         helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Decision-0-1', count=2)
 
-        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification')
-        assert invitation and invitation.ddate
-        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Dates')
-        assert invitation and invitation.ddate
-        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Fields_to_Include')
-        assert invitation and invitation.ddate
-        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Templates')
-        assert invitation and invitation.ddate
+        deleted_invitations = openreview_client.get_invitations(prefix='EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification')
+
+        for invitation in deleted_invitations:
+            with pytest.raises(openreview.OpenReviewException, match=rf'The Invitation {invitation.id} was not found'):
+                openreview_client.get_invitation(invitation.id)
 
         invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification')
         assert invitation and not invitation.ddate
@@ -1248,7 +1254,7 @@ note={under review}
         ]
         assert decisions[0].nonreaders == []
 
-    def test_decison_notification_stage(self, openreview_client, helpers):
+    def test_decision_notification_stage(self, openreview_client, helpers):
 
         pc_client = openreview.api.OpenReviewClient(username='programchair@efgh.cc', password=helpers.strong_password)
 

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -1250,7 +1250,7 @@ note={under review}
         ]
         assert decisions[0].nonreaders == []
 
-    def test_decion_notification_stage(self, openreview_client, helpers):
+    def test_decison_notification_stage(self, openreview_client, helpers):
 
         pc_client = openreview.api.OpenReviewClient(username='programchair@efgh.cc', password=helpers.strong_password)
 

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -1073,11 +1073,24 @@ note={under review}
 
         invitation =  pc_client.get_invitation('EFGH.cc/2025/Conference/-/Decision')
         assert invitation
+        assert invitation.content['decision_options']['value'] == ['Accept', 'Reject']
+        assert invitation.content['accept_decision_options']['value'] == ['Accept']
         assert pc_client.get_invitation('EFGH.cc/2025/Conference/-/Decision/Dates')
         assert pc_client.get_invitation('EFGH.cc/2025/Conference/-/Decision/Readers')
         assert pc_client.get_invitation('EFGH.cc/2025/Conference/-/Decision/Decision_Options')
         assert pc_client.get_invitation('EFGH.cc/2025/Conference/-/Decision_Upload')
         assert pc_client.get_invitation('EFGH.cc/2025/Conference/-/Decision_Upload/Decision_CSV')
+
+        # edit decision options
+        edit = pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Decision/Decision_Options',
+            content={
+                'decision_options': { 'value': ['Accept (Oral)', 'Accept (Poster)', 'Reject'] },
+                'accept_decision_options': { 'value': ['Accept (Oral)', 'Accept (Poster)'] }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Decision-0-1', count=2)
 
         # create child invitations
         now = datetime.datetime.now()
@@ -1092,7 +1105,7 @@ note={under review}
                 'expiration_date': { 'value': new_duedate }
             }
         )
-        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Decision-0-1', count=2)
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Decision-0-1', count=3)
 
         invitations = openreview_client.get_invitations(invitation='EFGH.cc/2025/Conference/-/Decision')
         assert len(invitations) == 10
@@ -1207,7 +1220,7 @@ note={under review}
             }
         )
         helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Decision_Release-0-1', count=3)
-        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Decision-0-1', count=3)
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Decision-0-1', count=4)
 
         # assert decisions are visible to PCs, paper ACs and paper authors
         decisions = openreview_client.get_notes(invitation='EFGH.cc/2025/Conference/Submission1/-/Decision', sort='number:asc')

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -1094,6 +1094,12 @@ note={under review}
 
         invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification')
         assert invitation and invitation.ddate
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Dates')
+        assert invitation and invitation.ddate
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Fields_to_Include')
+        assert invitation and invitation.ddate
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification/Templates')
+        assert invitation and invitation.ddate
 
         invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification')
         assert invitation and not invitation.ddate

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -1092,6 +1092,18 @@ note={under review}
         helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
         helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Decision-0-1', count=2)
 
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Decision_Notification')
+        assert invitation and invitation.ddate
+
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification')
+        assert invitation and not invitation.ddate
+
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Oral_Decision_Notification')
+        assert invitation and not invitation.ddate
+
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Reject_Decision_Notification')
+        assert invitation and not invitation.ddate
+
         # create child invitations
         now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
@@ -1231,6 +1243,142 @@ note={under review}
             'EFGH.cc/2025/Conference/Submission1/Authors'
         ]
         assert decisions[0].nonreaders == []
+
+    def test_decion_notification_stage(self, openreview_client, helpers):
+
+        pc_client = openreview.api.OpenReviewClient(username='programchair@efgh.cc', password=helpers.strong_password)
+
+        # change decision notification templates
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification/Templates',
+            content={
+                'email_subject': { 'value': '[EFGH 2025] The decision for your submission #{submission_number}, titled "{submission_title}" is now available' },
+                'email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted for a poster presentation. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nEFGH 2025 Program Chairs' },
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification-0-1', count=2)
+
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Accept_Oral_Decision_Notification/Templates',
+            content={
+                'email_subject': { 'value': '[EFGH 2025] The decision for your submission #{submission_number}, titled "{submission_title}" is now available' },
+                'email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted for an oral presentation. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nEFGH 2025 Program Chairs' },
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Accept_Oral_Decision_Notification-0-1', count=2)
+
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Reject_Decision_Notification/Templates',
+            content={
+                'email_subject': { 'value': '[EFGH 2025] The decision for your submission #{submission_number}, titled "{submission_title}" is now available' },
+                'email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe regret to inform you that, based on the evaluation of the reviewers, your submission has been rejected.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nEFGH 2025 Program Chairs' },
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Reject_Decision_Notification-0-1', count=2)
+
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Accept_Oral_Decision_Notification/Fields_to_Include',
+            content={
+                'fields': { 'value': ['decision', 'comment'] }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Accept_Oral_Decision_Notification-0-1', count=3)
+
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification/Fields_to_Include',
+            content={
+                'fields': { 'value': ['decision', 'comment'] }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification-0-1', count=3)
+
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Reject_Decision_Notification/Fields_to_Include',
+            content={
+                'fields': { 'value': ['decision', 'comment'] }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Reject_Decision_Notification-0-1', count=3)
+
+        now = datetime.datetime.now()
+
+        # trigger notification date process
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification/Dates',
+            content={
+                'activation_date': { 'value': openreview.tools.datetime_millis(now) }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification-0-1', count=4)
+
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Accept_Oral_Decision_Notification/Dates',
+            content={
+                'activation_date': { 'value': openreview.tools.datetime_millis(now) }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Accept_Oral_Decision_Notification-0-1', count=4)
+
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/-/Author_Reject_Decision_Notification/Dates',
+            content={
+                'activation_date': { 'value': openreview.tools.datetime_millis(now) }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='EFGH.cc/2025/Conference/-/Author_Reject_Decision_Notification-0-1', count=4)
+
+        submissions = openreview_client.get_notes(invitation='EFGH.cc/2025/Conference/-/Submission', sort='number:asc')
+
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[EFGH 2025] The decision for your submission #1, titled \"Paper title 1\" is now available')
+        assert messages and len(messages) == 1
+        assert messages[0]['content']['text'] == f'''Hi SomeFirstName User,
+
+We are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted for an oral presentation. Congratulations!
+
+**decision**: Accept (Oral)
+**comment**: Congratulations on your oral acceptance.
+
+To view this paper, please go to https://openreview.net/forum?id={submissions[0].id}
+
+Best,
+EFGH 2025 Program Chairs
+
+Please note that responding to this email will direct your reply to efgh2025.programchairs@gmail.com.
+'''
+
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[EFGH 2025] The decision for your submission #2, titled \"Paper title 2\" is now available')
+        assert messages and len(messages) == 1
+        assert messages[0]['content']['text'] == f'''Hi SomeFirstName User,
+
+We are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted for a poster presentation. Congratulations!
+
+**decision**: Accept (Poster)
+**comment**: Congratulations on your poster acceptance.
+
+To view this paper, please go to https://openreview.net/forum?id={submissions[1].id}
+
+Best,
+EFGH 2025 Program Chairs
+
+Please note that responding to this email will direct your reply to efgh2025.programchairs@gmail.com.
+'''
+        
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[EFGH 2025] The decision for your submission #3, titled \"Paper title 3\" is now available')
+        assert messages and len(messages) == 1
+        assert messages[0]['content']['text'] == f'''Hi SomeFirstName User,
+
+We regret to inform you that, based on the evaluation of the reviewers, your submission has been rejected.
+
+**decision**: Reject
+**comment**: We regret to inform you...
+
+To view this paper, please go to https://openreview.net/forum?id={submissions[2].id}
+
+Best,
+EFGH 2025 Program Chairs
+
+Please note that responding to this email will direct your reply to efgh2025.programchairs@gmail.com.
+'''
 
     def test_release_submissions(self, openreview_client, helpers):
 

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -1107,12 +1107,36 @@ note={under review}
 
         invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Poster_Decision_Notification')
         assert invitation and not invitation.ddate
+        assert invitation.content['source']['value'] == {
+            'venueid': [
+                'EFGH.cc/2025/Conference/Submission',
+                'EFGH.cc/2025/Conference',
+                'EFGH.cc/2025/Conference/Rejected_Submission'
+            ],
+            'decision_options': ['Accept (Poster)']
+        }
 
         invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Accept_Oral_Decision_Notification')
         assert invitation and not invitation.ddate
+        assert invitation.content['source']['value'] == {
+            'venueid': [
+                'EFGH.cc/2025/Conference/Submission',
+                'EFGH.cc/2025/Conference',
+                'EFGH.cc/2025/Conference/Rejected_Submission'
+            ],
+            'decision_options': ['Accept (Oral)']
+        }
 
         invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/-/Author_Reject_Decision_Notification')
         assert invitation and not invitation.ddate
+        assert invitation.content['source']['value'] == {
+            'venueid': [
+                'EFGH.cc/2025/Conference/Submission',
+                'EFGH.cc/2025/Conference',
+                'EFGH.cc/2025/Conference/Rejected_Submission'
+            ],
+            'decision_options': ['Reject']
+        }
 
         # create child invitations
         now = datetime.datetime.now()

--- a/tests/test_change_venue_email.py
+++ b/tests/test_change_venue_email.py
@@ -104,8 +104,11 @@ class TestChangeVenueEmail():
         review_notification_inv = openreview_client.get_invitation('VenueEmail.cc/2025/Conference/-/Author_Reviews_Notification')
         assert review_notification_inv.message['replyTo']['param']['regex'] == r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})'
 
-        decision_notification_inv = openreview_client.get_invitation('VenueEmail.cc/2025/Conference/-/Author_Decision_Notification')
-        assert decision_notification_inv.message['replyTo']['param']['regex'] == r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})'
+        accept_decision_notification_inv = openreview_client.get_invitation('VenueEmail.cc/2025/Conference/-/Author_Accept_Decision_Notification')
+        assert accept_decision_notification_inv.message['replyTo']['param']['regex'] == r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})'
+
+        reject_decision_notification_inv = openreview_client.get_invitation('VenueEmail.cc/2025/Conference/-/Author_Reject_Decision_Notification')
+        assert reject_decision_notification_inv.message['replyTo']['param']['regex'] == r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})'
 
     def test_change_venue_email(self, openreview_client, helpers):
 
@@ -135,8 +138,11 @@ class TestChangeVenueEmail():
         review_notification_inv = openreview_client.get_invitation('VenueEmail.cc/2025/Conference/-/Author_Reviews_Notification')
         assert review_notification_inv.message['replyTo']['param']['regex'] == r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})'
 
-        decision_notification_inv = openreview_client.get_invitation('VenueEmail.cc/2025/Conference/-/Author_Decision_Notification')
-        assert decision_notification_inv.message['replyTo']['param']['regex'] == r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})'
+        accept_decision_notification_inv = openreview_client.get_invitation('VenueEmail.cc/2025/Conference/-/Author_Accept_Decision_Notification')
+        assert accept_decision_notification_inv.message['replyTo']['param']['regex'] == r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})'
+
+        reject_decision_notification_inv = openreview_client.get_invitation('VenueEmail.cc/2025/Conference/-/Author_Reject_Decision_Notification')
+        assert reject_decision_notification_inv.message['replyTo']['param']['regex'] == r'~.*|([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})'
 
     def test_recruitment_invitations(self, openreview_client, helpers):
 

--- a/tests/test_iclr_conference_with_templates.py
+++ b/tests/test_iclr_conference_with_templates.py
@@ -1920,7 +1920,7 @@ def test_author_reviews_notification(client, openreview_client, helpers):
     assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Reviews_Notification')
     assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Reviews_Notification/Dates')
     assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Reviews_Notification/Fields_to_Include')
-    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Reviews_Notification/Message')
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Reviews_Notification/Templates')
 
     # select the review fields to include in the email
     pc_client.post_invitation_edit(
@@ -2330,6 +2330,17 @@ def test_decision_stage(client, openreview_client, helpers):
     assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Decision_Upload')
     assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Decision_Upload/Decision_CSV')
 
+    # edit decision options
+    edit = pc_client.post_invitation_edit(
+        invitations='ICLR.cc/2026/Conference/-/Decision/Decision_Options',
+        content={
+            'decision_options': { 'value': ['Accept (Oral)', 'Accept (Poster)', 'Reject'] },
+            'accept_decision_options': { 'value': ['Accept (Oral)', 'Accept (Poster)'] }
+        }
+    )
+    helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Decision-0-1', count=2)
+
     # create child invitations
     now = datetime.datetime.now()
     new_cdate = openreview.tools.datetime_millis(now)
@@ -2343,7 +2354,7 @@ def test_decision_stage(client, openreview_client, helpers):
             'expiration_date': { 'value': new_duedate }
         }
     )
-    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Decision-0-1', count=2)
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Decision-0-1', count=3)
 
     invitations = openreview_client.get_invitations(invitation='ICLR.cc/2026/Conference/-/Decision')
     assert len(invitations) == 10
@@ -2432,7 +2443,7 @@ def test_decision_release_stage(client, openreview_client, helpers):
         }
     )
     helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Decision_Release-0-1', count=2)
-    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Decision-0-1', count=3)
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Decision-0-1', count=4)
 
     decisions = openreview_client.get_notes(invitation='ICLR.cc/2026/Conference/Submission1/-/Decision')
     assert len(decisions) == 1
@@ -2449,29 +2460,68 @@ def test_author_decision_notification(client, openreview_client, helpers):
 
     pc_client = openreview.api.OpenReviewClient(username='programchair@iclr.cc', password=helpers.strong_password)
 
-    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Decision_Notification')
-    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Decision_Notification/Dates')
-    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Decision_Notification/Fields_to_Include')
-    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Decision_Notification/Message')
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Accept_Oral_Decision_Notification')
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Accept_Oral_Decision_Notification/Dates')
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Accept_Oral_Decision_Notification/Fields_to_Include')
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Accept_Oral_Decision_Notification/Templates')
+
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Accept_Poster_Decision_Notification')
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Accept_Poster_Decision_Notification/Dates')
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Accept_Poster_Decision_Notification/Fields_to_Include')
+    assert pc_client.get_invitation('ICLR.cc/2026/Conference/-/Author_Accept_Poster_Decision_Notification/Templates')
 
     # select the decision fields to include in the email
     pc_client.post_invitation_edit(
-        invitations='ICLR.cc/2026/Conference/-/Author_Decision_Notification/Fields_to_Include',
+        invitations='ICLR.cc/2026/Conference/-/Author_Accept_Oral_Decision_Notification/Fields_to_Include',
         content={
             'fields': { 'value': ['decision', 'comment'] }
         }
     )
-    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Author_Decision_Notification-0-1', count=2)
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Author_Accept_Oral_Decision_Notification-0-1', count=2)
+
+    pc_client.post_invitation_edit(
+        invitations='ICLR.cc/2026/Conference/-/Author_Accept_Poster_Decision_Notification/Fields_to_Include',
+        content={
+            'fields': { 'value': ['decision', 'comment'] }
+        }
+    )
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Author_Accept_Poster_Decision_Notification-0-1', count=2)
+
+    pc_client.post_invitation_edit(
+        invitations='ICLR.cc/2026/Conference/-/Author_Reject_Decision_Notification/Fields_to_Include',
+        content={
+            'fields': { 'value': ['decision', 'comment'] }
+        }
+    )
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Author_Reject_Decision_Notification-0-1', count=2)
 
     # trigger the notification process
     now = datetime.datetime.now()
     pc_client.post_invitation_edit(
-        invitations='ICLR.cc/2026/Conference/-/Author_Decision_Notification/Dates',
+        invitations='ICLR.cc/2026/Conference/-/Author_Accept_Oral_Decision_Notification/Dates',
         content={
             'activation_date': { 'value': openreview.tools.datetime_millis(now) }
         }
     )
-    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Author_Decision_Notification-0-1', count=3)
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Author_Accept_Oral_Decision_Notification-0-1', count=3)
+
+    now = datetime.datetime.now()
+    pc_client.post_invitation_edit(
+        invitations='ICLR.cc/2026/Conference/-/Author_Accept_Poster_Decision_Notification/Dates',
+        content={
+            'activation_date': { 'value': openreview.tools.datetime_millis(now) }
+        }
+    )
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Author_Accept_Poster_Decision_Notification-0-1', count=3)
+
+    now = datetime.datetime.now()
+    pc_client.post_invitation_edit(
+        invitations='ICLR.cc/2026/Conference/-/Author_Reject_Decision_Notification/Dates',
+        content={
+            'activation_date': { 'value': openreview.tools.datetime_millis(now) }
+        }
+    )
+    helpers.await_queue_edit(openreview_client, edit_id='ICLR.cc/2026/Conference/-/Author_Reject_Decision_Notification-0-1', count=3)
 
     # all the submissions have a decision, the authors of each submission are notified
     messages = openreview_client.get_messages(to='test@mail.com', subject='[ICLR 2026] The decision for your submission.*')

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2258,7 +2258,7 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/Program_Committee/-/Review_Assignment_Count')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/Program_Committee/-/Review_Days_Late_Sum')
 
-        assert 'accept_decision_options' in invitation.content and invitation.content['accept_decision_options']['value'] == ['Accept (Oral)', 'Accept (Poster)']
+        assert 'accept_decision_options' in invitation.content and invitation.content['accept_decision_options']['value'] == ['Accept']
 
         now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
@@ -2278,18 +2278,18 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         edit = pc_client.post_invitation_edit(
             invitations='ABCD.cc/2025/Conference/-/Decision/Decision_Options',
             content={
-                'decision_options': { 'value': ['Accept', 'Revision Needed', 'Reject'] },
-                'accept_decision_options': { 'value': ['Accept'] }
+                'decision_options': { 'value': ['Accept', 'Poster', 'Revision Needed', 'Reject'] },
+                'accept_decision_options': { 'value': ['Accept', 'Poster'] }
             }
         )
         helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
         helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Decision-0-1', count=3)
 
         invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Decision')
-        assert 'accept_decision_options' in invitation.content and invitation.content['accept_decision_options']['value'] == ['Accept']
+        assert 'accept_decision_options' in invitation.content and invitation.content['accept_decision_options']['value'] == ['Accept', 'Poster']
 
         venue_group = openreview_client.get_group('ABCD.cc/2025/Conference')
-        assert 'accept_decision_options' in venue_group.content and venue_group.content['accept_decision_options']['value'] == ['Accept']
+        assert 'accept_decision_options' in venue_group.content and venue_group.content['accept_decision_options']['value'] == ['Accept', 'Poster']
 
         now = datetime.datetime.now()
         now = openreview.tools.datetime_millis(now)

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2516,10 +2516,18 @@ ABCD 2025 Program Chairs'''
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Fields_to_Include')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Fields_to_Include')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Poster_Decision_Notification/Fields_to_Include')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Revision_Needed_Decision_Notification/Fields_to_Include')
         invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Templates')
         assert invitation
         assert all(key in invitation.edit['content'] for key in ['email_subject', 'email_content'])
         invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Templates')
+        assert invitation
+        assert all(key in invitation.edit['content'] for key in ['email_subject', 'email_content'])
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Poster_Decision_Notification/Templates')
+        assert invitation
+        assert all(key in invitation.edit['content'] for key in ['email_subject', 'email_content'])
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Revision_Needed_Decision_Notification/Templates')
         assert invitation
         assert all(key in invitation.edit['content'] for key in ['email_subject', 'email_content'])
 

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2077,7 +2077,7 @@ For more details, please check the following links:
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification/Fields_to_Include')
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification/Message')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification/Templates')
 
         # trigger notification date process with no fields to include
         now = datetime.datetime.now()
@@ -2438,10 +2438,40 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
         submissions = openreview_client.get_notes(invitation='ABCD.cc/2025/Conference/-/Submission', sort='number:asc')
 
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification')
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification')
+        assert invitation
+        assert 'accept_message' in invitation.content and invitation.content['accept_message']['value'] == '''Hi {{{{fullname}}}},
+
+We are delighted to inform you that your submission has been accepted. Congratulations!
+
+{formatted_decision}
+To view this paper, please go to https://openreview.net/forum?id={submission_forum}
+
+Best,
+ABCD 2025 Program Chairs'''
+        assert 'reject_message' in invitation.content and invitation.content['reject_message']['value'] == '''Hi {{{{fullname}}}},
+
+We regret to inform you that your submission was not accepted. We encourage you to consider the feedback provided and submit to future venues.
+
+{formatted_decision}
+To view this paper, please go to https://openreview.net/forum?id={submission_forum}
+
+Best,
+ABCD 2025 Program Chairs'''
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Fields_to_Include')
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Message')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Templates')
+
+        # change accept and reject email templates
+        pc_client.post_invitation_edit(
+            invitations='ABCD.cc/2025/Conference/-/Author_Decision_Notification/Templates',
+            content={
+                'email_subject': { 'value': '[ABCD 2025] The decision for your submission #{submission_number}, titled "{submission_title}" is now available' },
+                'accept_email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nABCD 2025 Program Chairs' },
+                'reject_email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are sorry to inform you that, after consideration by reviewers, your submission has not been accepted.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nABCD 2025 Program Chairs' }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Decision_Notification-0-1', count=2)
 
         now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
@@ -2453,7 +2483,7 @@ Please note that responding to this email will direct your reply to abcd2025.pro
                 'activation_date': { 'value': new_cdate }
             }
         )
-        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Decision_Notification-0-1', count=2)
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Decision_Notification-0-1', count=3)
 
         helpers.await_queue_edit(openreview_client, invitation='openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Status', count=6)
 
@@ -2469,22 +2499,42 @@ Please note that responding to this email will direct your reply to abcd2025.pro
                 'fields': { 'value': ['decision', 'comment'] }
             }
         )
-        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Decision_Notification-0-1', count=3)
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Decision_Notification-0-1', count=4)
 
         messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #1, titled \"Paper title 1\" is now available')
         assert messages and len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi SomeFirstName User,
 
-This is to inform you that the decision for your submission #1, "Paper title 1", to ABCD 2025 is now available.
+We are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted. Congratulations!
 
 **decision**: Accept
 **comment**: Congratulations on your acceptance.
 
-
 To view this paper, please go to https://openreview.net/forum?id={submissions[0].id}
+
+Best,
+ABCD 2025 Program Chairs
 
 Please note that responding to this email will direct your reply to abcd2025.programchairs@gmail.com.
 '''
+
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #3, titled \"Paper title 3\" is now available')
+        assert messages and len(messages) == 1
+        assert messages[0]['content']['text'] == f'''Hi SomeFirstName User,
+
+We are sorry to inform you that, after consideration by reviewers, your submission has not been accepted.
+
+**decision**: Reject
+**comment**: We regret to inform you...
+
+To view this paper, please go to https://openreview.net/forum?id={submissions[2].id}
+
+Best,
+ABCD 2025 Program Chairs
+
+Please note that responding to this email will direct your reply to abcd2025.programchairs@gmail.com.
+'''
+
         messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #10, titled \"Paper title 10\" is now available')
         assert not messages
 

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2074,10 +2074,17 @@ For more details, please check the following links:
         pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
         submissions = openreview_client.get_notes(invitation='ABCD.cc/2025/Conference/-/Submission', sort='number:asc')
 
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification')
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification')
+        assert invitation
+        assert 'subject' in invitation.content
+        assert 'message' in invitation.content
+        assert 'accept_message' not in invitation.content
+        assert 'reject_message' not in invitation.content
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification/Fields_to_Include')
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification/Templates')
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification/Templates')
+        assert 'email_subject' in invitation.edit['content'] and 'email_content' in invitation.edit['content']
+        assert 'accept_email_content' not in invitation.edit['content'] and 'reject_email_content' not in invitation.edit['content']
 
         # trigger notification date process with no fields to include
         now = datetime.datetime.now()
@@ -2440,6 +2447,8 @@ Please note that responding to this email will direct your reply to abcd2025.pro
 
         invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification')
         assert invitation
+        assert 'subject' in invitation.content
+        assert 'message' not in invitation.content
         assert 'accept_message' in invitation.content and invitation.content['accept_message']['value'] == '''Hi {{{{fullname}}}},
 
 We are delighted to inform you that your submission has been accepted. Congratulations!
@@ -2460,7 +2469,10 @@ Best,
 ABCD 2025 Program Chairs'''
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Fields_to_Include')
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Templates')
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Templates')
+        assert invitation
+        assert all(key in invitation.edit['content'] for key in ['email_subject', 'accept_email_content', 'reject_email_content'])
+        assert 'email_content' not in invitation.edit['content']
 
         # change accept and reject email templates
         pc_client.post_invitation_edit(

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -322,7 +322,8 @@ class TestReviewersOnly():
         assert openreview_client.get_invitation('ABCD.cc/2025/Conference/Program_Committee/-/Bid/Settings')
         assert openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Venue_Information')
         assert openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reviews_Notification')
-        assert openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification')
+        assert openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification')
+        assert openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification')
 
         invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/Program_Committee/-/Submission_Group')
         assert invitation and invitation.edit['group']['deanonymizers'] == ['ABCD.cc/2025/Conference']
@@ -2445,11 +2446,10 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
         submissions = openreview_client.get_notes(invitation='ABCD.cc/2025/Conference/-/Submission', sort='number:asc')
 
-        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification')
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification')
         assert invitation
         assert 'subject' in invitation.content
-        assert 'message' not in invitation.content
-        assert 'accept_message' in invitation.content and invitation.content['accept_message']['value'] == '''Hi {{{{fullname}}}},
+        assert 'message' in invitation.content and invitation.content['message']['value'] == '''Hi {{{{fullname}}}},
 
 We are delighted to inform you that your submission has been accepted. Congratulations!
 
@@ -2458,7 +2458,11 @@ To view this paper, please go to https://openreview.net/forum?id={submission_for
 
 Best,
 ABCD 2025 Program Chairs'''
-        assert 'reject_message' in invitation.content and invitation.content['reject_message']['value'] == '''Hi {{{{fullname}}}},
+
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification')
+        assert invitation
+        assert 'subject' in invitation.content
+        assert 'message' in invitation.content and invitation.content['message']['value'] == '''Hi {{{{fullname}}}},
 
 We regret to inform you that your submission was not accepted. We encourage you to consider the feedback provided and submit to future venues.
 
@@ -2467,35 +2471,49 @@ To view this paper, please go to https://openreview.net/forum?id={submission_for
 
 Best,
 ABCD 2025 Program Chairs'''
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Dates')
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Fields_to_Include')
-        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Decision_Notification/Templates')
+
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Dates')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Dates')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Fields_to_Include')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Fields_to_Include')
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Templates')
         assert invitation
-        assert all(key in invitation.edit['content'] for key in ['email_subject', 'accept_email_content', 'reject_email_content'])
-        assert 'email_content' not in invitation.edit['content']
+        assert all(key in invitation.edit['content'] for key in ['email_subject', 'email_content'])
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Templates')
+        assert invitation
+        assert all(key in invitation.edit['content'] for key in ['email_subject', 'email_content'])
 
         # change accept and reject email templates
         pc_client.post_invitation_edit(
-            invitations='ABCD.cc/2025/Conference/-/Author_Decision_Notification/Templates',
+            invitations='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Templates',
             content={
                 'email_subject': { 'value': '[ABCD 2025] The decision for your submission #{submission_number}, titled "{submission_title}" is now available' },
-                'accept_email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nABCD 2025 Program Chairs' },
-                'reject_email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are sorry to inform you that, after consideration by reviewers, your submission has not been accepted.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nABCD 2025 Program Chairs' }
+                'email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nABCD 2025 Program Chairs' },
             }
         )
-        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Decision_Notification-0-1', count=2)
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification-0-1', count=2)
+
+        pc_client.post_invitation_edit(
+            invitations='ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Templates',
+            content={
+                'email_subject': { 'value': '[ABCD 2025] The decision for your submission #{submission_number}, titled "{submission_title}" is now available' },
+                'email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are sorry to inform you that, after consideration by reviewers, your submission has not been accepted.\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nABCD 2025 Program Chairs' }
+
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification-0-1', count=2)
 
         now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
 
         # trigger notification date process with no fields to include
         pc_client.post_invitation_edit(
-            invitations='ABCD.cc/2025/Conference/-/Author_Decision_Notification/Dates',
+            invitations='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Dates',
             content={
                 'activation_date': { 'value': new_cdate }
             }
         )
-        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Decision_Notification-0-1', count=3)
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification-0-1', count=3)
 
         helpers.await_queue_edit(openreview_client, invitation='openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Status', count=6)
 
@@ -2503,15 +2521,15 @@ ABCD 2025 Program Chairs'''
         # assert status comment posted to request form
         notes = openreview_client.get_notes(invitation='openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Status', forum=venue.content['request_form_id']['value'], sort='number:asc')
         assert len(notes) == 6
-        assert notes[-1].content['title']['value'] == 'Author Decision Notification Failed'
+        assert notes[-1].content['title']['value'] == 'Author Accept Decision Notification Failed'
 
         pc_client.post_invitation_edit(
-            invitations='ABCD.cc/2025/Conference/-/Author_Decision_Notification/Fields_to_Include',
+            invitations='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Fields_to_Include',
             content={
                 'fields': { 'value': ['decision', 'comment'] }
             }
         )
-        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Decision_Notification-0-1', count=4)
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification-0-1', count=4)
 
         messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #1, titled \"Paper title 1\" is now available')
         assert messages and len(messages) == 1
@@ -2530,6 +2548,35 @@ ABCD 2025 Program Chairs
 Please note that responding to this email will direct your reply to abcd2025.programchairs@gmail.com.
 '''
 
+        # rejected papers and papers with no decision should not receive an email if the decision notification is sent to accepted papers only
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #3, titled \"Paper title 3\" is now available')
+        assert not messages
+
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #10, titled \"Paper title 10\" is now available')
+        assert not messages
+
+        # for rejected papers, do not include the comment field in the email notification
+        pc_client.post_invitation_edit(
+            invitations='ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Fields_to_Include',
+            content={
+                'fields': { 'value': ['decision'] }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification-0-1', count=3)
+
+        # send emails 
+        now = datetime.datetime.now()
+        new_cdate = openreview.tools.datetime_millis(now)
+
+        # trigger notification date process with no fields to include
+        pc_client.post_invitation_edit(
+            invitations='ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Dates',
+            content={
+                'activation_date': { 'value': new_cdate }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification-0-1', count=4)
+
         messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #3, titled \"Paper title 3\" is now available')
         assert messages and len(messages) == 1
         assert messages[0]['content']['text'] == f'''Hi SomeFirstName User,
@@ -2537,7 +2584,6 @@ Please note that responding to this email will direct your reply to abcd2025.pro
 We are sorry to inform you that, after consideration by reviewers, your submission has not been accepted.
 
 **decision**: Reject
-**comment**: We regret to inform you...
 
 To view this paper, please go to https://openreview.net/forum?id={submissions[2].id}
 
@@ -2547,6 +2593,7 @@ ABCD 2025 Program Chairs
 Please note that responding to this email will direct your reply to abcd2025.programchairs@gmail.com.
 '''
 
+        # papers with no decisions should not receive an email
         messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #10, titled \"Paper title 10\" is now available')
         assert not messages
 

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2645,6 +2645,48 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #10, titled \"Paper title 10\" is now available')
         assert not messages
 
+    def test_retrigger_accept_decision_notification_with_same_subject(self, openreview_client, helpers):
+
+        pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
+
+        # accepted paper #1 already received an accept decision notification earlier
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #1, titled \"Paper title 1\" is now available')
+        assert messages and len(messages) == 1
+
+        # retrigger the accept decision notification
+        now = datetime.datetime.now()
+        new_cdate = openreview.tools.datetime_millis(now)
+
+        pc_client.post_invitation_edit(
+            invitations='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Dates',
+            content={
+                'activation_date': { 'value': new_cdate }
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification-0-1', count=5)
+
+        # emails should not be sent again since the subject matches the subject of the email sent earlier
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] The decision for your submission #1, titled \"Paper title 1\" is now available')
+        assert messages and len(messages) == 1
+
+    def test_retrigger_accept_decision_notification_new_subject(self, openreview_client, helpers):
+
+        pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
+
+        # change the accept email subject
+        pc_client.post_invitation_edit(
+            invitations='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Templates',
+            content={
+                'email_subject': { 'value': '[ABCD 2025] Update on your submission #{submission_number}, titled "{submission_title}"' },
+                'email_content': { 'value': 'Hi {{{{fullname}}}},\n\nWe are happy to inform you that, based on the evaluation of the reviewers, your submission has been accepted. Congratulations!\n\n{formatted_decision}\nTo view this paper, please go to https://openreview.net/forum?id={submission_forum}\n\nBest,\nABCD 2025 Program Chairs' },
+            }
+        )
+        helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification-0-1', count=6)
+
+        # the email now gets sent since the subject no longer matches a previously sent email
+        messages = openreview_client.get_messages(to='test@mail.com', subject='[ABCD 2025] Update on your submission #1, titled \"Paper title 1\"')
+        assert messages and len(messages) == 1
+
     def test_camera_ready_revisions(self, openreview_client, helpers):
 
         pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2292,6 +2292,18 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         venue_group = openreview_client.get_group('ABCD.cc/2025/Conference')
         assert 'accept_decision_options' in venue_group.content and venue_group.content['accept_decision_options']['value'] == ['Accept', 'Poster']
 
+        invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification')
+        assert invitation and not invitation.ddate
+
+        invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification')
+        assert invitation and not invitation.ddate
+
+        invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Poster_Decision_Notification')
+        assert invitation and not invitation.ddate
+
+        invitation = openreview_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Revision_Needed_Decision_Notification')
+        assert invitation and not invitation.ddate
+
         now = datetime.datetime.now()
         now = openreview.tools.datetime_millis(now)
 
@@ -2459,6 +2471,19 @@ To view this paper, please go to https://openreview.net/forum?id={submission_for
 Best,
 ABCD 2025 Program Chairs'''
 
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Poster_Decision_Notification')
+        assert invitation
+        assert 'subject' in invitation.content
+        assert 'message' in invitation.content and invitation.content['message']['value'] == '''Hi {{{{fullname}}}},
+
+We are delighted to inform you that your submission has been accepted. Congratulations!
+
+{formatted_decision}
+To view this paper, please go to https://openreview.net/forum?id={submission_forum}
+
+Best,
+ABCD 2025 Program Chairs'''
+
         invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification')
         assert invitation
         assert 'subject' in invitation.content
@@ -2472,7 +2497,22 @@ To view this paper, please go to https://openreview.net/forum?id={submission_for
 Best,
 ABCD 2025 Program Chairs'''
 
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Revision_Needed_Decision_Notification')
+        assert invitation
+        assert 'subject' in invitation.content
+        assert 'message' in invitation.content and invitation.content['message']['value'] == '''Hi {{{{fullname}}}},
+
+We regret to inform you that your submission was not accepted. We encourage you to consider the feedback provided and submit to future venues.
+
+{formatted_decision}
+To view this paper, please go to https://openreview.net/forum?id={submission_forum}
+
+Best,
+ABCD 2025 Program Chairs'''
+
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Dates')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Poster_Decision_Notification/Dates')
+        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Revision_Needed_Decision_Notification/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Accept_Decision_Notification/Fields_to_Include')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Author_Reject_Decision_Notification/Fields_to_Include')

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2271,6 +2271,15 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         )
         helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Decision-0-1', count=2)
 
+        with pytest.raises(openreview.OpenReviewException, match=r'can not contain the following characters: ; : / or ,'):
+            edit = pc_client.post_invitation_edit(
+                invitations='ABCD.cc/2025/Conference/-/Decision/Decision_Options',
+                content={
+                    'decision_options': { 'value': ['Accept: Poster', 'Revision Needed', 'Reject'] },
+                    'accept_decision_options': { 'value': ['Accept: Poster'] }
+                }
+            )
+
         # edit decision options
         edit = pc_client.post_invitation_edit(
             invitations='ABCD.cc/2025/Conference/-/Decision/Decision_Options',

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2271,7 +2271,7 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         )
         helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Decision-0-1', count=2)
 
-        with pytest.raises(openreview.OpenReviewException, match=r'can not contain the following characters: ; : / or ,'):
+        with pytest.raises(openreview.OpenReviewException, match=r'can only contain letters, numbers, spaces, underscores and parentheses'):
             edit = pc_client.post_invitation_edit(
                 invitations='ABCD.cc/2025/Conference/-/Decision/Decision_Options',
                 content={


### PR DESCRIPTION
The main changes include supporting dynamic decision options (like "Accept (Oral)", "Accept (Poster)", etc.), generating separate notification invitations for each decision type, and ensuring that email templates and processes are updated automatically when decision options change. The test suite has also been updated to verify these new behaviors.

**Dynamic Decision Notification Management**

* The system now creates and manages separate notification invitations for each decision option (e.g., `Author_Accept_Oral_Decision_Notification`, `Author_Reject_Decision_Notification`). When decision options are changed, the system automatically deletes old invitations and creates new ones as needed. [[1]](diffhunk://#diff-1fa89c4d1fb091dec33cbb2b11119802c44e48a18a6c52d887111331c3b09423R22-R77) [[2]](diffhunk://#diff-74260f29e7fc95bead83e92cd455b248137d36e7c83c327786064179127996bcL238-R256) [[3]](diffhunk://#diff-30d9aec9183a045aa1dc63028d7bf001f4e17ed5ee9b684fd9dcb4fc05c1bd3cR1076-R1106)

* The `decision_option` is now passed through the workflow, and decision notification emails are sent only to submissions matching the relevant decision. This ensures that authors receive the correct notification for their decision outcome. [[1]](diffhunk://#diff-38907fc3d85563371197af87b7fe34413b945de8239cab0d22713e697ea1d6e0R24-R29) [[2]](diffhunk://#diff-38907fc3d85563371197af87b7fe34413b945de8239cab0d22713e697ea1d6e0R68-R71) [[3]](diffhunk://#diff-38907fc3d85563371197af87b7fe34413b945de8239cab0d22713e697ea1d6e0L81-R89)

**Test Suite Updates**

* Tests have been updated to check for the presence and correct state of the new, dynamically named decision notification invitations, and to verify that the system correctly handles changes to decision options. [[1]](diffhunk://#diff-30d9aec9183a045aa1dc63028d7bf001f4e17ed5ee9b684fd9dcb4fc05c1bd3cR1076-R1106) [[2]](diffhunk://#diff-30d9aec9183a045aa1dc63028d7bf001f4e17ed5ee9b684fd9dcb4fc05c1bd3cL1095-R1120) [[3]](diffhunk://#diff-30d9aec9183a045aa1dc63028d7bf001f4e17ed5ee9b684fd9dcb4fc05c1bd3cL1210-R1235) [[4]](diffhunk://#diff-a8f6f4a0736227326c4df8d2ce912f33d9dbefee1f980addaf13ef9c1da7e47dL137-R138)