### PR TITLE
Let PCs choose whether role participation becomes public

### DIFF
--- a/openreview/arr/arr.py
+++ b/openreview/arr/arr.py
@@ -87,6 +87,7 @@ class ARR(object):
         self.submission_license = None
         self.use_publication_chairs = False
         self.source_submissions_query_mapping = {}
+        self.release_role_participation = True
         self.sac_paper_assignments = False
         self.submission_assignment_max_reviewers = None
         self.comment_notification_threshold = None
@@ -136,6 +137,7 @@ class ARR(object):
         self.venue.senior_area_chair_identity_readers = self.senior_area_chair_identity_readers
         self.venue.decision_heading_map = self.decision_heading_map
         self.venue.source_submissions_query_mapping = self.source_submissions_query_mapping
+        self.venue.release_role_participation = self.release_role_participation
         self.venue.sac_paper_assignments = self.sac_paper_assignments
         self.venue.submission_assignment_max_reviewers = self.submission_assignment_max_reviewers
         self.venue.comment_notification_threshold = self.comment_notification_threshold

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -165,6 +165,7 @@ class GroupBuilder(object):
             'start_date': { 'value': self.venue.start_date if self.venue.start_date else '' },
             'date': { 'value': self.venue.date if self.venue.date else '' },
             'release_role_participation': { 'value': self.venue.release_role_participation },
+            'release_accepted_submissions': { 'value': self.venue.release_accepted_submissions },
             'program_chairs_id': { 'value': self.venue.get_program_chairs_id() },
             'reviewers_id': { 'value': self.venue.get_reviewers_id() },
             'reviewers_name': { 'value': self.venue.reviewers_name },

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -164,6 +164,7 @@ class GroupBuilder(object):
             'instructions': { 'value': self.venue.instructions if self.venue.instructions else '' },
             'start_date': { 'value': self.venue.start_date if self.venue.start_date else '' },
             'date': { 'value': self.venue.date if self.venue.date else '' },
+            'release_role_participation': { 'value': self.venue.release_role_participation },
             'program_chairs_id': { 'value': self.venue.get_program_chairs_id() },
             'reviewers_id': { 'value': self.venue.get_reviewers_id() },
             'reviewers_name': { 'value': self.venue.reviewers_name },

--- a/openreview/venue/group.py
+++ b/openreview/venue/group.py
@@ -165,7 +165,6 @@ class GroupBuilder(object):
             'start_date': { 'value': self.venue.start_date if self.venue.start_date else '' },
             'date': { 'value': self.venue.date if self.venue.date else '' },
             'release_role_participation': { 'value': self.venue.release_role_participation },
-            'release_accepted_submissions': { 'value': self.venue.release_accepted_submissions },
             'program_chairs_id': { 'value': self.venue.get_program_chairs_id() },
             'reviewers_id': { 'value': self.venue.get_reviewers_id() },
             'reviewers_name': { 'value': self.venue.reviewers_name },

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -5411,77 +5411,79 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
             }
         ) 
 
-        self.client.post_invitation_edit(
-            invitations=f'{super_id}/-/Reviewer_Role',
-            signatures=[template_domain],
-            content={
-                'venue_id': {'value': self.venue_id},
-                'committee_name': {'value': tools.singularize(self.venue.reviewers_name) },
-                'activation_date': { 'value': activation_date },
-            }
-        )
-
-        if self.venue.use_ethics_reviewers:
+        ## Only collect and publicly release role participation tags if the PC opted in
+        if self.venue.release_role_participation:
             self.client.post_invitation_edit(
-                invitations=f'{super_id}/-/Ethics_Reviewer_Role',
+                invitations=f'{super_id}/-/Reviewer_Role',
                 signatures=[template_domain],
                 content={
                     'venue_id': {'value': self.venue_id},
-                    'committee_name': {'value': tools.singularize(self.venue.ethics_reviewers_name) },
+                    'committee_name': {'value': tools.singularize(self.venue.reviewers_name) },
                     'activation_date': { 'value': activation_date },
                 }
             )
 
-        if self.venue.use_area_chairs:
+            if self.venue.use_ethics_reviewers:
+                self.client.post_invitation_edit(
+                    invitations=f'{super_id}/-/Ethics_Reviewer_Role',
+                    signatures=[template_domain],
+                    content={
+                        'venue_id': {'value': self.venue_id},
+                        'committee_name': {'value': tools.singularize(self.venue.ethics_reviewers_name) },
+                        'activation_date': { 'value': activation_date },
+                    }
+                )
+
+            if self.venue.use_area_chairs:
+                self.client.post_invitation_edit(
+                    invitations=f'{super_id}/-/Meta_Reviewer_Role',
+                    signatures=[template_domain],
+                    content={
+                        'venue_id': {'value': self.venue_id},
+                        'committee_name': {'value': tools.singularize(self.venue.area_chairs_name) },
+                        'activation_date': { 'value': activation_date },
+                    }
+                )
+
+            if self.venue.use_senior_area_chairs:
+                self.client.post_invitation_edit(
+                    invitations=f'{super_id}/-/Senior_Meta_Reviewer_Role',
+                    signatures=[template_domain],
+                    content={
+                        'venue_id': {'value': self.venue_id},
+                        'committee_name': {'value': tools.singularize(self.venue.senior_area_chairs_name) },
+                        'activation_date': { 'value': activation_date },
+                    }
+                )
+
             self.client.post_invitation_edit(
-                invitations=f'{super_id}/-/Meta_Reviewer_Role',
+                invitations=f'{super_id}/-/Program_Chair_Role',
                 signatures=[template_domain],
                 content={
                     'venue_id': {'value': self.venue_id},
-                    'committee_name': {'value': tools.singularize(self.venue.area_chairs_name) },
+                    'committee_name': {'value': tools.singularize(self.venue.program_chairs_name) },
                     'activation_date': { 'value': activation_date },
                 }
             )
 
