### PR TITLE
Fix MongoDB install in CI and add a test for conditional (subset) values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,11 @@ jobs:
       - image: cimg/redis:7.2
       - image: mongo:8.0
         command: [ --replSet, rs0 ]
+        environment:
+          # Workaround for SERVER-121912: MongoDB 8.x's vendored TCMalloc violates
+          # the rseq ABI and crashes on Linux kernel >= 6.19 (CircleCI's runner
+          # kernel). Disabling glibc rseq sidesteps the crash.
+          GLIBC_TUNABLES: "glibc.pthread.rseq=0"
       - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
         environment:
           xpack.security.enabled: false
@@ -361,6 +366,11 @@ jobs:
       - image: cimg/redis:7.2
       - image: mongo:8.0
         command: [ --replSet, rs0 ]
+        environment:
+          # Workaround for SERVER-121912: MongoDB 8.x's vendored TCMalloc violates
+          # the rseq ABI and crashes on Linux kernel >= 6.19 (CircleCI's runner
+          # kernel). Disabling glibc rseq sidesteps the crash.
+          GLIBC_TUNABLES: "glibc.pthread.rseq=0"
       - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
         environment:
           xpack.security.enabled: false
@@ -422,6 +432,11 @@ jobs:
       - image: cimg/redis:7.2
       - image: mongo:8.0
         command: [ --replSet, rs0 ]
+        environment:
+          # Workaround for SERVER-121912: MongoDB 8.x's vendored TCMalloc violates
+          # the rseq ABI and crashes on Linux kernel >= 6.19 (CircleCI's runner
+          # kernel). Disabling glibc rseq sidesteps the crash.
+          GLIBC_TUNABLES: "glibc.pthread.rseq=0"
       - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
         environment:
           xpack.security.enabled: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,17 +73,32 @@ commands:
             # Make token available to subsequent steps
             echo "export GITHUB_TOKEN=$TOKEN" >> $BASH_ENV
   setup-python:
-    description: "Select Python 3.10 for pip/python on the VM (matches the old cimg/python:3.10)"
+    description: "Select the requested Python version (latest patch) via pyenv on the VM"
+    parameters:
+      python-version:
+        type: string
     steps:
       - run:
-          name: Select Python 3.10
+          name: Select Python << parameters.python-version >>
           command: |
-            # Machine images manage Python through pyenv. Prefer a preinstalled 3.10.x;
-            # install the latest 3.10 only if none is present.
-            PY_VERSION=$(pyenv versions --bare | grep -E '^3\.10\.' | tail -1 || true)
-            if [ -z "$PY_VERSION" ]; then
-              pyenv install 3.10
-              PY_VERSION=$(pyenv versions --bare | grep -E '^3\.10\.' | tail -1)
+            REQUESTED="<< parameters.python-version >>"
+            # Machine images manage Python through pyenv. `pyenv install` needs a full
+            # version (e.g. 3.10.14). If a full X.Y.Z was requested, use it as-is;
+            # if only a minor (e.g. 3.10) was requested, resolve the latest installable
+            # patch (preferring one already present on the image).
+            if echo "$REQUESTED" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              PY_VERSION="$REQUESTED"
+              pyenv install -s "$PY_VERSION"
+            else
+              PY_VERSION=$(pyenv versions --bare | grep -E "^${REQUESTED}\.[0-9]+$" | sort -V | tail -1 || true)
+              if [ -z "$PY_VERSION" ]; then
+                PY_VERSION=$(pyenv install --list | tr -d ' ' | grep -E "^${REQUESTED}\.[0-9]+$" | sort -V | tail -1)
+                if [ -z "$PY_VERSION" ]; then
+                  echo "ERROR: could not resolve a ${REQUESTED}.x version from pyenv" >&2
+                  exit 1
+                fi
+                pyenv install -s "$PY_VERSION"
+              fi
             fi
             pyenv global "$PY_VERSION"
             python --version
@@ -107,24 +122,35 @@ commands:
       - run:
           name: Initialize MongoDB replica set
           command: |
+            ready=false
             for i in $(seq 1 30); do
               if docker exec mongo mongosh --quiet --eval 'db.adminCommand("ping").ok' >/dev/null 2>&1; then
+                ready=true
                 break
               fi
               echo "waiting for mongod... ($i)"
               sleep 2
             done
+            if [ "$ready" != "true" ]; then
+              echo "ERROR: mongod did not become ready after 60s" >&2
+              docker logs mongo 2>&1 | tail -50 || true
+              exit 1
+            fi
             docker exec mongo mongosh --quiet --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "localhost:27017"}]})'
       - run:
           name: Wait for Elasticsearch
           command: |
             for i in $(seq 1 30); do
               if curl -s http://localhost:9200 >/dev/null 2>&1; then
-                break
+                echo "elasticsearch is up"
+                exit 0
               fi
               echo "waiting for elasticsearch... ($i)"
               sleep 2
             done
+            echo "ERROR: elasticsearch did not become ready after 60s" >&2
+            docker logs elasticsearch 2>&1 | tail -50 || true
+            exit 1
 
   clone-repos:
     description: "Clone OpenReview API repositories"
@@ -308,8 +334,7 @@ jobs:
     # Run only tests from files that were modified/added in the PR
     executor: mongo8-vm
     parameters:
