### PR TITLE
Fix/ Fix assigned-committee readers on submission release

### DIFF
--- a/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
+++ b/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
@@ -145,10 +145,13 @@ def process(client, edit, invitation):
     venue.create_comment_stage()
 
     additional_readers = []
+    submission_release_additional_readers = []
     if venue.use_senior_area_chairs:
         additional_readers.append(venue.get_senior_area_chairs_id(number='${5/content/noteNumber/value}'))
+        submission_release_additional_readers.append(venue.get_senior_area_chairs_id(number='${{2/id}/number}'))
     if venue.use_area_chairs:
         additional_readers.append(venue.get_area_chairs_id(number='${5/content/noteNumber/value}'))
+        submission_release_additional_readers.append(venue.get_area_chairs_id(number='${{2/id}/number}'))
 
     client.post_invitation_edit(
         invitations=f'{invitation_prefix}/-/Note_Release',
@@ -273,7 +276,7 @@ def process(client, edit, invitation):
             'submission_name': { 'value': 'Submission' },
             'reviewers_name': { 'value': reviewers_name },
             'authors_name': { 'value': authors_name },
-            'additional_readers': { 'value': additional_readers },
+            'additional_readers': { 'value': submission_release_additional_readers },
             'decision_option': { 'value': 'Accepted' },
             'decision_venue_id': { 'value': venue_id }
         }
@@ -288,7 +291,7 @@ def process(client, edit, invitation):
             'submission_name': { 'value': 'Submission' },
             'reviewers_name': { 'value': reviewers_name },
             'authors_name': { 'value': authors_name },
-            'additional_readers': { 'value': additional_readers },
+            'additional_readers': { 'value': submission_release_additional_readers },
             'decision_option': { 'value': 'Rejected' },
             'decision_venue_id': { 'value': venue.get_rejected_submission_venue_id() }
         }

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -1595,6 +1595,13 @@ Please note that responding to this email will direct your reply to efgh2025.pro
         assert submissions[0].content['venue']['value'] == 'EFGH 2025 Conference Submission'
         inv = pc_client.get_invitation('EFGH.cc/2025/Conference/-/Accepted_Submission_Release')
         assert 'reveal_author_identities' not in inv.content
+        # default readers before any customization: PCs, assigned ACs, assigned reviewers and paper authors
+        assert inv.edit['note']['readers'] == [
+            'EFGH.cc/2025/Conference',
+            'EFGH.cc/2025/Conference/Submission${{2/id}/number}/Action_Editors',
+            'EFGH.cc/2025/Conference/Submission${{2/id}/number}/Reviewers',
+            'EFGH.cc/2025/Conference/Submission${{2/id}/number}/Authors'
+        ]
         inv = pc_client.get_invitation('EFGH.cc/2025/Conference/-/Rejected_Submission_Release')
         assert 'reveal_author_identities' not in inv.content
         assert pc_client.get_invitation('EFGH.cc/2025/Conference/-/Accepted_Submission_Release/Dates')


### PR DESCRIPTION
Submission_Release reused Note_Release's reader template, which referenced a noteNumber field that Submission_Release never sets — so assigned ACs/SACs never actually got added as readers. Now builds a separate readers list using the correct placeholder for a direct note edit, and adds a test asserting the default readers (PCs, assigned ACs, assigned reviewers, authors).

**Note**: I have fixed all invitations on the live site.