-        if self.venue.use_senior_area_chairs:
-            self.client.post_invitation_edit(
-                invitations=f'{super_id}/-/Senior_Meta_Reviewer_Role',
-                signatures=[template_domain],
-                content={
-                    'venue_id': {'value': self.venue_id},
-                    'committee_name': {'value': tools.singularize(self.venue.senior_area_chairs_name) },
-                    'activation_date': { 'value': activation_date },
-                }
-            )
+            if self.venue.use_ethics_chairs:
+                self.client.post_invitation_edit(
+                    invitations=f'{super_id}/-/Ethics_Chair_Role',
+                    signatures=[template_domain],
+                    content={
+                        'venue_id': {'value': self.venue_id},
+                        'committee_name': {'value': tools.singularize(self.venue.ethics_chairs_name) },
+                        'activation_date': { 'value': activation_date },
+                    }
+                )
 
-        self.client.post_invitation_edit(
-            invitations=f'{super_id}/-/Program_Chair_Role',
-            signatures=[template_domain],
-            content={
-                'venue_id': {'value': self.venue_id},
-                'committee_name': {'value': tools.singularize(self.venue.program_chairs_name) },
-                'activation_date': { 'value': activation_date },
-            }
-        )
-
-        if self.venue.use_ethics_chairs:
-            self.client.post_invitation_edit(
-                invitations=f'{super_id}/-/Ethics_Chair_Role',
-                signatures=[template_domain],
-                content={
-                    'venue_id': {'value': self.venue_id},
-                    'committee_name': {'value': tools.singularize(self.venue.ethics_chairs_name) },
-                    'activation_date': { 'value': activation_date },
-                }
-            )
-
-        if self.venue.use_publication_chairs:
-            self.client.post_invitation_edit(
-                invitations=f'{super_id}/-/Publication_Chair_Role',
-                signatures=[template_domain],
-                content={
-                    'venue_id': {'value': self.venue_id},
-                    'committee_name': {'value': tools.singularize(self.venue.publication_chairs_name) },
-                    'activation_date': { 'value': activation_date },
-                }
-            )
+            if self.venue.use_publication_chairs:
+                self.client.post_invitation_edit(
+                    invitations=f'{super_id}/-/Publication_Chair_Role',
+                    signatures=[template_domain],
+                    content={
+                        'venue_id': {'value': self.venue_id},
+                        'committee_name': {'value': tools.singularize(self.venue.publication_chairs_name) },
+                        'activation_date': { 'value': activation_date },
+                    }
+                )

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -5412,78 +5412,80 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
         ) 
 
         ## Only collect and publicly release role participation tags if the PC opted in
-        if self.venue.release_role_participation:
+        if not self.venue.release_role_participation:
+            return
+
+        self.client.post_invitation_edit(
+            invitations=f'{super_id}/-/Reviewer_Role',
+            signatures=[template_domain],
+            content={
+                'venue_id': {'value': self.venue_id},
+                'committee_name': {'value': tools.singularize(self.venue.reviewers_name) },
+                'activation_date': { 'value': activation_date },
+            }
+        )
+
+        if self.venue.use_ethics_reviewers:
             self.client.post_invitation_edit(
-                invitations=f'{super_id}/-/Reviewer_Role',
+                invitations=f'{super_id}/-/Ethics_Reviewer_Role',
                 signatures=[template_domain],
                 content={
                     'venue_id': {'value': self.venue_id},
-                    'committee_name': {'value': tools.singularize(self.venue.reviewers_name) },
+                    'committee_name': {'value': tools.singularize(self.venue.ethics_reviewers_name) },
                     'activation_date': { 'value': activation_date },
                 }
             )
 
-            if self.venue.use_ethics_reviewers:
-                self.client.post_invitation_edit(
-                    invitations=f'{super_id}/-/Ethics_Reviewer_Role',
-                    signatures=[template_domain],
-                    content={
-                        'venue_id': {'value': self.venue_id},
-                        'committee_name': {'value': tools.singularize(self.venue.ethics_reviewers_name) },
-                        'activation_date': { 'value': activation_date },
-                    }
-                )
-
-            if self.venue.use_area_chairs:
-                self.client.post_invitation_edit(
-                    invitations=f'{super_id}/-/Meta_Reviewer_Role',
-                    signatures=[template_domain],
-                    content={
-                        'venue_id': {'value': self.venue_id},
-                        'committee_name': {'value': tools.singularize(self.venue.area_chairs_name) },
-                        'activation_date': { 'value': activation_date },
-                    }
-                )
-
-            if self.venue.use_senior_area_chairs:
-                self.client.post_invitation_edit(
-                    invitations=f'{super_id}/-/Senior_Meta_Reviewer_Role',
-                    signatures=[template_domain],
-                    content={
-                        'venue_id': {'value': self.venue_id},
-                        'committee_name': {'value': tools.singularize(self.venue.senior_area_chairs_name) },
-                        'activation_date': { 'value': activation_date },
-                    }
-                )
-
+        if self.venue.use_area_chairs:
             self.client.post_invitation_edit(
-                invitations=f'{super_id}/-/Program_Chair_Role',
+                invitations=f'{super_id}/-/Meta_Reviewer_Role',
                 signatures=[template_domain],
                 content={
                     'venue_id': {'value': self.venue_id},
-                    'committee_name': {'value': tools.singularize(self.venue.program_chairs_name) },
+                    'committee_name': {'value': tools.singularize(self.venue.area_chairs_name) },
                     'activation_date': { 'value': activation_date },
                 }
             )
 
-            if self.venue.use_ethics_chairs:
-                self.client.post_invitation_edit(
-                    invitations=f'{super_id}/-/Ethics_Chair_Role',
-                    signatures=[template_domain],
-                    content={
-                        'venue_id': {'value': self.venue_id},
-                        'committee_name': {'value': tools.singularize(self.venue.ethics_chairs_name) },
-                        'activation_date': { 'value': activation_date },
-                    }
-                )
+        if self.venue.use_senior_area_chairs:
+            self.client.post_invitation_edit(
+                invitations=f'{super_id}/-/Senior_Meta_Reviewer_Role',
+                signatures=[template_domain],
+                content={
+                    'venue_id': {'value': self.venue_id},
+                    'committee_name': {'value': tools.singularize(self.venue.senior_area_chairs_name) },
+                    'activation_date': { 'value': activation_date },
+                }
+            )
 