-      # Unused now that the test jobs run on the VM (system Python 3.10); kept so the
-      # workflow's `python-version: "3.10"` argument stays valid.
+      # Passed to setup-python; selects the Python the VM test job runs on.
       python-version:
         type: string
     steps:
@@ -357,7 +382,8 @@ jobs:
               echo "No modified test files - skipping test environment setup"
               circleci-agent step halt
             fi
-      - setup-python
+      - setup-python:
+          python-version: << parameters.python-version >>
       - start-services
       - get-github-token
       - install-nodejs
@@ -392,13 +418,13 @@ jobs:
     executor: mongo8-vm
     parallelism: 10
     parameters:
-      # Unused now that the test jobs run on the VM (system Python 3.10); kept so the
-      # workflow's `python-version: "3.10"` argument stays valid.
+      # Passed to setup-python; selects the Python the VM test job runs on.
       python-version:
         type: string
     steps:
       - checkout
-      - setup-python
+      - setup-python:
+          python-version: << parameters.python-version >>
       - start-services
       - get-github-token
       - install-nodejs
@@ -445,13 +471,13 @@ jobs:
     # from the CircleCI UI; bypasses install-package + build-pr-tests + build.
     executor: mongo8-vm
     parameters:
-      # Unused now that the test jobs run on the VM (system Python 3.10); kept so the
-      # workflow's `python-version: "3.10"` argument stays valid.
+      # Passed to setup-python; selects the Python the VM test job runs on.
       python-version:
         type: string
     steps:
       - checkout
-      - setup-python
+      - setup-python:
+          python-version: << parameters.python-version >>
       - start-services
       - get-github-token
       - install-nodejs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,21 @@ parameters:
     type: string
     default: ""
 
+executors:
+  # Test jobs run on a VM (machine executor) rather than the Docker executor so we
+  # control the kernel. MongoDB 8.x refuses to start on Linux kernel >= 6.19
+  # (SERVER-121912), which is what CircleCI's shared Docker hosts now run. Ubuntu
+  # 22.04's kernel stays well below 6.19, so Mongo 8 boots here. The redis/mongo/
+  # elasticsearch "service containers" the Docker executor provided are started
+  # manually with --network host in the start-services command, which reproduces the
+  # same localhost-shared networking (so transport.host=localhost, the replica-set
+  # member host, etc. behave exactly as before).
+  mongo8-vm:
+    machine:
+      image: ubuntu-2204:current
+    resource_class: large
+    working_directory: ~/openreview-py-repo
+
 # Reusable commands to reduce duplication between jobs
 commands:
   get-github-token:
@@ -57,26 +72,59 @@ commands:
 
             # Make token available to subsequent steps
             echo "export GITHUB_TOKEN=$TOKEN" >> $BASH_ENV
-  setup-mongodb:
-    description: "Initialize MongoDB replica set"
+  setup-python:
+    description: "Select Python 3.10 for pip/python on the VM (matches the old cimg/python:3.10)"
     steps:
       - run:
-          name: Initialize replica set
+          name: Select Python 3.10
           command: |
-            # Source the utility functions
-            source ~/openreview-py-repo/.circleci/ci-utils.sh
-            
-            retry sudo apt-get update
-            retry sudo apt-get install -y gnupg curl
+            # Machine images manage Python through pyenv. Prefer a preinstalled 3.10.x;
+            # install the latest 3.10 only if none is present.
+            PY_VERSION=$(pyenv versions --bare | grep -E '^3\.10\.' | tail -1 || true)
+            if [ -z "$PY_VERSION" ]; then
+              pyenv install 3.10
+              PY_VERSION=$(pyenv versions --bare | grep -E '^3\.10\.' | tail -1)
+            fi
+            pyenv global "$PY_VERSION"
+            python --version
+            pip --version
 
-            curl -fsSL https://pgp.mongodb.com/server-8.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
-            echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
-
-            retry sudo apt-get update
-            retry sudo apt-get upgrade -y
-            retry sudo apt-get install -y mongodb-org=8.0.0
-
-            mongosh mongodb://localhost:27017 --eval "rs.initiate()"
+  start-services:
+    description: "Start redis, MongoDB 8 (replica set) and elasticsearch as host-networked containers"
+    steps:
+      - run:
+          name: Start service containers
+          command: |
+            # --network host reproduces the localhost-shared networking the Docker
+            # executor's service containers had, so nothing downstream changes.
+            docker run -d --name redis --network host redis:7.2 redis-server --protected-mode no
+            docker run -d --name mongo --network host mongo:8.0 --replSet rs0
+            docker run -d --name elasticsearch --network host \
+              -e xpack.security.enabled=false \
+              -e transport.host=localhost \
+              -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+              docker.elastic.co/elasticsearch/elasticsearch:7.7.0
+      - run:
+          name: Initialize MongoDB replica set
+          command: |
+            for i in $(seq 1 30); do
+              if docker exec mongo mongosh --quiet --eval 'db.adminCommand("ping").ok' >/dev/null 2>&1; then
+                break
+              fi
+              echo "waiting for mongod... ($i)"
+              sleep 2
+            done
+            docker exec mongo mongosh --quiet --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "localhost:27017"}]})'
+      - run:
+          name: Wait for Elasticsearch
+          command: |
+            for i in $(seq 1 30); do
+              if curl -s http://localhost:9200 >/dev/null 2>&1; then
+                break
+              fi
+              echo "waiting for elasticsearch... ($i)"
+              sleep 2
+            done
 
   clone-repos:
     description: "Clone OpenReview API repositories"
