### PR TITLE
Feature/ Subinvitation to edit submission preprocess

### DIFF
--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -403,6 +403,41 @@ class EditInvitationsBuilder(object):
         self.save_invitation(invitation, replacement=False)
         return invitation
 
+    def set_edit_preprocess_one_level_invitation(self, invitation_id):
+
+        venue_id = self.venue_id
+        sub_invitation_id = f'{invitation_id}/Preprocess'
+
+        invitation = Invitation(
+            id = sub_invitation_id,
+            invitees = [venue_id],
+            signatures = [venue_id],
+            readers = [venue_id],
+            writers = [venue_id],
+            edit = {
+                'signatures': [venue_id],
+                'readers': [venue_id],
+                'writers': [venue_id],
+                'content': {
+                    'preprocess_script': {
+                        'value': {
+                            'param': {
+                                'type': 'script'
+                            }
+                        }
+                    },
+                },
+                'invitation': {
+                    'id': invitation_id,
+                    'signatures': [venue_id],
+                    'preprocess': '${2/content/preprocess_script/value}',
+                }
+            }
+        )
+
+        self.save_invitation(invitation, replacement=False)
+        return invitation
+
     def set_edit_dates_invitation(self, super_invitation_id, process_file=None, preprocess_file=None, include_activation_date=True, include_due_date=True, include_expiration_date=True, due_date=None):
 
         venue_id = self.venue_id

--- a/tests/test_iclr_conference_with_templates.py
+++ b/tests/test_iclr_conference_with_templates.py
@@ -215,6 +215,37 @@ class TestSimpleDualAnonymous():
         assert submission_invitation.edit['note']['content']['pdf']['readers'] == field_readers
         assert submission_invitation.edit['note']['content']['reciprocal_reviewing']['readers'] == field_readers
 
+        # create subinvitation to edit submission preprocess
+        edit_invitations_builder = openreview.workflows.EditInvitationsBuilder(openreview_client, 'ICLR.cc/2026/Conference')
+        edit_invitations_builder.set_edit_preprocess_one_level_invitation('ICLR.cc/2026/Conference/-/Submission')
+
+        assert openreview_client.get_invitation('ICLR.cc/2026/Conference/-/Submission/Preprocess')
+
+        # add preprocess to submission invitation
+        pc_client.post_invitation_edit(
+            invitations='ICLR.cc/2026/Conference/-/Submission/Preprocess',
+            content={
+                'preprocess_script': {
+                    'value': '''def process(client, edit, invitation):
+    domain = client.get_group(invitation.domain)
+
+    note = edit.note
+
+    if note.ddate:
+        return'''
+                }
+            }
+        )
+
+        submission_invitation = openreview_client.get_invitation('ICLR.cc/2026/Conference/-/Submission')
+        assert submission_invitation.preprocess == '''def process(client, edit, invitation):
+    domain = client.get_group(invitation.domain)
+
+    note = edit.note
+
+    if note.ddate:
+        return'''
+
     def test_sac_recruitment(self, client, openreview_client, helpers, request_page, selenium):
 
         # use invitation to recruit reviewers


### PR DESCRIPTION
Create an invitation to edit the submission preprocess. It is not part of the deployment of the venue, but can be added on demand. 