### PR TITLE
Feature/ Allow for hard deletion of invitation

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -2464,6 +2464,20 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return response.json()
 
+    def delete_invitation(self, invitation_id):
+        """
+        Deletes the invitation
+
+        :param invitation_id: ID of Invitation to be deleted
+        :type invitation_id: str
+
+        :return: a {status = 'ok'} in case of a successful deletion and an OpenReview exception otherwise
+        :rtype: dict
+        """
+        response = self.session.delete(self.invitations_url, json = {'id': invitation_id}, headers = self.headers)
+        response = self.__handle_response(response)
+        return response.json()
+
     def post_message(self, subject, recipients, message, invitation=None, signature=None, ignoreRecipients=None, sender=None, replyTo=None, parentGroup=None, use_job=None):
         """
         Posts a message to the recipients and consequently sends them emails

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -436,10 +436,59 @@ class TestClient():
 
     def test_get_notes_by_ids(self, openreview_client):
         notes = openreview_client.get_notes(invitation='Test.ws/2019/Conference/-/Submission', content = { 'title': 'Paper title'})
-        assert len(notes) == 1        
-       
+        assert len(notes) == 1
+
         notes = openreview_client.get_notes_by_ids(ids = [notes[0].id])
         assert len(notes) == 1, 'notes is not empty'
+
+    def test_delete_invitation(self, openreview_client):
+        invitation_id = 'openreview.net/-/To_Delete'
+
+        openreview_client.post_invitation_edit(
+            invitations='openreview.net/-/Edit',
+            readers=['openreview.net'],
+            writers=['openreview.net'],
+            signatures=['~Super_User1'],
+            invitation=openreview.api.Invitation(
+                id=invitation_id,
+                readers=['everyone'],
+                writers=['openreview.net'],
+                signatures=['~Super_User1'],
+                invitees=['everyone'],
+                edit={
+                    'readers': { 'param': { 'regex': '.+' } },
+                    'signatures': { 'param': { 'regex': '.+' } },
+                    'writers': { 'param': { 'regex': '.+' } },
+                    'note': {
+                        'readers': { 'param': { 'regex': '.+' } },
+                        'signatures': { 'param': { 'regex': '.+' } },
+                        'writers': { 'param': { 'regex': '.+' } },
+                        'content': {
+                        'title': { 'value': { 'param': { 'type': 'string', 'regex': '.*' } } },
+                        }
+                    }
+                }
+            )
+        )
+
+        ## Invitation and its edits exist before deletion
+        invitation = openreview_client.get_invitation(invitation_id)
+        assert invitation.id == invitation_id
+
+        edits = openreview_client.get_invitation_edits(invitation_id=invitation_id)
+        assert len(edits) == 1
+
+        ## Delete the invitation
+        response = openreview_client.delete_invitation(invitation_id)
+        assert response['status'] == 'ok'
+
+        ## Invitation no longer exists after deletion
+        with pytest.raises(openreview.OpenReviewException, match=r'The Invitation openreview.net/-/To_Delete was not found'):
+            openreview_client.get_invitation(invitation_id)
+
+        ## Its edits no longer exist after deletion
+        edits = openreview_client.get_invitation_edits(invitation_id=invitation_id)
+        assert len(edits) == 0
 
     # def test_infer_notes(self, client):
     #     notes = client.get_notes(signature='openreview.net/Support')


### PR DESCRIPTION
This pull request adds support for deleting invitations via the API client and includes comprehensive tests to verify the new functionality. The main changes are the introduction of a `delete_invitation` method and a corresponding test to ensure that invitations and their edits are properly removed.

**API Enhancements:**

* Added a new `delete_invitation` method to the `OpenReviewClient` class in `openreview/api/client.py`, allowing deletion of invitations by ID and returning a status response.

**Testing Improvements:**

* Introduced the `test_delete_invitation` test case in `tests/test_client.py` to verify that invitations and their edits are deleted as expected, including checks for successful deletion and proper exception handling when accessing deleted resources.

Requires https://github.com/openreview/openreview-api/pull/1185