### PR TITLE
Journal: Check new profiles fix

### DIFF
--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -2153,6 +2153,20 @@ OpenReview Team'''
 
                 if f'is member of {journal.venue_id}/Reviewers' in error_str:
                     print('User is already a member of the reviewers group, ignoring edge.')
+
+                    # send email to reviewer
+                    error_subject = f'[{journal.short_name}] Error accepting invitation for paper number {submission.number}'
+                    error_message = f'''Hi {{{{fullname}}}},
+
+There was an error accepting the invitation to review the paper number: {submission.number}, title: {submission.content['title']['value']}, because you have been added as an official reviewer for {journal.venue_id}.
+
+If you would like to be assigned to this submission, you have not reached your reviewing quota and have no pending reviews, please contact the paper's AC and ask them to directly assign you.
+If you have reached your reviewing quota, you can use the "Volunteer to Review" button on the submission's forum.
+
+Thank you,
+
+OpenReview Team'''
+                    client.post_message(error_subject, [user_profile.id], error_message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
                     return
 
             short_phrase = journal.short_name

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -2160,7 +2160,7 @@ OpenReview Team'''
 
 There was an error accepting the invitation to review the paper number: {submission.number}, title: {submission.content['title']['value']}, because you have been added as an official reviewer for {journal.venue_id}.
 
-If you would like to be assigned to this submission, you have not reached your reviewing quota and have no pending reviews, please contact the paper's AC and ask them to directly assign you.
+If you would like to be assigned to this submission, you have not reached your reviewing quota and have no pending reviews, please contact the paper's action editor and ask them to directly assign you.
 If you have reached your reviewing quota, you can use the "Volunteer to Review" button on the submission's forum.
 
 Thank you,
@@ -2168,6 +2168,8 @@ Thank you,
 OpenReview Team'''
                     client.post_message(error_subject, [user_profile.id], error_message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
                     return
+
+                return
 
             short_phrase = journal.short_name
             reviewer_name = 'Reviewer'  # add this to the invitation?

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -2144,7 +2144,16 @@ OpenReview Team'''
             edge.readers = None
             edge.writers = None
             edge.cdate = None
-            client.post_edge(edge)
+
+            try:
+                client.post_edge(edge)
+            except Exception as e:
+                print(f"Error posting edge: {e}")
+                error_str = str(e)
+
+                if f'is member of {journal.venue_id}/Reviewers' in error_str:
+                    print('User is already a member of the reviewers group, ignoring edge.')
+                    return
 
             short_phrase = journal.short_name
             reviewer_name = 'Reviewer'  # add this to the invitation?

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -2155,16 +2155,14 @@ OpenReview Team'''
                     print('User is already a member of the reviewers group, ignoring edge.')
 
                     # send email to reviewer
-                    error_subject = f'[{journal.short_name}] Error accepting invitation for paper number {submission.number}'
+                    error_subject = f'[{journal.short_name}] Invitation to review paper number {submission.number} cannot be accepted'
                     error_message = f'''Hi {{{{fullname}}}},
 
-There was an error accepting the invitation to review the paper number: {submission.number}, title: {submission.content['title']['value']}, because you have been added as an official reviewer for {journal.venue_id}.
+The invitation to review the paper number: {submission.number}, title: "{submission.content['title']['value']}" cannot be accepted. Only external reviewers can be invited to review papers, and you have been added as an official reviewer for {journal.venue_id}.
 
-If you would like to be assigned to this submission, you have not reached your reviewing quota and have no pending reviews, please contact the paper's action editor and ask them to directly assign you.
-If you have reached your reviewing quota, you can use the "Volunteer to Review" button on the submission's forum.
+Please contact the person who invited you if you have any questions.
 
 Thank you,
-
 OpenReview Team'''
                     client.post_message(error_subject, [user_profile.id], error_message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
                     return

--- a/openreview/journal/journal.py
+++ b/openreview/journal/journal.py
@@ -2167,7 +2167,8 @@ OpenReview Team'''
                     client.post_message(error_subject, [user_profile.id], error_message, replyTo=journal.contact_info, invitation=journal.get_meta_invitation_id(), signature=journal.venue_id, sender=journal.get_message_sender())
                     return
 
