### PR TITLE
Fix/remove stream=True when callong to get_all_notes without details

### DIFF
--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -1748,34 +1748,6 @@ class OpenReviewClient(object):
         if domain is not None:
             params['domain'] = domain
 
-        if 'details' not in params:
-            params['stream'] = True
-            # Handle sort param for local sorting
-            sort_key = None
-            reverse = False
-            if 'sort' in params:
-                # Accept format like "number:asc", "tcdate:desc", etc.
-                valid_fields = {
-                    'number': lambda n: n.number,
-                    'tcdate': lambda n: n.tcdate,
-                    'tmdate': lambda n: n.tmdate,
-                    'cdate': lambda n: n.cdate,
-                    'mdate': lambda n: n.mdate
-                }
-                if ':' in sort:
-                    field, direction = sort.split(':', 1)
-                else:
-                    field, direction = sort, 'desc'
-                if field in valid_fields:
-                    sort_key = valid_fields[field]
-                    reverse = direction == 'desc'
-                    params['sort'] = None  # Remove for API call, sort locally            
-            
-            results = self.get_notes(**params)
-            if sort_key:
-                return sorted(results, key=sort_key, reverse=reverse)
-            return results
-        
         return list(tools.efficient_iterget(self.get_notes, desc='Getting V2 Notes', **params))
 
     def get_note_edit(self, id, trash=None):

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -829,6 +829,43 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return response.content
 
+    def get_attachments(self, ids, field_name):
+        """
+        Gets a zip file with the attachments of the notes with the provided ids.
+
+        Note that when only one of the ids resolves to a note the server streams that
+        file directly instead of a zip.
+
+        :param ids: List of Note ids or Reference ids. The max number of ids is 50
+        :type ids: list[str]
+        :param field_name: name of the field associated with the attachment files
+        :type field_name: str
+
+        :return: The binary content of a zip file containing one file per note
+        :rtype: bytes
+
+        Example:
+
+        >>> f = client.get_attachments(ids=['Place Note-ID here', 'Place Note-ID here'], field_name='pdf')
+        >>> with open('attachments.zip','wb') as op: op.write(f)
+
+        """
+
+        if not ids:
+            raise OpenReviewException('Provide a non empty list of ids')
+
+        if len(set(ids)) > 50:
+            raise OpenReviewException('The max number of ids is 50')
+
+        params = {
+            'name': field_name,
+            'ids': ','.join(ids)
+        }
+
+        response = self.session.get(self.baseurl + '/attachment', params=tools.format_params(params), headers = self.headers)
+        response = self.__handle_response(response)
+        return response.content
+
     def get_venues(self, id=None, ids=None, invitations=None):
         """Get a list of Venue objects based on the filters provided.
 

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -829,37 +829,6 @@ class OpenReviewClient(object):
         response = self.__handle_response(response)
         return response.content
 
-    def get_attachments(self, ids, field_name):
-        """
-        Gets a zip file with the attachments of the notes with the provided ids.
-
-        Note that when only one of the ids resolves to a note the server streams that
-        file directly instead of a zip.
-
-        :param ids: List of Note ids or Reference ids. The max number of ids is limited by the API
-        :type ids: list[str]
-        :param field_name: name of the field associated with the attachment files
-        :type field_name: str
-
-        :return: The binary content of a zip file containing one file per note
-        :rtype: bytes
-
-        Example:
-
-        >>> f = client.get_attachments(ids=['Place Note-ID here', 'Place Note-ID here'], field_name='pdf')
-        >>> with open('attachments.zip','wb') as op: op.write(f)
-
-        """
-
-        params = {
-            'name': field_name,
-            'ids': ','.join(ids)
-        }
-
-        response = self.session.get(self.baseurl + '/attachment', params=tools.format_params(params), headers = self.headers)
-        response = self.__handle_response(response)
-        return response.content
-
     def get_venues(self, id=None, ids=None, invitations=None):
         """Get a list of Venue objects based on the filters provided.
 

--- a/openreview/api/client.py
+++ b/openreview/api/client.py
@@ -836,7 +836,7 @@ class OpenReviewClient(object):
         Note that when only one of the ids resolves to a note the server streams that
         file directly instead of a zip.
 