-            if self.venue.use_publication_chairs:
-                self.client.post_invitation_edit(
-                    invitations=f'{super_id}/-/Publication_Chair_Role',
-                    signatures=[template_domain],
-                    content={
-                        'venue_id': {'value': self.venue_id},
-                        'committee_name': {'value': tools.singularize(self.venue.publication_chairs_name) },
-                        'activation_date': { 'value': activation_date },
-                    }
-                )
+        self.client.post_invitation_edit(
+            invitations=f'{super_id}/-/Program_Chair_Role',
+            signatures=[template_domain],
+            content={
+                'venue_id': {'value': self.venue_id},
+                'committee_name': {'value': tools.singularize(self.venue.program_chairs_name) },
+                'activation_date': { 'value': activation_date },
+            }
+        )
+
+        if self.venue.use_ethics_chairs:
+            self.client.post_invitation_edit(
+                invitations=f'{super_id}/-/Ethics_Chair_Role',
+                signatures=[template_domain],
+                content={
+                    'venue_id': {'value': self.venue_id},
+                    'committee_name': {'value': tools.singularize(self.venue.ethics_chairs_name) },
+                    'activation_date': { 'value': activation_date },
+                }
+            )
+
+        if self.venue.use_publication_chairs:
+            self.client.post_invitation_edit(
+                invitations=f'{super_id}/-/Publication_Chair_Role',
+                signatures=[template_domain],
+                content={
+                    'venue_id': {'value': self.venue_id},
+                    'committee_name': {'value': tools.singularize(self.venue.publication_chairs_name) },
+                    'activation_date': { 'value': activation_date },
+                }
+            )

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -83,7 +83,6 @@ class Venue(object):
         self.use_publication_chairs = False
         self.source_submissions_query_mapping = {}
         self.release_role_participation = True
-        self.release_accepted_submissions = True
         self.sac_paper_assignments = False
         self.submission_assignment_max_reviewers = None
         self.preferred_emails_groups = []
@@ -162,7 +161,6 @@ class Venue(object):
             preferred_email_groups.append(self.get_senior_area_chairs_id())
 
         self.release_role_participation = request_note.content.get('release_role_participation', {}).get('value', True)
-        self.release_accepted_submissions = request_note.content.get('release_accepted_submissions', {}).get('value', True)
 
         self.preferred_emails_groups = preferred_email_groups
         self.automatic_reviewer_assignment = True

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -82,6 +82,7 @@ class Venue(object):
         self.submission_license = ['CC BY 4.0']
         self.use_publication_chairs = False
         self.source_submissions_query_mapping = {}
+        self.release_role_participation = True
         self.sac_paper_assignments = False
         self.submission_assignment_max_reviewers = None
         self.preferred_emails_groups = []
@@ -158,6 +159,8 @@ class Venue(object):
                 self.senior_area_chairs_name = self.senior_area_chair_roles[0]
             self.use_senior_area_chairs = True
             preferred_email_groups.append(self.get_senior_area_chairs_id())
+
+        self.release_role_participation = request_note.content.get('release_role_participation', {}).get('value', True)
 
         self.preferred_emails_groups = preferred_email_groups
         self.automatic_reviewer_assignment = True

--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -83,6 +83,7 @@ class Venue(object):
         self.use_publication_chairs = False
         self.source_submissions_query_mapping = {}
         self.release_role_participation = True
+        self.release_accepted_submissions = True
         self.sac_paper_assignments = False
         self.submission_assignment_max_reviewers = None
         self.preferred_emails_groups = []
@@ -161,6 +162,7 @@ class Venue(object):
             preferred_email_groups.append(self.get_senior_area_chairs_id())
 
         self.release_role_participation = request_note.content.get('release_role_participation', {}).get('value', True)
+        self.release_accepted_submissions = request_note.content.get('release_accepted_submissions', {}).get('value', True)
 
         self.preferred_emails_groups = preferred_email_groups
         self.automatic_reviewer_assignment = True

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -261,7 +261,7 @@ class EditInvitationsBuilder(object):
         self.save_invitation(invitation, replacement=False)
         return invitation
 
-    def set_edit_submission_readers_invitation(self, invitation_id, include_assigned_committee=False, content={}):
+    def set_edit_submission_readers_invitation(self, invitation_id, include_assigned_committee=False, content={}, include_public=True):
 
         venue_id = self.venue_id
         submission_name = self.get_content_value('submission_name', 'Submission')
@@ -301,10 +301,13 @@ class EditInvitationsBuilder(object):
                 {'value': f'{venue_id}/{submission_name}' + '${{2/id}/number}' +f'/{reviewers_name}', 'optional': True, 'description': 'Assigned Reviewers'}
             )
 
