### PR TITLE
ARR: Validate author response extension dates

### DIFF
--- a/openreview/arr/invitation.py
+++ b/openreview/arr/invitation.py
@@ -139,6 +139,7 @@ class InvitationBuilder(object):
             invitees=[venue_id],
             multiReply=True,
             process_string=self.get_process_content('process/configuration_process.py'),
+            preprocess=self.get_process_content('process/configuration_pre_process.py'),
             reply={
                 'forum':request_form_id,
                 'referent': request_form_id,

--- a/openreview/arr/process/configuration_pre_process.py
+++ b/openreview/arr/process/configuration_pre_process.py
@@ -10,14 +10,14 @@ def process(client, note, invitation):
     if not extension_start_date:
         return
 
-    author_response_date = note.content.get('setup_author_response_date')
-    if not author_response_date:
+    close_author_response_date = note.content.get('close_author_response_date')
+    if not close_author_response_date:
         for configuration in previous_configurations:
-            if configuration.content.get('setup_author_response_date'):
-                author_response_date = configuration.content['setup_author_response_date']
+            if configuration.content.get('close_author_response_date'):
+                close_author_response_date = configuration.content['close_author_response_date']
                 break
 
-    if not author_response_date:
+    if not close_author_response_date:
         return
 
     def parse_date(date):
@@ -26,7 +26,7 @@ def process(client, note, invitation):
         except ValueError:
             return datetime.datetime.strptime(date.strip(), '%Y/%m/%d')
 
-    if parse_date(extension_start_date) <= parse_date(author_response_date):
+    if parse_date(extension_start_date) <= parse_date(close_author_response_date):
         raise openreview.OpenReviewException(
-            'The author response extension start date must be after the author response date.'
+            'The author response extension start date must be after the close author response date.'
         )

--- a/openreview/arr/process/configuration_pre_process.py
+++ b/openreview/arr/process/configuration_pre_process.py
@@ -1,0 +1,32 @@
+def process(client, note, invitation):
+    import datetime
+
+    previous_configurations = client.get_references(
+        referent=note.forum,
+        invitation=note.invitation
+    )
+
+    extension_start_date = note.content.get('author_response_extension_start_date')
+    if not extension_start_date:
+        return
+
+    author_response_date = note.content.get('setup_author_response_date')
+    if not author_response_date:
+        for configuration in previous_configurations:
+            if configuration.content.get('setup_author_response_date'):
+                author_response_date = configuration.content['setup_author_response_date']
+                break
+
+    if not author_response_date:
+        return
+
+    def parse_date(date):
+        try:
+            return datetime.datetime.strptime(date.strip(), '%Y/%m/%d %H:%M')
+        except ValueError:
+            return datetime.datetime.strptime(date.strip(), '%Y/%m/%d')
+
+    if parse_date(extension_start_date) <= parse_date(author_response_date):
+        raise openreview.OpenReviewException(
+            'The author response extension start date must be after the author response date.'
+        )

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -6381,13 +6381,45 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
         venue_id = 'aclweb.org/ACL/ARR/2023/August'
         submissions = pc_client_v2.get_all_notes(invitation=f'{venue_id}/-/Submission', sort='number:asc', details='replies')
         now = datetime.datetime.now()
-        config_invitation = pc_client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration')
+        config_invitation = client.get_invitation(f'openreview.net/Support/-/Request{request_form.number}/ARR_Configuration')
+        assert config_invitation.preprocess
         assert 'author_response_extension_start_date' in config_invitation.reply['content']
         assert 'author_response_extension_end_date' in config_invitation.reply['content']
         assert 'author_response_extension_cron' in config_invitation.reply['content']
         assert config_invitation.reply['content']['author_response_extension_cron']['default'] == '0 */12 * * *'
 
-        ## Step 1: Enable author response extension and verify invitation structure/default cron
+        configuration_notes = pc_client.get_references(
+            referent=request_form.id,
+            invitation=config_invitation.id
+        )
+        author_response_date = next(
+            configuration.content['setup_author_response_date']
+            for configuration in configuration_notes
+            if configuration.content.get('setup_author_response_date')
+        )
+
+        ## Step 1: Reject an extension that does not start after the configured author response date
+        with pytest.raises(
+            openreview.OpenReviewException,
+            match=r'The author response extension start date must be after the author response date.'
+        ):
+            pc_client.post_note(
+                openreview.Note(
+                    content={
+                        'author_response_extension_start_date': author_response_date,
+                        'author_response_extension_end_date': (now + datetime.timedelta(days=14)).strftime('%Y/%m/%d %H:%M')
+                    },
+                    invitation=config_invitation.id,
+                    forum=request_form.id,
+                    readers=[f'{venue_id}/Program_Chairs', 'openreview.net/Support'],
+                    referent=request_form.id,
+                    replyto=request_form.id,
+                    signatures=['~Program_ARRChair1'],
+                    writers=[],
+                )
+            )
+
+        ## Step 2: Enable author response extension and verify invitation structure/default cron
         pc_client.post_note(
             openreview.Note(
                 content={

--- a/tests/test_arr_venue_v2.py
+++ b/tests/test_arr_venue_v2.py
@@ -6392,21 +6392,22 @@ reviewerextra2@aclrollingreview.com, Reviewer ARRExtraTwo
             referent=request_form.id,
             invitation=config_invitation.id
         )
-        author_response_date = next(
-            configuration.content['setup_author_response_date']
-            for configuration in configuration_notes
-            if configuration.content.get('setup_author_response_date')
-        )
+        close_author_response_date = None
+        for configuration in configuration_notes:
+            if configuration.content.get('close_author_response_date'):
+                close_author_response_date = configuration.content['close_author_response_date']
+                break
+        assert close_author_response_date
 
-        ## Step 1: Reject an extension that does not start after the configured author response date
+        ## Step 1: Reject an extension that does not start after the configured close author response date
         with pytest.raises(
             openreview.OpenReviewException,
-            match=r'The author response extension start date must be after the author response date.'
+            match=r'The author response extension start date must be after the close author response date.'
         ):
             pc_client.post_note(
                 openreview.Note(
                     content={
-                        'author_response_extension_start_date': author_response_date,
+                        'author_response_extension_start_date': close_author_response_date,
                         'author_response_extension_end_date': (now + datetime.timedelta(days=14)).strftime('%Y/%m/%d %H:%M')
                     },
                     invitation=config_invitation.id,


### PR DESCRIPTION
This PR adds a date ordering validation to the ARR configuration invitation with a condition that the author response extension period should start after the regular author response is closed to prevent unexpected closing of rebuttals