@@ -258,26 +306,12 @@ jobs:
           command: python -c "import openreview"
   build-pr-tests:
     # Run only tests from files that were modified/added in the PR
-    resource_class: large
-    working_directory: ~/openreview-py-repo
+    executor: mongo8-vm
     parameters:
+      # Unused now that the test jobs run on the VM (system Python 3.10); kept so the
+      # workflow's `python-version: "3.10"` argument stays valid.
       python-version:
         type: string
-    docker:
-      - image: cimg/python:<<parameters.python-version>>
-      - image: cimg/redis:7.2
-      - image: mongo:8.0
-        command: [ --replSet, rs0 ]
-        environment:
-          # Workaround for SERVER-121912: MongoDB 8.x's vendored TCMalloc violates
-          # the rseq ABI and crashes on Linux kernel >= 6.19 (CircleCI's runner
-          # kernel). Disabling glibc rseq sidesteps the crash.
-          GLIBC_TUNABLES: "glibc.pthread.rseq=0"
-      - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
-        environment:
-          xpack.security.enabled: false
-          transport.host: localhost
-          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     steps:
       - checkout
       - run:
@@ -323,9 +357,10 @@ jobs:
               echo "No modified test files - skipping test environment setup"
               circleci-agent step halt
             fi
+      - setup-python
+      - start-services
       - get-github-token
       - install-nodejs
-      - setup-mongodb
       - clone-repos
       - create-directories
       - install-firefox
@@ -354,33 +389,19 @@ jobs:
       - copy-logs-on-failure
       - store-test-artifacts
   build:
-    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large
+    executor: mongo8-vm
     parallelism: 10
-    working_directory: ~/openreview-py-repo
     parameters:
+      # Unused now that the test jobs run on the VM (system Python 3.10); kept so the
+      # workflow's `python-version: "3.10"` argument stays valid.
       python-version:
         type: string
-    docker:
-      - image: cimg/python:<<parameters.python-version>>
-      - image: cimg/redis:7.2
-      - image: mongo:8.0
-        command: [ --replSet, rs0 ]
-        environment:
-          # Workaround for SERVER-121912: MongoDB 8.x's vendored TCMalloc violates
-          # the rseq ABI and crashes on Linux kernel >= 6.19 (CircleCI's runner
-          # kernel). Disabling glibc rseq sidesteps the crash.
-          GLIBC_TUNABLES: "glibc.pthread.rseq=0"
-      - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
-        environment:
-          xpack.security.enabled: false
-          transport.host: localhost
-          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     steps:
       - checkout
+      - setup-python
+      - start-services
       - get-github-token
       - install-nodejs
-      - setup-mongodb
       - clone-repos
       - create-directories
       - install-firefox
@@ -422,31 +443,18 @@ jobs:
     # Run an explicit set of tests against custom openreview-api / openreview-api-v1
     # branches. Triggered by passing a non-empty `pytest-files` pipeline parameter
     # from the CircleCI UI; bypasses install-package + build-pr-tests + build.
-    resource_class: large
-    working_directory: ~/openreview-py-repo
+    executor: mongo8-vm
     parameters:
+      # Unused now that the test jobs run on the VM (system Python 3.10); kept so the
+      # workflow's `python-version: "3.10"` argument stays valid.
       python-version:
         type: string
-    docker:
-      - image: cimg/python:<<parameters.python-version>>
-      - image: cimg/redis:7.2
-      - image: mongo:8.0
-        command: [ --replSet, rs0 ]
-        environment:
-          # Workaround for SERVER-121912: MongoDB 8.x's vendored TCMalloc violates
-          # the rseq ABI and crashes on Linux kernel >= 6.19 (CircleCI's runner
-          # kernel). Disabling glibc rseq sidesteps the crash.
-          GLIBC_TUNABLES: "glibc.pthread.rseq=0"
-      - image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
-        environment:
-          xpack.security.enabled: false
-          transport.host: localhost
-          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     steps:
       - checkout
+      - setup-python
+      - start-services
       - get-github-token
       - install-nodejs
-      - setup-mongodb
       - clone-repos
       - create-directories
       - install-firefox

--- a/tests/test_serve_as_reviewer_validation.py
+++ b/tests/test_serve_as_reviewer_validation.py
@@ -145,43 +145,51 @@ class TestServeAsReviewerValidation():
         assert 'serve_as_reviewer' in submission_inv.edit['note']['content']
         assert submission_inv.edit['note']['content']['serve_as_reviewer']['value']['param']['enum'] == ['${...3/authors/value/*/username}']
 
