### PR TITLE
Support role overlap restrictions in workflow recruitment

### DIFF
--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1880,7 +1880,7 @@ class EditInvitationsBuilder(object):
                 'content' :{
                     'overlap_committee_ids': {
                         'order': 1,
-                        'description': 'List of committee group ids that invited users can not be members of when accepting this invitation. Users that are already members of any of these groups will be asked to decline that role first. Leave this field empty to allow users to serve in multiple roles.',
+                        'description': 'List of committee group ids that invited users cannot be members of when accepting this invitation. Users that are already members of any of these groups will be asked to decline that role first. Leave this field empty to allow users to serve in multiple roles.',
                         'value': {
                             'param': {
                                 'type': 'string[]',

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1864,9 +1864,54 @@ class EditInvitationsBuilder(object):
             invitation.duedate = due_date
 
         self.save_invitation(invitation, replacement=False)
-        
+
+        invitation_id = super_invitation_id + '/Overlap_Committees'
+
+        invitation = Invitation(
+            id = invitation_id,
+            invitees = [venue_id],
+            signatures = [venue_id],
+            readers = [venue_id],
+            writers = [venue_id],
+            edit = {
+                'signatures': [venue_id],
+                'readers': [venue_id],
+                'writers': [venue_id],
+                'content' :{
+                    'overlap_committee_ids': {
+                        'order': 1,
+                        'description': 'List of committee group ids that invited users can not be members of when accepting this invitation. Users that are already members of any of these groups will be asked to decline that role first. Leave this field empty to allow users to serve in multiple roles.',
+                        'value': {
+                            'param': {
+                                'type': 'string[]',
+                                'input': 'text',
+                                'default': []
+                            }
+                        }
+                    }
+                },
+                'invitation': {
+                    'id': super_invitation_id,
+                    'content': {
+                        'overlap_committee_ids': {
+                            'value': '${4/content/overlap_committee_ids/value}'
+                        }
+                    },
+                    'signatures': [venue_id]
+                }
+            }
+        )
+
+        if process_file:
+            invitation.process = self.get_process_content(f'{process_file}')
+
+        if due_date:
+            invitation.duedate = due_date
+
+        self.save_invitation(invitation, replacement=False)
+
         return invitation
-    
+
     def set_edit_committee_recruitment_request_invitation(self, super_invitation_id, process_file=None, due_date=None):
 
         venue_id = self.venue_id

--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -1880,12 +1880,12 @@ class EditInvitationsBuilder(object):
                 'content' :{
                     'overlap_committee_ids': {
                         'order': 1,
-                        'description': 'List of committee group ids that invited users cannot be members of when accepting this invitation. Users that are already members of any of these groups will be asked to decline that role first. Leave this field empty to allow users to serve in multiple roles.',
+                        'description': 'List of committee group ids that invited users cannot be members of when accepting this invitation. Users that are already members of any of these groups will be asked to decline that role first. Delete this value to allow users to serve in multiple roles.',
                         'value': {
                             'param': {
                                 'type': 'string[]',
                                 'input': 'text',
-                                'default': []
+                                'deletable': True
                             }
                         }
                     }

--- a/openreview/workflows/process/committee_recruitment_response_pre_process.js
+++ b/openreview/workflows/process/committee_recruitment_response_pre_process.js
@@ -12,6 +12,21 @@ async function process(client, edit, invitation) {
   const note = edit.note
   const user = edit.signatures[0]
 
+  if (note.content.response.value == 'Yes') {
+    const overlapCommitteeIds = invitation.content.overlap_committee_ids?.value ?? []
+    const shortPhrase = domain.content.subtitle?.value
+    const committeePrettyName = invitation.content.committee_pretty_name?.value
+
+    for (const overlapCommitteeId of overlapCommitteeIds) {
+      const { groups: overlapGroups } = await client.getGroups({ id: overlapCommitteeId, member: user })
+      if (overlapGroups.length > 0) {
+        const overlapPrettyName = overlapGroups[0].content?.committee_pretty_name?.value ?? Tools.prettyId(overlapCommitteeId, true)
+        return Promise.reject(new OpenReviewError({ name: 'Error', message: `You have already accepted an invitation to serve as ${overlapPrettyName} for ${shortPhrase}. If you would like to change your decision and serve as ${committeePrettyName}, please decline the invitation to be ${overlapPrettyName} and then accept the invitation to be ${committeePrettyName}.` }))
+      }
+    }
+    return
+  }
+
   if (note.content.response.value != 'No') {
     return
   }
@@ -22,5 +37,5 @@ async function process(client, edit, invitation) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: 'You have already been assigned to a paper. Please contact the paper area chair or program chairs to be unassigned.' }))
     }
   }
-  
+
 }

