### PR TITLE
Align test profiles with institution history validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,15 +47,19 @@ class Helpers:
         }
         if dblp_url:
             profile_content['dblp'] = dblp_url
+        ## institution accepts a list when the profile needs more than one affiliation, e.g.
+        ## when the email domain is an institution on its own and must be declared in the
+        ## history for the profile to be saved
+        institutions = institution if isinstance(institution, list) else [institution if institution else email.split('@')[1]]
         profile_content['history'] = [{
             'position': 'PhD Student',
             'start': 2017,
             'end': None,
             'institution': {
                 'country': 'US',
-                'domain': institution if institution else email.split('@')[1],
+                'domain': domain,
             }
-        }]
+        } for domain in institutions]
         res = client.activate_user(email, profile_content)
         assert res, "Res i none"
         return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,8 +49,9 @@ class Helpers:
             profile_content['dblp'] = dblp_url
         ## institution accepts a list when the profile needs more than one affiliation, e.g.
         ## when the email domain is an institution on its own and must be declared in the
-        ## history for the profile to be saved
-        institutions = institution if isinstance(institution, list) else [institution if institution else email.split('@')[1]]
+        ## history for the profile to be saved. An alternate email on a different
+        ## institutional domain has to be listed here too, otherwise the save is rejected
+        institutions = institution if isinstance(institution, list) and institution else [institution if institution else email.split('@')[1]]
         profile_content['history'] = [{
             'position': 'PhD Student',
             'start': 2017,

--- a/tests/test_neurips_conference_v2.py
+++ b/tests/test_neurips_conference_v2.py
@@ -30,7 +30,7 @@ class TestNeurIPSConference():
         helpers.create_user('another_andrew@mit.edu', 'Another', 'Andrew')
         helpers.create_user('sac1@google.com', 'SeniorArea', 'GoogleChair', institution='google.com')
         helpers.create_user('sac2@gmail.com', 'SeniorArea', 'NeurIPSChair', institution='fb.com')
-        helpers.create_user('ac1@mit.edu', 'Area', 'IBMChair', institution='ibm.com')
+        helpers.create_user('ac1@mit.edu', 'Area', 'IBMChair', institution=['ibm.com', 'mit.edu'])
         helpers.create_user('ac2@gmail.com', 'Area', 'GoogleChair', institution='google.com')
         helpers.create_user('ac3@umass.edu', 'Area', 'UMassChair', institution='umass.edu')
         helpers.create_user('reviewer1@umass.edu', 'Reviewer', 'UMass', institution='umass.edu')

--- a/tests/test_neurips_track_conference.py
+++ b/tests/test_neurips_track_conference.py
@@ -30,7 +30,7 @@ class TestNeurIPSTrackConference():
         helpers.create_user('another_andrew@mit.edu', 'Another', 'Andrew')
         helpers.create_user('sac1@google.com', 'SeniorArea', 'GoogleChair', institution='google.com')
         helpers.create_user('sac2@gmail.com', 'SeniorArea', 'NeurIPSChair', institution='fb.com')
-        helpers.create_user('ac1@mit.edu', 'Area', 'IBMChair', institution='ibm.com')
+        helpers.create_user('ac1@mit.edu', 'Area', 'IBMChair', institution=['ibm.com', 'mit.edu'])
         helpers.create_user('ac2@gmail.com', 'Area', 'GoogleChair', institution='google.com')
         helpers.create_user('ac3@umass.edu', 'Area', 'UMassChair', institution='umass.edu')
         helpers.create_user('reviewer1@umass.edu', 'Reviewer', 'UMass', institution='umass.edu')


### PR DESCRIPTION
## Summary
openreview-api [#1182](https://github.com/openreview/openreview-api/pull/1182) requires every institutional email on a profile to have its institution listed in the profile history, rejecting non-conforming saves with an `InferenceError`. This updates the test fixtures so the profiles they create satisfy that invariant.

## Changes
- **`tests/conftest.py`**: `Helpers.create_user` accepts a list for `institution` and emits one history entry per domain, so a profile can declare more than one affiliation. Passing a string or omitting it behaves exactly as before, leaving every existing call site unchanged.
- **`tests/test_neurips_conference_v2.py`, `tests/test_neurips_track_conference.py`**: The area chair whose email domain differs from its declared affiliation now declares both.

Conflict detection unions a profile's email domains with its history domains. Reconciling such a profile by replacing the declared affiliation with the email's own institution would silently narrow its conflict set while still passing, so the fixtures add the missing entry rather than substituting it — the resulting domains are identical to today.

## Tests
Verified against the api branch: `test_neurips_track_conference.py` (2), `test_neurips_conference_v2.py` (24), `test_profile_management.py` (31 passed, 1 skipped), `test_matching_v2.py` (6), `test_sac_paper_matching.py` (4) and `test_melba_journal.py` (5) all pass, with no institution-history errors in any run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TavXs4RySMdCZtL74EFALg