+    def _submission_content(self, serve_as_reviewer):
+        '''Full submission content with a given serve_as_reviewer value. The authors
+        are always included because the enum reference resolves against the posted
+        edit, not the merged note -- omitting authors would leave the reference
+        unresolved and reject even valid values.'''
+        return {
+            'title': { 'value': 'Serve As Reviewer Submission' },
+            'abstract': { 'value': 'Abstract for the serve-as-reviewer test.' },
+            'authors': {
+                'value': [
+                    {
+                        'fullname': 'SomeFirstName User',
+                        'username': '~SomeFirstName_User1',
+                        'institutions': [{ 'domain': 'mail.com', 'country': 'US' }]
+                    },
+                    {
+                        'fullname': 'AuthorOne SARC',
+                        'username': '~AuthorOne_SARC1',
+                        'institutions': [{ 'domain': 'sarc.cc', 'country': 'US' }]
+                    }
+                ]
+            },
+            'keywords': { 'value': ['serve', 'as', 'reviewer'] },
+            'pdf': { 'value': '/pdf/' + 'p' * 40 + '.pdf' },
+            'serve_as_reviewer': { 'value': serve_as_reviewer },
+            'email_sharing': { 'value': 'We authorize the sharing of all author emails with Program Chairs.' },
+            'data_release': { 'value': 'We authorize the release of our submission and author names to the public in the event of acceptance.' },
+        }
+
     def test_submission_with_valid_serve_as_reviewer_succeeds(self, openreview_client, test_client, helpers):
         '''
         `serve_as_reviewer` is a list whose every element is one of the authors
-        (a valid subset of authors/username). This must be accepted.
+        (a valid subset of authors/username). This must be accepted, regardless of
+        order and for any subset size.
         '''
 
         test_client = openreview.api.OpenReviewClient(token=test_client.token)
 
+        # both authors -> valid subset
         edit = test_client.post_note_edit(
             invitation='sarc.cc/2026/Conference/-/Submission',
             signatures=['~SomeFirstName_User1'],
             note=openreview.api.Note(
                 license='CC BY 4.0',
-                content={
-                    'title': { 'value': 'Serve As Reviewer Submission' },
-                    'abstract': { 'value': 'Abstract for the serve-as-reviewer test.' },
-                    'authors': {
-                        'value': [
-                            {
-                                'fullname': 'SomeFirstName User',
-                                'username': '~SomeFirstName_User1',
-                                'institutions': [{ 'domain': 'mail.com', 'country': 'US' }]
-                            },
-                            {
-                                'fullname': 'AuthorOne SARC',
-                                'username': '~AuthorOne_SARC1',
-                                'institutions': [{ 'domain': 'sarc.cc', 'country': 'US' }]
-                            }
-                        ]
-                    },
-                    'keywords': { 'value': ['serve', 'as', 'reviewer'] },
-                    'pdf': { 'value': '/pdf/' + 'p' * 40 + '.pdf' },
-                    # every element is one of the authors above -> valid subset
-                    'serve_as_reviewer': { 'value': ['~SomeFirstName_User1', '~AuthorOne_SARC1'] },
-                    'email_sharing': { 'value': 'We authorize the sharing of all author emails with Program Chairs.' },
-                    'data_release': { 'value': 'We authorize the release of our submission and author names to the public in the event of acceptance.' },
-                }
+                content=self._submission_content(['~SomeFirstName_User1', '~AuthorOne_SARC1'])
             )
         )
 
@@ -189,7 +197,40 @@ class TestServeAsReviewerValidation():
 
         submissions = openreview_client.get_notes(invitation='sarc.cc/2026/Conference/-/Submission', sort='number:asc')
         assert len(submissions) == 1