-        readers_items.extend([
-            {'value': f'{venue_id}/{submission_name}' + '${{2/id}/number}' +f'/{authors_name}', 'optional': True, 'description': 'Submission Authors'},
-            {'value': 'everyone', 'optional': True, 'description': 'Public'}
-        ])
+        readers_items.append(
+            {'value': f'{venue_id}/{submission_name}' + '${{2/id}/number}' +f'/{authors_name}', 'optional': True, 'description': 'Submission Authors'}
+        )
+        if include_public:
+            readers_items.append(
+                {'value': 'everyone', 'optional': True, 'description': 'Public'}
+            )
 
         edit_content = {
             'readers': {

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -261,7 +261,7 @@ class EditInvitationsBuilder(object):
         self.save_invitation(invitation, replacement=False)
         return invitation
 
-    def set_edit_submission_readers_invitation(self, invitation_id, include_assigned_committee=False, content={}, include_public=True):
+    def set_edit_submission_readers_invitation(self, invitation_id, include_assigned_committee=False, content={}):
 
         venue_id = self.venue_id
         submission_name = self.get_content_value('submission_name', 'Submission')
@@ -301,13 +301,10 @@ class EditInvitationsBuilder(object):
                 {'value': f'{venue_id}/{submission_name}' + '${{2/id}/number}' +f'/{reviewers_name}', 'optional': True, 'description': 'Assigned Reviewers'}
             )
 
-        readers_items.append(
-            {'value': f'{venue_id}/{submission_name}' + '${{2/id}/number}' +f'/{authors_name}', 'optional': True, 'description': 'Submission Authors'}
-        )
-        if include_public:
-            readers_items.append(
-                {'value': 'everyone', 'optional': True, 'description': 'Public'}
-            )
+        readers_items.extend([
+            {'value': f'{venue_id}/{submission_name}' + '${{2/id}/number}' +f'/{authors_name}', 'optional': True, 'description': 'Submission Authors'},
+            {'value': 'everyone', 'optional': True, 'description': 'Public'}
+        ])
 
         edit_content = {
             'readers': {

--- a/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
+++ b/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
@@ -302,7 +302,6 @@ def process(client, edit, invitation):
                 'senior_area_chairs_support': { 'readers': [support_user] },
                 'senior_area_chair_groups_names': { 'readers': [support_user] },
                 'release_role_participation': { 'readers': [support_user] },
-                'release_accepted_submissions': { 'readers': [support_user] },
                 'venue_organizer_agreement': { 'readers': [support_user] },
                 'program_chair_console': { 'value': f'https://openreview.net/group?id={venue_id}/Program_Chairs' },
                 'workflow_timeline': { 'value': f'https://openreview.net/group/edit?id={venue_id}' }

--- a/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
+++ b/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
@@ -302,6 +302,7 @@ def process(client, edit, invitation):
                 'senior_area_chairs_support': { 'readers': [support_user] },
                 'senior_area_chair_groups_names': { 'readers': [support_user] },
                 'release_role_participation': { 'readers': [support_user] },
+                'release_accepted_submissions': { 'readers': [support_user] },
                 'venue_organizer_agreement': { 'readers': [support_user] },
                 'program_chair_console': { 'value': f'https://openreview.net/group?id={venue_id}/Program_Chairs' },
                 'workflow_timeline': { 'value': f'https://openreview.net/group/edit?id={venue_id}' }

--- a/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
+++ b/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
@@ -301,6 +301,7 @@ def process(client, edit, invitation):
                 'area_chair_groups_names': { 'readers': [support_user] },
                 'senior_area_chairs_support': { 'readers': [support_user] },
                 'senior_area_chair_groups_names': { 'readers': [support_user] },
+                'release_role_participation': { 'readers': [support_user] },
                 'venue_organizer_agreement': { 'readers': [support_user] },
                 'program_chair_console': { 'value': f'https://openreview.net/group?id={venue_id}/Program_Chairs' },
                 'workflow_timeline': { 'value': f'https://openreview.net/group/edit?id={venue_id}' }

--- a/openreview/workflows/workflow_process/request_form_preprocess.py
+++ b/openreview/workflows/workflow_process/request_form_preprocess.py
@@ -3,7 +3,7 @@ def process(client, edit, invitation):
     request_note = edit.note
     venue_agreement = request_note.content['venue_organizer_agreement']['value']
 
-    if len(venue_agreement) != 9:
+    if len(venue_agreement) != 8:
         raise openreview.OpenReviewException('Please be sure to acknowledge and agree to all terms in the Venue Organizer Agreement.')
 
     if request_note.content.get('senior_area_chairs_support',{}).get('value') and not request_note.content.get('area_chairs_support',{}).get('value'):

--- a/openreview/workflows/workflow_process/request_form_preprocess.py
+++ b/openreview/workflows/workflow_process/request_form_preprocess.py
@@ -3,7 +3,7 @@ def process(client, edit, invitation):
     request_note = edit.note
     venue_agreement = request_note.content['venue_organizer_agreement']['value']
 
-    if len(venue_agreement) != 8:
+    if len(venue_agreement) != 7:
         raise openreview.OpenReviewException('Please be sure to acknowledge and agree to all terms in the Venue Organizer Agreement.')
 
     if request_note.content.get('senior_area_chairs_support',{}).get('value') and not request_note.content.get('area_chairs_support',{}).get('value'):

--- a/openreview/workflows/workflow_process/submission_release_template_process.py
+++ b/openreview/workflows/workflow_process/submission_release_template_process.py
@@ -36,26 +36,5 @@ def process(client, edit, invitation):
             }
         }
     }
-    # release_accepted_submissions controls whether accepted papers (metadata and PDF) are released
-    # to the public. When the venue opted out, do not offer the "Public" (everyone) reader option for
-    # the accepted release.
-    release_accepted_submissions = domain.content.get('release_accepted_submissions', {}).get('value', True)
-    include_public = release_accepted_submissions or not with_decision_accept
-    edit_invitations_builder.set_edit_submission_readers_invitation(invitation_id, True, content, include_public=include_public)
+    edit_invitations_builder.set_edit_submission_readers_invitation(invitation_id, True, content)
     # edit_invitations_builder.set_edit_reveal_authors(invitation_id)
-
-    # When the venue releases accepted submissions publicly, default the accepted release readers to
-    # everyone so accepted papers become public. The PC can still change this via the Readers step.
-    if with_decision_accept and release_accepted_submissions:
-        client.post_invitation_edit(
-            invitations=meta_invitation_id,
-            signatures=[domain.id],
-            invitation=openreview.api.Invitation(
-                id=invitation_id,
-                edit={
-                    'note': {
-                        'readers': ['everyone']
-                    }
-                }
-            )
-        )

--- a/openreview/workflows/workflow_process/submission_release_template_process.py
+++ b/openreview/workflows/workflow_process/submission_release_template_process.py
@@ -36,5 +36,26 @@ def process(client, edit, invitation):
             }
         }
     }
-    edit_invitations_builder.set_edit_submission_readers_invitation(invitation_id, True, content)
+    # release_accepted_submissions controls whether accepted papers (metadata and PDF) are released
+    # to the public. When the venue opted out, do not offer the "Public" (everyone) reader option for
+    # the accepted release.
+    release_accepted_submissions = domain.content.get('release_accepted_submissions', {}).get('value', True)
+    include_public = release_accepted_submissions or not with_decision_accept
+    edit_invitations_builder.set_edit_submission_readers_invitation(invitation_id, True, content, include_public=include_public)
     # edit_invitations_builder.set_edit_reveal_authors(invitation_id)