-        :param ids: List of Note ids or Reference ids. The max number of ids is 50
+        :param ids: List of Note ids or Reference ids. The max number of ids is limited by the API
         :type ids: list[str]
         :param field_name: name of the field associated with the attachment files
         :type field_name: str
@@ -850,12 +850,6 @@ class OpenReviewClient(object):
         >>> with open('attachments.zip','wb') as op: op.write(f)
 
         """
-
-        if not ids:
-            raise OpenReviewException('Provide a non empty list of ids')
-
-        if len(set(ids)) > 50:
-            raise OpenReviewException('The max number of ids is 50')
 
         params = {
             'name': field_name,

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -3,8 +3,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import inspect
 
+import io
 import json
 import os
+import zipfile
 
 import openreview
 import re
@@ -2270,6 +2272,88 @@ def singularize(word):
     elif word.endswith('s'):
         return word[:-1]
     return word
+
+def get_attachment_file_name(note, field_name):
+    """
+    Builds the name the API gives to the attachment of a note, so files downloaded
+    one by one are named like the ones extracted from a zip file.
+
+    :param note: Note that contains the attachment
+    :type note: openreview.api.Note
+    :param field_name: Name of the content field that contains the attachment
+    :type field_name: str
+
+    :return: Name of the file, like ``12_Attention_Is_All_You_Need_Latex Source Zip.zip``
+    :rtype: str
+    """
+    name = f"{note.number}_{note.content.get('title', {}).get('value', note.id)}"
+    ## Mirror the sanitization done by the API: keep alphanumeric runs only, join them with underscores
+    sanitized_name = re.sub(r'\s', '_', re.sub(r'[^a-zA-Z0-9]+', ' ', name.strip()))[:30]
+    suffix = '' if field_name == 'pdf' else '_' + ' '.join([w[:1].upper() + w[1:] for w in field_name.split('_')])
+    extension = note.content[field_name]['value'].split('.')[-1]
+    return f'{sanitized_name}{suffix}.{extension}'
+
+def get_all_attachments(client, venueid, field_name, output_dir=None):
+    """
+    Downloads the attachments of all the notes with the given ``venueid`` and extracts them into a directory.
+
+    The files are requested in batches of 50 ids, the max number of ids supported by the API,
+    and each batch is returned as a zip file that gets extracted into ``output_dir``.
+    Notes that don't have a file in ``field_name`` are skipped.
+
+    :param client: Client used to get the submissions and the attachments
+    :type client: openreview.api.OpenReviewClient
+    :param venueid: Value of the ``venueid`` content field, like ``auai.org/UAI/2026/Conference``
+    :type venueid: str
+    :param field_name: Name of the content field that contains the attachment, like ``pdf`` or ``latex_source_zip``
+    :type field_name: str
+    :param output_dir: Directory where the files are extracted, it gets created if it doesn't exist.
+        Defaults to a directory named after ``field_name``
+    :type output_dir: str, optional
+
+    :return: Paths of the downloaded files
+    :rtype: list[str]
+
+    Example:
+
+    >>> files = openreview.tools.get_all_attachments(client, venueid='auai.org/UAI/2026/Conference', field_name='latex_source_zip')
+
+    """
+    output_dir = output_dir or field_name
+
+    submissions = client.get_all_notes(content={ 'venueid': venueid }, sort='number:asc')
+    notes = [s for s in submissions if s.content.get(field_name, {}).get('value')]
+
+    print(f'{len(notes)} submissions out of {len(submissions)} have a file in {field_name}')
+
+    if not notes:
+        return []
+
+    batch_size = 50
+    batches = [notes[i:i + batch_size] for i in range(0, len(notes), batch_size)]
+
+    ## The API returns the file itself instead of a zip file when only one id is requested,
+    ## so avoid leaving a single note in the last batch
+    if len(batches) > 1 and len(batches[-1]) == 1:
+        batches[-1].insert(0, batches[-2].pop())
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    file_paths = []
+    for batch in tqdm(batches, desc='Downloading attachments'):
+        if len(batch) == 1:
+            note = batch[0]
+            file_path = os.path.join(output_dir, get_attachment_file_name(note, field_name))
+            with open(file_path, 'wb') as f:
+                f.write(client.get_attachment(field_name, id=note.id))
+            file_paths.append(file_path)
+        else:
+            archive_content = client.get_attachments([note.id for note in batch], field_name)
+            with zipfile.ZipFile(io.BytesIO(archive_content)) as archive:
+                archive.extractall(output_dir)
+                file_paths.extend([os.path.join(output_dir, name) for name in archive.namelist()])
+
+    return file_paths
 
 def percentile(data, percent):
     """Return the percentile value from *data* using linear interpolation,

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -6,6 +6,7 @@ import inspect
 import io
 import json
 import os