-        assert submissions[0].content['serve_as_reviewer']['value'] == ['~SomeFirstName_User1', '~AuthorOne_SARC1']
+        submission = submissions[0]
+        assert submission.content['serve_as_reviewer']['value'] == ['~SomeFirstName_User1', '~AuthorOne_SARC1']
+
+        # 1. both authors in reverse order -> still a valid subset (order-independent)
+        edit = test_client.post_note_edit(
+            invitation='sarc.cc/2026/Conference/-/Submission',
+            signatures=['~SomeFirstName_User1'],
+            note=openreview.api.Note(
+                id=submission.id,
+                license='CC BY 4.0',
+                content=self._submission_content(['~AuthorOne_SARC1', '~SomeFirstName_User1'])
+            )
+        )
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
+        submission = openreview_client.get_note(submission.id)
+        assert submission.content['serve_as_reviewer']['value'] == ['~AuthorOne_SARC1', '~SomeFirstName_User1']
+
+        # 2. a single author -> still a valid subset
+        edit = test_client.post_note_edit(
+            invitation='sarc.cc/2026/Conference/-/Submission',
+            signatures=['~SomeFirstName_User1'],
+            note=openreview.api.Note(
+                id=submission.id,
+                license='CC BY 4.0',
+                content=self._submission_content(['~AuthorOne_SARC1'])
+            )
+        )
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
+        submission = openreview_client.get_note(submission.id)
+        assert submission.content['serve_as_reviewer']['value'] == ['~AuthorOne_SARC1']
+
+        # still just the one submission
+        submissions = openreview_client.get_notes(invitation='sarc.cc/2026/Conference/-/Submission', sort='number:asc')
+        assert len(submissions) == 1
 
     def test_submission_with_invalid_serve_as_reviewer_fails(self, openreview_client, test_client, helpers):
         '''

--- a/tests/test_serve_as_reviewer_validation.py
+++ b/tests/test_serve_as_reviewer_validation.py
@@ -1,0 +1,231 @@
+import datetime
+import pytest
+import openreview
+from openreview.api import Note, OpenReviewClient
+
+
+class TestServeAsReviewerValidation():
+    '''
+    Conditional, same-edit validation for note edits.
+
+    A venue wants a new submission field `serve_as_reviewer` where the author enters
+    the profile ids of the submission's authors who will serve as reviewers. The API
+    should validate that the value of `serve_as_reviewer` (a list) is a subset of the
+    `authors` field's usernames *of the same edit*.
+
+    The proposed way to express this in the invitation is a `$` reference that points
+    at a sibling field of the edit, e.g. the enum of allowed values is:
+
+        "${4/authors/username/*}"
+
+    i.e. "the set of usernames of every author of this submission".
+
+    This file drives the desired behaviour: posting a submission whose
+    `serve_as_reviewer` is NOT one of the authors must be rejected, while posting one
+    that IS one of the authors must succeed. The exact reference (level number, the
+    `*` wildcard, whether it needs the spread `...` prefix) is what we will pin down
+    while implementing the validation on the API side.
+    '''
+
+    def test_setup(self, openreview_client, helpers):
+
+        super_id = 'openreview.net'
+        support_group_id = super_id + '/Support'
+
+        helpers.create_user('programchair@sarc.cc', 'ProgramChair', 'SARC')
+        helpers.create_user('author_one@sarc.cc', 'AuthorOne', 'SARC')
+        helpers.create_user('author_two@sarc.cc', 'AuthorTwo', 'SARC')
+        helpers.create_user('author_three@sarc.cc', 'AuthorThree', 'SARC')
+        pc_client = openreview.api.OpenReviewClient(username='programchair@sarc.cc', password=helpers.strong_password)
+
+        now = datetime.datetime.now()
+        due_date = now + datetime.timedelta(days=2)
+
+        request = pc_client.post_note_edit(invitation='openreview.net/Support/Venue_Request/-/Conference_Review_Workflow',
+            signatures=['~ProgramChair_SARC1'],
+            note=openreview.api.Note(
+                content={
+                    'official_venue_name': { 'value': 'Serve As Reviewer Conference' },
+                    'abbreviated_venue_name': { 'value': 'SARC 2026' },
+                    'venue_website_url': { 'value': 'https://sarc.cc/Conferences/2026' },
+                    'location': { 'value': 'Online' },
+                    'venue_start_date': { 'value': openreview.tools.datetime_millis(now + datetime.timedelta(weeks=52)) },
+                    'program_chair_emails': { 'value': ['programchair@sarc.cc'] },
+                    'contact_email': { 'value': 'sarc2026.programchairs@gmail.com' },
+                    'submission_start_date': { 'value': openreview.tools.datetime_millis(now - datetime.timedelta(days=1)) },
+                    'submission_deadline': { 'value': openreview.tools.datetime_millis(due_date) },
+                    'reviewer_groups_names': { 'value': ['Reviewers'] },
+                    'area_chair_groups_names': { 'value': ['Area_Chairs'] },
+                    'senior_area_chair_groups_names': { 'value': ['Senior_Area_Chairs'] },
+                    'expected_submissions': { 'value': 5 },
+                    'venue_organizer_agreement': {
+                        'value': [
+                            'OpenReview natively supports a wide variety of reviewing workflow configurations. However, if we want significant reviewing process customizations or experiments, we will detail these requests to the OpenReview staff at least three months in advance.',
+                            'We will ask authors and reviewers to create an OpenReview Profile at least two weeks in advance of the paper submission deadlines.',
+                            'When assembling our group of reviewers, we will only include email addresses or OpenReview Profile IDs of people we know to have authored publications relevant to our venue.  (We will not solicit new reviewers using an open web form, because unfortunately some malicious actors sometimes try to create "fake ids" aiming to be assigned to review their own paper submissions.)',
+                            'We acknowledge that, if our venue\'s reviewing workflow is non-standard, or if our venue is expecting more than a few hundred submissions for any one deadline, we should designate our own Workflow Chair, who will read the OpenReview documentation and manage our workflow configurations throughout the reviewing process.',
+                            'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
+                            'We will treat the OpenReview staff with kindness and consideration.',
+                            'We acknowledge that authors and reviewers will be required to share their preferred email.',
+                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
+                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
+                        ]
+                    }
+                }
+            ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=request['id'])
+
+        # deploy the venue
+        edit = openreview_client.post_note_edit(
+            invitation='openreview.net/Support/Venue_Request/Conference_Review_Workflow/-/Deployment',
+            signatures=[support_group_id],
+            note=openreview.api.Note(
+                id=request['note']['id'],
+                content={
+                    'venue_id': { 'value': 'sarc.cc/2026/Conference' }
+                }
+            ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
+
+        assert openreview_client.get_invitation('sarc.cc/2026/Conference/-/Submission')
+        assert openreview_client.get_invitation('sarc.cc/2026/Conference/-/Submission/Form_Fields')
+
+    def test_add_serve_as_reviewer_field(self, openreview_client, helpers):
+        '''
+        Add the `serve_as_reviewer` field to the submission form. It is a list whose
+        allowed values are a `$` reference to the usernames of the authors of the same
+        submission edit, so the API can validate that the entered list is a subset of
+        the authors.
+        '''
+
+        pc_client = openreview.api.OpenReviewClient(username='programchair@sarc.cc', password=helpers.strong_password)
+
+        content_inv = openreview.tools.get_invitation(openreview_client, 'sarc.cc/2026/Conference/-/Submission/Form_Fields')
+        assert content_inv
+
+        pc_client.post_invitation_edit(
+            invitations=content_inv.id,
+            content={
+                'content': {
+                    'value': {
+                        'serve_as_reviewer': {
+                            'order': 11,
+                            'description': 'Enter the profile ids of the authors of this submission who will serve as reviewers.',
+                            'value': {
+                                'param': {
+                                    'type': 'string[]',
+                                    # allowed values = the usernames of this submission's authors (same edit)
+                                    'enum': ['${4/authors/username/*}'],
+                                    'input': 'select'
+                                }
+                            }
+                        }
+                    }
+                },
+                'license': {
+                    'value': [
+                        {'value': 'CC BY 4.0', 'description': 'CC BY 4.0'}
+                    ]
+                }
+            }
+        )
+
+        helpers.await_queue_edit(openreview_client, invitation='sarc.cc/2026/Conference/-/Submission/Form_Fields')
+
+        submission_inv = openreview.tools.get_invitation(openreview_client, 'sarc.cc/2026/Conference/-/Submission')
+        assert submission_inv
+        assert 'serve_as_reviewer' in submission_inv.edit['note']['content']
+        assert submission_inv.edit['note']['content']['serve_as_reviewer']['value']['param']['enum'] == ['${4/authors/username/*}']
+
+    def test_submission_with_valid_serve_as_reviewer_succeeds(self, openreview_client, test_client, helpers):
+        '''
+        `serve_as_reviewer` is a list whose every element is one of the authors
+        (a valid subset of authors/username). This must be accepted.
+        '''
+
+        test_client = openreview.api.OpenReviewClient(token=test_client.token)
+
+        edit = test_client.post_note_edit(
+            invitation='sarc.cc/2026/Conference/-/Submission',
+            signatures=['~SomeFirstName_User1'],
+            note=openreview.api.Note(
+                license='CC BY 4.0',
+                content={
+                    'title': { 'value': 'Serve As Reviewer Submission' },
+                    'abstract': { 'value': 'Abstract for the serve-as-reviewer test.' },
+                    'authors': {
+                        'value': [
+                            {
+                                'fullname': 'SomeFirstName User',
+                                'username': '~SomeFirstName_User1',
+                                'institutions': [{ 'domain': 'mail.com', 'country': 'US' }]
+                            },
+                            {
+                                'fullname': 'AuthorOne SARC',
+                                'username': '~AuthorOne_SARC1',
+                                'institutions': [{ 'domain': 'sarc.cc', 'country': 'US' }]
+                            }
+                        ]
+                    },
+                    'keywords': { 'value': ['serve', 'as', 'reviewer'] },
+                    'pdf': { 'value': '/pdf/' + 'p' * 40 + '.pdf' },
+                    # every element is one of the authors above -> valid subset
+                    'serve_as_reviewer': { 'value': ['~SomeFirstName_User1', '~AuthorOne_SARC1'] },
+                    'email_sharing': { 'value': 'We authorize the sharing of all author emails with Program Chairs.' },
+                    'data_release': { 'value': 'We authorize the release of our submission and author names to the public in the event of acceptance.' },
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
+
+        submissions = openreview_client.get_notes(invitation='sarc.cc/2026/Conference/-/Submission', sort='number:asc')
+        assert len(submissions) == 1
+        assert submissions[0].content['serve_as_reviewer']['value'] == ['~SomeFirstName_User1', '~AuthorOne_SARC1']
+
+    def test_submission_with_invalid_serve_as_reviewer_fails(self, openreview_client, test_client, helpers):
+        '''
+        `serve_as_reviewer` is a list that is NOT a subset of the authors: it contains
+        ~ProgramChair_SARC1 (the PC, not an author). This must be rejected.
+        '''
+
+        test_client = openreview.api.OpenReviewClient(token=test_client.token)
+
+        with pytest.raises(openreview.OpenReviewException) as openReviewError:
+            test_client.post_note_edit(
+                invitation='sarc.cc/2026/Conference/-/Submission',
+                signatures=['~SomeFirstName_User1'],
+                note=openreview.api.Note(
+                    license='CC BY 4.0',
+                    content={
+                        'title': { 'value': 'Serve As Reviewer Invalid Submission' },
+                        'abstract': { 'value': 'Abstract for the serve-as-reviewer invalid test.' },
+                        'authors': {
+                            'value': [
+                                {
+                                    'fullname': 'SomeFirstName User',
+                                    'username': '~SomeFirstName_User1',
+                                    'institutions': [{ 'domain': 'mail.com', 'country': 'US' }]
+                                },
+                                {
+                                    'fullname': 'AuthorOne SARC',
+                                    'username': '~AuthorOne_SARC1',
+                                    'institutions': [{ 'domain': 'sarc.cc', 'country': 'US' }]
+                                }
+                            ]
+                        },
+                        'keywords': { 'value': ['serve', 'as', 'reviewer'] },
+                        'pdf': { 'value': '/pdf/' + 'p' * 40 + '.pdf' },
+                        # ~ProgramChair_SARC1 is NOT one of the authors above, so this
+                        # list is not a subset of authors/username
+                        'serve_as_reviewer': { 'value': ['~AuthorOne_SARC1', '~ProgramChair_SARC1'] },
+                        'email_sharing': { 'value': 'We authorize the sharing of all author emails with Program Chairs.' },
+                        'data_release': { 'value': 'We authorize the release of our submission and author names to the public in the event of acceptance.' },
+                    }
+                )
+            )
+
+        # The exact message will be defined when the validation is implemented.
+        print(openReviewError.value)

--- a/tests/test_serve_as_reviewer_validation.py
+++ b/tests/test_serve_as_reviewer_validation.py
@@ -13,18 +13,22 @@ class TestServeAsReviewerValidation():
     should validate that the value of `serve_as_reviewer` (a list) is a subset of the
     `authors` field's usernames *of the same edit*.
 
-    The proposed way to express this in the invitation is a `$` reference that points
-    at a sibling field of the edit, e.g. the enum of allowed values is:
+    This is expressed with a `$` reference in the field's enum that points at the
+    sibling `authors` field of the same edit:
 
-        "${4/authors/username/*}"
+        "${...3/authors/value/*/username}"
 
-    i.e. "the set of usernames of every author of this submission".
+    which resolves, per edit, to the list of author usernames. The existing API
+    interpreter already supports this (no server-side change needed):
+      - `...`      spreads the resolved array into the enum (so enum becomes the
+                   flat list of usernames, not a single nested array);
+      - `3/`       pops enum-index, `value`, `serve_as_reviewer` off the field's path
+                   to land at `note/content`;
+      - `authors/value/*/username` reads each author-object's username.
 
-    This file drives the desired behaviour: posting a submission whose
-    `serve_as_reviewer` is NOT one of the authors must be rejected, while posting one
-    that IS one of the authors must succeed. The exact reference (level number, the
-    `*` wildcard, whether it needs the spread `...` prefix) is what we will pin down
-    while implementing the validation on the API side.
+    Because `serve_as_reviewer` is a `string[]` whose allowed values are exactly the
+    author usernames, AJV validates it as a subset of the authors: posting a value
+    that is NOT one of the authors is rejected, one that IS an author is accepted.
     '''
 
     def test_setup(self, openreview_client, helpers):
