### PR TITLE
Fix/ Venue Request: KeyError on re-deployment when legacy role name fields are missing

### DIFF
--- a/openreview/venue/venue.py
+++ b/openreview/venue/venue.py
@@ -137,7 +137,7 @@ class Venue(object):
         if request_note.content.get('reviewer_groups_names', {}).get('value'):
             self.reviewer_roles = request_note.content['reviewer_groups_names']['value']
             self.reviewers_name = self.reviewer_roles[0]
-        elif 'reviewers_name' in request_note.content:
+        elif request_note.content.get('reviewers_name', {}).get('value'):
             self.reviewers_name = request_note.content['reviewers_name']['value']
             self.reviewer_roles = [self.reviewers_name]
         preferred_email_groups = [self.get_reviewers_id(), self.get_authors_id()]
@@ -146,7 +146,7 @@ class Venue(object):
             if request_note.content.get('area_chair_groups_names', {}).get('value'):
                 self.area_chair_roles = request_note.content['area_chair_groups_names']['value']
                 self.area_chairs_name = self.area_chair_roles[0]
-            elif 'area_chairs_name' in request_note.content:
+            elif request_note.content.get('area_chairs_name', {}).get('value'):
                 self.area_chairs_name = request_note.content['area_chairs_name']['value']
                 self.area_chair_roles = [self.area_chairs_name]
             self.use_area_chairs = True

--- a/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
+++ b/openreview/workflows/workflow_process/conference_review_workflow_deployment.py
@@ -298,6 +298,28 @@ def process(client, edit, invitation):
     )
 
     # remove PC access to editing the note and make note visible to PC group and Support
+    hidden_fields = [
+        'venue_start_date',
+        'program_chair_emails',
+        'contact_email',
+        'submission_start_date',
+        'submission_deadline',
+        'full_submission_deadline',
+        'reviewers_name',
+        'reviewer_groups_names',
+        'area_chairs_support',
+        'area_chairs_name',
+        'area_chair_groups_names',
+        'senior_area_chairs_support',
+        'senior_area_chair_groups_names',
+        'release_role_participation',
+        'venue_organizer_agreement'
+    ]
+    # only hide fields present in the note, otherwise the edit creates value-less stub fields
+    note_content = { field: { 'readers': [support_user] } for field in hidden_fields if field in note.content }
+    note_content['program_chair_console'] = { 'value': f'https://openreview.net/group?id={venue_id}/Program_Chairs' }
+    note_content['workflow_timeline'] = { 'value': f'https://openreview.net/group/edit?id={venue_id}' }
+
     client.post_note_edit(
         invitation=f'{support_user}/-/Edit',
         signatures=[venue_id],
@@ -305,25 +327,7 @@ def process(client, edit, invitation):
             id = note.id,
             readers = [venue_id, support_user],
             writers = [support_user],
-            content = {
-                'venue_start_date': { 'readers': [support_user] },
-                'program_chair_emails': { 'readers': [support_user] },
-                'contact_email': { 'readers': [support_user] },
-                'submission_start_date': { 'readers': [support_user] },
-                'submission_deadline': { 'readers': [support_user] },
-                'full_submission_deadline': { 'readers': [support_user] },
-                'reviewers_name': { 'readers': [support_user] },
-                'reviewer_groups_names': { 'readers': [support_user] },
-                'area_chairs_support': { 'readers': [support_user] },
-                'area_chairs_name': { 'readers': [support_user] },
-                'area_chair_groups_names': { 'readers': [support_user] },
-                'senior_area_chairs_support': { 'readers': [support_user] },
-                'senior_area_chair_groups_names': { 'readers': [support_user] },
-                'release_role_participation': { 'readers': [support_user] },
-                'venue_organizer_agreement': { 'readers': [support_user] },
-                'program_chair_console': { 'value': f'https://openreview.net/group?id={venue_id}/Program_Chairs' },
-                'workflow_timeline': { 'value': f'https://openreview.net/group/edit?id={venue_id}' }
-            }
+            content = note_content
         )
     )
 


### PR DESCRIPTION

## Problem

Re-deploying an already-deployed venue (Conference_Review_Workflow) fails in the deployment process function with:

```
KeyError: 'value'
  File "openreview/venue/venue.py", line 141, in set_main_settings
    self.reviewers_name = request_note.content['reviewers_name']['value']
```

## Root cause

After the first deployment, the process hides request form fields from PCs by posting a note edit that sets `readers` on each field — including the legacy `reviewers_name` and `area_chairs_name` fields. Those fields were removed from the request form in #3027 (renamed to `reviewer_groups_names` / `area_chair_groups_names`), but the hide edit was never updated.

When an edit sets only `readers` on a field the note doesn't have, the API creates a value-less stub field (`{'readers': [...]}` with no `value` key). On re-deployment, `set_main_settings` sees the stub, passes the `'reviewers_name' in request_note.content` check, and crashes reading `['value']`.

Existing re-deployment tests didn't catch this because they all set `reviewer_groups_names`, which takes the first branch of the guard and never reaches the legacy field.

## Changes

- **`conference_review_workflow_deployment.py`**: the hide-fields edit now only includes fields actually present on the request note, so it never creates stub fields. The legacy field names stay in the list because request notes created before #3027 still carry them with real values and should remain hidden. This also prevents stub creation for optional fields the PC left empty (`full_submission_deadline`, `senior_area_chair_groups_names`, etc.).
- **`venue.py` (`set_main_settings`)**: the `reviewers_name` / `area_chairs_name` guards now check for an actual value (`.get(field, {}).get('value')`) instead of key presence, falling back to the defaults (`Reviewers` / `Area_Chairs`). This is needed for venues already deployed in production, whose request notes already have the stub fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
