### PR TITLE
Fix reply-readers options to include all reviewer/AC roles

### DIFF
--- a/openreview/workflows/edit_invitations.py
+++ b/openreview/workflows/edit_invitations.py
@@ -633,29 +633,55 @@ class EditInvitationsBuilder(object):
         authors_name = self.domain_group.get_content_value('authors_name', 'Authors')
         reviewers_name = self.domain_group.get_content_value('reviewers_name', 'Reviewers')
 
+        # Support venues configured with multiple reviewer/area chair roles per
+        # submission build one set of reader options per role instead
+        # of only offering the primary/default role of each committee type. The
+        # "All X" options are built from the top-level committee roles (one group
+        # per role, always present), while the "Assigned X" (per-submission)
+        # options are built from the submission-level roles
+        senior_area_chairs_name = self.get_content_value('senior_area_chairs_name')
+        senior_area_chair_roles = self.domain_group.get_content_value(
+            'senior_area_chair_roles', [senior_area_chairs_name] if senior_area_chairs_name else [])
+        submission_senior_area_chair_roles = self.domain_group.get_content_value(
+            'submission_senior_area_chair_roles', senior_area_chair_roles)
+
+        area_chairs_name = self.get_content_value('area_chairs_name')
+        area_chair_roles = self.domain_group.get_content_value(
+            'area_chair_roles', [area_chairs_name] if area_chairs_name else [])
+        submission_area_chair_roles = self.domain_group.get_content_value(
+            'submission_area_chair_roles', area_chair_roles)
+
+        reviewer_roles = self.domain_group.get_content_value('reviewer_roles', [reviewers_name])
+        submission_reviewer_roles = self.domain_group.get_content_value(
+            'submission_reviewer_roles', reviewer_roles)
+
         reply_readers = [
             {'value': program_chairs_id, 'optional': True, 'description': 'Program Chairs'}
         ]
 
-        senior_area_chairs_name = self.get_content_value('senior_area_chairs_name')
-        if senior_area_chairs_name:
-            reply_readers.extend([
-                {'value': self.get_content_value('senior_area_chairs_id'), 'optional': True, 'description': 'All Senior Area Chairs'},
-                {'value': f'{venue_id}/{submission_name}' + '${5/content/noteNumber/value}' +f'/{senior_area_chairs_name}', 'optional': True, 'description': 'Assigned Senior Area Chairs'}
-            ])
+        for role in senior_area_chair_roles:
+            pretty_role = role.replace('_', ' ')
+            reply_readers.append({'value': f'{venue_id}/{role}', 'optional': True, 'description': f'All {pretty_role}'})
+        for role in submission_senior_area_chair_roles:
+            pretty_role = role.replace('_', ' ')
+            reply_readers.append({'value': f'{venue_id}/{submission_name}' + '${5/content/noteNumber/value}' +f'/{role}', 'optional': True, 'description': f'Assigned {pretty_role}'})
 
-        area_chairs_name = self.get_content_value('area_chairs_name')
-        if area_chairs_name:
-            reply_readers.extend([
-                {'value': self.get_content_value('area_chairs_id'), 'optional': True, 'description': 'All Area Chairs'},
-                {'value': f'{venue_id}/{submission_name}' + '${5/content/noteNumber/value}' +f'/{area_chairs_name}', 'optional': True, 'description': 'Assigned Area Chairs'}
-            ])
+        for role in area_chair_roles:
+            pretty_role = role.replace('_', ' ')
+            reply_readers.append({'value': f'{venue_id}/{role}', 'optional': True, 'description': f'All {pretty_role}'})
+        for role in submission_area_chair_roles:
+            pretty_role = role.replace('_', ' ')
+            reply_readers.append({'value': f'{venue_id}/{submission_name}' + '${5/content/noteNumber/value}' +f'/{role}', 'optional': True, 'description': f'Assigned {pretty_role}'})
 