+
+    # When the venue releases accepted submissions publicly, default the accepted release readers to
+    # everyone so accepted papers become public. The PC can still change this via the Readers step.
+    if with_decision_accept and release_accepted_submissions:
+        client.post_invitation_edit(
+            invitations=meta_invitation_id,
+            signatures=[domain.id],
+            invitation=openreview.api.Invitation(
+                id=invitation_id,
+                edit={
+                    'note': {
+                        'readers': ['everyone']
+                    }
+                }
+            )
+        )

--- a/openreview/workflows/workflows.py
+++ b/openreview/workflows/workflows.py
@@ -371,8 +371,25 @@ class Workflows():
                                 }
                             }
                         },
-                        'venue_organizer_agreement': {
+                        'release_accepted_submissions': {
                             'order': 23,
+                            'description': 'Should accepted papers—including their metadata (title, authors, abstract) and PDF—be made publicly available in OpenReview? Select "Yes" to release accepted submissions to the public by default. Select "No" if you do not want accepted papers to become public; in that case the "Public" option will not be offered when releasing accepted submissions.',
+                            'value': {
+                                'param': {
+                                    'type': 'boolean',
+                                    'enum': [
+                                        { 'value': True, 'description': 'Yes, make accepted papers (metadata and PDF) publicly available in OpenReview.' },
+                                        { 'value': False, 'description': 'No, do not make accepted papers publicly available.' }
+                                    ],
+                                    'input': 'radio',
+                                    'default': True,
+                                    'optional': True,
+                                    'deletable': True
+                                }
+                            }
+                        },
+                        'venue_organizer_agreement': {
+                            'order': 24,
                             'description': 'In order to use OpenReview, venue chairs must agree to the following:',
                             'value': {
                                 'param': {
@@ -384,8 +401,7 @@ class Workflows():
                                         { 'value': 'We acknowledge that, if our venue\'s reviewing workflow is non-standard, or if our venue is expecting more than a few hundred submissions for any one deadline, we should designate our own Workflow Chair, who will read the OpenReview documentation and manage our workflow configurations throughout the reviewing process.', 'description': 'We acknowledge that, if our venue’s reviewing workflow is non-standard, or if our venue is expecting more than a few hundred submissions for any one deadline, we should designate our own Workflow Chair, who will read the OpenReview documentation and manage our workflow configurations throughout the reviewing process.', 'optional': True},
                                         { 'value': 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.', 'description': 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.', 'optional': True},
                                         { 'value': 'We will treat the OpenReview staff with kindness and consideration.', 'description': 'We will treat the OpenReview staff with kindness and consideration.', 'optional': True},
-                                        { 'value': 'We acknowledge that authors and reviewers will be required to share their preferred email.', 'description': 'We acknowledge that authors and reviewers will be required to share their preferred email.', 'optional': True},
-                                        { 'value': 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.', 'description': 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.', 'optional': True}
+                                        { 'value': 'We acknowledge that authors and reviewers will be required to share their preferred email.', 'description': 'We acknowledge that authors and reviewers will be required to share their preferred email.', 'optional': True}
                                     ],
                                     'input': 'checkbox'
                                 }

--- a/openreview/workflows/workflows.py
+++ b/openreview/workflows/workflows.py
@@ -371,25 +371,8 @@ class Workflows():
                                 }
                             }
                         },
-                        'release_accepted_submissions': {
-                            'order': 23,
-                            'description': 'Should accepted papers—including their metadata (title, authors, abstract) and PDF—be made publicly available in OpenReview? Select "Yes" to release accepted submissions to the public by default. Select "No" if you do not want accepted papers to become public; in that case the "Public" option will not be offered when releasing accepted submissions.',
-                            'value': {
-                                'param': {
-                                    'type': 'boolean',
-                                    'enum': [
-                                        { 'value': True, 'description': 'Yes, make accepted papers (metadata and PDF) publicly available in OpenReview.' },
-                                        { 'value': False, 'description': 'No, do not make accepted papers publicly available.' }
-                                    ],
-                                    'input': 'radio',
-                                    'default': True,
-                                    'optional': True,
-                                    'deletable': True
-                                }
-                            }
-                        },
                         'venue_organizer_agreement': {
-                            'order': 24,
+                            'order': 23,
                             'description': 'In order to use OpenReview, venue chairs must agree to the following:',
                             'value': {
                                 'param': {

--- a/openreview/workflows/workflows.py
+++ b/openreview/workflows/workflows.py
@@ -354,8 +354,25 @@ class Workflows():
                                 }
                             }
                         },
-                        'venue_organizer_agreement': {
+                        'release_role_participation': {
                             'order': 22,
+                            'description': 'Should role participation be collected for all participants—including reviewers, area chairs, senior area chairs, program chairs, publication chairs, workflow chairs, and any other role—and made publicly available in the OpenReview profile of each participant? Select "No" if you do not want this information to become public.',
+                            'value': {
+                                'param': {
+                                    'type': 'boolean',
+                                    'enum': [
+                                        { 'value': True, 'description': 'Yes, collect role participation and make it publicly available in each participant\'s OpenReview profile.' },
+                                        { 'value': False, 'description': 'No, do not make role participation publicly available.' }
+                                    ],
+                                    'input': 'radio',
+                                    'default': True,
+                                    'optional': True,
+                                    'deletable': True
+                                }
+                            }
+                        },
+                        'venue_organizer_agreement': {
+                            'order': 23,
                             'description': 'In order to use OpenReview, venue chairs must agree to the following:',
                             'value': {
                                 'param': {
@@ -368,7 +385,6 @@ class Workflows():
                                         { 'value': 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.', 'description': 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.', 'optional': True},
                                         { 'value': 'We will treat the OpenReview staff with kindness and consideration.', 'description': 'We will treat the OpenReview staff with kindness and consideration.', 'optional': True},
                                         { 'value': 'We acknowledge that authors and reviewers will be required to share their preferred email.', 'description': 'We acknowledge that authors and reviewers will be required to share their preferred email.', 'optional': True},
-                                        { 'value': 'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.', 'description': 'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.', 'optional': True},
                                         { 'value': 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.', 'description': 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.', 'optional': True}
                                     ],
                                     'input': 'checkbox'

--- a/tests/test_abstract_deadline.py
+++ b/tests/test_abstract_deadline.py
@@ -49,7 +49,6 @@ class TestAbstractDeadline():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
                 }

--- a/tests/test_abstract_deadline.py
+++ b/tests/test_abstract_deadline.py
@@ -49,7 +49,6 @@ class TestAbstractDeadline():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -59,7 +59,6 @@ class TestSimpleDualAnonymous():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
                 }

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -59,7 +59,6 @@ class TestSimpleDualAnonymous():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_assign_committee_open_deadline.py
+++ b/tests/test_assign_committee_open_deadline.py
@@ -52,7 +52,6 @@ class TestAssignCommitteeOpenDeadline():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }

