### PR TITLE
Fix/arr submission revision

### DIFF
--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -1762,6 +1762,11 @@ class ARRStage(object):
             latest_reference = latest_references[0]
             stage_dates = self._get_stage_note_dates(format_type='strftime')
             latest_reference.content.update(stage_dates)
+            if latest_reference.content.get('submission_revision_remove_options'):
+                latest_reference.content['submission_revision_remove_options'] = list(set(venue.submission_stage.get_content(api_version='2').keys()) -
+                {
+                    'Association_for_Computational_Linguistics_-_Blind_Submission_License_Agreement',
+                })
 
             stage_note = openreview.Note(
                 content = latest_reference.content,

--- a/openreview/arr/helpers.py
+++ b/openreview/arr/helpers.py
@@ -1762,7 +1762,7 @@ class ARRStage(object):
             latest_reference = latest_references[0]
             stage_dates = self._get_stage_note_dates(format_type='strftime')
             latest_reference.content.update(stage_dates)
-            if latest_reference.content.get('submission_revision_remove_options'):
+            if latest_reference.content.get('submission_revision_remove_options') and latest_reference.content.get('submission_revision_name', '') == 'Blind_Submission_License_Agreement':
                 latest_reference.content['submission_revision_remove_options'] = list(set(venue.submission_stage.get_content(api_version='2').keys()) -
                 {
                     'Association_for_Computational_Linguistics_-_Blind_Submission_License_Agreement',

--- a/tests/test_arr_metadata_revision_bug.py
+++ b/tests/test_arr_metadata_revision_bug.py
@@ -196,3 +196,152 @@ class TestARRMetadataRevisionBug():
         # And the Blind_Submission_License_Agreement super invitation should also
         # have been built (proving the BSLA stage did not blow up).
         assert openreview_client.get_invitation(f'{venue_id}/-/Blind_Submission_License_Agreement')
+
+    def test_arr_config_rerun_after_second_revision(self, client, openreview_client, helpers):
+        """
+        Same bug, but on the second pass through set_workflow.
+
+        Once the Blind_Submission_License_Agreement invitation exists, the stage
+        goes through `ARRStage._post_new_dates`, which re-posts the *previous*
+        Submission_Revision_Stage note with new dates. The stored
+        `submission_revision_remove_options` of that note is the submission
+        content as it was when the stage was first built, so a later Revision
+        that drops a field leaves the note referencing a key the
+        Submission_Revision_Stage dropdown no longer offers -> NotMatchError ->
+        the workflow aborts before the Submission_Metadata_Revision dates are
+        updated. The fix recomputes the remove options from the venue's current
+        submission stage content on every re-post as well.
+        """
+
+        now = datetime.datetime.now()
+        venue_id = 'aclweb.org/ACL/ARR/2099/MetadataBug'
+        author_consent_end = now + datetime.timedelta(days=4)
+        metadata_edit_start = now + datetime.timedelta(days=2)
+        metadata_edit_end = now + datetime.timedelta(days=6)
+
+        pc_client = openreview.Client(username='pc-metadatabug@aclrollingreview.org', password=helpers.strong_password)
+        request_form_note = [
+            note for note in pc_client.get_notes(invitation='openreview.net/Support/-/Request_Form')
+            if note.content.get('title') == 'ACL Rolling Review 2099 - MetadataBug'
+        ][0]
+
+        # Second Revision: the PCs bring `justification_for_author_changes` back,
+        # drop `preferred_venue` and add a brand new field. Dropping a field is
+        # what breaks the stale remove options stored on the first BSLA stage
+        # note.
+        customized_submission_content = deepcopy(arr_submission_content)
+        customized_submission_content['software']['value']['param']['maxSize'] = 50
+        del customized_submission_content['preferred_venue']
+        customized_submission_content['metadata_bug_custom_field'] = {
+            'order': 100,
+            'description': 'Extra field added by the PCs in a later revision',
+            'value': {
+                'param': {
+                    'type': 'string',
+                    'maxLength': 200,
+                    'optional': True,
+                    'deletable': True
+                }
+            }
+        }
+
+        pc_client.post_note(openreview.Note(
+            invitation=f'openreview.net/Support/-/Request{request_form_note.number}/Revision',
+            forum=request_form_note.id,
+            readers=[f'{venue_id}/Program_Chairs', 'openreview.net/Support'],
+            referent=request_form_note.id,
+            replyto=request_form_note.id,
+            signatures=['~ProgramBug_ARRChair1'],
+            writers=[],
+            content={
+                'title': 'ACL Rolling Review 2099 - MetadataBug',
+                'Official Venue Name': 'ACL Rolling Review 2099 - MetadataBug',
+                'Abbreviated Venue Name': 'ARR - MetadataBug 2099',
+                'Official Website URL': 'http://aclrollingreview.org',
+                'program_chair_emails': ['pc-metadatabug@aclrollingreview.org'],
+                'contact_email': 'pc-metadatabug@aclrollingreview.org',
+                'Venue Start Date': '2099/08/01',
+                'Submission Deadline': request_form_note.content['Submission Deadline'],
+                'publication_chairs': 'No, our venue does not have Publication Chairs',
+                'Location': 'Virtual',
+                'submission_reviewer_assignment': 'Automatic',
+                'How did you hear about us?': 'ML conferences',
+                'Expected Submissions': '10',
+                'use_recruitment_template': 'Yes',
+                'Additional Submission Options': customized_submission_content,
+                'remove_submission_options': ['keywords'],
+            }
+        ))
+        helpers.await_queue_edit(
+            client,
+            invitation=f'openreview.net/Support/-/Request{request_form_note.number}/Revision',
+            count=2
+        )
+
+        # The submission form now differs from what it was when the BSLA stage
+        # note was first posted: one key gone, two keys back/new.
+        submission_invitation = openreview_client.get_invitation(f'{venue_id}/-/Submission')
+        submission_content = submission_invitation.edit['note']['content']
+        assert 'preferred_venue' not in submission_content
+        assert 'justification_for_author_changes' in submission_content
+        assert 'metadata_bug_custom_field' in submission_content
+
+        # Re-run the ARR_Configuration with shifted dates so every stage is
+        # actually re-posted instead of skipped as unchanged.
+        pc_client.post_note(
+            openreview.Note(
+                content={
+                    'author_consent_start_date': now.strftime('%Y/%m/%d %H:%M'),
+                    'author_consent_end_date': author_consent_end.strftime('%Y/%m/%d %H:%M'),
+                    'metadata_edit_start_date': metadata_edit_start.strftime('%Y/%m/%d %H:%M'),
+                    'metadata_edit_end_date': metadata_edit_end.strftime('%Y/%m/%d %H:%M')
+                },
+                invitation=f'openreview.net/Support/-/Request{request_form_note.number}/ARR_Configuration',
+                forum=request_form_note.id,
+                readers=[f'{venue_id}/Program_Chairs', 'openreview.net/Support'],
+                referent=request_form_note.id,
+                replyto=request_form_note.id,
+                signatures=['~ProgramBug_ARRChair1'],
+                writers=[],
+            )
+        )
+
+        # The second ARR_Configuration should complete without error.
+        helpers.await_queue()
+
+        # The BSLA stage note was re-posted against the new submission content,
+        # so its form still only asks for the license agreement field.
+        bsla_invitation = openreview_client.get_invitation(f'{venue_id}/-/Blind_Submission_License_Agreement')
+        bsla_content = bsla_invitation.edit['invitation']['edit']['note']['content']
+        assert set(bsla_content.keys()) == {
+            'Association_for_Computational_Linguistics_-_Blind_Submission_License_Agreement'
+        }, f'Unexpected fields in the BSLA form: {sorted(bsla_content.keys())}'
+        assert bsla_invitation.edit['invitation']['duedate'] == openreview.tools.datetime_millis(
+            datetime.datetime.strptime(
+                author_consent_end.strftime('%Y/%m/%d %H:%M'), '%Y/%m/%d %H:%M'
+            )
+        )
+
+        # And the workflow got past BSLA: the Submission_Metadata_Revision dates
+        # were updated to the new configuration.
+        metadata_super_invitation = openreview_client.get_invitation(
+            f'{venue_id}/-/Submission_Metadata_Revision'
+        )
+        assert metadata_super_invitation.edit['invitation']['cdate'] == openreview.tools.datetime_millis(
+            datetime.datetime.strptime(
+                metadata_edit_start.strftime('%Y/%m/%d %H:%M'), '%Y/%m/%d %H:%M'
+            )
+        )
+        assert metadata_super_invitation.edit['invitation']['expdate'] == openreview.tools.datetime_millis(
+            datetime.datetime.strptime(
+                metadata_edit_end.strftime('%Y/%m/%d %H:%M'), '%Y/%m/%d %H:%M'
+            )
+        )
+
+        # Still before the cdate, so no per-submission invitations yet.
+        child_invitations = openreview_client.get_all_invitations(
+            invitation=f'{venue_id}/-/Submission_Metadata_Revision'
+        )
+        assert child_invitations == [], (
+            f'Expected no child invitations, found {[i.id for i in child_invitations]}'
+        )


### PR DESCRIPTION
**Problem**: The `Blind_Submission_License_Agreement` stage builds its form by removing all
submission fields except the license question. 

When the ARR Configuration is posted again, the stage reuses the saved list. If a Revision added or deleted a field from the submission form in between, the remove_options list in the invitation does not match the remove_options list in the Submission Revision note, causing a `NotMatchError`.

**Fix:** rebuild the list from the venue's current submission form instead of
reusing the saved one. Only applies to the license agreement stage.