+import shutil
 import zipfile
 
 import openreview
@@ -2273,31 +2274,11 @@ def singularize(word):
         return word[:-1]
     return word
 
-def get_attachment_file_name(note, field_name):
-    """
-    Builds the name the API gives to the attachment of a note, so files downloaded
-    one by one are named like the ones extracted from a zip file.
-
-    :param note: Note that contains the attachment
-    :type note: openreview.api.Note
-    :param field_name: Name of the content field that contains the attachment
-    :type field_name: str
-
-    :return: Name of the file, like ``12_Attention_Is_All_You_Need_Latex Source Zip.zip``
-    :rtype: str
-    """
-    name = f"{note.number}_{note.content.get('title', {}).get('value', note.id)}"
-    ## Mirror the sanitization done by the API: keep alphanumeric runs only, join them with underscores
-    sanitized_name = re.sub(r'\s', '_', re.sub(r'[^a-zA-Z0-9]+', ' ', name.strip()))[:30]
-    suffix = '' if field_name == 'pdf' else '_' + ' '.join([w[:1].upper() + w[1:] for w in field_name.split('_')])
-    extension = note.content[field_name]['value'].split('.')[-1]
-    return f'{sanitized_name}{suffix}.{extension}'
-
 def get_all_attachments(client, venueid, field_name, output_dir=None):
     """
     Downloads the attachments of all the notes with the given ``venueid`` and extracts them into a directory.
 
-    The files are requested in batches of 50 ids, the max number of ids supported by the API,
+    The files are requested sequentially in batches of 50 ids, the max number of ids supported by the API,
     and each batch is returned as a zip file that gets extracted into ``output_dir``.
     Notes that don't have a file in ``field_name`` are skipped.
 
@@ -2341,17 +2322,14 @@ def get_all_attachments(client, venueid, field_name, output_dir=None):
 
     file_paths = []
     for batch in tqdm(batches, desc='Downloading attachments'):
-        if len(batch) == 1:
-            note = batch[0]
-            file_path = os.path.join(output_dir, get_attachment_file_name(note, field_name))
-            with open(file_path, 'wb') as f:
-                f.write(client.get_attachment(field_name, id=note.id))
-            file_paths.append(file_path)
-        else:
-            archive_content = client.get_attachments([note.id for note in batch], field_name)
-            with zipfile.ZipFile(io.BytesIO(archive_content)) as archive:
-                archive.extractall(output_dir)
-                file_paths.extend([os.path.join(output_dir, name) for name in archive.namelist()])
+        archive_content = client.get_attachments([note.id for note in batch], field_name)
+        with zipfile.ZipFile(io.BytesIO(archive_content)) as archive:
+            for member in archive.infolist():
+                file_path = os.path.join(output_dir, member.filename)
+                with archive.open(member) as source, open(file_path, 'wb') as target:
+                    shutil.copyfileobj(source, target)
+
+                file_paths.append(file_path)
 
     return file_paths
 

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -2322,7 +2322,7 @@ def get_all_attachments(client, venueid, field_name, output_dir=None):
 
     file_paths = []
     for batch in tqdm(batches, desc='Downloading attachments'):
-        archive_content = client.get_attachments([note.id for note in batch], field_name)
+        archive_content = client.get_attachment(ids=[note.id for note in batch], field_name=field_name)
         with zipfile.ZipFile(io.BytesIO(archive_content)) as archive:
             for member in archive.infolist():
                 file_path = os.path.join(output_dir, member.filename)


### PR DESCRIPTION
Do not make the exception to call the get notes with stream = True if there are no details requested. 

Using after param is faster than streaming when the venue is very large. 