--- a/tests/test_assign_committee_open_deadline.py
+++ b/tests/test_assign_committee_open_deadline.py
@@ -52,7 +52,6 @@ class TestAssignCommitteeOpenDeadline():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_change_venue_email.py
+++ b/tests/test_change_venue_email.py
@@ -55,7 +55,6 @@ class TestChangeVenueEmail():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_change_venue_email.py
+++ b/tests/test_change_venue_email.py
@@ -55,7 +55,6 @@ class TestChangeVenueEmail():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
                 }

--- a/tests/test_full_submission_authors_lock.py
+++ b/tests/test_full_submission_authors_lock.py
@@ -48,7 +48,6 @@ class TestFullSubmissionAuthorsLock():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_full_submission_authors_lock.py
+++ b/tests/test_full_submission_authors_lock.py
@@ -48,7 +48,6 @@ class TestFullSubmissionAuthorsLock():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }

--- a/tests/test_iclr_conference_with_templates.py
+++ b/tests/test_iclr_conference_with_templates.py
@@ -56,7 +56,6 @@ class TestSimpleDualAnonymous():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_iclr_conference_with_templates.py
+++ b/tests/test_iclr_conference_with_templates.py
@@ -56,7 +56,6 @@ class TestSimpleDualAnonymous():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
                 }

--- a/tests/test_reduced_load_new_ui.py
+++ b/tests/test_reduced_load_new_ui.py
@@ -49,7 +49,6 @@ class TestReducedLoadNewUI():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }

--- a/tests/test_reduced_load_new_ui.py
+++ b/tests/test_reduced_load_new_ui.py
@@ -49,7 +49,6 @@ class TestReducedLoadNewUI():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_registration_step.py
+++ b/tests/test_registration_step.py
@@ -58,7 +58,6 @@ class TestRegistrationStep():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_registration_step.py
+++ b/tests/test_registration_step.py
@@ -58,7 +58,6 @@ class TestRegistrationStep():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
                 }

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -78,7 +78,6 @@ class TestReviewersOnly():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
@@ -600,7 +599,6 @@ If you have any questions, please contact the Program Chairs at abcd2025.program
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -78,7 +78,6 @@ class TestReviewersOnly():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
                 }
@@ -599,7 +598,6 @@ If you have any questions, please contact the Program Chairs at abcd2025.program
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
                 }

--- a/tests/test_serve_as_reviewer_validation.py
+++ b/tests/test_serve_as_reviewer_validation.py
@@ -71,7 +71,6 @@ class TestServeAsReviewerValidation():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_serve_as_reviewer_validation.py
+++ b/tests/test_serve_as_reviewer_validation.py
@@ -71,7 +71,6 @@ class TestServeAsReviewerValidation():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }

--- a/tests/test_submission_authors_email.py
+++ b/tests/test_submission_authors_email.py
@@ -55,7 +55,6 @@ class TestSubmissionAuthorsEmail():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_submission_authors_email.py
+++ b/tests/test_submission_authors_email.py
@@ -55,7 +55,6 @@ class TestSubmissionAuthorsEmail():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }

--- a/tests/test_submission_limits.py
+++ b/tests/test_submission_limits.py
@@ -44,7 +44,6 @@ class TestSubmissionLimits():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }

--- a/tests/test_submission_limits.py
+++ b/tests/test_submission_limits.py
@@ -44,7 +44,6 @@ class TestSubmissionLimits():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -59,7 +59,6 @@ class TestTasks():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -59,7 +59,6 @@ class TestTasks():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                     }
                 }

--- a/tests/test_venue_deployment.py
+++ b/tests/test_venue_deployment.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 import datetime
 import openreview
 
@@ -36,7 +37,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
                     }
@@ -67,7 +67,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
                     }
@@ -99,7 +98,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
                     }
@@ -140,7 +138,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
                     }
@@ -176,7 +173,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
                     }
@@ -212,7 +208,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
                     }
@@ -243,6 +238,7 @@ class TestVenueDeployment():
                     'area_chair_groups_names': { 'value': ['Senior_Program_Committee'] },
                     'expected_submissions': { 'value': 50 },
                     'release_role_participation': { 'value': False },
+                    'release_accepted_submissions': { 'value': False },
                     'venue_organizer_agreement': {
                         'value': [
                             'OpenReview natively supports a wide variety of reviewing workflow configurations. However, if we want significant reviewing process customizations or experiments, we will detail these requests to the OpenReview staff at least three months in advance.',
@@ -252,7 +248,6 @@ class TestVenueDeployment():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }
@@ -290,6 +285,31 @@ class TestVenueDeployment():
         assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Program_Committee') is None
         assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Senior_Program_Committee') is None
         assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Program_Chair') is None
+
+        # this venue opted out of publicly releasing accepted papers, so the "Public" (everyone)
+        # reader option must NOT be offered and the accepted release must not default to public
+        assert venue_group.content['release_accepted_submissions']['value'] == False
+
+        accepted_readers_invitation = None
+        for _ in range(60):
+            accepted_readers_invitation = openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Accepted_Submission_Release/Readers')
+            if accepted_readers_invitation:
+                break
+            time.sleep(1)
+        assert accepted_readers_invitation, 'Accepted_Submission_Release/Readers invitation was not created'
+        accepted_reader_values = [item['value'] for item in accepted_readers_invitation.edit['content']['readers']['value']['param']['items']]
+        assert 'everyone' not in accepted_reader_values
+
+        # the accepted release readers must NOT default to everyone when the venue opted out
+        accepted_release_invitation = openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Accepted_Submission_Release')
+        assert accepted_release_invitation
+        assert accepted_release_invitation.edit['note']['readers'] != ['everyone']
+
+        # the rejected release is not gated by this option, so it still offers all reader options
+        rejected_readers_invitation = openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Rejected_Submission_Release/Readers')
+        assert rejected_readers_invitation
+        rejected_reader_values = [item['value'] for item in rejected_readers_invitation.edit['content']['readers']['value']['param']['items']]
+        assert 'everyone' in rejected_reader_values
 
     def test_rename_reschedules_date_processes(self, openreview_client, helpers):
 
@@ -336,7 +356,6 @@ class TestVenueDeployment():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }
@@ -361,6 +380,21 @@ class TestVenueDeployment():
         assert openreview.tools.get_group(openreview_client, venue_id)
         assert openreview.tools.get_invitation(openreview_client, f'{venue_id}/-/Withdrawal').date_processes
         assert openreview.tools.get_invitation(openreview_client, f'{venue_id}/-/Preferred_Emails').date_processes