@@ -116,8 +120,10 @@ class TestServeAsReviewerValidation():
                             'value': {
                                 'param': {
                                     'type': 'string[]',
-                                    # allowed values = the usernames of this submission's authors (same edit)
-                                    'enum': ['${4/authors/username/*}'],
+                                    # allowed values = the usernames of this submission's authors (same edit).
+                                    # `...` spreads the resolved array into the enum; `3/` pops enum/0, value,
+                                    # serve_as_reviewer to land at note/content, then reads authors/value/*/username.
+                                    'enum': ['${...3/authors/value/*/username}'],
                                     'input': 'select'
                                 }
                             }
@@ -137,7 +143,7 @@ class TestServeAsReviewerValidation():
         submission_inv = openreview.tools.get_invitation(openreview_client, 'sarc.cc/2026/Conference/-/Submission')
         assert submission_inv
         assert 'serve_as_reviewer' in submission_inv.edit['note']['content']
-        assert submission_inv.edit['note']['content']['serve_as_reviewer']['value']['param']['enum'] == ['${4/authors/username/*}']
+        assert submission_inv.edit['note']['content']['serve_as_reviewer']['value']['param']['enum'] == ['${...3/authors/value/*/username}']
 
     def test_submission_with_valid_serve_as_reviewer_succeeds(self, openreview_client, test_client, helpers):
         '''
@@ -227,5 +233,7 @@ class TestServeAsReviewerValidation():
                 )
             )
 
-        # The exact message will be defined when the validation is implemented.
-        print(openReviewError.value)
+        # The non-author value is rejected against the resolved enum of author usernames.
+        error = str(openReviewError.value)
+        assert 'serve_as_reviewer' in error
+        assert '~ProgramChair_SARC1' in error

--- a/tests/test_serve_as_reviewer_validation.py
+++ b/tests/test_serve_as_reviewer_validation.py
@@ -120,10 +120,7 @@ class TestServeAsReviewerValidation():
                             'value': {
                                 'param': {
                                     'type': 'string[]',
-                                    # allowed values = the usernames of this submission's authors (same edit).
-                                    # `...` spreads the resolved array into the enum; `3/` pops enum/0, value,
-                                    # serve_as_reviewer to land at note/content, then reads authors/value/*/username.
-                                    'enum': ['${...3/authors/value/*/username}'],
+                                    'enum': ['${3/authors/value/*/username}'],
                                     'input': 'select'
                                 }
                             }
@@ -143,7 +140,7 @@ class TestServeAsReviewerValidation():
         submission_inv = openreview.tools.get_invitation(openreview_client, 'sarc.cc/2026/Conference/-/Submission')
         assert submission_inv
         assert 'serve_as_reviewer' in submission_inv.edit['note']['content']
-        assert submission_inv.edit['note']['content']['serve_as_reviewer']['value']['param']['enum'] == ['${...3/authors/value/*/username}']
+        assert submission_inv.edit['note']['content']['serve_as_reviewer']['value']['param']['enum'] == ['${3/authors/value/*/username}']
 
     def _submission_content(self, serve_as_reviewer):
         '''Full submission content with a given serve_as_reviewer value. The authors