-                return
+                else:
+                    raise openreview.OpenReviewException(error_str)
 
             short_phrase = journal.short_name
             reviewer_name = 'Reviewer'  # add this to the invitation?

--- a/tests/test_jmlr_journal.py
+++ b/tests/test_jmlr_journal.py
@@ -6,6 +6,7 @@ import datetime
 import random
 import os
 import re
+from urllib.parse import urlparse, parse_qs
 from openreview.api import OpenReviewClient
 from openreview.api import Note
 from openreview.journal import Journal
@@ -73,7 +74,7 @@ class TestJMLRJournal():
         openreview_client.add_members_to_group('JMLR/Action_Editors', ['~Xukun_JMLR1', '~Melisa_JMLR1', '~Celeste_JMLR1'])
         openreview_client.add_members_to_group('JMLR/Reviewers', ['~Carlos_JMLR1', '~Andrew_JMLR1', '~Hugo_JMLR1', '~Rachel_JMLR1'])
 
-    def test_submission(self, journal, openreview_client, test_client, helpers):
+    def test_submission(self, journal, openreview_client, test_client, helpers, selenium, request_page):
 
         venue_id = journal.venue_id
         test_client = OpenReviewClient(username='test@mail.com', password=helpers.strong_password)
@@ -198,6 +199,63 @@ class TestJMLRJournal():
         ))
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
+
+        # invite reviewers to paper
+        paper_assignment_edge = celeste_client.post_edge(openreview.api.Edge(invitation='JMLR/Reviewers/-/Invite_Assignment',
+            signatures=[celeste_paper1_anon_group.id],
+            head=note_id_1,
+            tail='outside_reviewer@gmail.com',
+            weight=1,
+            label='Invitation Sent'
+        ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
+
+        # accept invitation
+        messages = openreview_client.get_messages(to = 'outside_reviewer@gmail.com', subject = '[JMLR] Invitation to review paper titled "Paper title"')
+        assert len(messages) == 1
+        url_match = re.search(r'https://openreview\.net/invitation\?[^\s]+', messages[0]['content']['text'])
+
+        if url_match:
+            url = url_match.group(0)
+            parsed_url = urlparse(url)
+            params = parse_qs(parsed_url.query)
+            key_value = params['key'][0]
+        assert messages[0]['content']['text'] == f'''Hi outside_reviewer@gmail.com,
+
+You were invited to review the paper number: {note.number}, title: "Paper title".
+
+Abstract: Paper abstract
+
+Please respond the invitation clicking the following link:
+
+https://openreview.net/invitation?id=JMLR/Reviewers/-/Assignment_Recruitment&user=outside_reviewer@gmail.com&key={key_value}&submission_id={note_id_1}&inviter=~Celeste_JMLR1
+
+Thanks,
+
+JMLR Paper{note.number} Action Editor {celeste_paper1_anon_group.id.split('_')[-1]}
+Celeste JMLR
+
+Please note that responding to this email will direct your reply to celeste@jmlr.com.
+'''
+
+        invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+        helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
+
+        helpers.await_queue_edit(openreview_client, invitation='JMLR/Reviewers/-/Assignment_Recruitment', count=1)
+
+        # edge is labeled as 'Pending Signup'
+        invite_edges=openreview_client.get_edges(invitation='JMLR/Reviewers/-/Invite_Assignment', head=note_id_1, tail='outside_reviewer@gmail.com')
+        assert len(invite_edges) == 1
+        assert invite_edges[0].label == 'Pending Sign Up'
+
+        helpers.create_user('outside_reviewer@gmail.com', 'Outside', 'Reviewer')
+
+        # add user to reviewers group
+        openreview_client.add_members_to_group('JMLR/Reviewers', ['~Outside_Reviewer1'])
+
+        ## Run Job
+        openreview.journal.Journal.check_new_profiles(openreview_client, support_group_id = 'openreview.net/Support')
 
         # post reviews
         reviewer_one_client = OpenReviewClient(username='rachel@jmlr.com', password=helpers.strong_password)

--- a/tests/test_jmlr_journal.py
+++ b/tests/test_jmlr_journal.py
@@ -257,6 +257,23 @@ Please note that responding to this email will direct your reply to celeste@jmlr
         ## Run Job
         openreview.journal.Journal.check_new_profiles(openreview_client, support_group_id = 'openreview.net/Support')
 
+        # error email is sent to the reviewer because they are already an official reviewer
+        error_messages = openreview_client.get_messages(to = 'outside_reviewer@gmail.com', subject = f'[JMLR] Error accepting invitation for paper number {note.number}')
+        assert len(error_messages) == 1
+        assert error_messages[0]['content']['text'] == f'''Hi Outside Reviewer,
+
+There was an error accepting the invitation to review the paper number: {note.number}, title: Paper title, because you have been added as an official reviewer for JMLR.
+
+If you would like to be assigned to this submission, you have not reached your reviewing quota and have no pending reviews, please contact the paper's AC and ask them to directly assign you.
+If you have reached your reviewing quota, you can use the "Volunteer to Review" button on the submission's forum.
+
+Thank you,
+
+OpenReview Team
+
+Please note that responding to this email will direct your reply to editor@jmlr.org.
+'''
+
         # post reviews
         reviewer_one_client = OpenReviewClient(username='rachel@jmlr.com', password=helpers.strong_password)
         reviewer_one_anon_groups=reviewer_one_client.get_groups(prefix=f'{venue_id}/Paper1/Reviewer_.*', signatory='~Rachel_JMLR1')

--- a/tests/test_jmlr_journal.py
+++ b/tests/test_jmlr_journal.py
@@ -264,7 +264,7 @@ Please note that responding to this email will direct your reply to celeste@jmlr
 
 There was an error accepting the invitation to review the paper number: {note.number}, title: Paper title, because you have been added as an official reviewer for JMLR.
 
-If you would like to be assigned to this submission, you have not reached your reviewing quota and have no pending reviews, please contact the paper's AC and ask them to directly assign you.
+If you would like to be assigned to this submission, you have not reached your reviewing quota and have no pending reviews, please contact the paper's action editor and ask them to directly assign you.
 If you have reached your reviewing quota, you can use the "Volunteer to Review" button on the submission's forum.
 
 Thank you,

--- a/tests/test_jmlr_journal.py
+++ b/tests/test_jmlr_journal.py
@@ -258,17 +258,15 @@ Please note that responding to this email will direct your reply to celeste@jmlr
         openreview.journal.Journal.check_new_profiles(openreview_client, support_group_id = 'openreview.net/Support')
 
         # error email is sent to the reviewer because they are already an official reviewer
-        error_messages = openreview_client.get_messages(to = 'outside_reviewer@gmail.com', subject = f'[JMLR] Error accepting invitation for paper number {note.number}')
+        error_messages = openreview_client.get_messages(to = 'outside_reviewer@gmail.com', subject = f'[JMLR] Invitation to review paper number {note.number} cannot be accepted')
         assert len(error_messages) == 1
         assert error_messages[0]['content']['text'] == f'''Hi Outside Reviewer,
 
-There was an error accepting the invitation to review the paper number: {note.number}, title: Paper title, because you have been added as an official reviewer for JMLR.
+The invitation to review the paper number: {note.number}, title: "Paper title" cannot be accepted. Only external reviewers can be invited to review papers, and you have been added as an official reviewer for JMLR.
 
-If you would like to be assigned to this submission, you have not reached your reviewing quota and have no pending reviews, please contact the paper's action editor and ask them to directly assign you.
-If you have reached your reviewing quota, you can use the "Volunteer to Review" button on the submission's forum.
+Please contact the person who invited you if you have any questions.
 
 Thank you,
-
 OpenReview Team
 
 Please note that responding to this email will direct your reply to editor@jmlr.org.


### PR DESCRIPTION
If a user is invited to a paper and they get added to the reviewers group before accepting, once they try to accept they won't be able to because they are an official reviewer. In this case, we should catch the error and send an email to the reviewer. 

I am sending an email to the reviewer letting them know why they can't accept and further instructions.

Fixes #3092 and #2591