+
+        # release_accepted_submissions defaults to Yes, so accepted papers are released to the public:
+        # the accepted release readers default to everyone and the "Public" option is offered
+        assert openreview.tools.get_group(openreview_client, venue_id).content['release_accepted_submissions']['value'] == True
+        accepted_release_invitation = None
+        for _ in range(60):
+            accepted_release_invitation = openreview.tools.get_invitation(openreview_client, f'{venue_id}/-/Accepted_Submission_Release')
+            if accepted_release_invitation and accepted_release_invitation.edit['note']['readers'] == ['everyone']:
+                break
+            time.sleep(1)
+        assert accepted_release_invitation.edit['note']['readers'] == ['everyone']
+        accepted_readers_invitation = openreview.tools.get_invitation(openreview_client, f'{venue_id}/-/Accepted_Submission_Release/Readers')
+        assert accepted_readers_invitation
+        accepted_reader_values = [item['value'] for item in accepted_readers_invitation.edit['content']['readers']['value']['param']['items']]
+        assert 'everyone' in accepted_reader_values
 
         # Schedule the Withdrawal cdate date process (-0-0) to run a few minutes from now,
         # so it is still a pending (in-flight) job when we rename. This lets us verify the
@@ -444,7 +478,6 @@ class TestVenueDeployment():
             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
             'We will treat the OpenReview staff with kindness and consideration.',
             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
         ]
 
         def post_request(name):

--- a/tests/test_venue_deployment.py
+++ b/tests/test_venue_deployment.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 import datetime
 import openreview
 
@@ -238,7 +237,6 @@ class TestVenueDeployment():
                     'area_chair_groups_names': { 'value': ['Senior_Program_Committee'] },
                     'expected_submissions': { 'value': 50 },
                     'release_role_participation': { 'value': False },
-                    'release_accepted_submissions': { 'value': False },
                     'venue_organizer_agreement': {
                         'value': [
                             'OpenReview natively supports a wide variety of reviewing workflow configurations. However, if we want significant reviewing process customizations or experiments, we will detail these requests to the OpenReview staff at least three months in advance.',
@@ -285,31 +283,6 @@ class TestVenueDeployment():
         assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Program_Committee') is None
         assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Senior_Program_Committee') is None
         assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Program_Chair') is None
-
-        # this venue opted out of publicly releasing accepted papers, so the "Public" (everyone)
-        # reader option must NOT be offered and the accepted release must not default to public
-        assert venue_group.content['release_accepted_submissions']['value'] == False
-
-        accepted_readers_invitation = None
-        for _ in range(60):
-            accepted_readers_invitation = openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Accepted_Submission_Release/Readers')
-            if accepted_readers_invitation:
-                break
-            time.sleep(1)
-        assert accepted_readers_invitation, 'Accepted_Submission_Release/Readers invitation was not created'
-        accepted_reader_values = [item['value'] for item in accepted_readers_invitation.edit['content']['readers']['value']['param']['items']]
-        assert 'everyone' not in accepted_reader_values
-
-        # the accepted release readers must NOT default to everyone when the venue opted out
-        accepted_release_invitation = openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Accepted_Submission_Release')
-        assert accepted_release_invitation
-        assert accepted_release_invitation.edit['note']['readers'] != ['everyone']
-
-        # the rejected release is not gated by this option, so it still offers all reader options
-        rejected_readers_invitation = openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Rejected_Submission_Release/Readers')
-        assert rejected_readers_invitation
-        rejected_reader_values = [item['value'] for item in rejected_readers_invitation.edit['content']['readers']['value']['param']['items']]
-        assert 'everyone' in rejected_reader_values
 
     def test_rename_reschedules_date_processes(self, openreview_client, helpers):
 
@@ -380,21 +353,6 @@ class TestVenueDeployment():
         assert openreview.tools.get_group(openreview_client, venue_id)
         assert openreview.tools.get_invitation(openreview_client, f'{venue_id}/-/Withdrawal').date_processes
         assert openreview.tools.get_invitation(openreview_client, f'{venue_id}/-/Preferred_Emails').date_processes
-
-        # release_accepted_submissions defaults to Yes, so accepted papers are released to the public:
-        # the accepted release readers default to everyone and the "Public" option is offered
-        assert openreview.tools.get_group(openreview_client, venue_id).content['release_accepted_submissions']['value'] == True
-        accepted_release_invitation = None
-        for _ in range(60):
-            accepted_release_invitation = openreview.tools.get_invitation(openreview_client, f'{venue_id}/-/Accepted_Submission_Release')
-            if accepted_release_invitation and accepted_release_invitation.edit['note']['readers'] == ['everyone']:
-                break
-            time.sleep(1)
-        assert accepted_release_invitation.edit['note']['readers'] == ['everyone']
-        accepted_readers_invitation = openreview.tools.get_invitation(openreview_client, f'{venue_id}/-/Accepted_Submission_Release/Readers')
-        assert accepted_readers_invitation
-        accepted_reader_values = [item['value'] for item in accepted_readers_invitation.edit['content']['readers']['value']['param']['items']]
-        assert 'everyone' in accepted_reader_values
 
         # Schedule the Withdrawal cdate date process (-0-0) to run a few minutes from now,
         # so it is still a pending (in-flight) job when we rename. This lets us verify the

--- a/tests/test_venue_deployment.py
+++ b/tests/test_venue_deployment.py
@@ -36,7 +36,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -68,7 +67,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -101,7 +99,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -143,7 +140,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -180,7 +176,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -217,7 +212,6 @@ class TestVenueDeployment():
                                 'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                                 'We will treat the OpenReview staff with kindness and consideration.',
                                 'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                                'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                                 'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                             ]
                         }
@@ -248,6 +242,7 @@ class TestVenueDeployment():
                     'area_chairs_support': { 'value': True },
                     'area_chair_groups_names': { 'value': ['Senior_Program_Committee'] },
                     'expected_submissions': { 'value': 50 },
+                    'release_role_participation': { 'value': False },
                     'venue_organizer_agreement': {
                         'value': [
                             'OpenReview natively supports a wide variety of reviewing workflow configurations. However, if we want significant reviewing process customizations or experiments, we will detail these requests to the OpenReview staff at least three months in advance.',
@@ -257,8 +252,7 @@ class TestVenueDeployment():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
+                                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }
@@ -290,6 +284,12 @@ class TestVenueDeployment():
 
         assert openreview.tools.get_group(openreview_client, 'TVD.cc/2026/Conference/Program_Committee')
         assert openreview.tools.get_group(openreview_client, 'TVD.cc/2026/Conference/Senior_Program_Committee')
+
+        # this venue opted out of role participation, so the role participation invitations must NOT be created
+        assert venue_group.content['release_role_participation']['value'] == False
+        assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Program_Committee') is None
+        assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Senior_Program_Committee') is None
+        assert openreview.tools.get_invitation(openreview_client, 'TVD.cc/2026/Conference/-/Program_Chair') is None
 
     def test_rename_reschedules_date_processes(self, openreview_client, helpers):
 
@@ -336,8 +336,7 @@ class TestVenueDeployment():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
+                                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }
@@ -445,7 +444,6 @@ class TestVenueDeployment():
             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
             'We will treat the OpenReview staff with kindness and consideration.',
             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
         ]
 

