### PR TITLE
fix empty list of recipients

### DIFF
--- a/openreview/arr/process/comment_process.py
+++ b/openreview/arr/process/comment_process.py
@@ -88,10 +88,12 @@ Comment: {comment.content['comment']['value']}
 
 To view the comment, click here: https://openreview.net/forum?id={submission.id}&noteId={comment.id}'''
 
+    program_chairs_id = domain.get_content_value('program_chairs_id')
+    email_pcs = domain.get_content_value('comment_email_pcs')
+
     if comment_threshold is None or (signed_by_author and comment_count <= comment_threshold) or (signed_by_reviewer and comment_count <= comment_threshold) or not (signed_by_author or signed_by_reviewer):
-        program_chairs_id = domain.get_content_value('program_chairs_id')
         minimum_number_of_readers = 3 if domain.get_content_value('senior_area_chairs_name') else 2
-        email_PC = domain.get_content_value('comment_email_pcs') or (domain.get_content_value('direct_comment_email_pcs') and len(comment.readers) == minimum_number_of_readers)
+        email_PC = email_pcs or (domain.get_content_value('direct_comment_email_pcs') and len(comment.readers) == minimum_number_of_readers)
         if email_PC and (program_chairs_id in comment.readers or 'everyone' in comment.readers):
             client.post_message(
                 invitation=meta_invitation_id,
@@ -177,15 +179,20 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
             )
 
     #send email to author of comment
-    client.post_message(
-        invitation=meta_invitation_id,
-        recipients=[edit.tauthor] if edit.tauthor != 'OpenReview.net' else [],
-        subject=f'''[{short_name}] Your comment was received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-        message=f'''Your comment was received on a submission to {short_name}.{content}''',
-        replyTo=contact,
-        signature=venue_id,
-        sender=sender
-    )
+    comment_author_recipients = [edit.tauthor] if edit.tauthor.lower() != 'openreview.net' else []
+    if program_chairs_id in comment.signatures and not email_pcs:
+        comment_author_recipients = []
+
+    if comment_author_recipients:
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=comment_author_recipients,
+            subject=f'''[{short_name}] Your comment was received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+            message=f'''Your comment was received on a submission to {short_name}.{content}''',
+            replyTo=contact,
+            signature=venue_id,
+            sender=sender
+        )
 
     #send email to paper authors
     paper_authors_id = f'{paper_group_id}/{authors_name}'

--- a/openreview/venue/process/comment_process.py
+++ b/openreview/venue/process/comment_process.py
@@ -134,15 +134,20 @@ To view the comment, click here: https://openreview.net/forum?id={submission.id}
                 )
 
     #send email to author of comment
