### PR TITLE
Venue: support filtering submissions by decision options

### DIFF
--- a/openreview/stages/venue_stages.py
+++ b/openreview/stages/venue_stages.py
@@ -633,7 +633,7 @@ class SubmissionRevisionStage():
                 if field not in content:
                     content[field] = { 'delete': True }
 
-            only_accepted = self.only_accepted
+            only_accepted = self.only_accepted or self.only_accepted_decision_options(conference)
 
             hidden_field_names = conference.submission_stage.get_hidden_field_names()
             
@@ -646,6 +646,18 @@ class SubmissionRevisionStage():
                     content[field]['readers'] = { 'delete': True }                        
 
         return content
+
+    def only_accepted_decision_options(self, venue):
+        # True when the source's decision_options exactly match the venue's accept
+        # options, so the stage targets only accepted papers and authors/authorids
+        # should be hidden like the only_accepted / with_decision_accept path.
+        decision_options = self.source.get('decision_options')
+        if not decision_options:
+            return False
+        accept_options = venue.client.get_group(venue.venue_id).content.get('accept_decision_options', {}).get('value')
+        if not accept_options:
+            return False
+        return set(decision_options) == set(accept_options)
 
     def get_source_submissions(self, venue):
 

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -2146,23 +2146,30 @@ def should_match_invitation_source(client, invitation, submission, note=None, do
             if value != submission.content.get(key, {}).get('value'):
                 return False
 
-    if 'with_decision_accept' in source:
-        with_decision_accept = source.get('with_decision_accept')
-        print('checking decision accept for submission', submission.id, 'with_decision_accept', with_decision_accept)
+    if 'with_decision_accept' in source or 'decision_options' in source:
         decision_invitation_id = f'{domain.id}/{domain.content["submission_name"]["value"]}{submission.number}/-/{domain.content.get("decision_name", {}).get("value", "Decision")}'
         replies = submission.details.get('replies', submission.details.get('directReplies'))
         if replies is None:
             decision_notes = client.get_notes(forum=submission.id, invitation=decision_invitation_id)
         else:
             decision_notes = [openreview.api.Note.from_json(note) for note in replies if note['invitations'][0] == decision_invitation_id]
-        
+
         if not decision_notes:
             return False
 
-        accept_options = domain.content.get('accept_decision_options', {}).get('value')
         decision_value = decision_notes[0].content[domain.content.get('decision_field_name', {}).get('value', 'decision')]['value']
-        if is_accept_decision(decision_value, accept_options) != with_decision_accept:
-            return False
+
+        if 'with_decision_accept' in source:
+            with_decision_accept = source.get('with_decision_accept')
+            print('checking decision accept for submission', submission.id, 'with_decision_accept', with_decision_accept)
+            accept_options = domain.content.get('accept_decision_options', {}).get('value')
+            if is_accept_decision(decision_value, accept_options) != with_decision_accept:
+                return False
+
+        if 'decision_options' in source:
+            decision_options = source.get('decision_options')
+            if decision_value not in decision_options:
+                return False
 
     content_keys = invitation.edit.get('content', {}).keys()
     

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -2159,16 +2159,15 @@ def should_match_invitation_source(client, invitation, submission, note=None, do
 
         decision_value = decision_notes[0].content[domain.content.get('decision_field_name', {}).get('value', 'decision')]['value']
 
-        if 'with_decision_accept' in source:
+        if 'decision_options' in source:
+            decision_options = source.get('decision_options')
+            if decision_value not in decision_options:
+                return False
+        elif 'with_decision_accept' in source:
             with_decision_accept = source.get('with_decision_accept')
             print('checking decision accept for submission', submission.id, 'with_decision_accept', with_decision_accept)
             accept_options = domain.content.get('accept_decision_options', {}).get('value')
             if is_accept_decision(decision_value, accept_options) != with_decision_accept:
-                return False
-
-        if 'decision_options' in source:
-            decision_options = source.get('decision_options')
-            if decision_value not in decision_options:
                 return False
 
     content_keys = invitation.edit.get('content', {}).keys()

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -52,10 +52,18 @@ def process(client, invitation):
                 source_submissions = client.get_all_notes(content={ 'venueid': ','.join([venue_id, rejected_venue_id]) }, sort='number:asc', details='replies', domain=venue_id)
             
             if 'with_decision_accept' in source:
-                source_submissions = [s for s in source_submissions 
-                                      if len([r for r in s.details['replies'] 
-                                        if f'{venue_id}/{submission_name}{s.number}/-/{decision_name}' in r['invitations'] 
+                source_submissions = [s for s in source_submissions
+                                      if len([r for r in s.details['replies']
+                                        if f'{venue_id}/{submission_name}{s.number}/-/{decision_name}' in r['invitations']
                                         and openreview.tools.is_accept_decision(r['content'][decision_field_name]['value'], accept_options) == source.get('with_decision_accept')]) > 0]
+
+            # decision_options has precedence over with_decision_accept
+            if 'decision_options' in source:
+                decision_options = source.get('decision_options')
+                source_submissions = [s for s in source_submissions
+                                      if any(f'{venue_id}/{submission_name}{s.number}/-/{decision_name}' in r['invitations']
+                                        and r['content'][decision_field_name]['value'] in decision_options
+                                        for r in s.details['replies'])]
 
             if 'readers' in source:
                 source_submissions = [s for s in source_submissions if set(source['readers']).issubset(set(s.readers))]

--- a/openreview/venue/process/invitation_edit_process.py
+++ b/openreview/venue/process/invitation_edit_process.py
@@ -51,12 +51,6 @@ def process(client, invitation):
             if not source_submissions:
                 source_submissions = client.get_all_notes(content={ 'venueid': ','.join([venue_id, rejected_venue_id]) }, sort='number:asc', details='replies', domain=venue_id)
             
-            if 'with_decision_accept' in source:
-                source_submissions = [s for s in source_submissions
-                                      if len([r for r in s.details['replies']
-                                        if f'{venue_id}/{submission_name}{s.number}/-/{decision_name}' in r['invitations']
-                                        and openreview.tools.is_accept_decision(r['content'][decision_field_name]['value'], accept_options) == source.get('with_decision_accept')]) > 0]
-
             # decision_options has precedence over with_decision_accept
             if 'decision_options' in source:
                 decision_options = source.get('decision_options')
@@ -64,6 +58,11 @@ def process(client, invitation):
                                       if any(f'{venue_id}/{submission_name}{s.number}/-/{decision_name}' in r['invitations']
                                         and r['content'][decision_field_name]['value'] in decision_options
                                         for r in s.details['replies'])]
+            elif 'with_decision_accept' in source:
+                source_submissions = [s for s in source_submissions
+                                      if len([r for r in s.details['replies']
+                                        if f'{venue_id}/{submission_name}{s.number}/-/{decision_name}' in r['invitations']
+                                        and openreview.tools.is_accept_decision(r['content'][decision_field_name]['value'], accept_options) == source.get('with_decision_accept')]) > 0]
 
             if 'readers' in source:
                 source_submissions = [s for s in source_submissions if set(source['readers']).issubset(set(s.readers))]

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -83,7 +83,9 @@ class TestVenueSubmission():
 
         venue.custom_stage = openreview.stages.CustomStage(
             name='Camera_Ready_Verification',
-            source=openreview.stages.CustomStage.Source.ACCEPTED_SUBMISSIONS,
+            source={
+                'venueid': ['TestVenue.cc/Submission', 'TestVenue.cc', 'TestVenue.cc/Rejected_Submission'], 
+                'decision_options': ['Accept (Oral)'] },
             reply_to=openreview.stages.CustomStage.ReplyTo.FORUM,
             start_date=now + datetime.timedelta(minutes = 10),
             due_date=now + datetime.timedelta(minutes = 40),

--- a/tests/test_workshop_v2.py
+++ b/tests/test_workshop_v2.py
@@ -1197,7 +1197,53 @@ Best,
         assert 'PRL/2023/ICAPS/Submission6/-/Opt_In_Public_Release' in ids
         assert 'PRL/2023/ICAPS/Submission9/-/Opt_In_Public_Release' in ids
 
-    
+    def test_filter_by_decision_option(self, client, openreview_client, helpers, selenium, request_page):
+
+        ## filter submissions by a specific decision option, not just accept/reject.
+        ## 'Invite to Venue' is an accept option, so it cannot be isolated with the
+        ## boolean with_decision_accept; decision_options targets it exactly.
+        pc_client=openreview.Client(username='pc@icaps.cc', password=helpers.strong_password)
+        request_form=pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')[0]
+
+        venue = openreview.helpers.get_conference(client, request_form.id, support_user='openreview.net/Support')
+
+        now = datetime.datetime.now()
+        due_date = now + datetime.timedelta(days=3)
+        venue.custom_stage = openreview.stages.CustomStage(name='Invited_Submission_Confirmation',
+            reply_to=openreview.stages.CustomStage.ReplyTo.FORUM,
+            source={ 'venueid': ['PRL/2023/ICAPS', 'PRL/2023/ICAPS/Submission', 'PRL/2023/ICAPS/Rejected_Submission'], 'decision_options': ['Invite to Venue'] },
+            due_date=due_date,
+            exp_date=due_date + datetime.timedelta(days=1),
+            invitees=[openreview.stages.CustomStage.Participants.AUTHORS],
+            readers=[openreview.stages.CustomStage.Participants.PROGRAM_CHAIRS, openreview.stages.CustomStage.Participants.SIGNATURES],
+            content={
+                'confirm_invitation': {
+                    'order': 1,
+                    'description': 'Confirm you will submit to the venue.',
+                    'value': {
+                        'param': {
+                            'type': 'string',
+                            'input': 'checkbox',
+                            'enum': ['I confirm my submission to the venue.']
+                        }
+                    }
+                }
+            },
+            notify_readers=False,
+            email_sacs=False)
+
+        venue.create_custom_stage()
+
+        helpers.await_queue_edit(openreview_client, 'PRL/2023/ICAPS/-/Invited_Submission_Confirmation-0-1', count=1)
+
+        invitations = openreview_client.get_invitations(invitation='PRL/2023/ICAPS/-/Invited_Submission_Confirmation')
+        assert len(invitations) == 3
+
+        ids = [invitation.id for invitation in invitations]
+        assert 'PRL/2023/ICAPS/Submission2/-/Invited_Submission_Confirmation' in ids
+        assert 'PRL/2023/ICAPS/Submission5/-/Invited_Submission_Confirmation' in ids
+        assert 'PRL/2023/ICAPS/Submission8/-/Invited_Submission_Confirmation' in ids
+
     def test_post_decision_for_new_submission(self, client, openreview_client, helpers):
 
         pc_client=openreview.Client(username='pc@icaps.cc', password=helpers.strong_password)


### PR DESCRIPTION
This pull request enhances support for filtering submissions based on specific decision options, not just a general accept/reject status. It introduces logic to handle the new `decision_options` parameter throughout the codebase, ensuring that features like invitation filtering and content visibility work correctly when targeting submissions with particular decision decisions. Additionally, a new test verifies this behavior.

**Filtering and Matching Enhancements:**

* Added logic in `openreview/stages/venue_stages.py` to determine if only accepted decision options are targeted by comparing the source's `decision_options` to the venue's accept options, and updated content visibility accordingly. [[1]](diffhunk://#diff-5753bcb1ca462c4479bbbc4be41859a89bd080fce2d2a4cb2859d0fe31a7a722L636-R636) [[2]](diffhunk://#diff-5753bcb1ca462c4479bbbc4be41859a89bd080fce2d2a4cb2859d0fe31a7a722R650-R661)
* Updated `openreview/tools.py` so that both `with_decision_accept` and `decision_options` can trigger decision-based filtering, and added checks to ensure submissions match the specified decision options. [[1]](diffhunk://#diff-a0a408fd57af11c3a81cfd044e307e78e5b96b29d4ec2f55a62cd5667b12b45dL2149-R2149) [[2]](diffhunk://#diff-a0a408fd57af11c3a81cfd044e307e78e5b96b29d4ec2f55a62cd5667b12b45dL2162-R2173)
* Modified `openreview/venue/process/invitation_edit_process.py` to give precedence to `decision_options` over `with_decision_accept` when filtering source submissions.

**Testing:**

* Added a new test `test_filter_by_decision_option` in `tests/test_workshop_v2.py` to verify that filtering submissions by a specific decision option (e.g., "Invite to Venue") works as expected.