-        reply_readers.extend([
-            {'value': self.get_content_value('reviewers_id'), 'optional': True, 'description': 'All Reviewers'},
-            {'value': f'{venue_id}/{submission_name}' + '${5/content/noteNumber/value}' +f'/{reviewers_name}', 'optional': True, 'description': 'Assigned Reviewers'},
-            {'value': f'{venue_id}/{submission_name}' + '${5/content/noteNumber/value}' +f'/{reviewers_name}/Submitted', 'optional': True, 'description': 'Assigned Reviewers who already submitted their review'}
-        ])
+        for role in reviewer_roles:
+            pretty_role = role.replace('_', ' ')
+            reply_readers.append({'value': f'{venue_id}/{role}', 'optional': True, 'description': f'All {pretty_role}'})
+        for role in submission_reviewer_roles:
+            pretty_role = role.replace('_', ' ')
+            reply_readers.extend([
+                {'value': f'{venue_id}/{submission_name}' + '${5/content/noteNumber/value}' +f'/{role}', 'optional': True, 'description': f'Assigned {pretty_role}'},
+                {'value': f'{venue_id}/{submission_name}' + '${5/content/noteNumber/value}' +f'/{role}/Submitted', 'optional': True, 'description': f'Assigned {pretty_role} who already submitted their review'}
+            ])
 
         if include_signatures:
             reply_readers.append({'value': '${3/signatures}', 'optional': True, 'description': 'Reviewer who submitted the review'})

--- a/tests/test_merged_committee_roles.py
+++ b/tests/test_merged_committee_roles.py
@@ -112,6 +112,51 @@ class TestMergedCommitteeRoles():
         assert venue_group.content['review_names']['value'] == ['Official_Review']
         assert openreview_client.get_invitation('MRG.cc/2025/Conference/-/Official_Review')
 