### PR DESCRIPTION
## Summary

Two independent changes:

1. **Fix the MongoDB install in CI** so the test suite runs on MongoDB 8. Recent MongoDB 8.x builds refuse to start on Linux kernel ≥ 6.19 ([SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912)), which is the kernel CircleCI's Docker executors now run. The mongo-dependent jobs are moved to a `machine` executor pinned to `ubuntu-2204` (kernel 5.15), where Mongo 8 boots.
2. **Add an integration test for conditional / same-edit values** — proving that "a field's value must be a subset of another field of the same note edit" already works with the existing API, using a `${...}` reference in the field's `enum`.

---

## 1. Fix MongoDB install in CI (`.circleci/config.yml`)

### Problem

MongoDB 8.x has a hard startup guard that aborts on Linux kernel ≥ 6.19 (`MongoDB cannot start: Linux kernel versions 6.19 and newer has a known incompatibility with this version of MongoDB`). CircleCI's shared Docker hosts were upgraded to that kernel, so the `mongo:8.0` service container exits before any test runs. A container cannot pick its own kernel — it shares the host's — so no image swap or `GLIBC_TUNABLES` tweak avoids it. The only lever for the kernel on CircleCI is a `machine` executor.

### Change

- Added a `mongo8-vm` **machine executor** (`ubuntu-2204:current`, `resource_class: large`), whose kernel (5.15) is below 6.19, so Mongo 8 starts.
- Replaced the automatic Docker **service containers** (which a machine executor doesn't provide) with a `start-services` command that launches redis, **mongo:8.0**, and elasticsearch via `docker run --network host` and initializes the replica set. `--network host` reproduces the localhost-shared networking the service containers had, so nothing downstream changes (`transport.host=localhost`, the replica-set member host, etc. behave exactly as before).
- Added a `setup-python` command that selects Python 3.10 via pyenv (the test jobs were pinned to `cimg/python:3.10`; Ubuntu 22.04's system Python is also 3.10).
- Pointed the three test jobs (`build-pr-tests`, `build`, `debug-tests`) at `executor: mongo8-vm`. `install-package` and `deploy-dev` stay on the Docker executor (they don't use MongoDB).

### What changes in test execution

Nothing about *how* the tests run changes — same jobs, same `parallelism: 10` on `build`, same test split (container 0 → `test_journal.py`, container 1 → `test_arr_venue_v2.py`, containers 2–9 → the rest split by timings), same clean DB per runner. Only the *environment* each runner executes in changes:

| | Before (Docker executor) | After (this branch) |
|---|---|---|
| Runner environment | `cimg/python:3.10` container on a shared host | `ubuntu-2204` machine VM |
| redis / mongo / ES | CircleCI **service containers** (auto-provisioned in the `docker:` block) | started by the `start-services` step via `docker run --network host` |
| Python | the `cimg/python:3.10` image | pyenv-selected 3.10 on the VM |
| MongoDB | crashed on the host's ≥6.19 kernel | **Mongo 8** boots (VM kernel 5.15) |

From the pytest process's point of view nothing changes: it still connects to mongo/redis/ES on `localhost` and the two API servers on ports 3000/3001. `--network host` was chosen specifically to preserve that localhost-shared topology, so the tests can't tell the difference.

### Notes / trade-offs

- The `build` job keeps `parallelism: 10`, which now means 10 machine VMs per run. Machine executors boot slower than Docker containers and each runner re-pulls the service images, so a run uses more CI minutes overall (not a billing concern — this is an open-source project on CircleCI's free plan). Parallelism can be lowered if run time/queueing ever becomes an issue.
- This is a kernel pin: if CircleCI refreshes the `ubuntu-2204` image family to a kernel ≥ 6.19, it would need revisiting. (Ubuntu 22.04's kernel line stays well below 6.19, so this is unlikely for the life of that image.)
- Local dev is unaffected: `docker/docker-compose.yml` runs Mongo 8 on Docker Desktop, whose LinuxKit kernel (6.12) is below 6.19.

---

## 2. Add a test for conditional / subset values (`tests/test_serve_as_reviewer_validation.py`)

### What it validates

A common venue request: add a submission field `serve_as_reviewer` where the author enters the profile ids of the submission's authors who will serve as reviewers, and the API validates that this list is a **subset of the submission's authors of the same edit**.

The test proves this is **already supported** by the existing `${...}` interpreter — no server-side change is required. The field is defined in the Submission `Form_Fields` as:

```python
'serve_as_reviewer': {
    'value': { 'param': {
        'type': 'string[]',
        'enum': ['${3/authors/value/*/username}'],
        'input': 'select'
    }}
}
```

The `enum` reference resolves per submission (against the posted edit) to the list of author usernames, and the `string[]` field is validated as a subset of it. Key points established by iterating the test:

- The reference must be inside a **list** (`enum` must be an array); a bare string is rejected with `enum must be array`.
- The `...` spread prefix is **optional** — the interpreter flattens the resolved array into the enum either way.
- Level `3` pops the enum index, `value`, and `serve_as_reviewer` to land at `note/content`, then reads `authors/value/*/username`.

### Test cases

- `test_setup` — deploys a `Conference_Review_Workflow` venue (`sarc.cc/2026/Conference`) that uses the author-object schema (each author has a `username`).
- `test_add_serve_as_reviewer_field` — adds the `serve_as_reviewer` field via `Submission/Form_Fields` and asserts the reference is stored.
- `test_submission_with_valid_serve_as_reviewer_succeeds` — a submission whose `serve_as_reviewer` is a valid subset of the authors is accepted; also covers reverse order and a single-element subset (each posted with the full author list, since the reference resolves against the edit, not the merged note).
- `test_submission_with_invalid_serve_as_reviewer_fails` — a submission whose `serve_as_reviewer` contains a non-author (`~ProgramChair_SARC1`) is rejected with an `EnumError`.

---

## Testing

- The full test file passes end-to-end against MongoDB 8 (`4 passed`), run via `docker/run.py`.
- Verified in serve mode (`docker/run.py --serve tests/test_serve_as_reviewer_validation.py`) that the venue and field render in the web UI.