--- a/tests/test_venue_restriction.py
+++ b/tests/test_venue_restriction.py
@@ -49,7 +49,6 @@ class TestVenueRestriction():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }
                 }

--- a/tests/test_venue_restriction.py
+++ b/tests/test_venue_restriction.py
@@ -49,7 +49,6 @@ class TestVenueRestriction():
                             'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
                             'We will treat the OpenReview staff with kindness and consideration.',
                             'We acknowledge that authors and reviewers will be required to share their preferred email.',
-                            'We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant.',
                             'We acknowledge that metadata for accepted papers will be publicly released in OpenReview.'
                         ]
                     }


### PR DESCRIPTION

## Motivation

The Venue Organizer Agreement (new Venue UI workflow) contained an item that PCs had to accept as an unconditional fact:

- *"We acknowledge that role participation will be collected for all participants—reviewers, area chairs, and senior area chairs—and made publicly available in the OpenReview profile of each participant."*

This assumed role participation is always computed and made public, with no way to opt out — which caused friction with venues that do **not** want their reviewer/committee lists to become public.

This PR turns that acknowledgement into an explicit **Yes/No question** on the venue request form and wires the answer into the workflow so the role-participation invitations are only created when the PC opts in.

## Changes

### New request-form question

A new radio question on `Conference_Review_Workflow`, defaulting to **Yes** (current behavior preserved), replacing the removed agreement item:

- **`release_role_participation`** — whether role participation is collected for **all** roles (reviewers, area chairs, senior area chairs, program chairs, publication chairs, workflow chairs, and any other role) and made publicly available in each participant's OpenReview profile.

The field is hidden from public readers after deployment (restricted to Support), like the agreement.

### Behavior

When set to **No**, none of the `*_Role` participation invitations are created at deploy time (`set_venue_template_invitations`), so no public profile tags are ever produced. When **Yes** (default), all role invitations are created as before.

### Agreement cleanup

Two agreement items were removed from `venue_organizer_agreement` (checkbox count 9 → 7):
- The **role participation** item — replaced by the `release_role_participation` question above.
- The **"metadata for accepted papers will be publicly released"** item — removed as a forced acknowledgement. Accepted-submission release behavior is unchanged from `master`: the Accepted Submission Release is always created and PCs choose the readers (including the public/everyone option) via the Readers step. No new question was added for it.

### Files

- `openreview/workflows/workflows.py` — remove the two agreement items; add the `release_role_participation` radio question.
- `openreview/workflows/workflow_process/request_form_preprocess.py` — required agreement-item count 9 → 7.
- `openreview/venue/venue.py` — default the flag to `True`; read it from the request note in `set_main_settings`.
- `openreview/venue/group.py` — persist the flag in the venue domain group content.
- `openreview/venue/invitation.py` — guard the `*_Role` invitation creation behind `release_role_participation` (early return).
- `openreview/workflows/workflow_process/conference_review_workflow_deployment.py` — restrict the new field's readers to Support.

## Behavior summary

| Question | Default | "Yes" | "No" |
|---|---|---|---|
| `release_role_participation` | Yes | All `*_Role` participation invitations created (public profile tags) | No role participation invitations created |

Defaults preserve the existing behavior, so venues that don't touch this question are unaffected.

## Tests

- `tests/test_venue_deployment.py` — deploys a venue with `release_role_participation: False` and asserts the role-participation invitations (`Program_Committee`, `Senior_Program_Committee`, `Program_Chair`) are **not** created, plus that the domain group records the flag.
- Removed the two obsolete agreement strings from all test files that submit the request form (agreement lists now have 7 items).

## Not in this PR

The ability for PCs to **delete** a role invitation and have its participation tags removed (revert the decision) was explored but deferred to a separate PR — it requires a server-side change so a deleted invitation runs its date-process one final time (the API currently skips date-processes at/after an invitation's `ddate`).
