### PR TITLE
Upgrade Read the Docs build OS from ubuntu-20.04 to ubuntu-24.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openreview-py"
-version = "2.2.3"
+version = "2.3.0"
 description = "OpenReview API Python client library"
 authors = [{name = "OpenReview Team", email = "info@openreview.net"}]
 license = {text = "MIT"}


### PR DESCRIPTION
ubuntu-20.04 is no longer a supported build.os value in Read the Docs; valid options are ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, and ubuntu-lts-latest.