-    client.post_message(
-        invitation=meta_invitation_id,
-        recipients=[edit.tauthor] if edit.tauthor != 'OpenReview.net' else [],
-        subject=f'''[{short_name}] Your comment was received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
-        message=f'''Your comment was received on a submission to {short_name}.{content}''',
-        replyTo=contact,
-        signature=venue_id,
-        sender=sender
-    )
+    comment_author_recipients = [edit.tauthor] if edit.tauthor.lower() != 'openreview.net' else []
+    if program_chairs_id in comment.signatures and not email_pcs:
+        comment_author_recipients = []
+
+    if comment_author_recipients:
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=comment_author_recipients,
+            subject=f'''[{short_name}] Your comment was received on Paper Number: {submission.number}, Paper Title: "{submission.content['title']['value']}"''',
+            message=f'''Your comment was received on a submission to {short_name}.{content}''',
+            replyTo=contact,
+            signature=venue_id,
+            sender=sender
+        )
 
     #send email to paper authors
     paper_authors_id = f'{paper_group_id}/{authors_name}'

--- a/openreview/venue/process/review_rebuttal_process.py
+++ b/openreview/venue/process/review_rebuttal_process.py
@@ -40,15 +40,18 @@ Title: {submission.content['title']['value']}
 {content}'''
 
     #send email to author of comment
-    client.post_message(
-        invitation=meta_invitation_id,
-        recipients=[edit.tauthor] if edit.tauthor != 'OpenReview.net' else [],
-        subject=f'''[{short_name}] Your author rebuttal was {action} on Submission Number: {submission.number}, Submission Title: "{submission.content['title']['value']}"''',
-        message=author_message,
-        replyTo=contact,
-        signature=venue_id,
-        sender=sender
-    )
+    rebuttal_author_recipients = [edit.tauthor] if edit.tauthor.lower() != 'openreview.net' else []
+
+    if rebuttal_author_recipients:
+        client.post_message(
+            invitation=meta_invitation_id,
+            recipients=rebuttal_author_recipients,
+            subject=f'''[{short_name}] Your author rebuttal was {action} on Submission Number: {submission.number}, Submission Title: "{submission.content['title']['value']}"''',
+            message=author_message,
+            replyTo=contact,
+            signature=venue_id,
+            sender=sender
+        )
 
     #send email to paper authors
     if email_authors:

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -632,7 +632,7 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         ## the API does not accept an empty list of recipients
         with pytest.raises(openreview.OpenReviewException):
             openreview_client.post_message(
-                invitation='TestVenue.cc/-/Edit',
+                invitation='TestVenue.cc/提交1/-/Message',
                 recipients=[],
                 subject='[TV 22] Message with no recipients',
                 message='Message with no recipients',

--- a/tests/test_venue_submission.py
+++ b/tests/test_venue_submission.py
@@ -625,7 +625,76 @@ Please follow this link: https://openreview.net/forum?id={submission_id}&noteId=
         invitation = openreview_client.get_invitation(venue.id + '/提交1/-/Public_Comment')
         assert not invitation.expdate
         invitation = openreview_client.get_invitation(venue.id + '/提交1/-/Official_Comment')
-        assert not invitation.expdate        
+        assert not invitation.expdate
+
+    def test_post_message_with_empty_recipients(self, venue, openreview_client, helpers):
+
+        ## the API does not accept an empty list of recipients
+        with pytest.raises(openreview.OpenReviewException):
+            openreview_client.post_message(
+                invitation='TestVenue.cc/-/Edit',
+                recipients=[],
+                subject='[TV 22] Message with no recipients',
+                message='Message with no recipients',
+                signature='TestVenue.cc'
+            )
+
+    def test_comment_posted_by_super_user(self, venue, openreview_client, helpers):
+
+        submissions = venue.get_submissions(sort='number:asc')
+
+        comment_edit = openreview_client.post_note_edit(
+            invitation='TestVenue.cc/提交1/-/Official_Comment',
+            signatures=['TestVenue.cc/Program_Chairs'],
+            note=Note(
+                replyto=submissions[0].id,
+                readers=['TestVenue.cc/Program_Chairs'],
+                content={
+                    'comment': { 'value': 'Comment posted by the super user' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=comment_edit['id'])
+
+        ## no confirmation email should be sent to the super user
+        messages = [m for m in openreview_client.get_messages() if m['content']['subject'].startswith('[TV 22] Your comment was received') and 'Comment posted by the super user' in m['content']['text']]
+        assert len(messages) == 0, [(m['content']['to'], m['content']['subject']) for m in messages]
+
+    def test_comment_posted_by_program_chairs(self, venue, openreview_client, helpers):
+
+        ## disable the email to the program chairs
+        venue.comment_stage = openreview.CommentStage(
+            allow_public_comments=True,
+            reader_selection=True,
+            email_pcs=False,
+            check_mandatory_readers=True,
+            readers=[openreview.CommentStage.Readers.REVIEWERS_ASSIGNED,openreview.CommentStage.Readers.AREA_CHAIRS_ASSIGNED,openreview.CommentStage.Readers.SENIOR_AREA_CHAIRS_ASSIGNED,openreview.CommentStage.Readers.AUTHORS,openreview.CommentStage.Readers.EVERYONE],
+            invitees=[openreview.CommentStage.Readers.REVIEWERS_ASSIGNED,openreview.CommentStage.Readers.AREA_CHAIRS_ASSIGNED,openreview.CommentStage.Readers.SENIOR_AREA_CHAIRS_ASSIGNED,openreview.CommentStage.Readers.AUTHORS])
+        venue.create_comment_stage()
+
+        assert openreview_client.get_invitation('TestVenue.cc/-/Official_Comment').content['email_program_chairs']['value'] == False
+
+        pc_client = OpenReviewClient(username='venue_pc@mail.com', password=helpers.strong_password)
+
+        submissions = venue.get_submissions(sort='number:asc')
+
+        comment_edit = pc_client.post_note_edit(
+            invitation='TestVenue.cc/提交3/-/Official_Comment',
+            signatures=['TestVenue.cc/Program_Chairs'],
+            note=Note(
+                replyto=submissions[2].id,
+                readers=['TestVenue.cc/Program_Chairs'],
+                content={
+                    'comment': { 'value': 'Comment posted by the program chairs' }
+                }
+            )
+        )
+
+        helpers.await_queue_edit(openreview_client, edit_id=comment_edit['id'])
+
+        messages = [m for m in openreview_client.get_messages(to='venue_pc@mail.com') if 'Comment posted by the program chairs' in m['content']['text']]
+        assert len(messages) == 0, [m['content']['subject'] for m in messages]
 
     def test_withdraw_submission(self, venue, openreview_client, helpers):
 


### PR DESCRIPTION
Make sure the list of recipients is not empty before posting a message and do not send any email to PCs if the emails_pcs is False.