### PR TITLE
Fix/ARR: fix wording in max load form

### DIFF
--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -17,6 +17,7 @@ from openreview.stages.arr_content import (
     arr_reviewer_ac_recognition_task_forum,
     arr_reviewer_ac_recognition_task,
     arr_max_load_task_forum,
+    arr_voluntary_reviewing_task_forum,
     arr_ethics_max_load_task,
     arr_reviewer_max_load_task,
     arr_ac_max_load_task,
@@ -784,8 +785,8 @@ class ARRWorkflow(object):
                 stage_arguments={
                     'committee_id': venue.get_reviewers_id(),
                     'name': self.invitation_builder.MAX_LOAD_AND_UNAVAILABILITY_NAME,
-                    'instructions': arr_max_load_task_forum['instructions'] + '\n\nThis will be overridden with the mandatory reviewing load if you submit at least one paper in this cycle and are qualified to review.',
-                    'title': venue.get_reviewers_name() + ' Volunteer ' + arr_max_load_task_forum['title'],
+                    'instructions': arr_voluntary_reviewing_task_forum['instructions'],
+                    'title': venue.get_reviewers_name() + ' ' + arr_voluntary_reviewing_task_forum['title'],
                     'additional_fields': arr_reviewer_max_load_task,
                     'remove_fields': ['profile_confirmed', 'expertise_confirmed']
                 },
@@ -802,8 +803,8 @@ class ARRWorkflow(object):
                 stage_arguments={
                     'committee_id': venue.get_area_chairs_id(),
                     'name': self.invitation_builder.MAX_LOAD_AND_UNAVAILABILITY_NAME,
-                    'instructions': arr_max_load_task_forum['instructions'] + '\n\nThis will be overridden with the mandatory meta-reviewing load if you submit at least one paper in this cycle and are qualified to review.',
-                    'title': venue.get_area_chairs_name() + ' Volunteer ' + arr_max_load_task_forum['title'],
+                    'instructions': arr_voluntary_reviewing_task_forum['instructions'],
+                    'title': venue.get_area_chairs_name() + ' ' + arr_voluntary_reviewing_task_forum['title'],
                     'additional_fields': arr_ac_max_load_task,
                     'remove_fields': ['profile_confirmed', 'expertise_confirmed']
                 },

--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -18,6 +18,7 @@ from openreview.stages.arr_content import (
     arr_reviewer_ac_recognition_task,
     arr_max_load_task_forum,
     arr_voluntary_reviewing_task_forum,
+    arr_voluntary_meta_reviewing_task_forum,
     arr_ethics_max_load_task,
     arr_reviewer_max_load_task,
     arr_ac_max_load_task,
@@ -803,8 +804,8 @@ class ARRWorkflow(object):
                 stage_arguments={
                     'committee_id': venue.get_area_chairs_id(),
                     'name': self.invitation_builder.MAX_LOAD_AND_UNAVAILABILITY_NAME,
-                    'instructions': arr_voluntary_reviewing_task_forum['instructions'],
-                    'title': venue.get_area_chairs_name() + ' ' + arr_voluntary_reviewing_task_forum['title'],
+                    'instructions': arr_voluntary_meta_reviewing_task_forum['instructions'],
+                    'title': venue.get_area_chairs_name() + ' ' + arr_voluntary_meta_reviewing_task_forum['title'],
                     'additional_fields': arr_ac_max_load_task,
                     'remove_fields': ['profile_confirmed', 'expertise_confirmed']
                 },

--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -784,8 +784,8 @@ class ARRWorkflow(object):
                 stage_arguments={
                     'committee_id': venue.get_reviewers_id(),
                     'name': self.invitation_builder.MAX_LOAD_AND_UNAVAILABILITY_NAME,
-                    'instructions': arr_max_load_task_forum['instructions'],
-                    'title': venue.get_reviewers_name() + ' ' + arr_max_load_task_forum['title'],
+                    'instructions': arr_max_load_task_forum['instructions'] + '\n\nThis will be overridden with the mandatory reviewing load if you submit at least one paper in this cycle and are qualified to review.',
+                    'title': venue.get_reviewers_name() + ' Volunteer ' + arr_max_load_task_forum['title'],
                     'additional_fields': arr_reviewer_max_load_task,
                     'remove_fields': ['profile_confirmed', 'expertise_confirmed']
                 },
@@ -802,8 +802,8 @@ class ARRWorkflow(object):
                 stage_arguments={
                     'committee_id': venue.get_area_chairs_id(),
                     'name': self.invitation_builder.MAX_LOAD_AND_UNAVAILABILITY_NAME,
-                    'instructions': arr_max_load_task_forum['instructions'],
-                    'title': venue.get_area_chairs_name() + ' ' + arr_max_load_task_forum['title'],
+                    'instructions': arr_max_load_task_forum['instructions'] + '\n\nThis will be overridden with the mandatory meta-reviewing load if you submit at least one paper in this cycle and are qualified to review.',
+                    'title': venue.get_area_chairs_name() + ' Volunteer ' + arr_max_load_task_forum['title'],
                     'additional_fields': arr_ac_max_load_task,
                     'remove_fields': ['profile_confirmed', 'expertise_confirmed']
                 },

--- a/openreview/stages/arr_content.py
+++ b/openreview/stages/arr_content.py
@@ -1767,7 +1767,12 @@ arr_max_load_task_forum = {
 
 arr_voluntary_reviewing_task_forum = {
     "title": "Voluntary Unavailability and Maximum Load Request",
-    "instructions": "Please complete this form to indicate your maximum load for voluntary reviewing for this cycle, or your (un)availability for voluntary reviewing. If you wish to change your maximum load, please delete your previous request using the trash icon, refresh the page and submit a new request.\n\n**This will be overridden with the mandatory reviewing load if you submit at least one paper in this cycle and are qualified to review.**."
+    "instructions": "Please complete this form to indicate your maximum load for voluntary reviewing for this cycle, or your (un)availability for voluntary reviewing. If you wish to change your maximum load, please delete your previous request using the trash icon, refresh the page and submit a new request.\n\n**This will be overridden with the mandatory reviewing load if you submit at least one paper in this cycle and are qualified to review.**"
+}
+
+arr_voluntary_meta_reviewing_task_forum = {
+    "title": "Voluntary Unavailability and Maximum Load Request",
+    "instructions": "Please complete this form to indicate your maximum load for voluntary meta-reviewing for this cycle, or your (un)availability for voluntary meta-reviewing. If you wish to change your maximum load, please delete your previous request using the trash icon, refresh the page and submit a new request.\n\n**This will be overridden with the mandatory meta-reviewing load if you submit at least one paper in this cycle and are qualified to meta-review.**"
 }
 
 arr_max_load_task = {

--- a/openreview/stages/arr_content.py
+++ b/openreview/stages/arr_content.py
@@ -1765,6 +1765,11 @@ arr_max_load_task_forum = {
     "instructions": "Please complete this form to indicate your (un)availability for reviewing. If you do not complete this form, you will receive the default load of this cycle.\n\nIf you wish to change your maximum load, please delete your previous request using the trash can icon, refresh the page and submit a new request."
 }
 
+arr_voluntary_reviewing_task_forum = {
+    "title": "Voluntary Unavailability and Maximum Load Request",
+    "instructions": "Please complete this form to indicate your maximum load for voluntary reviewing for this cycle, or your (un)availability for voluntary reviewing. If you wish to change your maximum load, please delete your previous request using the trash icon, refresh the page and submit a new request.\n\n**This will be overridden with the mandatory reviewing load if you submit at least one paper in this cycle and are qualified to review.**."
+}
+
 arr_max_load_task = {
     "maximum_load_this_cycle": {
         "value": {

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -25,6 +25,7 @@ from openreview.stages.arr_content import (
     arr_content_license_task,
     arr_max_load_task_forum,
     arr_voluntary_reviewing_task_forum,
+    arr_voluntary_meta_reviewing_task_forum,
     arr_reviewer_max_load_task,
     arr_ac_max_load_task,
     arr_sac_max_load_task
@@ -863,8 +864,8 @@ class TestARRVenueV2():
             name = max_load_name,
             start_date = None,
             due_date = due_date,
-            instructions = arr_voluntary_reviewing_task_forum['instructions'],
-            title = venue.get_area_chairs_name() + ' ' + arr_voluntary_reviewing_task_forum['title'],
+            instructions = arr_voluntary_meta_reviewing_task_forum['instructions'],
+            title = venue.get_area_chairs_name() + ' ' + arr_voluntary_meta_reviewing_task_forum['title'],
             additional_fields=arr_ac_max_load_task,
             remove_fields=['profile_confirmed', 'expertise_confirmed'])
         )
@@ -894,7 +895,13 @@ class TestARRVenueV2():
         assert note.content['title']['value'] == 'Reviewer Voluntary Unavailability and Maximum Load Request'
         assert note.content['instructions']['value'] == '''Please complete this form to indicate your maximum load for voluntary reviewing for this cycle, or your (un)availability for voluntary reviewing. If you wish to change your maximum load, please delete your previous request using the trash icon, refresh the page and submit a new request.
 
-**This will be overridden with the mandatory reviewing load if you submit at least one paper in this cycle and are qualified to review.**.'''
+**This will be overridden with the mandatory reviewing load if you submit at least one paper in this cycle and are qualified to review.**'''
+
+        note = openreview_client.get_notes(invitation=f'{venue.get_area_chairs_id()}/-/{max_load_name}_Form')[0]
+        assert note.content['title']['value'] == 'Area Chair Voluntary Unavailability and Maximum Load Request'
+        assert note.content['instructions']['value'] == '''Please complete this form to indicate your maximum load for voluntary meta-reviewing for this cycle, or your (un)availability for voluntary meta-reviewing. If you wish to change your maximum load, please delete your previous request using the trash icon, refresh the page and submit a new request.
+
+**This will be overridden with the mandatory meta-reviewing load if you submit at least one paper in this cycle and are qualified to meta-review.**'''
 
         # Add max load preprocess validation
         invitation_builder = openreview.arr.InvitationBuilder(venue)

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -24,6 +24,7 @@ from openreview.stages.arr_content import (
     arr_content_license_task_forum,
     arr_content_license_task,
     arr_max_load_task_forum,
+    arr_voluntary_reviewing_task_forum,
     arr_reviewer_max_load_task,
     arr_ac_max_load_task,
     arr_sac_max_load_task
@@ -832,8 +833,8 @@ class TestARRVenueV2():
             name = max_load_name,
             start_date = None,
             due_date = due_date,
-            instructions = arr_max_load_task_forum['instructions'],
-            title = venue.get_reviewers_name() + ' ' + arr_max_load_task_forum['title'],
+            instructions = arr_voluntary_reviewing_task_forum['instructions'],
+            title = venue.get_reviewers_name() + ' ' + arr_voluntary_reviewing_task_forum['title'],
             additional_fields=arr_reviewer_max_load_task,
             remove_fields=['profile_confirmed', 'expertise_confirmed'])
         )
@@ -862,8 +863,8 @@ class TestARRVenueV2():
             name = max_load_name,
             start_date = None,
             due_date = due_date,
-            instructions = arr_max_load_task_forum['instructions'],
-            title = venue.get_area_chairs_name() + ' ' + arr_max_load_task_forum['title'],
+            instructions = arr_voluntary_reviewing_task_forum['instructions'],
+            title = venue.get_area_chairs_name() + ' ' + arr_voluntary_reviewing_task_forum['title'],
             additional_fields=arr_ac_max_load_task,
             remove_fields=['profile_confirmed', 'expertise_confirmed'])
         )
@@ -888,6 +889,12 @@ class TestARRVenueV2():
             remove_fields=['profile_confirmed', 'expertise_confirmed'])
         )
         venue.create_registration_stages()
+
+        note = openreview_client.get_notes(invitation=f'{venue.get_reviewers_id()}/-/{max_load_name}_Form')[0]
+        assert note.content['title']['value'] == 'Reviewer Voluntary Unavailability and Maximum Load Request'
+        assert note.content['instructions']['value'] == '''Please complete this form to indicate your maximum load for voluntary reviewing for this cycle, or your (un)availability for voluntary reviewing. If you wish to change your maximum load, please delete your previous request using the trash icon, refresh the page and submit a new request.
+
+**This will be overridden with the mandatory reviewing load if you submit at least one paper in this cycle and are qualified to review.**.'''
 
         # Add max load preprocess validation
         invitation_builder = openreview.arr.InvitationBuilder(venue)


### PR DESCRIPTION
Fixes #3127

This change is only needed for reviewers and ACs, not for SACs or ethics reviewers.