### PR TITLE
Fix/ Remove source edition from revision workflow step

### DIFF
--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -3058,20 +3058,10 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
         self.save_invitation(invitation, replacement=False)
 
         if self.venue.is_template_related_workflow():
-            content = {
-                'source': {
-                    'description': 'Specify which submissions can be revised. By default, only authors of accepted submissions can submit a Camera-Ready revision.',
-                    'value': {
-                        'param': {
-                            'type': 'json'
-                        }
-                    }
-                }
-            }
             domain_group = self.client.get_group(self.venue_id)
             is_full_submission_revision = revision_invitation_id == domain_group.content.get('full_submission_invitation_id', {}).get('value', '')
             edit_invitations_builder = openreview.workflows.EditInvitationsBuilder(self.client, self.venue_id)
-            edit_invitations_builder.set_edit_content_invitation(revision_invitation_id, content if not is_full_submission_revision else {}, allow_license_edition=revision_stage.allow_license_edition)
+            edit_invitations_builder.set_edit_content_invitation(revision_invitation_id, allow_license_edition=revision_stage.allow_license_edition)
             process_file = '../workflows/workflow_process/edit_full_submission_deadline_process.py' if is_full_submission_revision else None
             preprocess_file = '../workflows/workflow_process/edit_full_submission_dates_preprocess.py' if is_full_submission_revision else None
             edit_invitations_builder.set_edit_dates_invitation(revision_invitation_id, process_file=process_file, preprocess_file=preprocess_file)

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -3060,6 +3060,7 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
         if self.venue.is_template_related_workflow():
             content = {
                 'source': {
+                    'description': 'Specify which submissions can be revised. By default, only authors of accepted submissions can submit a Camera-Ready revision.',
                     'value': {
                         'param': {
                             'type': 'json'

--- a/openreview/venue/invitation.py
+++ b/openreview/venue/invitation.py
@@ -3062,12 +3062,7 @@ To view your submission, click here: https://openreview.net/forum?id={{{{note_fo
                 'source': {
                     'value': {
                         'param': {
-                            'type': 'string',
-                            'enum': [
-                                'all_submissions',
-                                'accepted_submissions'
-                            ],
-                            'input': 'select'
+                            'type': 'json'
                         }
                     }
                 }

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2711,26 +2711,6 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Camera_Ready_Revision/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Camera_Ready_Revision/Form_Fields')
 
-        # enable Camera Ready Revisions only for "Accept" decision
-        pc_client.post_invitation_edit(
-            invitations='ABCD.cc/2025/Conference/-/Camera_Ready_Revision/Form_Fields',
-            content = {
-                'content': {
-                    'value': invitation.edit['invitation']['edit']['note']['content']
-                },
-                'source': {
-                    'value': {
-                        'venueid': [
-                            'ABCD.cc/2025/Conference',
-                            'ABCD.cc/2025/Conference/Submission',
-                            'ABCD.cc/2025/Conference/Rejected_Submission'
-                        ],
-                        'decision_options': ['Accept']
-                    }
-                }
-            }
-        )
-
         now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)
 
@@ -2745,7 +2725,7 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         helpers.await_queue_edit(openreview_client, edit_id='ABCD.cc/2025/Conference/-/Camera_Ready_Revision-0-1', count=2)
 
         decisions = [openreview.Note.from_json(reply) for note in submissions for reply in note.details['directReplies'] if '/-/Decision' in reply['invitations'][0]]
-        accept_decisions = [note for note in decisions if 'Accept' in note.content['decision']['value']]
+        accept_decisions = [note for note in decisions if 'Accept' in note.content['decision']['value'] or 'Poster' in note.content['decision']['value']]
 
         invitations = openreview_client.get_invitations(invitation='ABCD.cc/2025/Conference/-/Camera_Ready_Revision')
         assert len(invitations) == len(accept_decisions)

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2936,8 +2936,9 @@ url={https://openreview.net/forum?id='''+submissions[1].id+'''}
 
         endorsement_tags = openreview_client.get_tags(invitation='ABCD.cc/2025/Conference/-/Article_Endorsement')
         assert endorsement_tags
-        assert endorsement_tags[0].label is None
-        assert len(openreview_client.get_tags(invitation='ABCD.cc/2025/Conference/-/Article_Endorsement', forum=submissions[0].id))== 1
+        tag = openreview_client.get_tags(invitation='ABCD.cc/2025/Conference/-/Article_Endorsement', forum=submissions[0].id)
+        assert tag and len(tag) == 1
+        assert tag[0].label is None
 
         endorsement_tags = openreview_client.get_tags(parent_invitations='openreview.net/-/Article_Endorsement', stream=True)
         assert endorsement_tags

--- a/tests/test_reviewers_only.py
+++ b/tests/test_reviewers_only.py
@@ -2331,10 +2331,11 @@ Please note that responding to this email will direct your reply to abcd2025.pro
 
         submissions = openreview_client.get_notes(invitation='ABCD.cc/2025/Conference/-/Submission', sort='number:asc')
 
-        decisions = ['Accept', 'Revision Needed', 'Reject']
+        decisions = ['Accept', 'Poster', 'Revision Needed', 'Reject']
         comment = {
             'Accept': 'Congratulations on your acceptance.',
             'Revision Needed': 'Your paper must be revised.',
+            'Poster': 'Your paper has been accepted as a poster.',
             'Reject': 'We regret to inform you...'
         }
 
@@ -2343,7 +2344,8 @@ Please note that responding to this email will direct your reply to abcd2025.pro
             writer.writerow([submissions[0].number, 'Accept', comment['Accept']])
             writer.writerow([submissions[1].number, 'Revision Needed', comment['Revision Needed']])
             writer.writerow([submissions[2].number, 'Reject', comment['Reject']])
-            for submission in submissions[3:-1]:
+            writer.writerow([submissions[3].number, 'Poster', comment['Poster']])
+            for submission in submissions[4:-1]:
                 decision = random.choice(decisions)
                 writer.writerow([submission.number, decision, comment[decision]])
 
@@ -2697,9 +2699,37 @@ Please note that responding to this email will direct your reply to abcd2025.pro
         pc_client = openreview.api.OpenReviewClient(username='programchair@abcd.cc', password=helpers.strong_password)
         submissions = openreview_client.get_notes(invitation='ABCD.cc/2025/Conference/-/Submission', sort='number:asc', details='directReplies')
 
-        assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Camera_Ready_Revision')
+        invitation = pc_client.get_invitation('ABCD.cc/2025/Conference/-/Camera_Ready_Revision')
+        assert invitation and invitation.content['source']['value'] == {
+            'venueid': [
+                'ABCD.cc/2025/Conference',
+                'ABCD.cc/2025/Conference/Submission',
+                'ABCD.cc/2025/Conference/Rejected_Submission'
+            ],
+            'with_decision_accept': True
+        }
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Camera_Ready_Revision/Dates')
         assert pc_client.get_invitation('ABCD.cc/2025/Conference/-/Camera_Ready_Revision/Form_Fields')
+
+        # enable Camera Ready Revisions only for "Accept" decision
+        pc_client.post_invitation_edit(
+            invitations='ABCD.cc/2025/Conference/-/Camera_Ready_Revision/Form_Fields',
+            content = {
+                'content': {
+                    'value': invitation.edit['invitation']['edit']['note']['content']
+                },
+                'source': {
+                    'value': {
+                        'venueid': [
+                            'ABCD.cc/2025/Conference',
+                            'ABCD.cc/2025/Conference/Submission',
+                            'ABCD.cc/2025/Conference/Rejected_Submission'
+                        ],
+                        'decision_options': ['Accept']
+                    }
+                }
+            }
+        )
 
         now = datetime.datetime.now()
         new_cdate = openreview.tools.datetime_millis(now)


### PR DESCRIPTION
~~The submission revision invitation's source field was previously restricted to a fixed dropdown (all_submissions / accepted_submissions), which didn't give program chairs enough flexibility to scope revisions (e.g., limiting to a specific decision like "Accept" or "Poster" via decision_options, or targeting specific venueids).~~

~~This changes the source field's param type from a select enum to free-form json, so PCs can edit the underlying JSON directly to express arbitrary source criteria.~~


Removed the option for PCs to edit the source for now. As I was writing the documentation I realize this might not be very easy for PCs to understand. We can revisit this if we think PCs will need it. 