### PR TITLE
Fix/ Journal: keep AE identity hidden from authors until paper is approved for review

### DIFF
--- a/openreview/journal/group.py
+++ b/openreview/journal/group.py
@@ -491,7 +491,7 @@ Visit [this page](https://openreview.net/group?id={self.journal.get_expert_revie
         action_editors_group=openreview.tools.get_group(self.client, action_editors_group_id)
         if not action_editors_group:
             action_editors_group=self.post_group(Group(id=action_editors_group_id,
-                readers=[venue_id, action_editors_group_id, reviewers_group_id] if self.journal.is_action_editor_anonymous() else ['everyone'],
+                readers=[venue_id, action_editors_group_id, reviewers_group_id],
                 writers=[venue_id],
                 signatures=[venue_id],
                 signatories=[venue_id],

--- a/openreview/journal/invitation.py
+++ b/openreview/journal/invitation.py
@@ -3175,6 +3175,17 @@ If you have questions please contact the Editors-In-Chief: {self.journal.get_edi
             process=self.get_process_content('process/under_review_submission_process.py')
         )
 
+        if not self.journal.is_action_editor_anonymous():
+            invitation.edit['note']['content']['assigned_action_editor'] = {
+                'readers': {
+                    'param': {
+                        'const': {
+                            'delete': True
+                        }
+                    }
+                }
+            }
+
         self.save_invitation(invitation)
 
     def set_desk_rejected_invitation(self):

--- a/openreview/journal/process/ae_assignment_process.py
+++ b/openreview/journal/process/ae_assignment_process.py
@@ -74,14 +74,12 @@ def process_update(client, edge, invitation, existing_edge):
             'assigned_action_editor': { 'value': edge.tail }
         }
 
-        if journal.is_action_editor_anonymous():
-            content['assigned_action_editor']['readers'] = [journal.venue_id, journal.get_action_editors_id(number=note.number), journal.get_reviewers_id(number=note.number)]
-
+        # when AC is assigned, keep hidden until paper is approved for review
+        content['assigned_action_editor']['readers'] = [journal.venue_id, journal.get_action_editors_id(number=note.number), journal.get_reviewers_id(number=note.number)]
 
         if journal.assigning_AE_venue_id == note.content['venueid']['value']:
             content['venueid'] = { 'value': journal.assigned_AE_venue_id }
             content['venue'] = { 'value': f'{journal.short_name} Assigned AE' }
-
 
         client.post_note_edit(invitation= journal.get_meta_invitation_id(),
                             signatures=[journal.venue_id],

--- a/openreview/journal/process/ae_assignment_process.py
+++ b/openreview/journal/process/ae_assignment_process.py
@@ -74,8 +74,9 @@ def process_update(client, edge, invitation, existing_edge):
             'assigned_action_editor': { 'value': edge.tail }
         }
 
-        # when AC is assigned, keep hidden until paper is approved for review
-        content['assigned_action_editor']['readers'] = [journal.venue_id, journal.get_action_editors_id(number=note.number), journal.get_reviewers_id(number=note.number)]
+        # when AC is assigned, keep hidden if AE should be anonymous or if paper is not yet approved for review
+        if journal.is_action_editor_anonymous() or note.content.get('venueid', {}).get('value') in [journal.submitted_venue_id, journal.assigning_AE_venue_id, journal.assigned_AE_venue_id]:
+            content['assigned_action_editor']['readers'] = [journal.venue_id, journal.get_action_editors_id(number=note.number), journal.get_reviewers_id(number=note.number)]
 
         if journal.assigning_AE_venue_id == note.content['venueid']['value']:
             content['venueid'] = { 'value': journal.assigned_AE_venue_id }

--- a/openreview/journal/process/review_approval_process.py
+++ b/openreview/journal/process/review_approval_process.py
@@ -22,13 +22,14 @@ def process(client, edit, invitation):
         ## Notify readers
         journal.notify_readers(edit, content_fields=['under_review', 'comment'])
 
-        # update AE group readers to be everyone if AE is not anonymous
+        # update AE group readers to include authors if the AE is not anonymous
         if not journal.is_action_editor_anonymous():
+            readers = ['everyone'] if journal.is_submission_public() else [venue_id, paper_action_editor_group.id, journal.get_reviewers_id(submission.number), journal.get_authors_id(submission.number)]
             client.post_group_edit(invitation=journal.get_meta_invitation_id(),
                 signatures=[venue_id],
                 group=openreview.api.Group(
                     id=paper_action_editor_group.id, 
-                    readers=['everyone']
+                    readers=readers
                 )
             )
 

--- a/openreview/journal/process/review_approval_process.py
+++ b/openreview/journal/process/review_approval_process.py
@@ -21,7 +21,18 @@ def process(client, edit, invitation):
         )
         ## Notify readers
         journal.notify_readers(edit, content_fields=['under_review', 'comment'])
-        
+
+        # update AE group readers to be everyone if AE is not anonymous
+        if not journal.is_action_editor_anonymous():
+            client.post_group_edit(invitation=journal.get_meta_invitation_id(),
+                signatures=[venue_id],
+                group=openreview.api.Group(
+                    id=paper_action_editor_group.id, 
+                    readers=['everyone']
+                )
+            )
+
+        # this releases AE name in the note if the AE is not anonymous
         return client.post_note_edit(invitation= journal.get_under_review_id(),
                                 signatures=[venue_id],
                                 note=openreview.api.Note(id=edit.note.forum,

--- a/tests/test_dmlr_journal.py
+++ b/tests/test_dmlr_journal.py
@@ -425,12 +425,12 @@ note={Under review}
 
         ae_group = ce_client.get_group('DMLR/Paper1/Action_Editors')
         assert ae_group.members == ['~Andrew_Ng1']
-        assert ae_group.readers == ['everyone']
+        assert ae_group.readers == ['DMLR', 'DMLR/Paper1/Action_Editors', 'DMLR/Paper1/Reviewers', 'DMLR/Paper1/Authors']
 
         andrew_paper1_anon_groups = andrew_client.get_groups(prefix=f'DMLR/Paper1/Action_Editor_.*', signatory='~Andrew_Ng1')
         assert len(andrew_paper1_anon_groups) == 1
         andrew_paper1_anon_group = andrew_paper1_anon_groups[0]        
-        assert andrew_paper1_anon_group.readers == ['everyone', andrew_paper1_anon_group.id]
+        assert andrew_paper1_anon_group.readers == ['DMLR', 'DMLR/Paper1/Action_Editors', 'DMLR/Paper1/Reviewers', 'DMLR/Paper1/Authors', andrew_paper1_anon_group.id]
 
         edits = openreview_client.get_note_edits(note.id, invitation='DMLR/-/Under_Review')
         helpers.await_queue_edit(openreview_client, edit_id=edits[0].id)

--- a/tests/test_dmlr_journal.py
+++ b/tests/test_dmlr_journal.py
@@ -327,7 +327,7 @@ note: replies to this email will go to the AE, {assigned_action_editor}.
         assert author_group.members == ['~SomeFirstName_User1', '~Melisa_Ane1']
         assert openreview_client.get_group("DMLR/Paper1/Reviewers")
         ae_group = openreview_client.get_group("DMLR/Paper1/Action_Editors")
-        assert ae_group.readers == ['everyone']
+        assert ae_group.readers == ['DMLR', 'DMLR/Paper1/Action_Editors', 'DMLR/Paper1/Reviewers']
 
         note = openreview_client.get_note(note_id_1)
         assert note
@@ -360,6 +360,11 @@ note: replies to this email will go to the AE, {assigned_action_editor}.
 
         ae_group = ce_client.get_group('DMLR/Paper1/Action_Editors')
         assert ae_group.members == ['~Andrew_Ng1']
+        assert ae_group.readers == ['DMLR', 'DMLR/Paper1/Action_Editors', 'DMLR/Paper1/Reviewers']
+
+        note = openreview_client.get_note(note_id_1)
+        assert 'assigned_action_editor' in note.content and note.content['assigned_action_editor']['value'] == '~Andrew_Ng1'
+        assert 'readers' in note.content['assigned_action_editor'] and note.content['assigned_action_editor']['readers'] == ['DMLR', 'DMLR/Paper1/Action_Editors', 'DMLR/Paper1/Reviewers']
 
         messages = journal.client.get_messages(to = 'andrew@dmlrzero.com', subject = '[DMLR] Assignment to new DMLR submission 1: Paper title')
         assert len(messages) == 1
@@ -385,11 +390,12 @@ Please note that responding to this email will direct your reply to dmlr@jmlr.or
 
         andrew_paper1_anon_groups = andrew_client.get_groups(prefix=f'DMLR/Paper1/Action_Editor_.*', signatory='~Andrew_Ng1')
         assert len(andrew_paper1_anon_groups) == 1
-        graham_paper1_anon_group = andrew_paper1_anon_groups[0]         
+        andrew_paper1_anon_group = andrew_paper1_anon_groups[0]        
+        assert andrew_paper1_anon_group.readers == ['DMLR', 'DMLR/Paper1/Action_Editors', 'DMLR/Paper1/Reviewers', andrew_paper1_anon_group.id]
 
         ## Accept the submission 1
         under_review_note = andrew_client.post_note_edit(invitation= 'DMLR/Paper1/-/Review_Approval',
-                                    signatures=[graham_paper1_anon_group.id],
+                                    signatures=[andrew_paper1_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -416,6 +422,15 @@ year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},
 note={Under review}
 }'''
+
+        ae_group = ce_client.get_group('DMLR/Paper1/Action_Editors')
+        assert ae_group.members == ['~Andrew_Ng1']
+        assert ae_group.readers == ['everyone']
+
+        andrew_paper1_anon_groups = andrew_client.get_groups(prefix=f'DMLR/Paper1/Action_Editor_.*', signatory='~Andrew_Ng1')
+        assert len(andrew_paper1_anon_groups) == 1
+        andrew_paper1_anon_group = andrew_paper1_anon_groups[0]        
+        assert andrew_paper1_anon_group.readers == ['everyone', andrew_paper1_anon_group.id]
 
         edits = openreview_client.get_note_edits(note.id, invitation='DMLR/-/Under_Review')
         helpers.await_queue_edit(openreview_client, edit_id=edits[0].id)
@@ -445,14 +460,14 @@ note={Under review}
 
         andrew_paper1_anon_groups = andrew_client.get_groups(prefix=f'DMLR/Paper1/Action_Editor_.*', signatory='~Andrew_Ng1')
         assert len(andrew_paper1_anon_groups) == 1
-        graham_paper1_anon_group = andrew_paper1_anon_groups[0]
+        andrew_paper1_anon_group = andrew_paper1_anon_groups[0]
 
         # add David Belanger again
         paper_assignment_edge = paper_assignment_edge = andrew_client.post_edge(openreview.Edge(invitation='DMLR/Reviewers/-/Assignment',
             readers=["DMLR", "DMLR/Paper1/Action_Editors", '~David_Bo1'],
             nonreaders=["DMLR/Paper1/Authors"],
             writers=["DMLR", "DMLR/Paper1/Action_Editors"],
-            signatures=[graham_paper1_anon_group.id],
+            signatures=[andrew_paper1_anon_group.id],
             head=note_id_1,
             tail='~David_Bo1',
             weight=1
@@ -492,7 +507,7 @@ Please note that responding to this email will direct your reply to andrew@dmlrz
             readers=["DMLR", "DMLR/Paper1/Action_Editors", '~Carlos_Ge1'],
             nonreaders=["DMLR/Paper1/Authors"],
             writers=["DMLR", "DMLR/Paper1/Action_Editors"],
-            signatures=[graham_paper1_anon_group.id],
+            signatures=[andrew_paper1_anon_group.id],
             head=note_id_1,
             tail='~Carlos_Ge1',
             weight=1

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1113,7 +1113,7 @@ note={Under review}
         # check authors can now see AE identity
         ae_group = raia_client.get_group(f'{venue_id}/Paper1/Action_Editors')
         assert ae_group.members == ['~Joelle_Pineau1']
-        # assert authors cannot see AE name
+        # assert authors can see AE name
         assert ae_group.readers == ['everyone']
         ae_anon_group_id = ae_group.anon_members[0]
         assert openreview_client.get_group(ae_anon_group_id).readers == ['everyone', ae_anon_group_id]

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -6094,7 +6094,7 @@ note={Expert Certification}
 
         note = openreview_client.get_note(note_id_14)
         assert 'assigned_action_editor' not in note.content
-        assert note.content['venueid']['value'] == 'TMLR/Assigned_AE'
+        assert note.content['venueid']['value'] == 'TMLR/Under_Review'
 
         paper_assignment_edge = raia_client.post_edge(openreview.api.Edge(invitation='TMLR/Action_Editors/-/Assignment',
             readers=[venue_id, editor_in_chief_group_id, '~Samy_Bengio1'],
@@ -6144,11 +6144,11 @@ note={Expert Certification}
             parsed_url = urlparse(url)
             params = parse_qs(parsed_url.query)
             key_value = params['key'][0]
-        assert messages[0]['content']['text'] == f'''Hi Melisa Bok,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=~Melisa_Bok1&key={key_value}&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {joelle_paper13_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to samy@bengio.com.\n'''
+        assert messages[0]['content']['text'] == f'''Hi Melisa Bok,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=~Melisa_Bok1&key={key_value}&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {sammy_paper14_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to samy@bengio.com.\n'''
 
         messages = openreview_client.get_messages(to = 'samy@bengio.com', subject = '[TMLR] Invitation to review paper titled "Paper title 14"')
         assert len(messages) == 1
-        assert messages[0]['content']['text'] == f'''Hi Samy Bengio,\n\nThe following invitation email was sent to Melisa Bok:\n\nHi Melisa Bok,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=~Melisa_Bok1&key={key_value}&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {joelle_paper13_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to melisa@mailten.com.\n'''
+        assert messages[0]['content']['text'] == f'''Hi Samy Bengio,\n\nThe following invitation email was sent to Melisa Bok:\n\nHi Melisa Bok,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=~Melisa_Bok1&key={key_value}&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {sammy_paper14_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to melisa@mailten.com.\n'''
 
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
@@ -6188,7 +6188,7 @@ note={Expert Certification}
                       
         ## Invite external reviewer with no profile
         paper_assignment_edge = samy_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Invite_Assignment',
-            signatures=[joelle_paper13_anon_group.id],
+            signatures=[sammy_paper14_anon_group.id],
             head=note_id_14,
             tail='harold@hotmail.com',
             weight=1,
@@ -6206,7 +6206,7 @@ note={Expert Certification}
             parsed_url = urlparse(url)
             params = parse_qs(parsed_url.query)
             key_value = params['key'][0]
-        assert messages[0]['content']['text'] == f'''Hi harold@hotmail.com,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=harold@hotmail.com&key={key_value}&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {joelle_paper13_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to samy@bengio.com.\n'''
+        assert messages[0]['content']['text'] == f'''Hi harold@hotmail.com,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=harold@hotmail.com&key={key_value}&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {sammy_paper14_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to samy@bengio.com.\n'''
 
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
@@ -6234,7 +6234,7 @@ note={Expert Certification}
         ## Invite external reviewer with a conflict of interest
         with pytest.raises(openreview.OpenReviewException, match=r'Conflict detected for harold@mail'):
             paper_assignment_edge = samy_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Invite_Assignment',
-                signatures=[joelle_paper13_anon_group.id],
+                signatures=[sammy_paper14_anon_group.id],
                 head=note_id_14,
                 tail='harold@mail.com',
                 weight=1,
@@ -6244,7 +6244,7 @@ note={Expert Certification}
         ## Invite reviewer that is already in the pool
         with pytest.raises(openreview.OpenReviewException, match=r'tail "javier@mailtwo.com" is member of TMLR/Reviewers'):
             paper_assignment_edge = samy_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Invite_Assignment',
-                signatures=[joelle_paper13_anon_group.id],
+                signatures=[sammy_paper14_anon_group.id],
                 head=note_id_14,
                 tail='javier@mailtwo.com',
                 weight=1,
@@ -6254,7 +6254,7 @@ note={Expert Certification}
         ## Invite reviewer that is already has an assignment
         with pytest.raises(openreview.OpenReviewException, match=r'Already invited as ~Melisa_Bok1'):
             paper_assignment_edge = samy_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Invite_Assignment',
-                signatures=[joelle_paper13_anon_group.id],
+                signatures=[sammy_paper14_anon_group.id],
                 head=note_id_14,
                 tail='melisa@mailten.com',
                 weight=1,
@@ -6298,7 +6298,7 @@ note={Expert Certification}
 
         ## Invite archived reviewers with status unavailable
         paper_assignment_edge = samy_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Invite_Assignment',
-            signatures=[joelle_paper13_anon_group.id],
+            signatures=[sammy_paper14_anon_group.id],
             head=note_id_14,
             tail='~David_Belanger1',
             weight=1,
@@ -6320,7 +6320,7 @@ note={Expert Certification}
             parsed_url = urlparse(url)
             params = parse_qs(parsed_url.query)
             key_value = params['key'][0]
-        assert messages[0]['content']['text'] == f'''Hi David Belanger,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=~David_Belanger1&key={key_value}&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {joelle_paper13_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to samy@bengio.com.\n'''
+        assert messages[0]['content']['text'] == f'''Hi David Belanger,\n\nYou were invited to review the paper number: {submission.number}, title: \"Paper title 14\".\n\nAbstract: Paper abstract\n\nPlease respond the invitation clicking the following link:\n\nhttps://openreview.net/invitation?id=TMLR/Reviewers/-/Assignment_Recruitment&user=~David_Belanger1&key={key_value}&submission_id={submission.id}&inviter=~Samy_Bengio1\n\nThanks,\n\nTMLR Paper{submission.number} Action Editor {sammy_paper14_anon_group.id.split('_')[-1]}\nSamy Bengio\n\nPlease note that responding to this email will direct your reply to samy@bengio.com.\n'''
 
         invitation_url = re.search('https://.*\n', messages[0]['content']['text']).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
         helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -396,6 +396,18 @@ class TestJournal():
 
         helpers.await_queue_edit(openreview_client, deployment_edit['id'])
 
+        under_review_invitation = openreview_client.get_invitation('TMLR/-/Under_Review')
+        assert 'assigned_action_editor' in under_review_invitation.edit['note']['content']
+        assert under_review_invitation.edit['note']['content']['assigned_action_editor'] == {
+            'readers': {
+                'param': {
+                    'const': {
+                        'delete': True
+                    }
+                }
+            }
+        }
+
         openreview_client.add_members_to_group('TMLR/Expert_Reviewers', ['~Andrew_McCallumm1'])
 
         tmlr =  openreview_client.get_group('TMLR')
@@ -950,7 +962,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         editor_in_chief_group_id = f"{venue_id}/Editors_In_Chief"
         action_editors_id=f'{venue_id}/Action_Editors'
 
-        # Assign Action Editor and immediately remove  assignment
+        # Assign Action Editor and immediately remove assignment
         paper_assignment_edge = raia_client.post_edge(openreview.api.Edge(invitation='TMLR/Action_Editors/-/Assignment',
             readers=[venue_id, editor_in_chief_group_id, '~Joelle_Pineau1'],
             writers=[venue_id, editor_in_chief_group_id],
@@ -980,10 +992,15 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
 
         ae_group = raia_client.get_group(f'{venue_id}/Paper1/Action_Editors')
         assert ae_group.members == ['~Joelle_Pineau1']
+        # assert authors cannot see AE name
+        assert ae_group.readers == ['TMLR', 'TMLR/Paper1/Action_Editors', 'TMLR/Paper1/Reviewers']
+        ae_anon_group_id = ae_group.anon_members[0]
+        assert openreview_client.get_group(ae_anon_group_id).readers == ['TMLR', 'TMLR/Paper1/Action_Editors', 'TMLR/Paper1/Reviewers', ae_anon_group_id]
 
         note = joelle_client.get_note(note_id_1)
         assert note
-        assert note.content['assigned_action_editor']['value'] == '~Joelle_Pineau1'        
+        assert note.content['assigned_action_editor']['value'] == '~Joelle_Pineau1'
+        assert note.content['assigned_action_editor']['readers'] == ['TMLR', 'TMLR/Paper1/Action_Editors', 'TMLR/Paper1/Reviewers']
 
         messages = journal.client.get_messages(to = 'joelle@mailseven.com', subject = '[TMLR] Assignment to new TMLR submission 1: Paper title UPDATED')
         assert len(messages) == 1
@@ -1072,6 +1089,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert note.content['venue']['value'] == 'Under review for TMLR'
         assert note.content['venueid']['value'] == 'TMLR/Under_Review'
         assert note.content['assigned_action_editor']['value'] == '~Joelle_Pineau1'
+        assert 'readers' not in note.content['assigned_action_editor']
         assert note.content['_bibtex']['value'] == '''@article{
 anonymous''' + str(datetime.datetime.fromtimestamp(note.cdate/1000).year) + '''paper,
 title={Paper title {UPDATED}},
@@ -1091,6 +1109,14 @@ note={Under review}
         assert edits
         for edit in edits:
             assert 'everyone' in edit.readers
+
+        # check authors can now see AE identity
+        ae_group = raia_client.get_group(f'{venue_id}/Paper1/Action_Editors')
+        assert ae_group.members == ['~Joelle_Pineau1']
+        # assert authors cannot see AE name
+        assert ae_group.readers == ['everyone']
+        ae_anon_group_id = ae_group.anon_members[0]
+        assert openreview_client.get_group(ae_anon_group_id).readers == ['everyone', ae_anon_group_id]
 
         ## Remove assertion, the process function may run faster in the new machines
         ## try to make an assignment before the scores were computed
@@ -1188,6 +1214,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         # assert new AE is still assigned
         submission_two = raia_client.get_note(note_id_2)
         assert 'assigned_action_editor' in submission_two.content and submission_two.content['assigned_action_editor']['value'] == '~Joelle_Pineau1'
+        assert 'readers' in submission_two.content['assigned_action_editor'] and submission_two.content['assigned_action_editor']['readers'] == ['TMLR', 'TMLR/Paper2/Action_Editors', 'TMLR/Paper2/Reviewers']
 
         joelle_paper2_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper2/Action_Editor_.*', signatory='~Joelle_Pineau1')
         assert len(joelle_paper2_anon_groups) == 1
@@ -1284,6 +1311,14 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert note.content['venue']['value'] == 'Desk rejected by TMLR'
         assert note.content['venueid']['value'] == 'TMLR/Desk_Rejected'
 
+        # assert AE stays anonymous after desk-rejection
+        assert 'readers' in note.content['assigned_action_editor'] and note.content['assigned_action_editor']['readers'] == ['TMLR', 'TMLR/Paper2/Action_Editors', 'TMLR/Paper2/Reviewers']
+        ae_group = openreview_client.get_group(f'{venue_id}/Paper2/Action_Editors')
+        assert ae_group.members == ['~Joelle_Pineau1']
+        assert ae_group.readers == ['TMLR', 'TMLR/Paper2/Action_Editors', 'TMLR/Paper2/Reviewers']
+        ae_anon_group_id = ae_group.anon_members[0]
+        assert openreview_client.get_group(ae_anon_group_id).readers == ['TMLR', 'TMLR/Paper2/Action_Editors', 'TMLR/Paper2/Reviewers', ae_anon_group_id]
+
         ## Check invitations as an author
         invitations = test_client.get_invitations(replyForum=note_id_2)
         assert len(invitations) == 1
@@ -1345,6 +1380,10 @@ year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_3 + '''},
 note={Withdrawn}
 }'''
+
+        assert 'assigned_action_editor' not in note.content
+        ae_group = openreview_client.get_group(f'{venue_id}/Paper3/Action_Editors')
+        assert ae_group.readers == ['TMLR', 'TMLR/Paper3/Action_Editors', 'TMLR/Paper3/Reviewers']
 
         ## Check invitations
         invitations = openreview_client.get_invitations(replyForum=note_id_1)

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -3444,7 +3444,8 @@ note={Retracted after acceptance}
 
         joelle_paper4_anon_groups = joelle_client.get_groups(prefix=f'{venue_id}/Paper4/Action_Editor_.*', signatory='~Joelle_Pineau1')
         assert len(joelle_paper4_anon_groups) == 1
-        joelle_paper4_anon_group = joelle_paper4_anon_groups[0]         
+        joelle_paper4_anon_group = joelle_paper4_anon_groups[0]
+        assert joelle_paper4_anon_group.readers == ['everyone', joelle_paper4_anon_group.id]
 
         ## Assign David Belanger
         paper_assignment_edge = joelle_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Assignment',
@@ -5384,7 +5385,7 @@ Please note that responding to this email will direct your reply to tmlr@jmlr.or
         assert len(joelle_paper11_anon_groups) == 1
         joelle_paper11_anon_group = joelle_paper11_anon_groups[0]         
 
-        ## Accept the submission 8
+        ## Accept the submission 11
         under_review_note = joelle_client.post_note_edit(invitation= f'TMLR/Paper{note.number}/-/Review_Approval',
                                     signatures=[joelle_paper11_anon_group.id],
                                     note=Note(content={
@@ -5597,7 +5598,7 @@ note={Under review}
             )
         )
         
-        ## Accept the submission 1
+        ## Accept the submission 13
         under_review_note = joelle_client.post_note_edit(invitation= 'TMLR/Paper13/-/Review_Approval',
                                     signatures=[joelle_paper13_anon_group.id],
                                     note=Note(content={
@@ -6033,7 +6034,7 @@ note={Expert Certification}
 
         editor_in_chief_group_id = f"{venue_id}/Editors_In_Chief"
 
-        # Assign Action Editor and immediately remove  assignment
+        # Assign Action Editor
         paper_assignment_edge = raia_client.post_edge(openreview.api.Edge(invitation='TMLR/Action_Editors/-/Assignment',
             readers=[venue_id, editor_in_chief_group_id, '~Samy_Bengio1'],
             writers=[venue_id, editor_in_chief_group_id],
@@ -6045,16 +6046,22 @@ note={Expert Certification}
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        note = openreview_client.get_note(note_id_14)
+        assert 'readers' in note.content['assigned_action_editor']
+        assert note.content['assigned_action_editor']['readers'] == [venue_id, f'{venue_id}/Paper{submission.number}/Action_Editors', f'{venue_id}/Paper{submission.number}/Reviewers']
+
         ae_group = raia_client.get_group(f'{venue_id}/Paper{submission.number}/Action_Editors')
         assert ae_group.members == ['~Samy_Bengio1']
+        assert ae_group.readers == [venue_id, f'{venue_id}/Paper{submission.number}/Action_Editors', f'{venue_id}/Paper{submission.number}/Reviewers']
 
-        joelle_paper13_anon_groups = samy_client.get_groups(prefix=f'{venue_id}/Paper{submission.number}/Action_Editor_.*', signatory='~Samy_Bengio1')
-        assert len(joelle_paper13_anon_groups) == 1
-        joelle_paper13_anon_group = joelle_paper13_anon_groups[0]         
+        sammy_paper14_anon_groups = samy_client.get_groups(prefix=f'{venue_id}/Paper{submission.number}/Action_Editor_.*', signatory='~Samy_Bengio1')
+        assert len(sammy_paper14_anon_groups) == 1
+        sammy_paper14_anon_group = sammy_paper14_anon_groups[0]
+        assert sammy_paper14_anon_group.readers == [venue_id, f'{venue_id}/Paper{submission.number}/Action_Editors', f'{venue_id}/Paper{submission.number}/Reviewers', sammy_paper14_anon_group.id]     
 
-        ## Accept the submission 1
+        ## Accept the submission 14
         under_review_note = samy_client.post_note_edit(invitation= f'TMLR/Paper{submission.number}/-/Review_Approval',
-                                    signatures=[joelle_paper13_anon_group.id],
+                                    signatures=[sammy_paper14_anon_group.id],
                                     note=Note(content={
                                         'under_review': { 'value': 'Appropriate for Review' }
                                     }))
@@ -6066,9 +6073,56 @@ note={Expert Certification}
 
         helpers.await_queue_edit(openreview_client, invitation='TMLR/-/Under_Review')
 
+        note = openreview_client.get_note(note_id_14)
+        assert 'readers' not in note.content['assigned_action_editor']
+        assert note.content['assigned_action_editor']['value'] == '~Samy_Bengio1'
+
+        ae_group = raia_client.get_group(f'{venue_id}/Paper{submission.number}/Action_Editors')
+        assert ae_group.members == ['~Samy_Bengio1']
+        assert ae_group.readers == ['everyone']
+
+        sammy_paper14_anon_groups = samy_client.get_groups(prefix=f'{venue_id}/Paper{submission.number}/Action_Editor_.*', signatory='~Samy_Bengio1')
+        assert len(sammy_paper14_anon_groups) == 1
+        sammy_paper14_anon_group = sammy_paper14_anon_groups[0]
+        assert sammy_paper14_anon_group.readers == ['everyone', sammy_paper14_anon_group.id]
+
+        #re-assign AE after paper was marked appropriate for review
+        paper_assignment_edge.ddate = openreview.tools.datetime_millis(datetime.datetime.now())
+        paper_assignment_edge = raia_client.post_edge(paper_assignment_edge)
+
+        helpers.await_queue_edit(openreview_client, invitation='TMLR/Action_Editors/-/Assignment', count=19)
+
+        note = openreview_client.get_note(note_id_14)
+        assert 'assigned_action_editor' not in note.content
+        assert note.content['venueid']['value'] == 'TMLR/Assigned_AE'
+
+        paper_assignment_edge = raia_client.post_edge(openreview.api.Edge(invitation='TMLR/Action_Editors/-/Assignment',
+            readers=[venue_id, editor_in_chief_group_id, '~Samy_Bengio1'],
+            writers=[venue_id, editor_in_chief_group_id],
+            signatures=[editor_in_chief_group_id],
+            head=note_id_14,
+            tail='~Samy_Bengio1',
+            weight=1
+        ))
+
+        helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
+
+        note = openreview_client.get_note(note_id_14)
+        assert 'readers' not in note.content['assigned_action_editor']
+        assert note.content['assigned_action_editor']['value'] == '~Samy_Bengio1'
+
+        ae_group = raia_client.get_group(f'{venue_id}/Paper{submission.number}/Action_Editors')
+        assert ae_group.members == ['~Samy_Bengio1']
+        assert ae_group.readers == ['everyone']
+
+        sammy_paper14_anon_groups = samy_client.get_groups(prefix=f'{venue_id}/Paper{submission.number}/Action_Editor_.*', signatory='~Samy_Bengio1')
+        assert len(sammy_paper14_anon_groups) == 1
+        sammy_paper14_anon_group = sammy_paper14_anon_groups[0]
+        assert sammy_paper14_anon_group.readers == ['everyone', sammy_paper14_anon_group.id]
+
         ## Invite external reviewer with profile
         paper_assignment_edge = samy_client.post_edge(openreview.api.Edge(invitation='TMLR/Reviewers/-/Invite_Assignment',
-            signatures=[joelle_paper13_anon_group.id],
+            signatures=[sammy_paper14_anon_group.id],
             head=note_id_14,
             tail='melisa@mailten.com',
             weight=1,

--- a/tests/test_slads_journal.py
+++ b/tests/test_slads_journal.py
@@ -113,6 +113,8 @@ class TestSLADSJournal():
 
         helpers.await_queue_edit(openreview_client, deployment_edit['id'])
 
+        under_review_invitation = openreview_client.get_invitation('SLADS/-/Under_Review')
+        assert 'assigned_action_editor' not in under_review_invitation.edit['note']['content']
 
         ## Action Editors
         helpers.create_user('andrew@sladszero.com', 'Jiashun', 'Jin')
@@ -221,7 +223,6 @@ Thanks,
         assert note.content['venue']['value'] == 'Submitted to SLADS'
         assert note.content['venueid']['value'] == 'SLADS/Submitted'
 
-
     def test_review_approval(self, journal, openreview_client, helpers):
 
         ce_client = OpenReviewClient(username='ce@mailseven.com', password=helpers.strong_password)
@@ -240,8 +241,13 @@ Thanks,
 
         helpers.await_queue_edit(openreview_client, edit_id=paper_assignment_edge.id)
 
+        note = openreview_client.get_note(note_id_1)
+        assert note.content['assigned_action_editor']['value'] == '~Jiashun_Jin1'
+        assert note.content['assigned_action_editor']['readers'] == ['SLADS', 'SLADS/Paper1/Action_Editors', 'SLADS/Paper1/Reviewers']
+
         ae_group = ce_client.get_group('SLADS/Paper1/Action_Editors')
         assert ae_group.members == ['~Jiashun_Jin1']
+        assert ae_group.readers == ['SLADS', 'SLADS/Paper1/Action_Editors', 'SLADS/Paper1/Reviewers']
 
         messages = journal.client.get_messages(to = 'andrew@sladszero.com', subject = '[SLADS] Assignment to new SLADS submission 1: Paper title')
         assert len(messages) == 1
@@ -267,7 +273,8 @@ Please note that responding to this email will direct your reply to slads@scichi
 
         andrew_paper1_anon_groups = andrew_client.get_groups(prefix=f'SLADS/Paper1/Action_Editor_.*', signatory='~Jiashun_Jin1')
         assert len(andrew_paper1_anon_groups) == 1
-        graham_paper1_anon_group = andrew_paper1_anon_groups[0]         
+        graham_paper1_anon_group = andrew_paper1_anon_groups[0]
+        assert graham_paper1_anon_group.readers == ['SLADS', 'SLADS/Paper1/Action_Editors', 'SLADS/Paper1/Reviewers', graham_paper1_anon_group.id]
 
         ## Accept the submission 1
         under_review_note = andrew_client.post_note_edit(invitation= 'SLADS/Paper1/-/Review_Approval',
@@ -298,6 +305,20 @@ year={''' + str(datetime.datetime.today().year) + '''},
 url={https://openreview.net/forum?id=''' + note_id_1 + '''},
 note={Under review}
 }'''
+
+        # after approval, AE is still anonymous to authors
+        note = openreview_client.get_note(note_id_1)
+        assert note.content['assigned_action_editor']['value'] == '~Jiashun_Jin1'
+        assert note.content['assigned_action_editor']['readers'] == ['SLADS', 'SLADS/Paper1/Action_Editors', 'SLADS/Paper1/Reviewers']
+
+        ae_group = ce_client.get_group('SLADS/Paper1/Action_Editors')
+        assert ae_group.members == ['~Jiashun_Jin1']
+        assert ae_group.readers == ['SLADS', 'SLADS/Paper1/Action_Editors', 'SLADS/Paper1/Reviewers']
+
+        andrew_paper1_anon_groups = andrew_client.get_groups(prefix=f'SLADS/Paper1/Action_Editor_.*', signatory='~Jiashun_Jin1')
+        assert len(andrew_paper1_anon_groups) == 1
+        graham_paper1_anon_group = andrew_paper1_anon_groups[0]
+        assert graham_paper1_anon_group.readers == ['SLADS', 'SLADS/Paper1/Action_Editors', 'SLADS/Paper1/Reviewers', graham_paper1_anon_group.id]
 
         edits = openreview_client.get_note_edits(note.id, invitation='SLADS/-/Under_Review')
         helpers.await_queue_edit(openreview_client, edit_id=edits[0].id)


### PR DESCRIPTION
TMLR asked to keep the AE's name hidden until the paper has been approved for review. This way, the AE can desk-reject a paper anonymously. 

If AE names should be public, they get released once the paper is approved for review and stays public even if the AE is changed. 