+        # The /Readers edit invitation for Official_Review should offer an "All X"
+        # reader option for every top-level reviewer/area chair role (recruitment
+        # still tracks Expert_Reviewers and Technical_Reviewers, Area_Chairs and
+        # Technical_Area_Chairs, separately) -- but only ONE "Assigned X" option
+        # per committee type, since both roles are merged into a single
+        # per-submission group here. There is no per-submission
+        # Expert_Reviewers/Technical_Reviewers or Technical_Area_Chairs subgroup
+        # to point to, unlike in the two-separate-submission-groups scenario.
+        reviewer_roles = venue_group.content['reviewer_roles']['value']
+        submission_reviewer_roles = venue_group.content['submission_reviewer_roles']['value']
+        area_chair_roles = venue_group.content['area_chair_roles']['value']
+        submission_area_chair_roles = venue_group.content['submission_area_chair_roles']['value']
+        assert submission_reviewer_roles == ['Reviewers']
+        assert submission_area_chair_roles == ['Area_Chairs']
+
+        readers_invitation = openreview_client.get_invitation('MRG.cc/2025/Conference/-/Official_Review/Readers')
+        items = readers_invitation.edit['content']['readers']['value']['param']['items']
+        values = [item['value'] for item in items]
+
+        def assigned_value(role):
+            return next((value for value in values if value.endswith(f'/{role}') and 'Submission' in value), None)
+
+        assert any(value.endswith('/Program_Chairs') for value in values), 'Missing Program Chairs reader option'
+
+        # "All X": one option per top-level role, merged or not.
+        for role in reviewer_roles:
+            assert f'MRG.cc/2025/Conference/{role}' in values, f'Missing "All {role}" reader option'
+        for role in area_chair_roles:
+            assert f'MRG.cc/2025/Conference/{role}' in values, f'Missing "All {role}" reader option'
+
+        # "Assigned X": only the shared per-submission group name(s) should
+        # appear as an option -- not the individual roles merged into them.
+        for role in submission_reviewer_roles:
+            assert assigned_value(role) is not None, f'Missing "Assigned {role}" reader option'
+            assert any(value.endswith(f'/{role}/Submitted') for value in values), f'Missing "Assigned {role} Submitted" reader option'
+        for role in reviewer_roles:
+            if role not in submission_reviewer_roles:
+                assert assigned_value(role) is None, f'Unexpected per-submission reader option for merged reviewer role {role}'
+
+        for role in submission_area_chair_roles:
+            assert assigned_value(role) is not None, f'Missing "Assigned {role}" reader option'
+        for role in area_chair_roles:
+            if role not in submission_area_chair_roles:
+                assert assigned_value(role) is None, f'Unexpected per-submission reader option for merged area chair role {role}'
+
         # Populate committee groups
         openreview_client.post_group_edit(
             invitation='MRG.cc/2025/Conference/Expert_Reviewers/-/Members',

--- a/tests/test_two_submission_committee_roles.py
+++ b/tests/test_two_submission_committee_roles.py
@@ -522,6 +522,45 @@ class TestTwoSubmissionCommitteeRoles():
             assert any('Technical_Reviewer_' in item.get('prefix', '') for item in signatures_items)
             assert not any('Expert_Reviewer_' in item.get('prefix', '') for item in signatures_items)
 
+        # The /Readers edit invitation for each review form should offer a reader
+        # option for every reviewer/area chair role configured on the venue (both
+        # the "primary" role and any additional roles added via reviewer_groups_names
+        # / area_chair_groups_names), not just the primary role of each committee type.
+        venue_group = openreview_client.get_group('XYZW.cc/2025/Conference')
+        reviewer_roles = venue_group.content['reviewer_roles']['value']
+        area_chair_roles = venue_group.content['area_chair_roles']['value']
+
+        def assert_all_role_reader_options(readers_invitation_id):
+            readers_invitation = openreview_client.get_invitation(readers_invitation_id)
+            items = readers_invitation.edit['content']['readers']['value']['param']['items']
+            values = [item['value'] for item in items]
+
+            assert any(value.endswith('/Program_Chairs') for value in values), (
+                f'Missing Program Chairs reader option in {readers_invitation_id}'
+            )
+
+            for role in area_chair_roles:
+                assert f'XYZW.cc/2025/Conference/{role}' in values, (
+                    f'Missing "All {role}" reader option in {readers_invitation_id}'
+                )
+                assert any(value.endswith(f'/{role}') and 'Submission' in value for value in values), (
+                    f'Missing "Assigned {role}" reader option in {readers_invitation_id}'
+                )
+
+            for role in reviewer_roles:
+                assert f'XYZW.cc/2025/Conference/{role}' in values, (
+                    f'Missing "All {role}" reader option in {readers_invitation_id}'
+                )
+                assert any(value.endswith(f'/{role}') and 'Submission' in value for value in values), (
+                    f'Missing "Assigned {role}" reader option in {readers_invitation_id}'
+                )
+                assert any(value.endswith(f'/{role}/Submitted') for value in values), (
+                    f'Missing "Assigned {role} Submitted" reader option in {readers_invitation_id}'
+                )
+
+        assert_all_role_reader_options('XYZW.cc/2025/Conference/-/Official_Review/Readers')
+        assert_all_role_reader_options('XYZW.cc/2025/Conference/-/Technical_Reviewers_Review/Readers')
+
         # Reviewer assignments were undeployed earlier; redeploy them so reviewers
         # can actually post reviews for submission 1.
         venue = openreview.venue.helpers.get_venue(openreview_client, 'XYZW.cc/2025/Conference', support_user='openreview.net/Support')


### PR DESCRIPTION
## Summary

PR #3009 added support for multiple reviewer/area chair roles per submission, but the "Readers" edit invitations that let PCs configure who can see a reply (Official_Review, Official_Comment, Withdrawn/Desk_Rejected notes, identity-reveal, review release, etc.) were never updated. They still read a single `reviewers_name`/`area_chairs_name` off the domain content, so on a venue with more than one reviewer or area chair role, the reader/participant dropdown silently only offered the primary role — the other roles had no way to be selected as readers.