--- a/openreview/workflows/workflow_process/committee_group_template_process.py
+++ b/openreview/workflows/workflow_process/committee_group_template_process.py
@@ -142,6 +142,26 @@ def process(client, edit, invitation):
 
     content[f'{committee_role}_recruitment_id'] = { 'value': invitation_edit['invitation']['id'] }
 
+    ## By default, do not allow users to serve as both reviewers and area chairs
+    if committee_role == 'area_chairs' and 'reviewers_recruitment_id' in domain.content:
+        client.post_invitation_edit(
+            invitations=f"{invitation_edit['invitation']['id']}/Overlap_Committees",
+            signatures=[venue_id],
+            content={
+                'overlap_committee_ids': { 'value': [domain.content['reviewers_id']['value']] }
+            },
+            invitation=openreview.api.Invitation()
+        )
+
+        client.post_invitation_edit(
+            invitations=f"{domain.content['reviewers_recruitment_id']['value']}/Overlap_Committees",
+            signatures=[venue_id],
+            content={
+                'overlap_committee_ids': { 'value': [edit.group.id] }
+            },
+            invitation=openreview.api.Invitation()
+        )
+
     client.post_group_edit(
         invitation=domain.content['meta_invitation_id']['value'],
         signatures=[invitation.domain],

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -326,16 +326,12 @@ For more details, please check the following links:
 
         pc_client=openreview.api.OpenReviewClient(username='programchair@efgh.cc', password=helpers.strong_password)
 
-        ## Do not allow action editors to also serve as reviewers
-        pc_client.post_invitation_edit(
-            invitations='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response/Overlap_Committees',
-            content={
-                'overlap_committee_ids': { 'value': ['EFGH.cc/2025/Conference/Action_Editors'] }
-            }
-        )
-
+        ## By default, the deployment does not allow overlap between reviewers and action editors
         invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response')
         assert invitation.content['overlap_committee_ids']['value'] == ['EFGH.cc/2025/Conference/Action_Editors']
+
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/Action_Editors/-/Recruitment_Response')
+        assert invitation.content['overlap_committee_ids']['value'] == ['EFGH.cc/2025/Conference/Reviewers']
 
         # use invitation to recruit reviewers, including an accepted action editor
         edit = openreview_client.post_group_edit(
@@ -406,6 +402,32 @@ For more details, please check the following links:
         helpers.await_queue_edit(openreview_client, invitation='EFGH.cc/2025/Conference/Action_Editors/-/Recruitment_Response', count=3)
         assert openreview_client.get_group('EFGH.cc/2025/Conference/Action_Editors').members == ['~ACOne_EFGH1']
         assert openreview_client.get_group('EFGH.cc/2025/Conference/Action_Editors/Declined').members == []
+
+        ## Program chairs can delete the overlap restriction to allow users to serve in multiple roles
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response/Overlap_Committees',
+            content={
+                'overlap_committee_ids': { 'value': { 'delete': True } }
+            }
+        )
+
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response')
+        assert invitation.content.get('overlap_committee_ids', {}).get('value') is None
+
+        ## The action editor can now accept the reviewer invitation while keeping the action editor role
+        openreview_client.flush_members_cache('~ACOne_EFGH1')
+        helpers.respond_invitation(selenium, request_page, ac_reviewer_invitation_url, accept=True)
+
+        helpers.await_queue_edit(openreview_client, invitation='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response', count=4)
+        assert set(openreview_client.get_group('EFGH.cc/2025/Conference/Reviewers').members) == {'~ReviewerOne_EFGH1', '~ACOne_EFGH1'}
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Action_Editors').members == ['~ACOne_EFGH1']
+
+        ## Restore the state for the following tests: decline the reviewer invitation
+        helpers.respond_invitation(selenium, request_page, ac_reviewer_invitation_url, accept=False)
+
+        helpers.await_queue_edit(openreview_client, invitation='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response', count=5)
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Reviewers').members == ['~ReviewerOne_EFGH1']
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Action_Editors').members == ['~ACOne_EFGH1']
 
     def test_post_submissions(self, openreview_client, test_client, helpers):
 

--- a/tests/test_acs_and_reviewers.py
+++ b/tests/test_acs_and_reviewers.py
@@ -322,6 +322,91 @@ For more details, please check the following links:
         assert openreview_client.get_messages(to='areachair_two@efgh.cc', subject = '[EFGH 2025] Reminder: Invitation to serve as Action Editor')
         assert openreview_client.get_messages(to='areachair_three@efgh.cc', subject = '[EFGH 2025] Reminder: Invitation to serve as Action Editor')
 
+    def test_recruit_reviewers(self, openreview_client, selenium, request_page, helpers):
+
+        pc_client=openreview.api.OpenReviewClient(username='programchair@efgh.cc', password=helpers.strong_password)
+
+        ## Do not allow action editors to also serve as reviewers
+        pc_client.post_invitation_edit(
+            invitations='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response/Overlap_Committees',
+            content={
+                'overlap_committee_ids': { 'value': ['EFGH.cc/2025/Conference/Action_Editors'] }
+            }
+        )
+
+        invitation = openreview_client.get_invitation('EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response')
+        assert invitation.content['overlap_committee_ids']['value'] == ['EFGH.cc/2025/Conference/Action_Editors']
+
+        # use invitation to recruit reviewers, including an accepted action editor
+        edit = openreview_client.post_group_edit(
+                invitation='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Request',
+                content={
+                    'invitee_details': { 'value':  'reviewer_one@efgh.cc, Reviewer EFGHOne\nareachair_one@efgh.cc, ActionEditor EFGHOne' },
+                    'invite_message_subject_template': { 'value': '[EFGH 2025] Invitation to serve as Reviewer' },
+                    'invite_message_body_template': { 'value': 'Dear Reviewer {{fullname}},\n\nWe are pleased to invite you to serve as a Reviewer for the EFGH 2025 Conference.\n\nPlease accept or decline the invitation using the link below:\n\n{{invitation_url}}\n\nBest regards,\nEFGH 2025 Program Chairs' },
+                },
+                group=openreview.api.Group()
+            )
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'])
+        helpers.await_queue_edit(openreview_client, edit_id=edit['id'], process_index=1)
+
+        invited_group = openreview_client.get_group('EFGH.cc/2025/Conference/Reviewers/Invited')
+        assert set(invited_group.members) == {'~ReviewerOne_EFGH1', '~ACOne_EFGH1'}
+
+        ## Accepting the reviewer invitation is not allowed while being an action editor
+        messages = openreview_client.get_messages(to='areachair_one@efgh.cc', subject = '[EFGH 2025] Invitation to serve as Reviewer')
+        assert len(messages) == 1
+        text = messages[0]['content']['text']
+        ac_reviewer_invitation_url = re.search('https://.*\n', text).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+
+        openreview_client.flush_members_cache('~ACOne_EFGH1')
+        helpers.respond_invitation(selenium, request_page, ac_reviewer_invitation_url, accept=True, expected_error_message='Error: You have already accepted an invitation to serve as Action Editor for EFGH 2025. If you would like to change your decision and serve as Reviewer, please decline the invitation to be Action Editor and then accept the invitation to be Reviewer.')
+
+        assert openreview_client.get_note_edits(invitation='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response') == []
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Reviewers').members == []
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Reviewers/Declined').members == []
+
+        ## Users that are not members of the overlap committees can accept the invitation
+        messages = openreview_client.get_messages(to='reviewer_one@efgh.cc', subject = '[EFGH 2025] Invitation to serve as Reviewer')
+        assert len(messages) == 1
+        text = messages[0]['content']['text']
+        invitation_url = re.search('https://.*\n', text).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+        helpers.respond_invitation(selenium, request_page, invitation_url, accept=True)
+
+        helpers.await_queue_edit(openreview_client, invitation='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response', count=1)
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Reviewers').members == ['~ReviewerOne_EFGH1']
+
+        ## The action editor declines the action editor invitation and then accepts the reviewer invitation
+        messages = openreview_client.get_messages(to='areachair_one@efgh.cc', subject = '[EFGH 2025] Invitation to serve as Action Editor')
+        assert len(messages) == 1
+        text = messages[0]['content']['text']
+        ac_invitation_url = re.search('https://.*\n', text).group(0).replace('https://openreview.net', 'http://localhost:3030').replace('&amp;', '&')[:-1]
+        helpers.respond_invitation(selenium, request_page, ac_invitation_url, accept=False)
+
+        helpers.await_queue_edit(openreview_client, invitation='EFGH.cc/2025/Conference/Action_Editors/-/Recruitment_Response', count=2)
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Action_Editors').members == []
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Action_Editors/Declined').members == ['~ACOne_EFGH1']
+
+        openreview_client.flush_members_cache('~ACOne_EFGH1')
+        helpers.respond_invitation(selenium, request_page, ac_reviewer_invitation_url, accept=True)
+
+        helpers.await_queue_edit(openreview_client, invitation='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response', count=2)
+        assert set(openreview_client.get_group('EFGH.cc/2025/Conference/Reviewers').members) == {'~ReviewerOne_EFGH1', '~ACOne_EFGH1'}
+
+        ## Restore the state for the following tests: decline the reviewer invitation and accept the action editor invitation again
+        openreview_client.flush_members_cache('~ACOne_EFGH1')
+        helpers.respond_invitation(selenium, request_page, ac_reviewer_invitation_url, accept=False)
+
+        helpers.await_queue_edit(openreview_client, invitation='EFGH.cc/2025/Conference/Reviewers/-/Recruitment_Response', count=3)
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Reviewers').members == ['~ReviewerOne_EFGH1']
+
+        openreview_client.flush_members_cache('~ACOne_EFGH1')
+        helpers.respond_invitation(selenium, request_page, ac_invitation_url, accept=True)
+
+        helpers.await_queue_edit(openreview_client, invitation='EFGH.cc/2025/Conference/Action_Editors/-/Recruitment_Response', count=3)
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Action_Editors').members == ['~ACOne_EFGH1']
+        assert openreview_client.get_group('EFGH.cc/2025/Conference/Action_Editors/Declined').members == []
+
     def test_post_submissions(self, openreview_client, test_client, helpers):
 
         test_client = openreview.api.OpenReviewClient(token=test_client.token)


### PR DESCRIPTION
## Motivation

The old venue request form supports an **`allow_role_overlap`** setting that lets venue organizers prevent the same person from serving as both a Reviewer and an Area Chair. The legacy implementation enforces it in two places: at invite time (`invite_committee` skips invitees already invited to or members of another official role) and at response time (the recruitment process silently converts an "Accept" into a decline and emails the user when they already belong to the overlapping committee).

The new workflow configuration (`openreview/workflows/`) had no equivalent — any invited user could accept a recruitment invitation regardless of the roles they already hold.

This PR adds overlap support to the workflow recruitment. Instead of a `true`/`false` flag, the restriction is expressed as a **list of group ids the responding user cannot be a member of**, configured on the `Recruitment_Response` invitation.

## Design decisions

- **Validation happens at response time only.** Program chairs can invite the same person to multiple roles; whichever invitation the user accepts first wins, and to switch roles they decline one and accept the other. Response-time validation is the only authoritative check anyway, since memberships change between invite and response. An invite-time courtesy filter can be layered on later without any schema change (the request process can read the list off the response invitation).
- **Validation happens in the preprocess, not the process.** The legacy flow accepted the note, then silently moved the user to the declined group and emailed them that their accept didn't count. Here the accept is rejected up front with a clear, actionable error shown in the UI, so no invalid state is ever written and no follow-up email is needed. This matches the existing preprocess pattern (rejecting a decline after a paper assignment).
- **Empty/absent list means overlap is allowed** — the default behavior is unchanged for venues that don't configure it.

## Changes

### `openreview/workflows/edit_invitations.py`

`set_edit_committee_recruitment_invitation` now also creates an **`Overlap_Committees`** edit invitation (`<committee_id>/-/Recruitment_Response/Overlap_Committees`), following the existing `Reduced_Load` pattern. PCs post:

- **`overlap_committee_ids`** — `string[]` of group ids (default `[]`), stamped into the `Recruitment_Response` invitation content.

Since the builder runs from `committee_group_template_process.py` at deployment, every committee of a newly deployed venue gets this invitation automatically.

### `openreview/workflows/process/committee_recruitment_response_pre_process.js`

On a **Yes** response, the preprocess reads `overlap_committee_ids` from the invitation content and checks membership with `getGroups({ id: <group_id>, member: user })` for each listed group. If the user belongs to any of them, the edit is rejected with:

> You have already accepted an invitation to serve as Action Editor for EFGH 2025. If you would like to change your decision and serve as Reviewer, please decline the invitation to be Action Editor and then accept the invitation to be Reviewer.

Role names come from each group's `committee_pretty_name` content (falling back to `Tools.prettyId`); the wording follows the legacy venue request form message. The existing decline-after-assignment check is unchanged.

## Tests

New `test_recruit_reviewers` in `tests/test_acs_and_reviewers.py`:

1. PC configures `overlap_committee_ids: [<venue>/Action_Editors]` on the Reviewers `Recruitment_Response` via the new `Overlap_Committees` invitation and the value is stamped on the invitation.
2. An accepted Action Editor is invited as a Reviewer; their **Accept is rejected** with the error above, and no response note edit or group change is produced.
3. A regular invitee accepts normally.
4. The Action Editor **declines the AC invitation and then successfully accepts** the Reviewer invitation (the "let the user decide" flow).
5. State is restored (AC re-accepts their original role) so the downstream matching/assignment tests in the file are unaffected.

## Not in this PR

- **Invite-time filtering** (legacy option: refuse to even invite users holding another role). Deferred; can be added to `committee_recruitment_request_process.py` by reading the same list.
- **Backfill for already-deployed venues** — existing venues get the `Overlap_Committees` invitation only when their recruitment edit invitations are rebuilt.
- The old venue request form / `venue/` module behavior is untouched.
